### PR TITLE
Add ledger entry diff to simulateTransaction response

### DIFF
--- a/.github/actions/setup-integration-tests/action.yml
+++ b/.github/actions/setup-integration-tests/action.yml
@@ -53,6 +53,9 @@ runs:
       sudo apt-get remove -y moby-compose
       sudo apt-get install -y docker-compose-plugin
 
+      # add alias for docker compose
+      ln -f -s /usr/libexec/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose
+      
       echo "Docker Compose Version:"
       docker-compose version
 

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -107,7 +107,6 @@ jobs:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
         go: [1.22]
-        test: ['.*CLI.*', '^Test(([^C])|(C[^L])|(CL[^I])).*$']
     runs-on: ${{ matrix.os }}
     env:
       SOROBAN_RPC_INTEGRATION_TESTS_ENABLED: true
@@ -127,4 +126,4 @@ jobs:
       - name: Run Soroban RPC Integration Tests
         run: |
           make install_rust
-          go test -race -run '${{ matrix.test }}' -timeout 60m -v ./cmd/soroban-rpc/internal/test/...
+          go test -race -timeout 60m -v ./cmd/soroban-rpc/internal/test/...

--- a/cmd/soroban-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/simulate_transaction.go
@@ -3,7 +3,10 @@ package methods
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/creachadair/jrpc2"
 	"github.com/creachadair/jrpc2/handler"
@@ -34,12 +37,107 @@ type RestorePreamble struct {
 	TransactionData string `json:"transactionData"` // SorobanTransactionData XDR in base64
 	MinResourceFee  int64  `json:"minResourceFee,string"`
 }
+type LedgerEntryChangeType int
 
-// LedgerEntryDiff designates a change in a ledger entry. Before and After cannot be be omitted at the same time.
+const (
+	LedgerEntryChangeTypeCreated LedgerEntryChangeType = iota + 1
+	LedgerEntryChangeTypeUpdated
+	LedgerEntryChangeTypeDeleted
+)
+
+var (
+	LedgerEntryChangeTypeName = map[LedgerEntryChangeType]string{
+		LedgerEntryChangeTypeCreated: "created",
+		LedgerEntryChangeTypeUpdated: "updated",
+		LedgerEntryChangeTypeDeleted: "deleted",
+	}
+	LedgerEntryChangeTypeValue = map[string]LedgerEntryChangeType{
+		"created": LedgerEntryChangeTypeCreated,
+		"updated": LedgerEntryChangeTypeUpdated,
+		"deleted": LedgerEntryChangeTypeDeleted,
+	}
+)
+
+func (l LedgerEntryChangeType) String() string {
+	return LedgerEntryChangeTypeName[l]
+}
+
+func (l LedgerEntryChangeType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(l.String())
+}
+
+func (l *LedgerEntryChangeType) Parse(s string) error {
+	s = strings.TrimSpace(strings.ToLower(s))
+	value, ok := LedgerEntryChangeTypeValue[s]
+	if !ok {
+		return fmt.Errorf("%q is not a valid ledger entry change type", s)
+	}
+	*l = value
+	return nil
+}
+
+func (l *LedgerEntryChangeType) UnmarshalJSON(data []byte) (err error) {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	return l.Parse(s)
+}
+
+func (l *LedgerEntryChange) FromXDRDiff(diff preflight.XDRDiff) error {
+	beforePresent := len(diff.Before) > 0
+	afterPresent := len(diff.After) > 0
+	var (
+		entryXDR   []byte
+		changeType LedgerEntryChangeType
+	)
+	switch {
+	case beforePresent:
+		entryXDR = diff.Before
+		if afterPresent {
+			changeType = LedgerEntryChangeTypeUpdated
+		} else {
+			changeType = LedgerEntryChangeTypeDeleted
+		}
+	case afterPresent:
+		entryXDR = diff.After
+		changeType = LedgerEntryChangeTypeCreated
+	default:
+		return errors.New("missing before and after")
+	}
+	var entry xdr.LedgerEntry
+
+	if err := xdr.SafeUnmarshal(entryXDR, &entry); err != nil {
+		return err
+	}
+	key, err := entry.LedgerKey()
+	if err != nil {
+		return err
+	}
+	keyB64, err := xdr.MarshalBase64(key)
+	if err != nil {
+		return err
+	}
+	l.Type = changeType
+	l.Key = keyB64
+	if beforePresent {
+		before := base64.StdEncoding.EncodeToString(diff.Before)
+		l.Before = &before
+	}
+	if afterPresent {
+		after := base64.StdEncoding.EncodeToString(diff.After)
+		l.After = &after
+	}
+	return nil
+}
+
+// LedgerEntryChange designates a change in a ledger entry. Before and After cannot be be omitted at the same time.
 // If Before is omitted, it constitutes a creation, if After is omitted, it constitutes a delation.
-type LedgerEntryDiff struct {
-	Before string `json:"before,omitempty"` // LedgerEntry XDR in base64
-	After  string `json:"after,omitempty"`  // LedgerEntry XDR in base64
+type LedgerEntryChange struct {
+	Type   LedgerEntryChangeType
+	Key    string  // LedgerEntryKey in base64
+	Before *string `json:"before"` // LedgerEntry XDR in base64
+	After  *string `json:"after"`  // LedgerEntry XDR in base64
 }
 
 type SimulateTransactionResponse struct {
@@ -50,7 +148,7 @@ type SimulateTransactionResponse struct {
 	Results         []SimulateHostFunctionResult `json:"results,omitempty"`         // an array of the individual host function call results
 	Cost            SimulateTransactionCost      `json:"cost,omitempty"`            // the effective cpu and memory cost of the invoked transaction execution.
 	RestorePreamble *RestorePreamble             `json:"restorePreamble,omitempty"` // If present, it indicates that a prior RestoreFootprint is required
-	StateDiff       []LedgerEntryDiff            `json:"stateDiff,omitempty"`       // If present, it indicates how the state (ledger entries) will change as a result of the transaction execution.
+	StateChanges    []LedgerEntryChange          `json:"stateChanges,omitempty"`    // If present, it indicates how the state (ledger entries) will change as a result of the transaction execution.
 	LatestLedger    uint32                       `json:"latestLedger"`
 }
 
@@ -157,10 +255,9 @@ func NewSimulateTransactionHandler(logger *log.Entry, ledgerEntryReader db.Ledge
 			}
 		}
 
-		stateDiff := make([]LedgerEntryDiff, len(result.LedgerEntryDiff))
-		for i := 0; i < len(stateDiff); i++ {
-			stateDiff[i].Before = base64.StdEncoding.EncodeToString(result.LedgerEntryDiff[i].Before)
-			stateDiff[i].After = base64.StdEncoding.EncodeToString(result.LedgerEntryDiff[i].After)
+		stateChanges := make([]LedgerEntryChange, len(result.LedgerEntryDiff))
+		for i := 0; i < len(stateChanges); i++ {
+			stateChanges[i].FromXDRDiff(result.LedgerEntryDiff[i])
 		}
 
 		return SimulateTransactionResponse{
@@ -175,7 +272,7 @@ func NewSimulateTransactionHandler(logger *log.Entry, ledgerEntryReader db.Ledge
 			},
 			LatestLedger:    latestLedger,
 			RestorePreamble: restorePreamble,
-			StateDiff:       stateDiff,
+			StateChanges:    stateChanges,
 		}
 	})
 }

--- a/cmd/soroban-rpc/internal/methods/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/methods/simulate_transaction_test.go
@@ -1,0 +1,94 @@
+package methods
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/preflight"
+)
+
+func TestLedgerEntryChange(t *testing.T) {
+	entry := xdr.LedgerEntry{
+		LastModifiedLedgerSeq: 100,
+		Data: xdr.LedgerEntryData{
+			Type: xdr.LedgerEntryTypeAccount,
+			Account: &xdr.AccountEntry{
+				AccountId: xdr.MustAddress("GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON"),
+				Balance:   100,
+				SeqNum:    1,
+			},
+		},
+	}
+
+	entryXDR, err := entry.MarshalBinary()
+	require.NoError(t, err)
+	entryB64 := base64.StdEncoding.EncodeToString(entryXDR)
+
+	key, err := entry.LedgerKey()
+	require.NoError(t, err)
+	keyXDR, err := key.MarshalBinary()
+	require.NoError(t, err)
+	keyB64 := base64.StdEncoding.EncodeToString(keyXDR)
+
+	for _, test := range []struct {
+		name           string
+		input          preflight.XDRDiff
+		expectedOutput LedgerEntryChange
+	}{
+		{
+			name: "creation",
+			input: preflight.XDRDiff{
+				Before: nil,
+				After:  entryXDR,
+			},
+			expectedOutput: LedgerEntryChange{
+				Type:   LedgerEntryChangeTypeCreated,
+				Key:    keyB64,
+				Before: nil,
+				After:  &entryB64,
+			},
+		},
+		{
+			name: "deletion",
+			input: preflight.XDRDiff{
+				Before: entryXDR,
+				After:  nil,
+			},
+			expectedOutput: LedgerEntryChange{
+				Type:   LedgerEntryChangeTypeDeleted,
+				Key:    keyB64,
+				Before: &entryB64,
+				After:  nil,
+			},
+		},
+		{
+			name: "update",
+			input: preflight.XDRDiff{
+				Before: entryXDR,
+				After:  entryXDR,
+			},
+			expectedOutput: LedgerEntryChange{
+				Type:   LedgerEntryChangeTypeUpdated,
+				Key:    keyB64,
+				Before: &entryB64,
+				After:  &entryB64,
+			},
+		},
+	} {
+		var change LedgerEntryChange
+		require.NoError(t, change.FromXDRDiff(test.input), test.name)
+		assert.Equal(t, test.expectedOutput, change)
+
+		// test json roundtrip
+		changeJSON, err := json.Marshal(change)
+		require.NoError(t, err, test.name)
+		var change2 LedgerEntryChange
+		require.NoError(t, json.Unmarshal(changeJSON, &change2))
+		assert.Equal(t, change, change2, test.name)
+	}
+}

--- a/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/test/simulate_transaction_test.go
@@ -260,6 +260,14 @@ func TestSimulateTransactionSucceeds(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedXdr, resultXdr)
 
+	// Check state diff
+	assert.Len(t, result.StateDiff, 1)
+	assert.Empty(t, result.StateDiff[0].Before)
+	assert.NotEmpty(t, result.StateDiff[0].After)
+	var after xdr.LedgerEntry
+	assert.NoError(t, xdr.SafeUnmarshalBase64(result.StateDiff[0].After, &after))
+	assert.Equal(t, xdr.LedgerEntryTypeContractCode, after.Data.Type)
+
 	// test operation which does not have a source account
 	withoutSourceAccountOp := createInstallContractCodeOperation("", contractBinary)
 	params = txnbuild.TransactionParams{

--- a/cmd/soroban-rpc/lib/preflight.h
+++ b/cmd/soroban-rpc/lib/preflight.h
@@ -22,21 +22,32 @@ typedef struct xdr_vector_t {
     size_t len;
 } xdr_vector_t;
 
+typedef struct xdr_diff_t {
+    xdr_t before;
+    xdr_t after;
+} xdr_diff_t;
+
+typedef struct xdr_diff_vector_t {
+    xdr_diff_t  *array;
+    size_t len;
+} xdr_diff_vector_t;
+
 typedef struct resource_config_t {
     uint64_t instruction_leeway; // Allow this many extra instructions when budgeting
 } resource_config_t;
 
 typedef struct preflight_result_t {
-    char          *error; // Error string in case of error, otherwise null
-    xdr_vector_t  auth; // array of SorobanAuthorizationEntries
-    xdr_t         result; // XDR SCVal
-    xdr_t         transaction_data;
-    int64_t       min_fee; // Minimum recommended resource fee
-    xdr_vector_t  events; // array of XDR DiagnosticEvents
-    uint64_t      cpu_instructions;
-    uint64_t      memory_bytes;
-    xdr_t         pre_restore_transaction_data; // SorobanTransactionData XDR for a prerequired RestoreFootprint operation
-    int64_t       pre_restore_min_fee; // Minimum recommended resource fee for a prerequired RestoreFootprint operation
+    char             *error; // Error string in case of error, otherwise null
+    xdr_vector_t      auth; // array of SorobanAuthorizationEntries
+    xdr_t             result; // XDR SCVal
+    xdr_t             transaction_data;
+    int64_t           min_fee; // Minimum recommended resource fee
+    xdr_vector_t      events; // array of XDR DiagnosticEvents
+    uint64_t          cpu_instructions;
+    uint64_t          memory_bytes;
+    xdr_t             pre_restore_transaction_data; // SorobanTransactionData XDR for a prerequired RestoreFootprint operation
+    int64_t           pre_restore_min_fee; // Minimum recommended resource fee for a prerequired RestoreFootprint operation
+    xdr_diff_vector_t ledger_entry_diff; // Contains the ledger entry changes which would be caused by the transaction execution
 } preflight_result_t;
 
 preflight_result_t *preflight_invoke_hf_op(uintptr_t handle, // Go Handle to forward to SnapshotSourceGet


### PR DESCRIPTION
### What

It adds the following field to `SimulateTransactionResponse`

```go
StateDiff       []LedgerEntryDiff            `json:"stateDiff,omitempty"`       // If present, it indicates how the state (ledger entries) will change as a result of the transaction execution.
```

where:

```go
// LedgerEntryDiff designates a change in a ledger entry. Before and After cannot be be omitted at the same time.
// If Before is omitted, it constitutes a creation, if After is omitted, it constitutes a delation.
type LedgerEntryDiff struct {
	Before string `json:"before,omitempty"` // LedgerEntry XDR in base64
	After  string `json:"after,omitempty"`  // LedgerEntry XDR in base64
}
```

### Why

Closes #11 

### Known limitations

It can considerably increase the size of simulate transaction responses (particularly for contract uploads, which will contain the full wasm).
