### PR TITLE
Enable Golangci-lint

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,21 +21,27 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - language: go
-          build-mode: autobuild
-        
+          - language: go
+            build-mode: autobuild
+
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-go
+        with:
+          go-version: 1.22
+      - run: rustup update
+      - uses: stellar/actions/rust-cache@main
+      - run: make build-libpreflight
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -1,11 +1,15 @@
 name: Go
 on:
+  push:
+    branches: [ main, release/** ]
   pull_request:
 
 permissions:
   contents: read
   # Optional: allow read access to pull request. Use with `only-new-issues` option.
   pull-requests: read
+  # Optional: allow write access to checks to allow the action to annotate code in the PR.
+  checks: write
 
 jobs:
   golangci-lint:

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -1,8 +1,5 @@
-name: Linters
+name: Go
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 permissions:
@@ -31,8 +28,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # version v6.0.1
         with:
-          version: v1.52.2 # this is the golangci-lint version
-          args: --issues-exit-code=0 # exit without errors for now - won't fail the build
+          version: v1.59.1 # this is the golangci-lint version
           github-token: ${{ secrets.GITHUB_TOKEN }}
           only-new-issues: true
 

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -8,7 +8,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  golangci:
+  golangci-lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -15,11 +15,13 @@ jobs:
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # version v3.0.2
         with:
           fetch-depth: 0 # required for new-from-rev option in .golangci.yml
+
       - name: Setup GO
         uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # version v3.3.0
         with:
           go-version: '>=1.22.1'
 
+      - uses: stellar/actions/rust-cache@main
       - name: Build libpreflight
         run: |
           rustup update

--- a/.github/workflows/required_status_check.yml
+++ b/.github/workflows/required_status_check.yml
@@ -13,6 +13,6 @@ jobs:
         with:
           filter-workflow-names: |
             Dependency sanity checker*
-            Linters*
+            Go*
             Rust*
             Soroban RPC*

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: stellar/actions/rust-cache@main
       - run: rustup update
+      - uses: stellar/actions/rust-cache@main
       - run: make rust-check
       - run: make rust-test

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - run: rustup update
+      - uses: stellar/actions/rust-cache@main
       - run: make build-libpreflight
       - run: go test -race -cover -timeout 25m -v ./cmd/soroban-rpc/...
 
@@ -81,9 +82,8 @@ jobs:
       - run: |
           rustup target add ${{ matrix.rust_target }}
           rustup update
-
-      - name: Build libpreflight
-        run: make build-libpreflight
+      - uses: stellar/actions/rust-cache@main
+      - run: make build-libpreflight
         env:
           CARGO_BUILD_TARGET: ${{ matrix.rust_target }}
 
@@ -132,8 +132,6 @@ jobs:
           docker pull "$PROTOCOL_${{ matrix.protocol-version }}_CORE_DOCKER_IMG"
           echo SOROBAN_RPC_INTEGRATION_TESTS_DOCKER_IMG="$PROTOCOL_${{ matrix.protocol-version }}_CORE_DOCKER_IMG" >> $GITHUB_ENV
 
-      - uses: stellar/actions/rust-cache@main
-
       - name: Install Captive Core
         shell: bash
         run: |
@@ -176,10 +174,8 @@ jobs:
           docker-compose version
 
       - run: rustup update
-
-      - name: Build libpreflight
-        shell: bash
-        run: make build-libpreflight
+      - uses: stellar/actions/rust-cache@main
+      - run: make build-libpreflight
 
       - name: Run Soroban RPC Integration Tests
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,10 +76,7 @@ linters-settings:
     # Forbid the following identifiers (list of regexp).
     # Default: ["^(fmt\\.Print(|f|ln)|print|println)$"]
     forbid:
-      # Builtin function:
-      - ^print.*$
-      # Optional message that gets included in error reports.
-      - p: ^fmt\.Print.*$
+      - p: "^(fmt\\.Print(|f|ln)|print|println)$"
         msg: Do not commit debug print statements.
       - p: .*
         pkg: ^stellar/go/support/errors$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,122 +1,125 @@
 linters-settings:
-  depguard:
   dupl:
     threshold: 100
+
   funlen:
     lines: 100
     statements: 50
-  goconst:
-    min-len: 2
-    min-occurrences: 3
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - whyNoLint
-  gocyclo:
-    min-complexity: 15
-  goimports:
-    local-prefixes: github.com/golangci/golangci-lint
-  gomnd:
-    # don't include the "operation" and "assign"
-    checks:
-      - argument
-      - case
-      - condition
-      - return
-    ignored-numbers:
-      - '0'
-      - '1'
-      - '2'
-      - '3'
-    ignored-functions:
-      - strings.SplitN
 
-  govet:
-    check-shadowing: true
-    settings:
-      printf:
-        funcs:
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
-  lll:
-    line-length: 140
   misspell:
     locale: US
-  nolintlint:
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+
+  gci:
+    # Section configuration to compare against.
+    # Section names are case-insensitive and may contain parameters in ().
+    # The default order of sections is `standard > default > custom > blank > dot > alias > localmodule`,
+    # If `custom-order` is `true`, it follows the order of `sections` option.
+    # Default: ["standard", "default"]
+    sections:
+      - standard # Standard section: captures all standard packages.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - prefix(github.com/stellar/) # Custom section: groups all imports with the specified Prefix.
+      - localmodule # Local module section: contains all local packages. This section is not present unless explicitly enabled.
+    skip-generated: false
+    # Enable custom order of sections.
+    # If `true`, make the section order the same as the order of `sections`.
+    # Default: false
+    custom-order: true
+
+  dogsled:
+    # Checks assignments with too many blank identifiers.
+    # Default: 2
+    max-blank-identifiers: 3
+
+  cyclop:
+    # The maximal code complexity to report.
+    # Default: 10
+    max-complexity: 15
+
+  wrapcheck:
+    # An array of strings that specify substrings of signatures to ignore.
+    # If this set, it will override the default set of ignored signatures.
+    # See https://github.com/tomarrell/wrapcheck#configuration for more information.
+    # Default: [".Errorf(", "errors.New(", "errors.Unwrap(", "errors.Join(", ".Wrap(", ".Wrapf(", ".WithMessage(", ".WithMessagef(", ".WithStack("]
+    ignoreSigs:
+      - .Errorf(
+      - errors.New(
+      - errors.Unwrap(
+      - errors.Join(
+      - .Wrap(
+      - .Wrapf(
+      - .WithMessage(
+      - .WithMessagef(
+      - .WithStack(
+    # An array of strings that specify regular expressions of signatures to ignore.
+    # Default: []
+    ignoreSigRegexps:
+      - \.New.*Error\(
+    # An array of strings that specify globs of packages to ignore.
+    # Default: []
+    ignorePackageGlobs:
+      - encoding/*
+      - github.com/pkg/*
+      - github.com/stellar/*
+    # An array of strings that specify regular expressions of interfaces to ignore.
+    # Default: []
+    ignoreInterfaceRegexps:
+      - ^(?i)c(?-i)ach(ing|e)
+
+  testifylint:
+    enable-all: true
+    disable:
+      # TODO: try to enable it
+      - go-require
+
+  forbidigo:
+    # Forbid the following identifiers (list of regexp).
+    # Default: ["^(fmt\\.Print(|f|ln)|print|println)$"]
+    forbid:
+      # Builtin function:
+      - ^print.*$
+      # Optional message that gets included in error reports.
+      - p: ^fmt\.Print.*$
+        msg: Do not commit debug print statements.
+      - p: .*
+        pkg: ^stellar/go/support/errors$
+        message: use standard errors package and fmt.Errorf().
+    exclude-godoc-examples: false
 
 linters:
-  disable-all: true
-  enable:
-    - bodyclose
+  enable-all: true
+  disable:
+    - gomnd
+    - execinquery
     - depguard
-    - dogsled
-    - dupl
-    - errcheck
-    - exportloopref
-    #- funlen
-    - gochecknoinits
-    - goconst
-    #- gocritic
-    #- gocyclo
-    - gofmt
-    - goimports
-    #- gomnd
-    - goprintffuncname
-    - gosec
-    - gosimple
-    - govet
-    - ineffassign
-    #- lll
-    - misspell
-    - nakedret
-    - noctx
-    - nolintlint
-    - staticcheck
-    - stylecheck
-    - typecheck
-    - unconvert
-    - unparam
-    - unused
-    - whitespace
-
-  # don't enable:
-  # - asciicheck
-  # - scopelint
-  # - gochecknoglobals
-  # - gocognit
-  # - godot
-  # - godox
-  # - goerr113
-  # - interfacer
-  # - maligned
-  # - nestif
-  # - prealloc
-  # - testpackage
-  # - revive
-  # - wsl
+    - nlreturn
+    - godox
+    # exhaustruct: enforcing exhaustive fields is useful in some cases, but there are
+    #              too many legitimate default field values in Go
+    - exhaustruct
+    # err113: Enforcing errors.Is() is useful but cannot be enabled in isoation
+    - err113
+    - thelper
+    - wsl
+    - wrapcheck
+    - testpackage
+    # TODO: I didn't manage to make it accept short parameter names
+    - varnamelen
+    # TODO: consider enabling it later on
+    - ireturn
+    - godot
+  presets: [ ]
+  fast: false
 
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
     - path: _test\.go
       linters:
-        - govet
+        - gosec
+    - path: cmd/soroban-rpc/internal/integrationtest/infrastructure/
+      linters:
+        - gosec
 
 run:
-  timeout: 5m
-  skip-dirs:
-    - docs
-    - vendor
+  timeout: 10m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -77,11 +77,12 @@ linters-settings:
     # Default: ["^(fmt\\.Print(|f|ln)|print|println)$"]
     forbid:
       - p: "^(fmt\\.Print(|f|ln)|print|println)$"
-        msg: Do not commit debug print statements.
-      - p: .*
-        pkg: ^stellar/go/support/errors$
-        message: use standard errors package and fmt.Errorf().
+        msg: Do not commit debug print statements (in tests use t.Log()).
+      - p: "^.*$"
+        pkg: "^github.com/stellar/go/support/errors$"
+        msg: Do not use stellar/go/support/errors, use the standard 'errors' package and fmt.Errorf().
     exclude-godoc-examples: false
+    analyze-types: true
 
 linters:
   enable-all: true
@@ -94,7 +95,7 @@ linters:
     # exhaustruct: enforcing exhaustive fields is useful in some cases, but there are
     #              too many legitimate default field values in Go
     - exhaustruct
-    # err113: Enforcing errors.Is() is useful but cannot be enabled in isoation
+    # err113: Enforcing errors.Is() is useful but cannot be enabled in isolation
     - err113
     - thelper
     - wsl

--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,8 @@ clean:
 build-soroban-rpc: build-libpreflight
 	go build -ldflags="${GOLDFLAGS}" ${MACOS_MIN_VER} -o soroban-rpc -trimpath -v ./cmd/soroban-rpc
 
-go-check-changes:
-	golangci-lint run ./... --new-from-rev $$(git rev-parse HEAD)
+go-check-branch:
+	golangci-lint run ./... --new-from-rev $$(git rev-parse origin/main)
 
 go-check:
 	golangci-lint run ./...

--- a/cmd/soroban-rpc/internal/config/config_option.go
+++ b/cmd/soroban-rpc/internal/config/config_option.go
@@ -1,13 +1,14 @@
 package config
 
 import (
+	"errors"
+	"fmt"
 	"reflect"
 	"strconv"
 	"time"
 
 	"github.com/spf13/pflag"
 
-	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/strutils"
 )
 
@@ -95,11 +96,11 @@ func (o *ConfigOption) setValue(i interface{}) (err error) {
 				return
 			}
 
-			err = errors.Errorf("config option setting error ('%s') %v", o.Name, recoverRes)
+			err = fmt.Errorf("config option setting error ('%s') %v", o.Name, recoverRes)
 		}
 	}()
 	parser := func(option *ConfigOption, i interface{}) error {
-		return errors.Errorf("no parser for flag %s", o.Name)
+		return fmt.Errorf("no parser for flag %s", o.Name)
 	}
 	switch o.ConfigKey.(type) {
 	case *bool:

--- a/cmd/soroban-rpc/internal/config/config_option.go
+++ b/cmd/soroban-rpc/internal/config/config_option.go
@@ -1,12 +1,12 @@
 package config
 
 import (
-	"fmt"
 	"reflect"
 	"strconv"
 	"time"
 
 	"github.com/spf13/pflag"
+
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/strutils"
 )
@@ -28,7 +28,7 @@ func (options ConfigOptions) Validate() error {
 				missingOptions = append(missingOptions, missingOption)
 				continue
 			}
-			return errors.Wrap(err, fmt.Sprintf("Invalid config value for %s", option.Name))
+			return errors.New("Invalid config value for " + option.Name)
 		}
 	}
 	if len(missingOptions) > 0 {

--- a/cmd/soroban-rpc/internal/config/options.go
+++ b/cmd/soroban-rpc/internal/config/options.go
@@ -1,3 +1,4 @@
+//nolint:mnd // lots of magic constants due to default values
 package config
 
 import (

--- a/cmd/soroban-rpc/internal/config/parse.go
+++ b/cmd/soroban-rpc/internal/config/parse.go
@@ -16,6 +16,7 @@ func parseBool(option *ConfigOption, i interface{}) error {
 	case nil:
 		return nil
 	case bool:
+		//nolint:forcetypeassert
 		*option.ConfigKey.(*bool) = v
 	case string:
 		lower := strings.ToLower(v)
@@ -23,6 +24,7 @@ func parseBool(option *ConfigOption, i interface{}) error {
 		if err != nil {
 			return fmt.Errorf("invalid boolean value %s: %s", option.Name, v)
 		}
+		//nolint:forcetypeassert
 		*option.ConfigKey.(*bool) = b
 	default:
 		return fmt.Errorf("could not parse boolean %s: %v", option.Name, i)

--- a/cmd/soroban-rpc/internal/config/parse.go
+++ b/cmd/soroban-rpc/internal/config/parse.go
@@ -21,7 +21,7 @@ func parseBool(option *ConfigOption, i interface{}) error {
 		lower := strings.ToLower(v)
 		b, err := strconv.ParseBool(lower)
 		if err != nil {
-			return err
+			return fmt.Errorf("invalid boolean value %s: %s", option.Name, v)
 		}
 		*option.ConfigKey.(*bool) = b
 	default:

--- a/cmd/soroban-rpc/internal/config/parse.go
+++ b/cmd/soroban-rpc/internal/config/parse.go
@@ -19,13 +19,11 @@ func parseBool(option *ConfigOption, i interface{}) error {
 		*option.ConfigKey.(*bool) = v
 	case string:
 		lower := strings.ToLower(v)
-		if lower == "true" {
-			*option.ConfigKey.(*bool) = true
-		} else if lower == "false" {
-			*option.ConfigKey.(*bool) = false
-		} else {
-			return fmt.Errorf("invalid boolean value %s: %s", option.Name, v)
+		b, err := strconv.ParseBool(lower)
+		if err != nil {
+			return err
 		}
+		*option.ConfigKey.(*bool) = b
 	default:
 		return fmt.Errorf("could not parse boolean %s: %v", option.Name, i)
 	}

--- a/cmd/soroban-rpc/internal/daemon/daemon.go
+++ b/cmd/soroban-rpc/internal/daemon/daemon.go
@@ -67,9 +67,11 @@ func (d *Daemon) GetDB() *db.DB {
 }
 
 func (d *Daemon) GetEndpointAddrs() (net.TCPAddr, *net.TCPAddr) {
+	//nolint:forcetypeassert
 	addr := d.listener.Addr().(*net.TCPAddr)
 	var adminAddr *net.TCPAddr
 	if d.adminListener != nil {
+		//nolint:forcetypeassert
 		adminAddr = d.adminListener.Addr().(*net.TCPAddr)
 	}
 	return *addr, adminAddr

--- a/cmd/soroban-rpc/internal/daemon/daemon.go
+++ b/cmd/soroban-rpc/internal/daemon/daemon.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
-	"net/http/pprof" //nolint:gosec
+	"net/http/pprof"
 	"os"
 	"os/signal"
 	runtimePprof "runtime/pprof"
@@ -15,6 +15,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	"github.com/stellar/go/clients/stellarcore"
 	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/ingest/ledgerbackend"
@@ -66,7 +67,7 @@ func (d *Daemon) GetDB() *db.DB {
 }
 
 func (d *Daemon) GetEndpointAddrs() (net.TCPAddr, *net.TCPAddr) {
-	var addr = d.listener.Addr().(*net.TCPAddr)
+	addr := d.listener.Addr().(*net.TCPAddr)
 	var adminAddr *net.TCPAddr
 	if d.adminListener != nil {
 		adminAddr = d.adminListener.Addr().(*net.TCPAddr)
@@ -142,7 +143,6 @@ func newCaptiveCore(cfg *config.Config, logger *supportlog.Entry) (*ledgerbacken
 		UseDB:               true,
 	}
 	return ledgerbackend.NewCaptive(captiveConfig)
-
 }
 
 func MustNew(cfg *config.Config, logger *supportlog.Entry) *Daemon {
@@ -173,10 +173,10 @@ func MustNew(cfg *config.Config, logger *supportlog.Entry) *Daemon {
 			CheckpointFrequency: cfg.CheckpointFrequency,
 			ConnectOptions: storage.ConnectOptions{
 				Context:   context.Background(),
-				UserAgent: cfg.HistoryArchiveUserAgent},
+				UserAgent: cfg.HistoryArchiveUserAgent,
+			},
 		},
 	)
-
 	if err != nil {
 		logger.WithError(err).Fatal("could not connect to history archive")
 	}

--- a/cmd/soroban-rpc/internal/daemon/interfaces/interfaces.go
+++ b/cmd/soroban-rpc/internal/daemon/interfaces/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/prometheus/client_golang/prometheus"
+
 	proto "github.com/stellar/go/protocols/stellarcore"
 )
 
@@ -18,5 +19,5 @@ type Daemon interface {
 
 type CoreClient interface {
 	Info(ctx context.Context) (*proto.InfoResponse, error)
-	SubmitTransaction(context.Context, string) (*proto.TXResponse, error)
+	SubmitTransaction(ctx context.Context, txBase64 string) (*proto.TXResponse, error)
 }

--- a/cmd/soroban-rpc/internal/daemon/interfaces/noOpDaemon.go
+++ b/cmd/soroban-rpc/internal/daemon/interfaces/noOpDaemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/prometheus/client_golang/prometheus"
+
 	proto "github.com/stellar/go/protocols/stellarcore"
 )
 

--- a/cmd/soroban-rpc/internal/daemon/metrics.go
+++ b/cmd/soroban-rpc/internal/daemon/metrics.go
@@ -2,13 +2,15 @@ package daemon
 
 import (
 	"context"
-	supportlog "github.com/stellar/go/support/log"
 	"runtime"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+
 	"github.com/stellar/go/clients/stellarcore"
 	proto "github.com/stellar/go/protocols/stellarcore"
+	supportlog "github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/logmetrics"
 	"github.com/stellar/go/xdr"
 
@@ -36,8 +38,8 @@ func (d *Daemon) registerMetrics() {
 		"goversion":       runtime.Version(),
 	}).Inc()
 
-	d.metricsRegistry.MustRegister(prometheus.NewGoCollector())
-	d.metricsRegistry.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
+	d.metricsRegistry.MustRegister(collectors.NewGoCollector())
+	d.metricsRegistry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	d.metricsRegistry.MustRegister(buildInfoGauge)
 }
 

--- a/cmd/soroban-rpc/internal/db/db.go
+++ b/cmd/soroban-rpc/internal/db/db.go
@@ -294,7 +294,7 @@ func (w writeTx) Commit(ledgerSeq uint32) error {
 	}
 
 	_, err := sq.Replace(metaTableName).
-		Values(latestLedgerSequenceMetaKey, fmt.Sprintf("%d", ledgerSeq)).
+		Values(latestLedgerSequenceMetaKey, strconv.FormatUint(uint64(ledgerSeq), 10)).
 		RunWith(w.stmtCache).
 		Exec()
 	if err != nil {

--- a/cmd/soroban-rpc/internal/db/ledgerentry.go
+++ b/cmd/soroban-rpc/internal/db/ledgerentry.go
@@ -85,7 +85,7 @@ func (l ledgerEntryWriter) maybeFlush() error {
 func (l ledgerEntryWriter) flush() error {
 	upsertCount := 0
 	upsertSQL := sq.StatementBuilder.RunWith(l.stmtCache).Replace(ledgerEntriesTableName)
-	var deleteKeys = make([]string, 0, len(l.keyToEntryBatch))
+	deleteKeys := make([]string, 0, len(l.keyToEntryBatch))
 
 	upsertCacheUpdates := make(map[string]*string, len(l.keyToEntryBatch))
 	for key, entry := range l.keyToEntryBatch {

--- a/cmd/soroban-rpc/internal/db/mocks.go
+++ b/cmd/soroban-rpc/internal/db/mocks.go
@@ -105,6 +105,8 @@ func (m *mockLedgerReader) StreamAllLedgers(ctx context.Context, f StreamLedgerF
 	return nil
 }
 
-var _ TransactionReader = &mockTransactionHandler{}
-var _ TransactionWriter = &mockTransactionHandler{}
-var _ LedgerReader = &mockLedgerReader{}
+var (
+	_ TransactionReader = &mockTransactionHandler{}
+	_ TransactionWriter = &mockTransactionHandler{}
+	_ LedgerReader      = &mockLedgerReader{}
+)

--- a/cmd/soroban-rpc/internal/db/transaction.go
+++ b/cmd/soroban-rpc/internal/db/transaction.go
@@ -237,9 +237,9 @@ func (txn *transactionHandler) getTransactionByHash(ctx context.Context, hash xd
 	}
 	rowQ := sq.
 		Select("t.application_order", "lcm.meta").
-		From(fmt.Sprintf("%s t", transactionTableName)).
-		Join(fmt.Sprintf("%s lcm ON (t.ledger_sequence = lcm.sequence)", ledgerCloseMetaTableName)).
-		Where(sq.Eq{"t.hash": []byte(hash[:])}).
+		From(transactionTableName + " t").
+		Join(ledgerCloseMetaTableName + " lcm ON (t.ledger_sequence = lcm.sequence)").
+		Where(sq.Eq{"t.hash": hash[:]}).
 		Limit(1)
 
 	if err := txn.db.Select(ctx, &rows, rowQ); err != nil {

--- a/cmd/soroban-rpc/internal/events/events.go
+++ b/cmd/soroban-rpc/internal/events/events.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/xdr"
 
@@ -19,7 +20,9 @@ type event struct {
 	diagnosticEventXDR []byte
 	txIndex            uint32
 	eventIndex         uint32
-	txHash             *xdr.Hash // intentionally stored as a pointer to save memory (amortized as soon as there are two events in a transaction)
+	// intentionally stored as a pointer to save memory
+	// (amortized as soon as there are two events in a transaction)
+	txHash *xdr.Hash
 }
 
 func (e event) cursor(ledgerSeq uint32) Cursor {

--- a/cmd/soroban-rpc/internal/feewindow/feewindow.go
+++ b/cmd/soroban-rpc/internal/feewindow/feewindow.go
@@ -1,3 +1,4 @@
+//nolint:mnd // percentile numbers are not really magical
 package feewindow
 
 import (
@@ -173,7 +174,6 @@ func (fw *FeeWindows) IngestFees(meta xdr.LedgerCloseMeta) error {
 		}
 		feePerOp := feeCharged / uint64(len(ops))
 		classicFees = append(classicFees, feePerOp)
-
 	}
 	bucket := ledgerbucketwindow.LedgerBucket[[]uint64]{
 		LedgerSeq:            meta.LedgerSequence(),

--- a/cmd/soroban-rpc/internal/ingest/ledgerentry.go
+++ b/cmd/soroban-rpc/internal/ingest/ledgerentry.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/xdr"
 

--- a/cmd/soroban-rpc/internal/ingest/service.go
+++ b/cmd/soroban-rpc/internal/ingest/service.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/ingest"
 	backends "github.com/stellar/go/ingest/ledgerbackend"
@@ -18,10 +19,9 @@ import (
 
 	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/daemon/interfaces"
 	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/db"
+	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/events"
 	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/feewindow"
 	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/util"
-
-	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/events"
 )
 
 const (

--- a/cmd/soroban-rpc/internal/ingest/service_test.go
+++ b/cmd/soroban-rpc/internal/ingest/service_test.go
@@ -8,11 +8,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/stellar/go/ingest/ledgerbackend"
 	"github.com/stellar/go/network"
 	supportlog "github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/daemon/interfaces"
 	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/db"

--- a/cmd/soroban-rpc/internal/integrationtest/infrastructure/test.go
+++ b/cmd/soroban-rpc/internal/integrationtest/infrastructure/test.go
@@ -18,20 +18,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/stellar/go/clients/stellarcore"
 	"github.com/stellar/go/keypair"
 	proto "github.com/stellar/go/protocols/stellarcore"
 	supportlog "github.com/stellar/go/support/log"
 	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/go/xdr"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/ledgerbucketwindow"
-	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/methods"
 
 	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/config"
 	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/daemon"
+	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/ledgerbucketwindow"
+	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/methods"
 )
 
 const (

--- a/cmd/soroban-rpc/internal/jsonrpc.go
+++ b/cmd/soroban-rpc/internal/jsonrpc.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-chi/chi/middleware"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/cors"
+
 	"github.com/stellar/go/support/log"
 
 	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/config"
@@ -139,7 +140,7 @@ func NewJSONRPCHandler(cfg *config.Config, params HandlerParams) Handler {
 	// While we transition from in-memory to database-oriented history storage,
 	// the on-disk (transaction) retention window will always be larger than the
 	// in-memory (events) one.
-	var retentionWindow = cfg.TransactionLedgerRetentionWindow
+	retentionWindow := cfg.TransactionLedgerRetentionWindow
 
 	handlers := []struct {
 		methodName           string

--- a/cmd/soroban-rpc/internal/ledgerbucketwindow/ledgerbucketwindow.go
+++ b/cmd/soroban-rpc/internal/ledgerbucketwindow/ledgerbucketwindow.go
@@ -43,7 +43,12 @@ func (w *LedgerBucketWindow[T]) Append(bucket LedgerBucket[T]) (*LedgerBucket[T]
 	if length > 0 {
 		expectedLedgerSequence := w.buckets[w.start].LedgerSeq + length
 		if expectedLedgerSequence != bucket.LedgerSeq {
-			return &LedgerBucket[T]{}, fmt.Errorf("error appending ledgers: ledgers not contiguous: expected ledger sequence %v but received %v", expectedLedgerSequence, bucket.LedgerSeq)
+			err := fmt.Errorf(
+				"error appending ledgers: ledgers not contiguous: expected ledger sequence %v but received %v",
+				expectedLedgerSequence,
+				bucket.LedgerSeq,
+			)
+			return &LedgerBucket[T]{}, err
 		}
 	}
 

--- a/cmd/soroban-rpc/internal/methods/get_events.go
+++ b/cmd/soroban-rpc/internal/methods/get_events.go
@@ -123,9 +123,11 @@ func (g *GetEventsRequest) Matches(event xdr.DiagnosticEvent) bool {
 	return false
 }
 
-const EventTypeSystem = "system"
-const EventTypeContract = "contract"
-const EventTypeDiagnostic = "diagnostic"
+const (
+	EventTypeSystem     = "system"
+	EventTypeContract   = "contract"
+	EventTypeDiagnostic = "diagnostic"
+)
 
 var eventTypeFromXDR = map[xdr.ContractEventType]string{
 	xdr.ContractEventTypeSystem:     EventTypeSystem,
@@ -201,8 +203,10 @@ func (e *EventFilter) matchesTopics(event xdr.ContractEvent) bool {
 
 type TopicFilter []SegmentFilter
 
-const minTopicCount = 1
-const maxTopicCount = 4
+const (
+	minTopicCount = 1
+	maxTopicCount = 4
+)
 
 func (t *TopicFilter) Valid() error {
 	if len(*t) < minTopicCount {

--- a/cmd/soroban-rpc/internal/methods/get_fee_stats.go
+++ b/cmd/soroban-rpc/internal/methods/get_fee_stats.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/creachadair/jrpc2"
+
 	"github.com/stellar/go/support/log"
 
 	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/db"
@@ -48,7 +49,6 @@ func convertFeeDistribution(distribution feewindow.FeeDistribution) FeeDistribut
 		TransactionCount: distribution.FeeCount,
 		LedgerCount:      distribution.LedgerCount,
 	}
-
 }
 
 type GetFeeStatsResult struct {

--- a/cmd/soroban-rpc/internal/methods/get_ledger_entries.go
+++ b/cmd/soroban-rpc/internal/methods/get_ledger_entries.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/creachadair/jrpc2"
+
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
 

--- a/cmd/soroban-rpc/internal/methods/get_ledger_entry.go
+++ b/cmd/soroban-rpc/internal/methods/get_ledger_entry.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/creachadair/jrpc2"
+
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
 
@@ -24,7 +25,8 @@ type GetLedgerEntryResponse struct {
 	LastModifiedLedger uint32 `json:"lastModifiedLedgerSeq"`
 	LatestLedger       uint32 `json:"latestLedger"`
 	// The ledger sequence until the entry is live, available for entries that have associated ttl ledger entries.
-	LiveUntilLedgerSeq *uint32 `json:"LiveUntilLedgerSeq,omitempty"`
+	// TODO: it should had been `liveUntilLedgerSeq` :(
+	LiveUntilLedgerSeq *uint32 `json:"LiveUntilLedgerSeq,omitempty"` //nolint:tagliatelle
 }
 
 // NewGetLedgerEntryHandler returns a json rpc handler to retrieve the specified ledger entry from stellar core

--- a/cmd/soroban-rpc/internal/methods/get_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/get_transaction.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/creachadair/jrpc2"
+
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
 

--- a/cmd/soroban-rpc/internal/methods/get_transactions.go
+++ b/cmd/soroban-rpc/internal/methods/get_transactions.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/creachadair/jrpc2"
 	"github.com/creachadair/jrpc2/handler"
+
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/log"
@@ -151,7 +152,7 @@ LedgerLoop:
 			}
 		}
 
-		// Initialise tx reader.
+		// Initialize tx reader.
 		reader, err := ingest.NewLedgerTransactionReaderFromLedgerCloseMeta(h.networkPassphrase, ledger)
 		if err != nil {
 			return GetTransactionsResponse{}, &jrpc2.Error{

--- a/cmd/soroban-rpc/internal/methods/get_version_info.go
+++ b/cmd/soroban-rpc/internal/methods/get_version_info.go
@@ -2,26 +2,29 @@ package methods
 
 import (
 	"context"
+
 	"github.com/creachadair/jrpc2"
 	"github.com/creachadair/jrpc2/handler"
+
 	"github.com/stellar/go/support/log"
+
 	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/config"
 	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/daemon/interfaces"
 	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/db"
 )
 
 type GetVersionInfoResponse struct {
-	Version            string `json:"version"`
-	CommitHash         string `json:"commit_hash"`
-	BuildTimestamp     string `json:"build_time_stamp"`
-	CaptiveCoreVersion string `json:"captive_core_version"`
-	ProtocolVersion    uint32 `json:"protocol_version"`
+	Version string `json:"version"`
+	// TODO: to be fixed by https://github.com/stellar/soroban-rpc/pull/164
+	CommitHash         string `json:"commit_hash"`          //nolint:tagliatelle
+	BuildTimestamp     string `json:"build_time_stamp"`     //nolint:tagliatelle
+	CaptiveCoreVersion string `json:"captive_core_version"` //nolint:tagliatelle
+	ProtocolVersion    uint32 `json:"protocol_version"`     //nolint:tagliatelle
 }
 
 func NewGetVersionInfoHandler(logger *log.Entry, ledgerEntryReader db.LedgerEntryReader, ledgerReader db.LedgerReader, daemon interfaces.Daemon) jrpc2.Handler {
 	coreClient := daemon.CoreClient()
 	return handler.New(func(ctx context.Context) (GetVersionInfoResponse, error) {
-
 		var captiveCoreVersion string
 		info, err := coreClient.Info(ctx)
 		if err != nil {

--- a/cmd/soroban-rpc/internal/methods/health.go
+++ b/cmd/soroban-rpc/internal/methods/health.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/creachadair/jrpc2"
+
 	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/db"
 )
 
@@ -27,7 +28,7 @@ func NewHealthCheck(
 		if err != nil || ledgerRange.LastLedger.Sequence < 1 {
 			extra := ""
 			if err != nil {
-				extra = fmt.Sprintf(": %s", err.Error())
+				extra = ": " + err.Error()
 			}
 			return HealthCheckResult{}, jrpc2.Error{
 				Code:    jrpc2.InternalError,

--- a/cmd/soroban-rpc/internal/methods/send_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/send_transaction.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 
 	"github.com/creachadair/jrpc2"
+
 	"github.com/stellar/go/network"
 	proto "github.com/stellar/go/protocols/stellarcore"
 	"github.com/stellar/go/support/log"

--- a/cmd/soroban-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/simulate_transaction.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/creachadair/jrpc2"
+
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
 
@@ -76,7 +77,7 @@ func (l *LedgerEntryChangeType) Parse(s string) error {
 	return nil
 }
 
-func (l *LedgerEntryChangeType) UnmarshalJSON(data []byte) (err error) {
+func (l *LedgerEntryChangeType) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err
@@ -158,7 +159,6 @@ type PreflightGetter interface {
 
 // NewSimulateTransactionHandler returns a json rpc handler to run preflight simulations
 func NewSimulateTransactionHandler(logger *log.Entry, ledgerEntryReader db.LedgerEntryReader, ledgerReader db.LedgerReader, daemon interfaces.Daemon, getter PreflightGetter) jrpc2.Handler {
-
 	return NewHandler(func(ctx context.Context, request SimulateTransactionRequest) SimulateTransactionResponse {
 		var txEnvelope xdr.TransactionEnvelope
 		if err := xdr.SafeUnmarshalBase64(request.Transaction, &txEnvelope); err != nil {
@@ -288,7 +288,7 @@ func base64EncodeSlice(in [][]byte) []string {
 
 func getBucketListSizeAndProtocolVersion(ctx context.Context, ledgerReader db.LedgerReader, latestLedger uint32) (uint64, uint32, error) {
 	// obtain bucket size
-	var closeMeta, ok, err = ledgerReader.GetLedger(ctx, latestLedger)
+	closeMeta, ok, err := ledgerReader.GetLedger(ctx, latestLedger)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/cmd/soroban-rpc/internal/network/backlogQ.go
+++ b/cmd/soroban-rpc/internal/network/backlogQ.go
@@ -2,15 +2,17 @@ package network
 
 import (
 	"context"
+	"math"
 	"net/http"
 	"sync/atomic"
 
 	"github.com/creachadair/jrpc2"
+
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/log"
 )
 
-const RequestBacklogQueueNoLimit = maxUint
+const RequestBacklogQueueNoLimit = math.MaxUint64
 
 // The gauge is a subset of prometheus.Gauge, and it allows us to mock the
 // gauge usage for testing purposes without requiring the implementation of the true
@@ -83,7 +85,6 @@ func (q *backlogHTTPQLimiter) ServeHTTP(res http.ResponseWriter, req *http.Reque
 		}
 	}
 	defer func() {
-
 		atomic.AddUint64(&q.pending, ^uint64(0))
 		if q.gauge != nil {
 			q.gauge.Dec()

--- a/cmd/soroban-rpc/internal/network/backlogQ_test.go
+++ b/cmd/soroban-rpc/internal/network/backlogQ_test.go
@@ -43,17 +43,17 @@ func TestBacklogQueueLimiter_HttpNonBlocking(t *testing.T) {
 	testGauge := &TestingGauge{}
 	limiter := MakeHTTPBacklogQueueLimiter(adding, testGauge, requestsSizeLimit, logCounter.Entry())
 	for i := 1; i < 50; i++ {
-		n := rand.Int63n(int64(requestsSizeLimit)) //nolint:gosec
+		requestCount := rand.Int63n(int64(requestsSizeLimit))
 		require.Zero(t, int(testGauge.count))
-		wg.Add(int(n))
-		for k := n; k > 0; k-- {
+		wg.Add(int(requestCount))
+		for k := requestCount; k > 0; k-- {
 			go func() {
 				limiter.ServeHTTP(nil, nil)
 				wg.Done()
 			}()
 		}
 		wg.Wait()
-		require.Equal(t, uint64(n), sum)
+		require.Equal(t, uint64(requestCount), sum)
 		require.Zero(t, int(testGauge.count))
 		sum = 0
 	}
@@ -75,10 +75,10 @@ func TestBacklogQueueLimiter_JrpcNonBlocking(t *testing.T) {
 	testGauge := &TestingGauge{}
 	limiter := MakeJrpcBacklogQueueLimiter(adding.Handle, testGauge, requestsSizeLimit, logCounter.Entry())
 	for i := 1; i < 50; i++ {
-		n := rand.Int63n(int64(requestsSizeLimit)) //nolint:gosec
+		requestCount := rand.Int63n(int64(requestsSizeLimit))
 		require.Zero(t, int(testGauge.count))
-		wg.Add(int(n))
-		for k := n; k > 0; k-- {
+		wg.Add(int(requestCount))
+		for k := requestCount; k > 0; k-- {
 			go func() {
 				_, err := limiter.Handle(context.Background(), nil)
 				require.Nil(t, err)
@@ -87,7 +87,7 @@ func TestBacklogQueueLimiter_JrpcNonBlocking(t *testing.T) {
 		}
 		wg.Wait()
 		require.Zero(t, int(testGauge.count))
-		require.Equal(t, uint64(n), sum)
+		require.Equal(t, uint64(requestCount), sum)
 		sum = 0
 	}
 	require.Equal(t, [7]int{0, 0, 0, 0, 0, 0, 0}, logCounter.writtenLogEntries)
@@ -204,7 +204,7 @@ func TestBacklogQueueLimiter_JrpcBlocking(t *testing.T) {
 		for i := queueSize / 2; i < queueSize; i++ {
 			go func() {
 				_, err := limiter.Handle(context.Background(), &jrpc2.Request{})
-				require.Nil(t, err)
+				require.NoError(t, err)
 				secondBlockingGroupWg.Done()
 			}()
 		}
@@ -214,7 +214,7 @@ func TestBacklogQueueLimiter_JrpcBlocking(t *testing.T) {
 		// now, try to place additional entry - which should be blocked.
 		var res TestingResponseWriter
 		_, err := limiter.Handle(context.Background(), &jrpc2.Request{})
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Equal(t, [7]int{0, 0, 0, 0, 1, 0, 0}, logCounter.writtenLogEntries)
 
 		secondBlockingGroupWg.Add(int(queueSize) - int(queueSize)/2)

--- a/cmd/soroban-rpc/internal/network/requestdurationlimiter.go
+++ b/cmd/soroban-rpc/internal/network/requestdurationlimiter.go
@@ -2,19 +2,20 @@ package network
 
 import (
 	"context"
+	"math"
 	"net/http"
 	"reflect"
 	"runtime"
 	"time"
 
 	"github.com/creachadair/jrpc2"
+
 	"github.com/stellar/go/support/log"
+
 	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/util"
 )
 
-const maxUint = ^uint64(0)         //18446744073709551615
-const maxInt = int64(maxUint >> 1) // 9223372036854775807
-const maxDuration = time.Duration(maxInt)
+const maxDuration = time.Duration(math.MaxInt64)
 
 const RequestDurationLimiterNoLimit = maxDuration
 
@@ -46,7 +47,8 @@ func MakeHTTPRequestDurationLimiter(
 	limitThreshold time.Duration,
 	warningCounter increasingCounter,
 	limitCounter increasingCounter,
-	logger *log.Entry) *httpRequestDurationLimiter {
+	logger *log.Entry,
+) *httpRequestDurationLimiter {
 	// make sure the warning threshold is less then the limit threshold; otherwise, just set it to the limit threshold.
 	if warningThreshold > limitThreshold {
 		warningThreshold = limitThreshold
@@ -83,10 +85,12 @@ func makeBufferedResponseWriter(rw http.ResponseWriter) *bufferedResponseWriter 
 func (w *bufferedResponseWriter) Header() http.Header {
 	return w.header
 }
+
 func (w *bufferedResponseWriter) Write(buf []byte) (int, error) {
 	w.buffer = append(w.buffer, buf...)
 	return len(buf), nil
 }
+
 func (w *bufferedResponseWriter) WriteHeader(statusCode int) {
 	w.statusCode = statusCode
 }
@@ -203,7 +207,8 @@ func MakeJrpcRequestDurationLimiter(
 	limitThreshold time.Duration,
 	warningCounter increasingCounter,
 	limitCounter increasingCounter,
-	logger *log.Entry) *rpcRequestDurationLimiter {
+	logger *log.Entry,
+) *rpcRequestDurationLimiter {
 	// make sure the warning threshold is less then the limit threshold; otherwise, just set it to the limit threshold.
 	if warningThreshold > limitThreshold {
 		warningThreshold = limitThreshold

--- a/cmd/soroban-rpc/internal/network/requestdurationlimiter_test.go
+++ b/cmd/soroban-rpc/internal/network/requestdurationlimiter_test.go
@@ -214,11 +214,11 @@ func TestJRPCRequestDurationLimiter_Limiting(t *testing.T) {
 		i int
 	}{1}
 	err := client.CallResult(context.Background(), "method", req, &res)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	jrpcError, ok := err.(*jrpc2.Error)
 	require.True(t, ok)
 	require.Equal(t, ErrRequestExceededProcessingLimitThreshold.Code, jrpcError.Code)
-	require.Equal(t, nil, res)
+	require.Nil(t, res)
 	require.Zero(t, warningCounter.count)
 	require.Equal(t, int64(1), limitCounter.count)
 	require.Equal(t, [7]int{0, 0, 0, 0, 1, 0, 0}, logCounter.writtenLogEntries)

--- a/cmd/soroban-rpc/internal/preflight/pool.go
+++ b/cmd/soroban-rpc/internal/preflight/pool.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
 

--- a/cmd/soroban-rpc/internal/util/panicgroup.go
+++ b/cmd/soroban-rpc/internal/util/panicgroup.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/stellar/go/support/log"
 )
 
@@ -62,7 +63,7 @@ func (pg *panicGroup) recoverRoutine(fn func()) {
 		return
 	}
 	cs := getPanicCallStack(recoverRes, fn)
-	if len(cs) <= 0 {
+	if len(cs) == 0 {
 		return
 	}
 	if pg.log != nil {
@@ -90,7 +91,7 @@ func getPanicCallStack(recoverRes any, fn func()) (outCallStack []string) {
 }
 
 // CallStack returns an array of strings representing the current call stack. The method is
-// tuned for the purpose of panic handler, and used as a helper in contructing the list of entries we want
+// tuned for the purpose of panic handler, and used as a helper in constructing the list of entries we want
 // to write to the log / stderr / telemetry.
 func CallStack(recoverRes any, topLevelFunctionName string, lastCallstackMethod string, unwindStackLines int) (callStack []string) {
 	if topLevelFunctionName != "" {

--- a/cmd/soroban-rpc/main.go
+++ b/cmd/soroban-rpc/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
 	supportlog "github.com/stellar/go/support/log"
 	goxdr "github.com/stellar/go/xdr"
 
@@ -27,7 +28,7 @@ func main() {
 				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
 			}
-			cfg.HistoryArchiveUserAgent = fmt.Sprintf("soroban-rpc/%s", config.Version)
+			cfg.HistoryArchiveUserAgent = "soroban-rpc/" + config.Version
 			daemon.MustNew(&cfg, supportlog.New()).Run()
 		},
 	}
@@ -37,6 +38,7 @@ func main() {
 		Short: "Print version information and exit",
 		Run: func(_ *cobra.Command, _ []string) {
 			if config.CommitHash == "" {
+				//nolint:forbidgo
 				fmt.Printf("soroban-rpc dev\n")
 			} else {
 				// avoid printing the branch for the main branch

--- a/cmd/soroban-rpc/main.go
+++ b/cmd/soroban-rpc/main.go
@@ -38,7 +38,7 @@ func main() {
 		Short: "Print version information and exit",
 		Run: func(_ *cobra.Command, _ []string) {
 			if config.CommitHash == "" {
-				//nolint:forbidgo
+				//nolint:forbidigo
 				fmt.Printf("soroban-rpc dev\n")
 			} else {
 				// avoid printing the branch for the main branch


### PR DESCRIPTION
### What

Enable [GolangCI-lint](https://golangci-lint.run/) in Pull requests

I tried to disable linters I found unreasonable, but I may have forgotten some of them.

I fixed a lot of issues (many of them legitimate). But after 4 hours I got sick of it, so people will need to fix more issues as they change code.

GolangCI-lint, until we clean everything up, is set to bark on code you change.

I may spend another long session cleaning up stuff, but not for today.

### Why

It wasn't enforced until now.

### Known limitations

You will have to be patient with false positives and fixing code unrelated to your PR until it stabilizes.
