### PR TITLE
Disable paralleltest linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -108,6 +108,7 @@ linters:
     # TODO: ireturn: consider enabling it later on
     - ireturn
     - godot
+    - paralleltest
   presets: [ ]
   fast: false
 


### PR DESCRIPTION
### What

Disable paralleltest linter

### Why

It simply was enabled unintentionally by default. Integration tests are already parallel, unit tests are fast enough when run sequentially (~1 minute)

### Known limitations

N/A
