### PR TITLE
Increase default ingestion timeout

### DIFF
--- a/cmd/soroban-rpc/internal/config/options.go
+++ b/cmd/soroban-rpc/internal/config/options.go
@@ -201,7 +201,7 @@ func (cfg *Config) options() ConfigOptions {
 			Name:         "ingestion-timeout",
 			Usage:        "Ingestion Timeout when bootstrapping data (checkpoint and in-memory initialization) and preparing ledger reads",
 			ConfigKey:    &cfg.IngestionTimeout,
-			DefaultValue: 40 * time.Minute,
+			DefaultValue: 50 * time.Minute,
 		},
 		{
 			Name:         "checkpoint-frequency",

--- a/cmd/soroban-rpc/internal/config/options.go
+++ b/cmd/soroban-rpc/internal/config/options.go
@@ -201,7 +201,7 @@ func (cfg *Config) options() ConfigOptions {
 			Name:         "ingestion-timeout",
 			Usage:        "Ingestion Timeout when bootstrapping data (checkpoint and in-memory initialization) and preparing ledger reads",
 			ConfigKey:    &cfg.IngestionTimeout,
-			DefaultValue: 30 * time.Minute,
+			DefaultValue: 40 * time.Minute,
 		},
 		{
 			Name:         "checkpoint-frequency",


### PR DESCRIPTION
### What

Increase default ingestion timeout to ~40~ 50 mins

### Why

We were reaching the timeout in pubnet (AWS/K8s). See https://github.com/stellar/soroban-rpc/issues/166#issuecomment-2103727828

### Known limitations

N/A
