### PR TITLE
Use commit hash for wait-for-workflows

### DIFF
--- a/.github/workflows/required_status_check.yml
+++ b/.github/workflows/required_status_check.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: int128/wait-for-workflows-action@v1
+      - uses: int128/wait-for-workflows-action@8aa9c53102cda84041a879b99a88b2a93721231d # v1.10.0
         with:
           filter-workflow-names: |
             Dependency sanity checker*


### PR DESCRIPTION
Because security :)
