### PR TITLE
soroban-rpc: Pull in Recent Soroban RPC changes from soroban-tools

### DIFF
--- a/cmd/soroban-rpc/internal/config/config_option.go
+++ b/cmd/soroban-rpc/internal/config/config_option.go
@@ -88,8 +88,6 @@ func (o *ConfigOption) setValue(i interface{}) (err error) {
 	if o.CustomSetValue != nil {
 		return o.CustomSetValue(o, i)
 	}
-	// it's unfortunate that Set below panics when it cannot set the value..
-	// we'll want to catch this so that we can alert the user nicely.
 	defer func() {
 		if recoverRes := recover(); recoverRes != nil {
 			var ok bool
@@ -101,7 +99,7 @@ func (o *ConfigOption) setValue(i interface{}) (err error) {
 		}
 	}()
 	parser := func(option *ConfigOption, i interface{}) error {
-		panic(fmt.Sprintf("no parser for flag %s", o.Name))
+		return errors.Errorf("no parser for flag %s", o.Name)
 	}
 	switch o.ConfigKey.(type) {
 	case *bool:

--- a/cmd/soroban-rpc/internal/config/config_option_test.go
+++ b/cmd/soroban-rpc/internal/config/config_option_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -113,6 +114,16 @@ func TestUnassignableField(t *testing.T) {
 	err := co.setValue("abc")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), co.Name)
+}
+
+func TestNoParserForFlag(t *testing.T) {
+	var co ConfigOption
+	var invalidKey []time.Duration
+	co.Name = "mykey"
+	co.ConfigKey = &invalidKey
+	err := co.setValue("abc")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no parser for flag mykey")
 }
 
 func TestSetValue(t *testing.T) {

--- a/cmd/soroban-rpc/internal/config/log_format.go
+++ b/cmd/soroban-rpc/internal/config/log_format.go
@@ -1,6 +1,8 @@
 package config
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type LogFormat int
 
@@ -47,13 +49,13 @@ func (f *LogFormat) UnmarshalTOML(i interface{}) error {
 	}
 }
 
-func (f LogFormat) String() string {
+func (f LogFormat) String() (string, error) {
 	switch f {
 	case LogFormatText:
-		return "text"
+		return "text", nil
 	case LogFormatJSON:
-		return "json"
+		return "json", nil
 	default:
-		panic(fmt.Sprintf("unknown log format: %d", f))
+		return "", fmt.Errorf("unknown log format: %d", f)
 	}
 }

--- a/cmd/soroban-rpc/internal/config/options.go
+++ b/cmd/soroban-rpc/internal/config/options.go
@@ -130,7 +130,7 @@ func (cfg *Config) options() ConfigOptions {
 				return nil
 			},
 			MarshalTOML: func(option *ConfigOption) (interface{}, error) {
-				return cfg.LogFormat.String(), nil
+				return cfg.LogFormat.String()
 			},
 		},
 		{

--- a/cmd/soroban-rpc/internal/events/cursor.go
+++ b/cmd/soroban-rpc/internal/events/cursor.go
@@ -20,6 +20,8 @@ type Cursor struct {
 	// Tx is the index of the transaction within the ledger which emitted the event.
 	Tx uint32
 	// Op is the index of the operation within the transaction which emitted the event.
+	// Note: Currently, there is no use for it (events are transaction-wide and not operation-specific)
+	//       but we keep it in order to make the API future-proof.
 	Op uint32
 	// Event is the index of the event within in the operation which emitted the event.
 	Event uint32

--- a/cmd/soroban-rpc/internal/events/events_test.go
+++ b/cmd/soroban-rpc/internal/events/events_test.go
@@ -83,7 +83,7 @@ func eventsAreEqual(t *testing.T, a, b []event) {
 
 func TestScanRangeValidation(t *testing.T) {
 	m := NewMemoryStore(interfaces.MakeNoOpDeamon(), "unit-tests", 4)
-	assertNoCalls := func(contractEvent xdr.DiagnosticEvent, cursor Cursor, timestamp int64) bool {
+	assertNoCalls := func(xdr.DiagnosticEvent, Cursor, int64, *xdr.Hash) bool {
 		t.Fatalf("unexpected call")
 		return true
 	}
@@ -362,7 +362,7 @@ func TestScan(t *testing.T) {
 		for _, input := range genEquivalentInputs(testCase.input) {
 			var events []event
 			iterateAll := true
-			f := func(contractEvent xdr.DiagnosticEvent, cursor Cursor, ledgerCloseTimestamp int64) bool {
+			f := func(contractEvent xdr.DiagnosticEvent, cursor Cursor, ledgerCloseTimestamp int64, hash *xdr.Hash) bool {
 				require.Equal(t, ledgerCloseTime(cursor.Ledger), ledgerCloseTimestamp)
 				diagnosticEventXDR, err := contractEvent.MarshalBinary()
 				require.NoError(t, err)
@@ -370,6 +370,7 @@ func TestScan(t *testing.T) {
 					diagnosticEventXDR: diagnosticEventXDR,
 					txIndex:            cursor.Tx,
 					eventIndex:         cursor.Event,
+					txHash:             hash,
 				})
 				return iterateAll
 			}

--- a/cmd/soroban-rpc/internal/ledgerbucketwindow/ledgerbucketwindow.go
+++ b/cmd/soroban-rpc/internal/ledgerbucketwindow/ledgerbucketwindow.go
@@ -35,12 +35,12 @@ func NewLedgerBucketWindow[T any](retentionWindow uint32) *LedgerBucketWindow[T]
 }
 
 // Append adds a new bucket to the window. If the window is full a bucket will be evicted and returned.
-func (w *LedgerBucketWindow[T]) Append(bucket LedgerBucket[T]) *LedgerBucket[T] {
+func (w *LedgerBucketWindow[T]) Append(bucket LedgerBucket[T]) (*LedgerBucket[T], error) {
 	length := w.Len()
 	if length > 0 {
 		expectedLedgerSequence := w.buckets[w.start].LedgerSeq + length
 		if expectedLedgerSequence != bucket.LedgerSeq {
-			panic(fmt.Errorf("ledgers not contiguous: expected ledger sequence %v but received %v", expectedLedgerSequence, bucket.LedgerSeq))
+			return &LedgerBucket[T]{}, fmt.Errorf("error appending ledgers: ledgers not contiguous: expected ledger sequence %v but received %v", expectedLedgerSequence, bucket.LedgerSeq)
 		}
 	}
 
@@ -57,7 +57,7 @@ func (w *LedgerBucketWindow[T]) Append(bucket LedgerBucket[T]) *LedgerBucket[T] 
 		w.start = (w.start + 1) % length
 	}
 
-	return evicted
+	return evicted, nil
 }
 
 // Len returns the length (number of buckets in the window)

--- a/cmd/soroban-rpc/internal/ledgerbucketwindow/ledgerbucketwindow_test.go
+++ b/cmd/soroban-rpc/internal/ledgerbucketwindow/ledgerbucketwindow_test.go
@@ -18,118 +18,87 @@ func TestAppend(t *testing.T) {
 	m := NewLedgerBucketWindow[uint32](3)
 	require.Equal(t, uint32(0), m.Len())
 
-	// test appending first bucket of events
-	evicted := m.Append(bucket(5))
+	// Test appending first bucket of events
+	evicted, err := m.Append(bucket(5))
+	require.NoError(t, err)
 	require.Nil(t, evicted)
 	require.Equal(t, uint32(1), m.Len())
 	require.Equal(t, bucket(5), *m.Get(0))
 
-	// the next bucket must follow the previous bucket (ledger 5)
+	// The next bucket must follow the previous bucket (ledger 5)
+	_, err = m.Append(LedgerBucket[uint32]{
+		LedgerSeq:            10,
+		LedgerCloseTimestamp: 100,
+		BucketContent:        10,
+	})
+	require.Errorf(t, err, "ledgers not contiguous: expected ledger sequence 6 but received 10")
 
-	require.PanicsWithError(
-		t, "ledgers not contiguous: expected ledger sequence 6 but received 10",
-		func() {
-			m.Append(LedgerBucket[uint32]{
-				LedgerSeq:            10,
-				LedgerCloseTimestamp: 100,
-				BucketContent:        10,
-			})
-		},
-	)
-	require.PanicsWithError(
-		t, "ledgers not contiguous: expected ledger sequence 6 but received 4",
-		func() {
-			m.Append(LedgerBucket[uint32]{
-				LedgerSeq:            4,
-				LedgerCloseTimestamp: 100,
-				BucketContent:        4,
-			})
-		},
-	)
-	require.PanicsWithError(
-		t, "ledgers not contiguous: expected ledger sequence 6 but received 5",
-		func() {
-			m.Append(LedgerBucket[uint32]{
-				LedgerSeq:            5,
-				LedgerCloseTimestamp: 100,
-				BucketContent:        5,
-			})
-		},
-	)
+	_, err = m.Append(LedgerBucket[uint32]{
+		LedgerSeq:            4,
+		LedgerCloseTimestamp: 100,
+		BucketContent:        4,
+	})
+	require.Errorf(t, err, "ledgers not contiguous: expected ledger sequence 6 but received 4")
+
 	// check that none of the calls above modified our buckets
 	require.Equal(t, uint32(1), m.Len())
 	require.Equal(t, bucket(5), *m.Get(0))
 
-	// append ledger 6 bucket, now we have two buckets filled
-	evicted = m.Append(bucket(6))
+	// Append ledger 6 bucket, now we have two buckets filled
+	evicted, err = m.Append(bucket(6))
+	require.NoError(t, err)
 	require.Nil(t, evicted)
 	require.Equal(t, uint32(2), m.Len())
 	require.Equal(t, bucket(5), *m.Get(0))
 	require.Equal(t, bucket(6), *m.Get(1))
 
-	// the next bucket of events must follow the previous bucket (ledger 6)
-	require.PanicsWithError(
-		t, "ledgers not contiguous: expected ledger sequence 7 but received 10",
-		func() {
-			m.Append(LedgerBucket[uint32]{
-				LedgerSeq:            10,
-				LedgerCloseTimestamp: 100,
-				BucketContent:        10,
-			})
-		},
-	)
-	require.PanicsWithError(
-		t, "ledgers not contiguous: expected ledger sequence 7 but received 4",
-		func() {
-			m.Append(LedgerBucket[uint32]{
-				LedgerSeq:            4,
-				LedgerCloseTimestamp: 100,
-				BucketContent:        4,
-			})
-		},
-	)
-	require.PanicsWithError(
-		t, "ledgers not contiguous: expected ledger sequence 7 but received 5",
-		func() {
-			m.Append(LedgerBucket[uint32]{
-				LedgerSeq:            5,
-				LedgerCloseTimestamp: 100,
-				BucketContent:        5,
-			})
-		},
-	)
-
-	// append ledger 7, now we have all three buckets filled
-	evicted = m.Append(bucket(7))
-	require.Nil(t, evicted)
+	// Append ledger 7, now we have all three buckets filled
+	evicted, err = m.Append(bucket(7))
+	require.NoError(t, err)
 	require.Nil(t, evicted)
 	require.Equal(t, uint32(3), m.Len())
 	require.Equal(t, bucket(5), *m.Get(0))
 	require.Equal(t, bucket(6), *m.Get(1))
 	require.Equal(t, bucket(7), *m.Get(2))
 
-	// append ledger 8, but all buckets are full, so we need to evict ledger 5
-	evicted = m.Append(bucket(8))
+	// Append ledger 8, but all buckets are full, so we need to evict ledger 5
+	evicted, err = m.Append(bucket(8))
+	require.NoError(t, err)
 	require.Equal(t, bucket(5), *evicted)
 	require.Equal(t, uint32(3), m.Len())
 	require.Equal(t, bucket(6), *m.Get(0))
 	require.Equal(t, bucket(7), *m.Get(1))
 	require.Equal(t, bucket(8), *m.Get(2))
 
-	// append ledger 9 events, but all buckets are full, so we need to evict ledger 6
-	evicted = m.Append(bucket(9))
+	// Append ledger 9 events, but all buckets are full, so we need to evict ledger 6
+	evicted, err = m.Append(bucket(9))
+	require.NoError(t, err)
 	require.Equal(t, bucket(6), *evicted)
 	require.Equal(t, uint32(3), m.Len())
 	require.Equal(t, bucket(7), *m.Get(0))
 	require.Equal(t, bucket(8), *m.Get(1))
 	require.Equal(t, bucket(9), *m.Get(2))
 
-	// append ledger 10, but all buckets are full, so we need to evict ledger 7.
+	// Append ledger 10, but all buckets are full, so we need to evict ledger 7.
 	// The start index must have wrapped around
-	evicted = m.Append(bucket(10))
+	evicted, err = m.Append(bucket(10))
+	require.NoError(t, err)
 	require.Equal(t, bucket(7), *evicted)
 	require.Equal(t, uint32(3), m.Len())
 	require.Equal(t, bucket(8), *m.Get(0))
 	require.Equal(t, bucket(9), *m.Get(1))
 	require.Equal(t, bucket(10), *m.Get(2))
+}
+
+func TestAppendError(t *testing.T) {
+	m := NewLedgerBucketWindow[uint32](3)
+	require.Equal(t, uint32(0), m.Len())
+
+	evicted, err := m.Append(bucket(5))
+	require.NoError(t, err)
+	require.Nil(t, evicted)
+
+	evicted, err = m.Append(bucket(1))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "error appending ledgers: ledgers not contiguous: expected ledger sequence 6 but received 1")
 }

--- a/cmd/soroban-rpc/internal/methods/get_events_test.go
+++ b/cmd/soroban-rpc/internal/methods/get_events_test.go
@@ -591,7 +591,8 @@ func TestGetEvents(t *testing.T) {
 				),
 			))
 		}
-		assert.NoError(t, store.IngestEvents(ledgerCloseMetaWithEvents(1, now.Unix(), txMeta...)))
+		ledgerCloseMeta := ledgerCloseMetaWithEvents(1, now.Unix(), txMeta...)
+		assert.NoError(t, store.IngestEvents(ledgerCloseMeta))
 
 		handler := eventsRPCHandler{
 			scanner:      store,
@@ -626,6 +627,7 @@ func TestGetEvents(t *testing.T) {
 				Topic:                    []string{value},
 				Value:                    value,
 				InSuccessfulContractCall: true,
+				TransactionHash:          ledgerCloseMeta.TransactionHash(i).HexString(),
 			})
 		}
 		assert.Equal(t, GetEventsResponse{expected, 1}, results)
@@ -699,7 +701,8 @@ func TestGetEvents(t *testing.T) {
 				),
 			))
 		}
-		assert.NoError(t, store.IngestEvents(ledgerCloseMetaWithEvents(1, now.Unix(), txMeta...)))
+		ledgerCloseMeta := ledgerCloseMetaWithEvents(1, now.Unix(), txMeta...)
+		assert.NoError(t, store.IngestEvents(ledgerCloseMeta))
 
 		number := xdr.Uint64(4)
 		handler := eventsRPCHandler{
@@ -738,6 +741,7 @@ func TestGetEvents(t *testing.T) {
 				Topic:                    []string{counterXdr, value},
 				Value:                    value,
 				InSuccessfulContractCall: true,
+				TransactionHash:          ledgerCloseMeta.TransactionHash(4).HexString(),
 			},
 		}
 		assert.Equal(t, GetEventsResponse{expected, 1}, results)
@@ -792,7 +796,8 @@ func TestGetEvents(t *testing.T) {
 				),
 			),
 		}
-		assert.NoError(t, store.IngestEvents(ledgerCloseMetaWithEvents(1, now.Unix(), txMeta...)))
+		ledgerCloseMeta := ledgerCloseMetaWithEvents(1, now.Unix(), txMeta...)
+		assert.NoError(t, store.IngestEvents(ledgerCloseMeta))
 
 		handler := eventsRPCHandler{
 			scanner:      store,
@@ -832,6 +837,7 @@ func TestGetEvents(t *testing.T) {
 				Topic:                    []string{counterXdr, value},
 				Value:                    value,
 				InSuccessfulContractCall: true,
+				TransactionHash:          ledgerCloseMeta.TransactionHash(3).HexString(),
 			},
 		}
 		assert.Equal(t, GetEventsResponse{expected, 1}, results)
@@ -865,7 +871,8 @@ func TestGetEvents(t *testing.T) {
 				),
 			),
 		}
-		assert.NoError(t, store.IngestEvents(ledgerCloseMetaWithEvents(1, now.Unix(), txMeta...)))
+		ledgerCloseMeta := ledgerCloseMetaWithEvents(1, now.Unix(), txMeta...)
+		assert.NoError(t, store.IngestEvents(ledgerCloseMeta))
 
 		handler := eventsRPCHandler{
 			scanner:      store,
@@ -892,6 +899,7 @@ func TestGetEvents(t *testing.T) {
 				Topic:                    []string{counterXdr},
 				Value:                    counterXdr,
 				InSuccessfulContractCall: true,
+				TransactionHash:          ledgerCloseMeta.TransactionHash(0).HexString(),
 			},
 		}
 		assert.Equal(t, GetEventsResponse{expected, 1}, results)
@@ -913,7 +921,8 @@ func TestGetEvents(t *testing.T) {
 				),
 			))
 		}
-		assert.NoError(t, store.IngestEvents(ledgerCloseMetaWithEvents(1, now.Unix(), txMeta...)))
+		ledgerCloseMeta := ledgerCloseMetaWithEvents(1, now.Unix(), txMeta...)
+		assert.NoError(t, store.IngestEvents(ledgerCloseMeta))
 
 		handler := eventsRPCHandler{
 			scanner:      store,
@@ -947,6 +956,7 @@ func TestGetEvents(t *testing.T) {
 				Topic:                    []string{value},
 				Value:                    value,
 				InSuccessfulContractCall: true,
+				TransactionHash:          ledgerCloseMeta.TransactionHash(i).HexString(),
 			})
 		}
 		assert.Equal(t, GetEventsResponse{expected, 1}, results)
@@ -996,7 +1006,8 @@ func TestGetEvents(t *testing.T) {
 				),
 			),
 		}
-		assert.NoError(t, store.IngestEvents(ledgerCloseMetaWithEvents(5, now.Unix(), txMeta...)))
+		ledgerCloseMeta := ledgerCloseMetaWithEvents(5, now.Unix(), txMeta...)
+		assert.NoError(t, store.IngestEvents(ledgerCloseMeta))
 
 		id := &events.Cursor{Ledger: 5, Tx: 1, Op: 0, Event: 0}
 		handler := eventsRPCHandler{
@@ -1031,6 +1042,7 @@ func TestGetEvents(t *testing.T) {
 				Topic:                    []string{counterXdr},
 				Value:                    expectedXdr,
 				InSuccessfulContractCall: true,
+				TransactionHash:          ledgerCloseMeta.TransactionHash(i).HexString(),
 			})
 		}
 		assert.Equal(t, GetEventsResponse{expected, 5}, results)

--- a/cmd/soroban-rpc/internal/transactions/transactions.go
+++ b/cmd/soroban-rpc/internal/transactions/transactions.go
@@ -122,7 +122,10 @@ func (m *MemoryStore) IngestTransactions(ledgerCloseMeta xdr.LedgerCloseMeta) er
 
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	evicted := m.transactionsByLedger.Append(bucket)
+	evicted, err := m.transactionsByLedger.Append(bucket)
+	if err != nil {
+		return err
+	}
 	if evicted != nil {
 		// garbage-collect evicted entries
 		for _, evictedTxHash := range evicted.BucketContent {


### PR DESCRIPTION
### What

Related to [CLI/RPC repo split](https://github.com/stellar/soroban-tools/issues/1171).

This PR pulls in all merged PRs from `soroban-tools` repo **after** [this PR](https://github.com/stellar/soroban-tools/pull/1168).
Note: Does not include:
- `soroban init` [PR](https://github.com/stellar/soroban-tools/pull/1156) (unrelated to RPC)
- Dependencies bump [PR for release](https://github.com/stellar/soroban-tools/pull/1189) (dependency conflicts with `soroban-tools` so we should do this separately next release from `soroban-rpc`)

### Why

All new contributions to RPC should live in `soroban-rpc`. However, for `soroban-tools` work that was already in progress during the initial repo migration, we should pull RPC related changes into this repo.