### PR TITLE
Change API field naming style to Camel Case.

### DIFF
--- a/cmd/soroban-rpc/internal/methods/get_version_info.go
+++ b/cmd/soroban-rpc/internal/methods/get_version_info.go
@@ -12,10 +12,10 @@ import (
 
 type GetVersionInfoResponse struct {
 	Version            string `json:"version"`
-	CommitHash         string `json:"commit_hash"`
-	BuildTimestamp     string `json:"build_time_stamp"`
-	CaptiveCoreVersion string `json:"captive_core_version"`
-	ProtocolVersion    uint32 `json:"protocol_version"`
+	CommitHash         string `json:"commitHash"`
+	BuildTimestamp     string `json:"buildTimestamp"`
+	CaptiveCoreVersion string `json:"captiveCoreVersion"`
+	ProtocolVersion    uint32 `json:"protocolVersion"`
 }
 
 func NewGetVersionInfoHandler(logger *log.Entry, ledgerEntryReader db.LedgerEntryReader, ledgerReader db.LedgerReader, daemon interfaces.Daemon) jrpc2.Handler {

--- a/cmd/soroban-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/simulate_transaction.go
@@ -131,8 +131,8 @@ func (l *LedgerEntryChange) FromXDRDiff(diff preflight.XDRDiff) error {
 	return nil
 }
 
-// LedgerEntryChange designates a change in a ledger entry. Before and After cannot be be omitted at the same time.
-// If Before is omitted, it constitutes a creation, if After is omitted, it constitutes a delation.
+// LedgerEntryChange designates a change in a ledger entry. Before and After cannot be omitted at the same time.
+// If Before is omitted, it constitutes a creation, if After is omitted, it constitutes a deletion.
 type LedgerEntryChange struct {
 	Type   LedgerEntryChangeType `json:"type"`
 	Key    string                `json:"key"`    // LedgerEntryKey in base64


### PR DESCRIPTION
### What

Change API field naming style to Camel Case.

### Why

Other APIs all use Camel Case style, let's keep it consistent.

### Known limitations

[TODO or N/A]
