### PR TITLE
Fix deadlock on events ingestion error

### DIFF
--- a/cmd/soroban-rpc/internal/events/events.go
+++ b/cmd/soroban-rpc/internal/events/events.go
@@ -207,6 +207,7 @@ func (m *MemoryStore) IngestEvents(ledgerCloseMeta xdr.LedgerCloseMeta) error {
 	}
 	m.lock.Lock()
 	if _, err = m.eventsByLedger.Append(bucket); err != nil {
+		m.lock.Unlock()
 		return err
 	}
 	m.lock.Unlock()


### PR DESCRIPTION
### What

Ensure mutex is unlocked in case of error

### Why

It causes a deadlock in case of error

### Known limitations

N/A
