### PR TITLE
Remove contract-committers from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-# Involve the contract committer team when making changes to the soroban
-# contract build command.
-/cmd/soroban-cli/src/commands/contract/build.rs         @stellar/contract-committers
+


### PR DESCRIPTION
### What

Remove contract-committers from CODEOWNERS.

### Why

This repo is only for the soroban-rpc and it's shared past history with the CLI is just historical. The CLI will be removed. There's no need for changes in this repo to be dependent on contract-committers.

### Known limitations

N/A