### PR TITLE
Fix getTransactions method internal error

### DIFF
--- a/cmd/soroban-rpc/internal/methods/get_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/get_transaction.go
@@ -105,7 +105,10 @@ func GetTransaction(
 		log.WithError(err).
 			WithField("hash", txHash).
 			Errorf("failed to fetch transaction")
-		return response, err
+		return response, &jrpc2.Error{
+			Code:    jrpc2.InternalError,
+			Message: err.Error(),
+		}
 	}
 
 	response.ApplicationOrder = tx.ApplicationOrder


### PR DESCRIPTION
Followup from https://github.com/stellar/soroban-rpc/pull/174

I don't think errors are surfaced to JSONRPC unless you use an explicit JSONRPC error