### PR TITLE
fix: return GetTransactionRaw with getTransaction

### DIFF
--- a/cmd/crates/stellar-rpc-client/src/lib.rs
+++ b/cmd/crates/stellar-rpc-client/src/lib.rs
@@ -799,7 +799,7 @@ impl Client {
 
     ///
     /// # Errors
-    pub async fn get_transaction(&self, tx_id: &Hash) -> Result<GetTransactionResponse, Error> {
+    pub async fn get_transaction(&self, tx_id: &Hash) -> Result<GetTransactionResponseRaw, Error> {
         let mut oparams = ObjectParams::new();
         oparams.insert("hash", tx_id)?;
         Ok(self.client().request("getTransaction", oparams).await?)
@@ -827,7 +827,7 @@ impl Client {
         let exponential_backoff: f64 = 1.0 / (1.0 - E.powf(-1.0));
         let mut sleep_time = Duration::from_secs(1);
         loop {
-            let response = self.get_transaction(tx_id).await?;
+            let response: GetTransactionResponse = self.get_transaction(tx_id).await?.try_into()?;
             match response.status.as_str() {
                 "SUCCESS" => {
                     // TODO: the caller should probably be printing this

--- a/cmd/crates/stellar-rpc-client/src/lib.rs
+++ b/cmd/crates/stellar-rpc-client/src/lib.rs
@@ -802,7 +802,8 @@ impl Client {
     pub async fn get_transaction(&self, tx_id: &Hash) -> Result<GetTransactionResponse, Error> {
         let mut oparams = ObjectParams::new();
         oparams.insert("hash", tx_id)?;
-        let resp: GetTransactionResponseRaw = self.client().request("getTransaction", oparams).await?;
+        let resp: GetTransactionResponseRaw =
+            self.client().request("getTransaction", oparams).await?;
         Ok(resp.try_into()?)
     }
 

--- a/cmd/crates/stellar-rpc-client/src/lib.rs
+++ b/cmd/crates/stellar-rpc-client/src/lib.rs
@@ -799,10 +799,11 @@ impl Client {
 
     ///
     /// # Errors
-    pub async fn get_transaction(&self, tx_id: &Hash) -> Result<GetTransactionResponseRaw, Error> {
+    pub async fn get_transaction(&self, tx_id: &Hash) -> Result<GetTransactionResponse, Error> {
         let mut oparams = ObjectParams::new();
         oparams.insert("hash", tx_id)?;
-        Ok(self.client().request("getTransaction", oparams).await?)
+        let resp: GetTransactionResponseRaw = self.client().request("getTransaction", oparams).await?;
+        Ok(resp.try_into()?)
     }
 
     /// Poll the transaction status. Can provide a timeout in seconds, otherwise uses the default timeout.
@@ -827,7 +828,7 @@ impl Client {
         let exponential_backoff: f64 = 1.0 / (1.0 - E.powf(-1.0));
         let mut sleep_time = Duration::from_secs(1);
         loop {
-            let response: GetTransactionResponse = self.get_transaction(tx_id).await?.try_into()?;
+            let response = self.get_transaction(tx_id).await?;
             match response.status.as_str() {
                 "SUCCESS" => {
                     // TODO: the caller should probably be printing this


### PR DESCRIPTION
### What

`getTransaction` method should return a `GetTransactionResponseRaw` which then can be converted to `GetTransaction`. This was causing the struct to not be deserialized correctly.

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
