### PR TITLE
Correctly report row iteration errors in StreamAllLedgers

### DIFF
--- a/cmd/soroban-rpc/internal/daemon/daemon.go
+++ b/cmd/soroban-rpc/internal/daemon/daemon.go
@@ -224,13 +224,13 @@ func MustNew(cfg *config.Config) *Daemon {
 		}
 		return nil
 	})
+	if err != nil {
+		logger.WithError(err).Fatal("could not obtain txmeta cache from the database")
+	}
 	if currentSeq != 0 {
 		logger.WithFields(supportlog.F{
 			"seq": currentSeq,
 		}).Info("finished initializing in-memory store")
-	}
-	if err != nil {
-		logger.WithError(err).Fatal("could not obtain txmeta cache from the database")
 	}
 
 	onIngestionRetry := func(err error, dur time.Duration) {

--- a/cmd/soroban-rpc/internal/db/ledger.go
+++ b/cmd/soroban-rpc/internal/db/ledger.go
@@ -49,7 +49,7 @@ func (r ledgerReader) StreamAllLedgers(ctx context.Context, f StreamLedgerFn) er
 			return err
 		}
 	}
-	return nil
+	return q.Err()
 }
 
 // GetLedger fetches a single ledger from the db.


### PR DESCRIPTION
### What

Correctly report row iteration errors in `StreamAllLedgers()`

Also, clean up logging ordering.

### Why

We were missing row iteration errors.

Closes https://github.com/stellar/soroban-rpc/issues/166

### Known limitations

N/A
