### PR TITLE
Fix failed build workflows for stellar-rpc-client crate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       VERSION: '${{ github.event.release.name }}'
-      NAME: 'soroban-rpc-${{ github.event.release.name }}-${{ matrix.target }}'
+      NAME: 'stellar-rpc-client-${{ github.event.release.name }}-${{ matrix.target }}'
     steps:
     - uses: actions/checkout@v3
     - run: rustup update
@@ -49,8 +49,8 @@ jobs:
         CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
       run: |
         cd target/package
-        tar xvfz soroban-rpc-$VERSION.crate
-        cd soroban-rpc-$VERSION
+        tar xvfz stellar-rpc-client-$VERSION.crate
+        cd stellar-rpc-client-$VERSION
         cargo build --target-dir=../.. --release --target ${{ matrix.target }}
     - name: Compress 
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -109,7 +109,7 @@ jobs:
           cargo-hack-feature-options: --features opt --ignore-unknown-features
     uses: stellar/actions/.github/workflows/rust-publish-dry-run-v2.yml@main
     with:
-      crates: soroban-rpc
+      crates: stellar-rpc-client
       runs-on: ${{ matrix.os }}
       target: ${{ matrix.target }}
       cargo-hack-feature-options: ${{ matrix.cargo-hack-feature-options }}


### PR DESCRIPTION
one of the last residual change from soroban-rpc to stellar-rpc-client crate

Fixes [this](https://github.com/stellar/soroban-rpc/actions/runs/8459325338/job/23175436714) failure 

We never got to see this error before as it was failing on vendor dependency (https://github.com/stellar/soroban-rpc/issues/104)