### PR TITLE
Obtain simulation protocol version dynamically

### DIFF
--- a/cmd/soroban-rpc/internal/jsonrpc.go
+++ b/cmd/soroban-rpc/internal/jsonrpc.go
@@ -208,7 +208,7 @@ func NewJSONRPCHandler(cfg *config.Config, params HandlerParams) Handler {
 		},
 		{
 			methodName:           "simulateTransaction",
-			underlyingHandler:    methods.NewSimulateTransactionHandler(params.Logger, params.LedgerEntryReader, params.LedgerReader, params.PreflightGetter),
+			underlyingHandler:    methods.NewSimulateTransactionHandler(params.Logger, params.LedgerEntryReader, params.LedgerReader, params.Daemon, params.PreflightGetter),
 			longName:             "simulate_transaction",
 			queueLimit:           cfg.RequestBacklogSimulateTransactionQueueLimit,
 			requestDurationLimit: cfg.MaxSimulateTransactionExecutionDuration,

--- a/cmd/soroban-rpc/internal/preflight/pool.go
+++ b/cmd/soroban-rpc/internal/preflight/pool.go
@@ -156,6 +156,7 @@ func (pwp *PreflightWorkerPool) GetPreflight(ctx context.Context, params Preflig
 		Footprint:         params.Footprint,
 		ResourceConfig:    params.ResourceConfig,
 		EnableDebug:       pwp.enableDebug,
+		ProtocolVersion:   params.ProtocolVersion,
 	}
 	resultC := make(chan workerResult)
 	select {

--- a/cmd/soroban-rpc/internal/preflight/preflight.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight.go
@@ -91,6 +91,7 @@ type PreflightGetterParameters struct {
 	OperationBody     xdr.OperationBody
 	Footprint         xdr.LedgerFootprint
 	ResourceConfig    ResourceConfig
+	ProtocolVersion   int
 }
 
 type PreflightParameters struct {
@@ -103,6 +104,7 @@ type PreflightParameters struct {
 	BucketListSize    uint64
 	ResourceConfig    ResourceConfig
 	EnableDebug       bool
+	ProtocolVersion   int
 }
 
 type XDRDiff struct {
@@ -174,7 +176,7 @@ func getLedgerInfo(params PreflightParameters) (C.ledger_info_t, error) {
 	li := C.ledger_info_t{
 		network_passphrase: C.CString(params.NetworkPassphrase),
 		sequence_number:    C.uint32_t(simulationLedgerSeq),
-		protocol_version:   20,
+		protocol_version:   C.uint32_t(params.ProtocolVersion),
 		timestamp:          C.uint64_t(time.Now().Unix()),
 		// Current base reserve is 0.5XLM (in stroops)
 		base_reserve: 5_000_000,

--- a/cmd/soroban-rpc/internal/preflight/preflight.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight.go
@@ -91,7 +91,7 @@ type PreflightGetterParameters struct {
 	OperationBody     xdr.OperationBody
 	Footprint         xdr.LedgerFootprint
 	ResourceConfig    ResourceConfig
-	ProtocolVersion   int
+	ProtocolVersion   uint32
 }
 
 type PreflightParameters struct {
@@ -104,7 +104,7 @@ type PreflightParameters struct {
 	BucketListSize    uint64
 	ResourceConfig    ResourceConfig
 	EnableDebug       bool
-	ProtocolVersion   int
+	ProtocolVersion   uint32
 }
 
 type XDRDiff struct {

--- a/cmd/soroban-rpc/internal/preflight/preflight_test.go
+++ b/cmd/soroban-rpc/internal/preflight/preflight_test.go
@@ -361,6 +361,7 @@ func getPreflightParameters(t testing.TB, dbConfig *preflightParametersDBConfig)
 		NetworkPassphrase: "foo",
 		LedgerEntryReadTx: ledgerEntryReadTx,
 		BucketListSize:    200,
+		ProtocolVersion:   20,
 	}
 	return params
 }


### PR DESCRIPTION
### What

Obtain protocol version for simulation dynamically

### Why

It used to be hardcoded to version 20 but. Now that we are releasing a new protocol version we cannot do that anymore.

### Known limitations

N/A
