### PR TITLE
Fix ingestion duration calculation

### DIFF
--- a/cmd/soroban-rpc/internal/ingest/service.go
+++ b/cmd/soroban-rpc/internal/ingest/service.go
@@ -249,12 +249,13 @@ func (s *Service) fillEntriesFromCheckpoint(ctx context.Context, archive history
 }
 
 func (s *Service) ingest(ctx context.Context, sequence uint32) error {
-	startTime := time.Now()
 	s.logger.Infof("Ingesting ledger %d", sequence)
 	ledgerCloseMeta, err := s.ledgerBackend.GetLedger(ctx, sequence)
 	if err != nil {
 		return err
 	}
+
+	startTime := time.Now()
 	reader, err := ingest.NewLedgerChangeReaderFromLedgerCloseMeta(s.networkPassPhrase, ledgerCloseMeta)
 	if err != nil {
 		return err


### PR DESCRIPTION
### What

Move startTime to after `GetLedger()` call.

### Why

We were incorrectly including core ledger close time in the ingestion duration metric. This change would correctly calculate just the ingestion time minus the ledger close duration of ~5s

### Known limitations

NA
