### PR TITLE
Add ledger range to getHealth endpoint

### DIFF
--- a/cmd/soroban-rpc/internal/events/events.go
+++ b/cmd/soroban-rpc/internal/events/events.go
@@ -264,3 +264,10 @@ func readEvents(networkPassphrase string, ledgerCloseMeta xdr.LedgerCloseMeta) (
 	}
 	return events, err
 }
+
+// GetLedgerRange returns the first and latest ledger available in the store.
+func (m *MemoryStore) GetLedgerRange() ledgerbucketwindow.LedgerRange {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	return m.eventsByLedger.GetLedgerRange()
+}

--- a/cmd/soroban-rpc/internal/jsonrpc.go
+++ b/cmd/soroban-rpc/internal/jsonrpc.go
@@ -143,7 +143,7 @@ func NewJSONRPCHandler(cfg *config.Config, params HandlerParams) Handler {
 	}{
 		{
 			methodName:           "getHealth",
-			underlyingHandler:    methods.NewHealthCheck(params.TransactionStore, cfg.MaxHealthyLedgerLatency),
+			underlyingHandler:    methods.NewHealthCheck(params.TransactionStore, params.EventStore, cfg.MaxHealthyLedgerLatency),
 			longName:             "get_health",
 			queueLimit:           cfg.RequestBacklogGetHealthQueueLimit,
 			requestDurationLimit: cfg.MaxGetHealthExecutionDuration,

--- a/cmd/soroban-rpc/internal/ledgerbucketwindow/ledgerbucketwindow.go
+++ b/cmd/soroban-rpc/internal/ledgerbucketwindow/ledgerbucketwindow.go
@@ -65,6 +65,35 @@ func (w *LedgerBucketWindow[T]) Len() uint32 {
 	return uint32(len(w.buckets))
 }
 
+type LedgerInfo struct {
+	Sequence  uint32
+	CloseTime int64
+}
+
+type LedgerRange struct {
+	FirstLedger LedgerInfo
+	LastLedger  LedgerInfo
+}
+
+func (w *LedgerBucketWindow[T]) GetLedgerRange() LedgerRange {
+	length := w.Len()
+	if length == 0 {
+		return LedgerRange{}
+	}
+	firstBucket := w.Get(0)
+	lastBucket := w.Get(length - 1)
+	return LedgerRange{
+		FirstLedger: LedgerInfo{
+			Sequence:  firstBucket.LedgerSeq,
+			CloseTime: firstBucket.LedgerCloseTimestamp,
+		},
+		LastLedger: LedgerInfo{
+			Sequence:  lastBucket.LedgerSeq,
+			CloseTime: lastBucket.LedgerCloseTimestamp,
+		},
+	}
+}
+
 // Get obtains a bucket from the window
 func (w *LedgerBucketWindow[T]) Get(i uint32) *LedgerBucket[T] {
 	length := w.Len()

--- a/cmd/soroban-rpc/internal/transactions/transactions_test.go
+++ b/cmd/soroban-rpc/internal/transactions/transactions_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/daemon/interfaces"
+	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/ledgerbucketwindow"
 )
 
 func expectedTransaction(t *testing.T, ledger uint32, feeBump bool) Transaction {
@@ -36,16 +37,16 @@ func expectedTransaction(t *testing.T, ledger uint32, feeBump bool) Transaction 
 	return tx
 }
 
-func expectedLedgerInfo(ledgerSequence uint32) LedgerInfo {
-	return LedgerInfo{
+func expectedLedgerInfo(ledgerSequence uint32) ledgerbucketwindow.LedgerInfo {
+	return ledgerbucketwindow.LedgerInfo{
 		Sequence:  ledgerSequence,
 		CloseTime: ledgerCloseTime(ledgerSequence),
 	}
 
 }
 
-func expectedStoreRange(startLedger uint32, endLedger uint32) StoreRange {
-	return StoreRange{
+func expectedStoreRange(startLedger uint32, endLedger uint32) ledgerbucketwindow.LedgerRange {
+	return ledgerbucketwindow.LedgerRange{
 		FirstLedger: expectedLedgerInfo(startLedger),
 		LastLedger:  expectedLedgerInfo(endLedger),
 	}
@@ -295,7 +296,7 @@ func TestIngestTransactions(t *testing.T) {
 
 	_, ok, storeRange := store.GetTransaction(txHash(1, false))
 	require.False(t, ok)
-	require.Equal(t, StoreRange{}, storeRange)
+	require.Equal(t, ledgerbucketwindow.LedgerRange{}, storeRange)
 
 	// Insert ledger 1
 	require.NoError(t, store.IngestTransactions(txMeta(1, false)))


### PR DESCRIPTION
### What

Add first and last known ledger sequences to the `getHealth` method response

### Why

Enable health probes to make decisions based on the ingested range

### Known limitations

N/A
