### PR TITLE
soroban-rpc: Add publish-dry-run Workflow Back

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -1,0 +1,87 @@
+name: Publish Dry Run
+
+on:
+  workflow_call:
+    inputs:
+      crates:
+        description: 'Space separated list of crate names in the order to be published.'
+        required: true
+        type: string
+      runs-on:
+        required: false
+        default: 'ubuntu-latest'
+        type: string
+      target:
+        required: false
+        default: 'x86_64-unknown-linux-gnu'
+        type: string
+      cargo-hack-feature-options:
+        required: false
+        default: '--feature-powerset'
+        type: string
+
+jobs:
+
+  publish-dry-run:
+    runs-on: ${{ inputs.runs-on }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      CARGO_BUILD_TARGET: ${{ inputs.target }}
+      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: stellar/actions/rust-cache@main
+
+    - run: rustup update
+    - run: rustup target add ${{ inputs.target }}
+    - if: inputs.target == 'aarch64-unknown-linux-gnu'
+      run: sudo apt-get update && sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+    - uses: stellar/binaries@v18
+      with:
+        name: cargo-hack
+        version: 0.5.28
+
+    # Vendor all the dependencies into the vendor/ folder. Temporarily remove
+    # [patch.crates-io] entries in the workspace Cargo.toml that reference git
+    # repos. These will be removed when published.
+    - name: Vendor Dependencies
+      run: |
+        cargo vendor --versioned-dirs
+
+    # Package the crates that will be published. Verification is disabled
+    # because we aren't ready to verify yet. Add each crate that was packaged to
+    # the vendor/ directory.
+    - name: Package Crates ${{ inputs.crates }}
+      run: |
+        for name in ${{ inputs.crates }}
+        do
+          version=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name=="'$name'") | .version')
+          cargo package \
+            --no-verify \
+            --package $name \
+            --config "source.crates-io.replace-with = 'vendored-sources'" \
+            --config "source.vendored-sources.directory = 'vendor'"
+          path="target/package/${name}-${version}.crate"
+          tar xvfz "$path" -C vendor/
+          # Crates in the vendor directory require a checksum file, but it doesn't
+          # matter if it is empty.
+          echo '{"files":{}}' > vendor/$name-$version/.cargo-checksum.json
+        done
+
+    # Rerun the package command but with verification enabled this time. Tell
+    # cargo to use the local vendor/ directory as the source for all packages. Run
+    # the package command on the full feature powerset so that all features of
+    # each crate are verified to compile.
+    - name: Verify Crates with ${{ inputs.cargo-hack-feature-options }}
+      run: >
+        cargo-hack hack
+        ${{ inputs.cargo-hack-feature-options }}
+        --ignore-private
+        --config "source.crates-io.replace-with = 'vendored-sources'"
+        --config "source.vendored-sources.directory = 'vendor'"
+        package
+        --target ${{ inputs.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -115,7 +115,7 @@ jobs:
         - os: windows-latest-8-cores
           target: x86_64-pc-windows-msvc
           cargo-hack-feature-options: --features opt --ignore-unknown-features
-    uses: stellar/actions/.github/workflows/rust-publish-dry-run-v2.yml@main
+    uses: ./.github/workflows/publish-dry-run.yml@main
     with:
       crates: soroban-rpc
       runs-on: ${{ matrix.os }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
 
   complete:
     if: always()
-    needs: [fmt, rust-analyzer-compat, build-and-test]
+    needs: [fmt, rust-analyzer-compat, build-and-test, publish-dry-run]
     runs-on: ubuntu-latest
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
@@ -80,3 +80,44 @@ jobs:
         for I in cmd/crates/* cmd/crates/soroban-test/tests/fixtures/test-wasms/hello_world ; do
           cargo test --target ${{ matrix.target }} --manifest-path $I/Cargo.toml
         done
+  publish-dry-run:
+    # if: github.event_name == 'push' || startsWith(github.head_ref, 'release/')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - os: ubuntu-latest
+          target: x86_64-unknown-linux-gnu
+          cargo-hack-feature-options: --feature-powerset
+        - os: ubuntu-latest
+          target: aarch64-unknown-linux-gnu
+          cargo-hack-feature-options: --feature-powerset
+        - os: macos-latest
+          target: x86_64-apple-darwin
+          cargo-hack-feature-options: --feature-powerset
+        - os: macos-latest
+          target: aarch64-apple-darwin
+          cargo-hack-feature-options: --feature-powerset
+        # Windows builds notes:
+        #
+        # The different features that need testing are split over unique
+        # isolated builds for Windows, because there's a bug in Cargo [1] that
+        # causes builds of wasm-opt [2] to fail when run one after the other and
+        # attempting to clean up artifacts in between. The bug has been fixed,
+        # but will not make it into a stable release of Cargo until ~August
+        # 2023.
+        #
+        # [1]: https://github.com/rust-lang/cargo/pull/11442
+        # [2]: https://github.com/brson/wasm-opt-rs/issues/116
+        - os: windows-latest-8-cores
+          target: x86_64-pc-windows-msvc
+          cargo-hack-feature-options: ''
+        - os: windows-latest-8-cores
+          target: x86_64-pc-windows-msvc
+          cargo-hack-feature-options: --features opt --ignore-unknown-features
+    uses: stellar/actions/.github/workflows/rust-publish-dry-run-v2.yml@main
+    with:
+      crates: soroban-rpc
+      runs-on: ${{ matrix.os }}
+      target: ${{ matrix.target }}
+      cargo-hack-feature-options: ${{ matrix.cargo-hack-feature-options }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -115,7 +115,7 @@ jobs:
         - os: windows-latest-8-cores
           target: x86_64-pc-windows-msvc
           cargo-hack-feature-options: --features opt --ignore-unknown-features
-    uses: stellar/actions/.github/workflows/rust-publish-dry-run-v2.yml@main
+    uses: stellar/soroban-rpc/.github/workflows/rust-publish-dry-run.yml@main
     with:
       crates: soroban-rpc
       runs-on: ${{ matrix.os }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -115,7 +115,7 @@ jobs:
         - os: windows-latest-8-cores
           target: x86_64-pc-windows-msvc
           cargo-hack-feature-options: --features opt --ignore-unknown-features
-    uses: ./.github/workflows/rust-publish-dry-run.yml@main
+    uses: stellar/actions/.github/workflows/rust-publish-dry-run-v2.yml@main
     with:
       crates: soroban-rpc
       runs-on: ${{ matrix.os }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -115,7 +115,7 @@ jobs:
         - os: windows-latest-8-cores
           target: x86_64-pc-windows-msvc
           cargo-hack-feature-options: --features opt --ignore-unknown-features
-    uses: stellar/soroban-rpc/.github/workflows/rust-publish-dry-run.yml@main
+    uses: ./.github/workflows/rust-publish-dry-run.yml@main
     with:
       crates: soroban-rpc
       runs-on: ${{ matrix.os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,8 +70,6 @@ version = "=20.3.1"
 
 [workspace.dependencies.soroban-cli]
 version = "20.3.0"
-git = "https://github.com/stellar/soroban-tools"
-rev = "a1e51d263df80682a3dab2b00738700c7326f872"
 
 [workspace.dependencies.soroban-rpc]
 version = "20.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,8 @@ version = "=20.3.1"
 
 [workspace.dependencies.soroban-cli]
 version = "20.3.0"
+git = "https://github.com/stellar/soroban-tools"
+rev = "a1e51d263df80682a3dab2b00738700c7326f872"
 
 [workspace.dependencies.soroban-rpc]
 version = "20.3.0"


### PR DESCRIPTION
### What

Adds `publish-dry-run` workflow for `soroban-rpc` crate.

### Why

This repo should be responsible for building & publishing this crate.