### PR TITLE
added jq to rpc image for readiness probe usage

### DIFF
--- a/cmd/soroban-rpc/docker/Dockerfile
+++ b/cmd/soroban-rpc/docker/Dockerfile
@@ -28,7 +28,7 @@ ENV STELLAR_CORE_BINARY_PATH /usr/bin/stellar-core
 ENV DEBIAN_FRONTEND=noninteractive
 
 # ca-certificates are required to make tls connections
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl wget gnupg apt-utils
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl jq wget gnupg apt-utils
 RUN wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true apt-key add -
 RUN echo "deb https://apt.stellar.org focal stable" >/etc/apt/sources.list.d/SDF.list
 RUN echo "deb https://apt.stellar.org focal unstable" >/etc/apt/sources.list.d/SDF-unstable.list

--- a/cmd/soroban-rpc/docker/Dockerfile.release
+++ b/cmd/soroban-rpc/docker/Dockerfile.release
@@ -8,7 +8,7 @@ ENV STELLAR_CORE_BINARY_PATH /usr/bin/stellar-core
 ENV DEBIAN_FRONTEND=noninteractive
 
 # ca-certificates are required to make tls connections
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl wget gnupg apt-utils gpg && \
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl jq wget gnupg apt-utils gpg && \
     curl -sSL https://apt.stellar.org/SDF.asc | gpg --dearmor >/etc/apt/trusted.gpg.d/SDF.gpg && \
     echo "deb https://apt.stellar.org focal stable" >/etc/apt/sources.list.d/SDF.list && \
     echo "deb https://apt.stellar.org focal testing" >/etc/apt/sources.list.d/SDF-testing.list && \


### PR DESCRIPTION
### What

added `jq` to rpc docker container

### Why

kubernetes readiness probes can then execute it to check health status

relates to:
https://github.com/stellar/helm-charts/issues/82
https://github.com/stellar/soroban-rpc/pull/133


### Known limitations

kubernetes readiness probes don't provide jq functionality externally from the app container under test, so have to use an 'exec' probe which only executes on the app container itself.