### PR TITLE
Fix golangcli failures

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc # version v3.2.0
         with:
-          version: v1.51.1 # this is the golangci-lint version
+          version: v1.52.2 # this is the golangci-lint version
           args: --issues-exit-code=0 # exit without errors for now - won't fail the build
           github-token: ${{ secrets.GITHUB_TOKEN }}
           only-new-issues: true


### PR DESCRIPTION
Fixes: #83 

Failure logs [here](https://github.com/stellar/soroban-rpc/actions/workflows/golangci-lint.yml)