### PR TITLE
bugfix: Supply captive core path for toml generation

### DIFF
--- a/cmd/soroban-rpc/internal/daemon/daemon.go
+++ b/cmd/soroban-rpc/internal/daemon/daemon.go
@@ -109,6 +109,7 @@ func newCaptiveCore(cfg *config.Config, logger *supportlog.Entry) (*ledgerbacken
 		Strict:                         true,
 		UseDB:                          true,
 		EnforceSorobanDiagnosticEvents: true,
+		CoreBinaryPath:                 cfg.StellarCoreBinaryPath,
 	}
 	captiveCoreToml, err := ledgerbackend.NewCaptiveCoreTomlFromFile(cfg.CaptiveCoreConfigPath, captiveCoreTomlParams)
 	if err != nil {


### PR DESCRIPTION
When missing the captive core binary, toml generation doesn't take Core's version and protocol into consideration, conservatively avoiding version-dependent default config options.

This causes default options like `EXPERIMENTAL_BUCKETLIST_DB` and `ENABLE_SOROBAN_DIAGNOSTIC_EVENTS` to be missing.

Due to its implications, `CoreBinaryPath` should not be an optional parameter.