### PR TITLE
Add prometheus hook to count different log levels

### DIFF
--- a/cmd/soroban-rpc/internal/daemon/metrics.go
+++ b/cmd/soroban-rpc/internal/daemon/metrics.go
@@ -16,13 +16,17 @@ import (
 )
 
 func (d *Daemon) registerMetrics() {
+	// LogMetricsHook is a metric which counts log lines emitted by soroban rpc
+	logMetricsHook := logmetrics.New(prometheusNamespace)
+	d.logger.AddHook(logMetricsHook)
+	for _, counter := range logMetricsHook {
+		d.metricsRegistry.MustRegister(counter)
+	}
+
 	buildInfoGauge := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{Namespace: prometheusNamespace, Subsystem: "build", Name: "info"},
 		[]string{"version", "goversion", "commit", "branch", "build_timestamp"},
 	)
-	// LogMetricsHook is a metric which counts log lines emitted by soroban rpc
-	LogMetricsHook := logmetrics.New(prometheusNamespace)
-	//
 	buildInfoGauge.With(prometheus.Labels{
 		"version":         config.Version,
 		"commit":          config.CommitHash,
@@ -34,10 +38,6 @@ func (d *Daemon) registerMetrics() {
 	d.metricsRegistry.MustRegister(prometheus.NewGoCollector())
 	d.metricsRegistry.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
 	d.metricsRegistry.MustRegister(buildInfoGauge)
-
-	for _, counter := range LogMetricsHook {
-		d.metricsRegistry.MustRegister(counter)
-	}
 }
 
 func (d *Daemon) MetricsRegistry() *prometheus.Registry {

--- a/cmd/soroban-rpc/internal/daemon/metrics.go
+++ b/cmd/soroban-rpc/internal/daemon/metrics.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	supportlog "github.com/stellar/go/support/log"
 	"runtime"
 	"time"
 
@@ -101,4 +102,8 @@ func (c *CoreClientWithMetrics) SubmitTransaction(ctx context.Context, envelopeB
 
 func (d *Daemon) CoreClient() interfaces.CoreClient {
 	return d.coreClient
+}
+
+func (d *Daemon) Logger() *supportlog.Entry {
+	return d.logger
 }

--- a/cmd/soroban-rpc/internal/test/metrics_test.go
+++ b/cmd/soroban-rpc/internal/test/metrics_test.go
@@ -47,19 +47,6 @@ func TestMetrics(t *testing.T) {
 	assert.Equal(t, val, 2.0)
 }
 
-//func TestLogMetrics(t *testing.T) {
-//	logMetrics := logmetrics.New("log_metrics_test")
-//	logger := supportlog.New()
-//	logger.AddHook(logMetrics)
-//
-//	err := errors.Errorf("test-error")
-//	logger.WithError(err).Error("test error 1")
-//	logger.WithError(err).Error("test error 2")
-//
-//	val := testutil.ToFloat64(logMetrics[logrus.ErrorLevel])
-//	assert.Equal(t, val, 2.0)
-//}
-
 func getMetrics(test *Test) string {
 	metricsURL, err := url.JoinPath(test.adminURL(), "/metrics")
 	require.NoError(test.t, err)

--- a/cmd/soroban-rpc/internal/test/metrics_test.go
+++ b/cmd/soroban-rpc/internal/test/metrics_test.go
@@ -44,7 +44,7 @@ func TestMetrics(t *testing.T) {
 		}
 	}
 	val := metric.Metric[0].Counter.GetValue()
-	assert.Equal(t, val, 2.0)
+	assert.GreaterOrEqual(t, val, 2.0)
 }
 
 func getMetrics(test *Test) string {

--- a/cmd/soroban-rpc/internal/test/metrics_test.go
+++ b/cmd/soroban-rpc/internal/test/metrics_test.go
@@ -43,6 +43,7 @@ func TestMetrics(t *testing.T) {
 			break
 		}
 	}
+	assert.NotNil(t, metric)
 	val := metric.Metric[0].Counter.GetValue()
 	assert.GreaterOrEqual(t, val, 2.0)
 }


### PR DESCRIPTION
### What

Part of #22 

Adds a hook to the default RPC logger so that it counts the number of error, warning, debug etc... logs generated and shows it on grafana dashboard.

### Why

Our current dashboard does not seem to calculate the values.

### Known limitations

[TODO or N/A]
