### PR TITLE
soroban-rpc: Add Workflow to Publish soroban-rpc Crate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,74 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+
+  publish:
+    uses: stellar/actions/.github/workflows/rust-publish.yml@main
+    secrets:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  upload:
+    needs: publish
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-20.04 # Use 20.04 to get an older version of glibc for increased compat
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-20.04 # Use 20.04 to get an older version of glibc for increased compat
+            target: aarch64-unknown-linux-gnu
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            ext: .exe
+    runs-on: ${{ matrix.os }}
+    env:
+      VERSION: '${{ github.event.release.name }}'
+      NAME: 'soroban-rpc-${{ github.event.release.name }}-${{ matrix.target }}'
+    steps:
+    - uses: actions/checkout@v3
+    - run: rustup update
+    - run: rustup target add ${{ matrix.target }}
+    - if: matrix.target == 'aarch64-unknown-linux-gnu'
+      run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+    - name: Package
+      run: cargo package --no-verify
+    - name: Build
+      env:
+        CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+      run: |
+        cd target/package
+        tar xvfz soroban-rpc-$VERSION.crate
+        cd soroban-rpc-$VERSION
+        cargo build --target-dir=../.. --features opt --release --target ${{ matrix.target }}
+    - name: Compress 
+      run: |
+          cd target/${{ matrix.target }}/release
+          tar czvf $NAME.tar.gz soroban${{ matrix.ext }}
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ${{ env.NAME }}
+        path: 'target/${{ matrix.target }}/release/${{ env.NAME }}.tar.gz'
+    - name: Upload
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const fs = require('fs');
+          await github.rest.repos.uploadReleaseAsset({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            release_id: ${{ github.event.release.id }},
+            name: '${{ env.NAME }}.tar.gz',
+            data: fs.readFileSync('target/${{ matrix.target }}/release/${{ env.NAME }}.tar.gz'),
+          });

--- a/cmd/crates/soroban-test/Cargo.toml
+++ b/cmd/crates/soroban-test/Cargo.toml
@@ -10,6 +10,7 @@ version = "20.3.0"
 edition = "2021"
 rust-version.workspace = true
 autobins = false
+publish = false
 
 
 [lib]


### PR DESCRIPTION
### What

This PR adds a release workflow to publish the `soroban-rpc` crate.

### Why

This repo should now be responsible for building & publishing this crate, not `soroban-tools`.
