### PR TITLE
Publish soroban-rpc Instead of soroban-test in Workflows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,7 +82,6 @@ jobs:
         done
 
   publish-dry-run:
-    if: github.event_name == 'push' || startsWith(github.head_ref, 'release/')
     strategy:
       fail-fast: false
       matrix:
@@ -118,7 +117,7 @@ jobs:
           cargo-hack-feature-options: --features opt --ignore-unknown-features
     uses: stellar/actions/.github/workflows/rust-publish-dry-run-v2.yml@main
     with:
-      crates: soroban-test
+      crates: soroban-rpc
       runs-on: ${{ matrix.os }}
       target: ${{ matrix.target }}
       cargo-hack-feature-options: ${{ matrix.cargo-hack-feature-options }}


### PR DESCRIPTION
### What

This PR updates the `rust.yml` workflow file to do a dry run publishing the `soroban-rpc` crate instead of the `soroban-test` crate.

### Why

The `soroban-tools` repo should be responsible for the `soroban-test` crate