### PR TITLE
Pass bucket list size from meta to simulation `NetworkConfig`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,9 +463,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "ecdsa"
-version = "0.16.9"
+version = "0.16.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
 dependencies = [
  "der",
  "digest",
@@ -1114,6 +1114,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1194,7 +1206,7 @@ dependencies = [
  "libc",
  "rand",
  "sha2",
- "soroban-env-host",
+ "soroban-env-host 20.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "soroban-simulation",
 ]
 
@@ -1206,6 +1218,15 @@ checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1378,9 +1399,9 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.7.3"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+checksum = "f0aec48e813d6b90b15f0b8948af3c63483992dee44c03e9930b3eebdabe046e"
 dependencies = [
  "base16ct",
  "der",
@@ -1514,9 +1535,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
  "digest",
  "rand_core",
@@ -1560,6 +1581,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "soroban-builtin-sdk-macros"
+version = "20.3.0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=a8c713db03ba5ebfdc4786b73dcba00284e15dbe#a8c713db03ba5ebfdc4786b73dcba00284e15dbe"
+dependencies = [
+ "itertools 0.11.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "soroban-env-common"
 version = "20.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,10 +1603,26 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
- "soroban-env-macros",
- "soroban-wasmi",
+ "soroban-env-macros 20.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "soroban-wasmi 0.31.1-soroban.20.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions",
- "stellar-xdr",
+ "stellar-xdr 20.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "soroban-env-common"
+version = "20.3.0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=a8c713db03ba5ebfdc4786b73dcba00284e15dbe#a8c713db03ba5ebfdc4786b73dcba00284e15dbe"
+dependencies = [
+ "crate-git-revision",
+ "ethnum",
+ "num-derive",
+ "num-traits",
+ "soroban-env-macros 20.3.0 (git+https://github.com/stellar/rs-soroban-env?rev=a8c713db03ba5ebfdc4786b73dcba00284e15dbe)",
+ "soroban-wasmi 0.31.1-soroban.20.0.1 (git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0)",
+ "static_assertions",
+ "stellar-xdr 20.1.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=3a001b1fbb20e4cfa2cef2c0cc450564e8528057)",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1583,7 +1631,7 @@ version = "20.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5122ca2abd5ebcc1e876a96b9b44f87ce0a0e06df8f7c09772ddb58b159b7454"
 dependencies = [
- "soroban-env-common",
+ "soroban-env-common 20.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions",
 ]
 
@@ -1607,11 +1655,42 @@ dependencies = [
  "rand_chacha",
  "sha2",
  "sha3",
- "soroban-builtin-sdk-macros",
- "soroban-env-common",
- "soroban-wasmi",
+ "soroban-builtin-sdk-macros 20.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "soroban-env-common 20.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "soroban-wasmi 0.31.1-soroban.20.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions",
  "stellar-strkey 0.0.8",
+]
+
+[[package]]
+name = "soroban-env-host"
+version = "20.3.0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=a8c713db03ba5ebfdc4786b73dcba00284e15dbe#a8c713db03ba5ebfdc4786b73dcba00284e15dbe"
+dependencies = [
+ "curve25519-dalek",
+ "ecdsa",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "generic-array",
+ "getrandom",
+ "hex-literal",
+ "hmac",
+ "k256",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "p256",
+ "rand",
+ "rand_chacha",
+ "sec1",
+ "sha2",
+ "sha3",
+ "soroban-builtin-sdk-macros 20.3.0 (git+https://github.com/stellar/rs-soroban-env?rev=a8c713db03ba5ebfdc4786b73dcba00284e15dbe)",
+ "soroban-env-common 20.3.0 (git+https://github.com/stellar/rs-soroban-env?rev=a8c713db03ba5ebfdc4786b73dcba00284e15dbe)",
+ "soroban-wasmi 0.31.1-soroban.20.0.1 (git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0)",
+ "static_assertions",
+ "stellar-strkey 0.0.8",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1625,7 +1704,21 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr",
+ "stellar-xdr 20.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn",
+]
+
+[[package]]
+name = "soroban-env-macros"
+version = "20.3.0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=a8c713db03ba5ebfdc4786b73dcba00284e15dbe#a8c713db03ba5ebfdc4786b73dcba00284e15dbe"
+dependencies = [
+ "itertools 0.11.0",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "stellar-xdr 20.1.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=3a001b1fbb20e4cfa2cef2c0cc450564e8528057)",
  "syn",
 ]
 
@@ -1638,8 +1731,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "soroban-env-common",
- "soroban-env-host",
+ "soroban-env-common 20.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "soroban-env-host 20.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
@@ -1654,7 +1747,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soroban-env-guest",
- "soroban-env-host",
+ "soroban-env-host 20.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "soroban-ledger-snapshot",
  "soroban-sdk-macros",
  "stellar-strkey 0.0.8",
@@ -1673,22 +1766,21 @@ dependencies = [
  "quote",
  "rustc_version",
  "sha2",
- "soroban-env-common",
+ "soroban-env-common 20.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "soroban-spec",
  "soroban-spec-rust",
- "stellar-xdr",
+ "stellar-xdr 20.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn",
 ]
 
 [[package]]
 name = "soroban-simulation"
 version = "20.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ddcf70d8b374a38ee47536add0c255ab72e9defced120be24cac55d69daaa4"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=a8c713db03ba5ebfdc4786b73dcba00284e15dbe#a8c713db03ba5ebfdc4786b73dcba00284e15dbe"
 dependencies = [
  "anyhow",
  "rand",
- "soroban-env-host",
+ "soroban-env-host 20.3.0 (git+https://github.com/stellar/rs-soroban-env?rev=a8c713db03ba5ebfdc4786b73dcba00284e15dbe)",
  "static_assertions",
  "thiserror",
 ]
@@ -1700,7 +1792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eefeb5d373b43f6828145d00f0c5cc35e96db56a6671ae9614f84beb2711cab"
 dependencies = [
  "base64 0.13.1",
- "stellar-xdr",
+ "stellar-xdr 20.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "wasmparser 0.88.0",
 ]
@@ -1716,7 +1808,7 @@ dependencies = [
  "quote",
  "sha2",
  "soroban-spec",
- "stellar-xdr",
+ "stellar-xdr 20.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn",
  "thiserror",
 ]
@@ -1729,8 +1821,20 @@ checksum = "710403de32d0e0c35375518cb995d4fc056d0d48966f2e56ea471b8cb8fc9719"
 dependencies = [
  "smallvec",
  "spin",
- "wasmi_arena",
- "wasmi_core",
+ "wasmi_arena 0.4.1",
+ "wasmi_core 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser-nostd",
+]
+
+[[package]]
+name = "soroban-wasmi"
+version = "0.31.1-soroban.20.0.1"
+source = "git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
+dependencies = [
+ "smallvec",
+ "spin",
+ "wasmi_arena 0.4.0",
+ "wasmi_core 0.13.0 (git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0)",
  "wasmparser-nostd",
 ]
 
@@ -1773,11 +1877,11 @@ dependencies = [
  "serde-aux",
  "serde_json",
  "sha2",
- "soroban-env-host",
+ "soroban-env-host 20.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "soroban-sdk",
  "soroban-spec",
  "stellar-strkey 0.0.7",
- "stellar-xdr",
+ "stellar-xdr 20.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor",
  "termcolor_output",
  "thiserror",
@@ -1821,6 +1925,18 @@ dependencies = [
  "hex",
  "serde",
  "serde_with",
+ "stellar-strkey 0.0.8",
+]
+
+[[package]]
+name = "stellar-xdr"
+version = "20.1.0"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=3a001b1fbb20e4cfa2cef2c0cc450564e8528057#3a001b1fbb20e4cfa2cef2c0cc450564e8528057"
+dependencies = [
+ "base64 0.13.1",
+ "crate-git-revision",
+ "escape-bytes",
+ "hex",
  "stellar-strkey 0.0.8",
 ]
 
@@ -2175,6 +2291,11 @@ checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "wasmi_arena"
+version = "0.4.0"
+source = "git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
+
+[[package]]
+name = "wasmi_arena"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "104a7f73be44570cac297b3035d76b169d6599637631cf37a1703326a0727073"
@@ -2184,6 +2305,17 @@ name = "wasmi_core"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf1a7db34bff95b85c261002720c00c3a6168256dcb93041d3fa2054d19856a"
+dependencies = [
+ "downcast-rs",
+ "libm",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "wasmi_core"
+version = "0.13.0"
+source = "git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
 dependencies = [
  "downcast-rs",
  "libm",
@@ -2207,6 +2339,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62c8d843f4423efee314dc75a1049886deba3214f7e7f9ff0e4e58b4d618581"
 dependencies = [
  "indexmap 1.9.3",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
+dependencies = [
+ "indexmap 2.2.3",
+ "semver",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,6 @@ dependencies = [
  "elliptic-curve",
  "rfc6979",
  "signature",
- "spki",
 ]
 
 [[package]]
@@ -517,7 +516,6 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "pkcs8",
  "rand_core",
  "sec1",
  "subtle",
@@ -981,9 +979,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "once_cell",
  "sha2",
- "signature",
 ]
 
 [[package]]
@@ -1206,7 +1202,7 @@ dependencies = [
  "libc",
  "rand",
  "sha2",
- "soroban-env-host 20.3.0 (git+https://github.com/stellar/rs-soroban-env?rev=a8c713db03ba5ebfdc4786b73dcba00284e15dbe)",
+ "soroban-env-host",
  "soroban-simulation",
 ]
 
@@ -1406,7 +1402,6 @@ dependencies = [
  "base16ct",
  "der",
  "generic-array",
- "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -1571,41 +1566,12 @@ dependencies = [
 [[package]]
 name = "soroban-builtin-sdk-macros"
 version = "20.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc32c6e817f3ca269764ec0d7d14da6210b74a5bf14d4e745aa3ee860558900"
-dependencies = [
- "itertools 0.11.0",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "soroban-builtin-sdk-macros"
-version = "20.3.0"
 source = "git+https://github.com/stellar/rs-soroban-env?rev=a8c713db03ba5ebfdc4786b73dcba00284e15dbe#a8c713db03ba5ebfdc4786b73dcba00284e15dbe"
 dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "soroban-env-common"
-version = "20.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c14e18d879c520ff82612eaae0590acaf6a7f3b977407e1abb1c9e31f94c7814"
-dependencies = [
- "crate-git-revision",
- "ethnum",
- "num-derive",
- "num-traits",
- "serde",
- "soroban-env-macros 20.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "soroban-wasmi 0.31.1-soroban.20.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "static_assertions",
- "stellar-xdr 20.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1618,47 +1584,21 @@ dependencies = [
  "ethnum",
  "num-derive",
  "num-traits",
- "soroban-env-macros 20.3.0 (git+https://github.com/stellar/rs-soroban-env?rev=a8c713db03ba5ebfdc4786b73dcba00284e15dbe)",
- "soroban-wasmi 0.31.1-soroban.20.0.1 (git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0)",
+ "serde",
+ "soroban-env-macros",
+ "soroban-wasmi",
  "static_assertions",
- "stellar-xdr 20.1.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=3a001b1fbb20e4cfa2cef2c0cc450564e8528057)",
+ "stellar-xdr",
  "wasmparser 0.116.1",
 ]
 
 [[package]]
 name = "soroban-env-guest"
 version = "20.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5122ca2abd5ebcc1e876a96b9b44f87ce0a0e06df8f7c09772ddb58b159b7454"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=a8c713db03ba5ebfdc4786b73dcba00284e15dbe#a8c713db03ba5ebfdc4786b73dcba00284e15dbe"
 dependencies = [
- "soroban-env-common 20.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "soroban-env-common",
  "static_assertions",
-]
-
-[[package]]
-name = "soroban-env-host"
-version = "20.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114a0fa0d0cc39d0be16b1ee35b6e5f4ee0592ddcf459bde69391c02b03cf520"
-dependencies = [
- "curve25519-dalek",
- "ed25519-dalek",
- "getrandom",
- "hex-literal",
- "hmac",
- "k256",
- "num-derive",
- "num-integer",
- "num-traits",
- "rand",
- "rand_chacha",
- "sha2",
- "sha3",
- "soroban-builtin-sdk-macros 20.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "soroban-env-common 20.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "soroban-wasmi 0.31.1-soroban.20.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "static_assertions",
- "stellar-strkey 0.0.8",
 ]
 
 [[package]]
@@ -1685,27 +1625,12 @@ dependencies = [
  "sec1",
  "sha2",
  "sha3",
- "soroban-builtin-sdk-macros 20.3.0 (git+https://github.com/stellar/rs-soroban-env?rev=a8c713db03ba5ebfdc4786b73dcba00284e15dbe)",
- "soroban-env-common 20.3.0 (git+https://github.com/stellar/rs-soroban-env?rev=a8c713db03ba5ebfdc4786b73dcba00284e15dbe)",
- "soroban-wasmi 0.31.1-soroban.20.0.1 (git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0)",
+ "soroban-builtin-sdk-macros",
+ "soroban-env-common",
+ "soroban-wasmi",
  "static_assertions",
  "stellar-strkey 0.0.8",
  "wasmparser 0.116.1",
-]
-
-[[package]]
-name = "soroban-env-macros"
-version = "20.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13e3f8c86f812e0669e78fcb3eae40c385c6a9dd1a4886a1de733230b4fcf27"
-dependencies = [
- "itertools 0.11.0",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "stellar-xdr 20.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn",
 ]
 
 [[package]]
@@ -1718,36 +1643,34 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr 20.1.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=3a001b1fbb20e4cfa2cef2c0cc450564e8528057)",
+ "stellar-xdr",
  "syn",
 ]
 
 [[package]]
 name = "soroban-ledger-snapshot"
 version = "20.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a54708f44890e0546180db6b4f530e2a88d83b05a9b38a131caa21d005e25a"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=67c1727cd5c632730d33eeb4ab1ad44f855b34df#67c1727cd5c632730d33eeb4ab1ad44f855b34df"
 dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "soroban-env-common 20.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "soroban-env-host 20.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "soroban-env-common",
+ "soroban-env-host",
  "thiserror",
 ]
 
 [[package]]
 name = "soroban-sdk"
 version = "20.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fc8be9068dd4e0212d8b13ad61089ea87e69ac212c262914503a961c8dc3a3"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=67c1727cd5c632730d33eeb4ab1ad44f855b34df#67c1727cd5c632730d33eeb4ab1ad44f855b34df"
 dependencies = [
  "bytes-lit",
  "rand",
  "serde",
  "serde_json",
  "soroban-env-guest",
- "soroban-env-host 20.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "soroban-env-host",
  "soroban-ledger-snapshot",
  "soroban-sdk-macros",
  "stellar-strkey 0.0.8",
@@ -1756,8 +1679,7 @@ dependencies = [
 [[package]]
 name = "soroban-sdk-macros"
 version = "20.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db20def4ead836663633f58d817d0ed8e1af052c9650a04adf730525af85b964"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=67c1727cd5c632730d33eeb4ab1ad44f855b34df#67c1727cd5c632730d33eeb4ab1ad44f855b34df"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1766,10 +1688,10 @@ dependencies = [
  "quote",
  "rustc_version",
  "sha2",
- "soroban-env-common 20.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "soroban-env-common",
  "soroban-spec",
  "soroban-spec-rust",
- "stellar-xdr 20.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stellar-xdr",
  "syn",
 ]
 
@@ -1780,7 +1702,7 @@ source = "git+https://github.com/stellar/rs-soroban-env?rev=a8c713db03ba5ebfdc47
 dependencies = [
  "anyhow",
  "rand",
- "soroban-env-host 20.3.0 (git+https://github.com/stellar/rs-soroban-env?rev=a8c713db03ba5ebfdc4786b73dcba00284e15dbe)",
+ "soroban-env-host",
  "static_assertions",
  "thiserror",
 ]
@@ -1788,42 +1710,27 @@ dependencies = [
 [[package]]
 name = "soroban-spec"
 version = "20.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eefeb5d373b43f6828145d00f0c5cc35e96db56a6671ae9614f84beb2711cab"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=67c1727cd5c632730d33eeb4ab1ad44f855b34df#67c1727cd5c632730d33eeb4ab1ad44f855b34df"
 dependencies = [
  "base64 0.13.1",
- "stellar-xdr 20.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stellar-xdr",
  "thiserror",
- "wasmparser 0.88.0",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
 name = "soroban-spec-rust"
 version = "20.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3152bca4737ef734ac37fe47b225ee58765c9095970c481a18516a2b287c7a33"
+source = "git+https://github.com/stellar/rs-soroban-sdk?rev=67c1727cd5c632730d33eeb4ab1ad44f855b34df#67c1727cd5c632730d33eeb4ab1ad44f855b34df"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
  "sha2",
  "soroban-spec",
- "stellar-xdr 20.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stellar-xdr",
  "syn",
  "thiserror",
-]
-
-[[package]]
-name = "soroban-wasmi"
-version = "0.31.1-soroban.20.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710403de32d0e0c35375518cb995d4fc056d0d48966f2e56ea471b8cb8fc9719"
-dependencies = [
- "smallvec",
- "spin",
- "wasmi_arena 0.4.1",
- "wasmi_core 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmparser-nostd",
 ]
 
 [[package]]
@@ -1833,8 +1740,8 @@ source = "git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a
 dependencies = [
  "smallvec",
  "spin",
- "wasmi_arena 0.4.0",
- "wasmi_core 0.13.0 (git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0)",
+ "wasmi_arena",
+ "wasmi_core",
  "wasmparser-nostd",
 ]
 
@@ -1877,11 +1784,11 @@ dependencies = [
  "serde-aux",
  "serde_json",
  "sha2",
- "soroban-env-host 20.3.0 (git+https://github.com/stellar/rs-soroban-env?rev=a8c713db03ba5ebfdc4786b73dcba00284e15dbe)",
+ "soroban-env-host",
  "soroban-sdk",
  "soroban-spec",
  "stellar-strkey 0.0.7",
- "stellar-xdr 20.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stellar-xdr",
  "termcolor",
  "termcolor_output",
  "thiserror",
@@ -1915,21 +1822,6 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "20.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e59cdf3eb4467fb5a4b00b52e7de6dca72f67fac6f9b700f55c95a5d86f09c9d"
-dependencies = [
- "base64 0.13.1",
- "crate-git-revision",
- "escape-bytes",
- "hex",
- "serde",
- "serde_with",
- "stellar-strkey 0.0.8",
-]
-
-[[package]]
-name = "stellar-xdr"
-version = "20.1.0"
 source = "git+https://github.com/stellar/rs-stellar-xdr?rev=3a001b1fbb20e4cfa2cef2c0cc450564e8528057#3a001b1fbb20e4cfa2cef2c0cc450564e8528057"
 dependencies = [
  "arbitrary",
@@ -1937,6 +1829,8 @@ dependencies = [
  "crate-git-revision",
  "escape-bytes",
  "hex",
+ "serde",
+ "serde_with",
  "stellar-strkey 0.0.8",
 ]
 
@@ -2295,24 +2189,6 @@ version = "0.4.0"
 source = "git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
 
 [[package]]
-name = "wasmi_arena"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104a7f73be44570cac297b3035d76b169d6599637631cf37a1703326a0727073"
-
-[[package]]
-name = "wasmi_core"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf1a7db34bff95b85c261002720c00c3a6168256dcb93041d3fa2054d19856a"
-dependencies = [
- "downcast-rs",
- "libm",
- "num-traits",
- "paste",
-]
-
-[[package]]
 name = "wasmi_core"
 version = "0.13.0"
 source = "git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0"
@@ -2321,15 +2197,6 @@ dependencies = [
  "libm",
  "num-traits",
  "paste",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.88.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb8cf7dd82407fe68161bedcd57fde15596f32ebf6e9b3bdbf3ae1da20e38e5e"
-dependencies = [
- "indexmap 1.9.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,7 +1206,7 @@ dependencies = [
  "libc",
  "rand",
  "sha2",
- "soroban-env-host 20.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "soroban-env-host 20.3.0 (git+https://github.com/stellar/rs-soroban-env?rev=a8c713db03ba5ebfdc4786b73dcba00284e15dbe)",
  "soroban-simulation",
 ]
 
@@ -1597,7 +1597,6 @@ version = "20.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c14e18d879c520ff82612eaae0590acaf6a7f3b977407e1abb1c9e31f94c7814"
 dependencies = [
- "arbitrary",
  "crate-git-revision",
  "ethnum",
  "num-derive",
@@ -1614,6 +1613,7 @@ name = "soroban-env-common"
 version = "20.3.0"
 source = "git+https://github.com/stellar/rs-soroban-env?rev=a8c713db03ba5ebfdc4786b73dcba00284e15dbe#a8c713db03ba5ebfdc4786b73dcba00284e15dbe"
 dependencies = [
+ "arbitrary",
  "crate-git-revision",
  "ethnum",
  "num-derive",
@@ -1641,7 +1641,6 @@ version = "20.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "114a0fa0d0cc39d0be16b1ee35b6e5f4ee0592ddcf459bde69391c02b03cf520"
 dependencies = [
- "backtrace",
  "curve25519-dalek",
  "ed25519-dalek",
  "getrandom",
@@ -1667,6 +1666,7 @@ name = "soroban-env-host"
 version = "20.3.0"
 source = "git+https://github.com/stellar/rs-soroban-env?rev=a8c713db03ba5ebfdc4786b73dcba00284e15dbe#a8c713db03ba5ebfdc4786b73dcba00284e15dbe"
 dependencies = [
+ "backtrace",
  "curve25519-dalek",
  "ecdsa",
  "ed25519-dalek",
@@ -1877,7 +1877,7 @@ dependencies = [
  "serde-aux",
  "serde_json",
  "sha2",
- "soroban-env-host 20.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "soroban-env-host 20.3.0 (git+https://github.com/stellar/rs-soroban-env?rev=a8c713db03ba5ebfdc4786b73dcba00284e15dbe)",
  "soroban-sdk",
  "soroban-spec",
  "stellar-strkey 0.0.7",
@@ -1918,7 +1918,6 @@ version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e59cdf3eb4467fb5a4b00b52e7de6dca72f67fac6f9b700f55c95a5d86f09c9d"
 dependencies = [
- "arbitrary",
  "base64 0.13.1",
  "crate-git-revision",
  "escape-bytes",
@@ -1933,6 +1932,7 @@ name = "stellar-xdr"
 version = "20.1.0"
 source = "git+https://github.com/stellar/rs-stellar-xdr?rev=3a001b1fbb20e4cfa2cef2c0cc450564e8528057#3a001b1fbb20e4cfa2cef2c0cc450564e8528057"
 dependencies = [
+ "arbitrary",
  "base64 0.13.1",
  "crate-git-revision",
  "escape-bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,14 @@ rev = "a8c713db03ba5ebfdc4786b73dcba00284e15dbe"
 
 [workspace.dependencies.soroban-spec]
 version = "=20.5.0"
-# git = "https://github.com/stellar/rs-soroban-sdk"
-# rev = "89efc3c211d41f1ab143bed0a09cd6af353bb098"
+git = "https://github.com/stellar/rs-soroban-sdk"
+rev = "67c1727cd5c632730d33eeb4ab1ad44f855b34df"
 # path = "../rs-soroban-sdk/soroban-spec"
 
 [workspace.dependencies.soroban-spec-rust]
 version = "=20.5.0"
-# git = "https://github.com/stellar/rs-soroban-sdk"
-# rev = "4aef54ff9295c2fca4c5b9fbd2c92d0ff99f67de"
+git = "https://github.com/stellar/rs-soroban-sdk"
+rev = "67c1727cd5c632730d33eeb4ab1ad44f855b34df"
 # path = "../rs-soroban-sdk/soroban-spec-rust"
 
 [workspace.dependencies.soroban-spec-json]
@@ -47,18 +47,18 @@ rev = "a59f5f421a27bab71472041fc619dd8b0d1cf902"
 
 [workspace.dependencies.soroban-sdk]
 version = "=20.5.0"
-# git = "https://github.com/stellar/rs-soroban-sdk"
-# rev = "89efc3c211d41f1ab143bed0a09cd6af353bb098"
+git = "https://github.com/stellar/rs-soroban-sdk"
+rev = "67c1727cd5c632730d33eeb4ab1ad44f855b34df"
 
 [workspace.dependencies.soroban-token-sdk]
 version = "=20.3.2"
-# git = "https://github.com/stellar/rs-soroban-sdk"
-# rev = "4aef54ff9295c2fca4c5b9fbd2c92d0ff99f67de"
+git = "https://github.com/stellar/rs-soroban-sdk"
+rev = "67c1727cd5c632730d33eeb4ab1ad44f855b34df"
 
 [workspace.dependencies.soroban-ledger-snapshot]
 version = "=20.3.2"
-# git = "https://github.com/stellar/rs-soroban-sdk"
-# rev = "4aef54ff9295c2fca4c5b9fbd2c92d0ff99f67de"
+git = "https://github.com/stellar/rs-soroban-sdk"
+rev = "67c1727cd5c632730d33eeb4ab1ad44f855b34df"
 
 [workspace.dependencies.stellar-rpc-client]
 version = "20.3.5"
@@ -67,6 +67,8 @@ path = "cmd/crates/stellar-rpc-client"
 [workspace.dependencies.stellar-xdr]
 version = "=20.1.0"
 default-features = true
+git = "https://github.com/stellar/rs-stellar-xdr"
+rev = "3a001b1fbb20e4cfa2cef2c0cc450564e8528057"
 
 [workspace.dependencies]
 stellar-strkey = "0.0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ rust-version = "1.74.0"
 
 [workspace.dependencies.soroban-env-host]
 version = "=20.3.0"
-# git = "https://github.com/stellar/rs-soroban-env"
-# rev = "8c9ab83c406bd86f56d52eae3e39dccf6b45b3da"
+git = "https://github.com/stellar/rs-soroban-env"
+rev = "a8c713db03ba5ebfdc4786b73dcba00284e15dbe"
 # path = "../rs-soroban-env/soroban-env-host"
 
 [workspace.dependencies.soroban-simulation]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ version = "=20.3.0"
 
 [workspace.dependencies.soroban-simulation]
 version = "=20.3.0"
-# git = "https://github.com/stellar/rs-soroban-env"
-# rev = "8c9ab83c406bd86f56d52eae3e39dccf6b45b3da"
+git = "https://github.com/stellar/rs-soroban-env"
+rev = "a8c713db03ba5ebfdc4786b73dcba00284e15dbe"
 # path = "../rs-soroban-env/soroban-simulation"
 
 [workspace.dependencies.soroban-spec]

--- a/cmd/crates/stellar-rpc-client/src/lib.rs
+++ b/cmd/crates/stellar-rpc-client/src/lib.rs
@@ -8,20 +8,18 @@ use serde_aux::prelude::{
     deserialize_option_number_from_string,
 };
 use soroban_env_host::xdr::{
-    self, AccountEntry, AccountId, ContractDataEntry, DiagnosticEvent, Error as XdrError,
-    LedgerEntryData, LedgerFootprint, LedgerKey, LedgerKeyAccount, Limited, PublicKey, ReadXdr,
-    SorobanAuthorizationEntry, SorobanResources, SorobanTransactionData, Transaction,
-    TransactionEnvelope, TransactionMeta, TransactionMetaV3, TransactionResult, Uint256, VecM,
-    WriteXdr,
+    self, AccountEntry, AccountId, ContractDataEntry, ContractEventType, DiagnosticEvent,
+    Error as XdrError, LedgerEntryData, LedgerFootprint, LedgerKey, LedgerKeyAccount, Limited,
+    Limits, PublicKey, ReadXdr, SorobanAuthorizationEntry, SorobanResources,
+    SorobanTransactionData, Transaction, TransactionEnvelope, TransactionMeta, TransactionMetaV3,
+    TransactionResult, Uint256, VecM, WriteXdr,
 };
 use soroban_sdk::token;
-use soroban_sdk::xdr::Limits;
 use std::{
     fmt::Display,
     str::FromStr,
     time::{Duration, Instant},
 };
-use stellar_xdr::curr::ContractEventType;
 use termcolor::{Color, ColorChoice, StandardStream, WriteColor};
 use termcolor_output::colored;
 use tokio::time::sleep;

--- a/cmd/soroban-rpc/internal/preflight/preflight.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight.go
@@ -178,6 +178,7 @@ func getLedgerInfo(params PreflightParameters) (C.ledger_info_t, error) {
 		timestamp:          C.uint64_t(time.Now().Unix()),
 		// Current base reserve is 0.5XLM (in stroops)
 		base_reserve: 5_000_000,
+		bucket_list_size: params.BucketListSize
 	}
 	return li, nil
 }

--- a/cmd/soroban-rpc/internal/preflight/preflight.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight.go
@@ -178,7 +178,7 @@ func getLedgerInfo(params PreflightParameters) (C.ledger_info_t, error) {
 		timestamp:          C.uint64_t(time.Now().Unix()),
 		// Current base reserve is 0.5XLM (in stroops)
 		base_reserve: 5_000_000,
-		bucket_list_size: params.BucketListSize
+		bucket_list_size: params.BucketListSize,
 	}
 	return li, nil
 }

--- a/cmd/soroban-rpc/internal/preflight/preflight_test.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight_test.go
@@ -190,16 +190,6 @@ var mockLedgerEntriesWithoutTTLs = []xdr.LedgerEntry{
 			},
 		},
 	},
-	{
-		LastModifiedLedgerSeq: 2,
-		Data: xdr.LedgerEntryData{
-			Type: xdr.LedgerEntryTypeConfigSetting,
-			ConfigSetting: &xdr.ConfigSettingEntry{
-				ConfigSettingId:      xdr.ConfigSettingIdConfigSettingBucketlistSizeWindow,
-				BucketListSizeWindow: &[]xdr.Uint64{100, 200},
-			},
-		},
-	},
 }
 
 // Adds ttl entries to mockLedgerEntriesWithoutTTLs

--- a/cmd/soroban-rpc/lib/preflight.h
+++ b/cmd/soroban-rpc/lib/preflight.h
@@ -10,6 +10,7 @@ typedef struct ledger_info_t {
   uint64_t timestamp;
   const char *network_passphrase;
   uint32_t base_reserve;
+  uint64_t bucket_list_size;
 } ledger_info_t;
 
 typedef struct xdr_t {

--- a/cmd/soroban-rpc/lib/preflight/src/lib.rs
+++ b/cmd/soroban-rpc/lib/preflight/src/lib.rs
@@ -35,6 +35,7 @@ pub struct CLedgerInfo {
     pub timestamp: u64,
     pub network_passphrase: *const libc::c_char,
     pub base_reserve: u32,
+    pub bucket_list_size: u64,
 }
 
 fn fill_ledger_info(c_ledger_info: CLedgerInfo, network_config: &NetworkConfig) -> LedgerInfo {
@@ -244,7 +245,8 @@ fn preflight_invoke_hf_op_or_maybe_panic(
     let source_account =
         AccountId::from_xdr(from_c_xdr(source_account), DEFAULT_XDR_RW_LIMITS).unwrap();
     let go_storage = Rc::new(GoLedgerStorage::new(handle));
-    let network_config = NetworkConfig::load_from_snapshot(go_storage.as_ref())?;
+    let network_config =
+        NetworkConfig::load_from_snapshot(go_storage.as_ref(), c_ledger_info.bucket_list_size)?;
     let ledger_info = fill_ledger_info(c_ledger_info, &network_config);
     let auto_restore_snapshot = Rc::new(AutoRestoringSnapshotSource::new(
         go_storage.clone(),
@@ -314,7 +316,8 @@ fn preflight_footprint_ttl_op_or_maybe_panic(
     let op_body = OperationBody::from_xdr(from_c_xdr(op_body), DEFAULT_XDR_RW_LIMITS)?;
     let footprint = LedgerFootprint::from_xdr(from_c_xdr(footprint), DEFAULT_XDR_RW_LIMITS)?;
     let go_storage = Rc::new(GoLedgerStorage::new(handle));
-    let network_config = NetworkConfig::load_from_snapshot(go_storage.as_ref())?;
+    let network_config =
+        NetworkConfig::load_from_snapshot(go_storage.as_ref(), c_ledger_info.bucket_list_size)?;
     let ledger_info = fill_ledger_info(c_ledger_info, &network_config);
     // TODO: It would make for a better UX if the user passed only the neccesary fields for every operation.
     // That would remove a possibility of providing bad operation body, or a possibility of filling wrong footprint


### PR DESCRIPTION
### What

Pass bucket list size from meta to `NetworkConfig`.

### Why

Unfortunately, Core currently doesn't emit the bucket list size config entry changes in the meta, so the only way to fetch the proper value as of now is to use the meta field directly.

### Known limitations

N/A
