### PR TITLE
Fix json specifiers for ledger entry changes

### DIFF
--- a/cmd/soroban-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/simulate_transaction.go
@@ -134,10 +134,10 @@ func (l *LedgerEntryChange) FromXDRDiff(diff preflight.XDRDiff) error {
 // LedgerEntryChange designates a change in a ledger entry. Before and After cannot be be omitted at the same time.
 // If Before is omitted, it constitutes a creation, if After is omitted, it constitutes a delation.
 type LedgerEntryChange struct {
-	Type   LedgerEntryChangeType
-	Key    string  // LedgerEntryKey in base64
-	Before *string `json:"before"` // LedgerEntry XDR in base64
-	After  *string `json:"after"`  // LedgerEntry XDR in base64
+	Type   LedgerEntryChangeType `json:"type"`
+	Key    string                `json:"key"`    // LedgerEntryKey in base64
+	Before *string               `json:"before"` // LedgerEntry XDR in base64
+	After  *string               `json:"after"`  // LedgerEntry XDR in base64
 }
 
 type SimulateTransactionResponse struct {


### PR DESCRIPTION
### What

Fix json specifiers for ledger entry changes (followup to https://github.com/stellar/soroban-rpc/pull/123 )

### Why

Field names were inconsistent (causing problems with system tests)

### Known limitations

This is technically a breaking change since we already released the state changes in 20.3.5 
