### PR TITLE
Remove unnecessary code to make GetLedgerRange conform to an interface

### DIFF
--- a/cmd/soroban-rpc/internal/events/events.go
+++ b/cmd/soroban-rpc/internal/events/events.go
@@ -1,7 +1,6 @@
 package events
 
 import (
-	"context"
 	"errors"
 	"io"
 	"sort"
@@ -268,7 +267,7 @@ func readEvents(networkPassphrase string, ledgerCloseMeta xdr.LedgerCloseMeta) (
 }
 
 // GetLedgerRange returns the first and latest ledger available in the store.
-func (m *MemoryStore) GetLedgerRange(_ context.Context) (ledgerbucketwindow.LedgerRange, error) {
+func (m *MemoryStore) GetLedgerRange() (ledgerbucketwindow.LedgerRange, error) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 	return m.eventsByLedger.GetLedgerRange(), nil


### PR DESCRIPTION
### What
Remove changes from the store in `events.go` because we aren't trying to conform to a `GetLedgerRange(context.Context)` interface anymore.

### Why
In an attempt to fix the CI errors occurring in #174, I realized that the changes to this file aren't even necessary. Maybe it'll at least give us a more enlightening error.

### Known limitations
n/a