### PR TITLE
Update stellar-xdr, soroban-env-*

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,9 +760,9 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "21.1.0"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084aab008009e712c445a9d7eab837a86559a6c2341f30bc4f33e9b258947688"
+checksum = "44877373b3dc6c662377cb1600e3a62706d75e484b6064f9cd22e467c676b159"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -772,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "21.1.0"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c16ee889fe99d6828bf3ffac00c84382793c31d62682401dbfa3e1b512f0c542"
+checksum = "590add16843a61b01844e19e89bccaaee6aa21dc76809017b0662c17dc139ee9"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -790,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "21.1.0"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b73f48ae8081ecfb6c0d56c67f139c52cb6d5b6800d5e1adb9eef8e14a155b9"
+checksum = "4e25aaffe0c62eb65e0e349f725b4b8b13ad0764d78a15aab5bbccb5c4797726"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -823,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "21.1.0"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d0581e3aba14892ee0ce63788f3d3e5d9eb1ab18906a9b7c66d77dae9e9fea"
+checksum = "3e16b761459fdf3c4b62b24df3941498d14e5246e6fadfb4774ed8114d243aa4"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -838,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-simulation"
-version = "21.1.0"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a21415ec408b0632763e7a6302a041701e06b1491dbe14fc0b8a8a1a927980"
+checksum = "b5869ccbe217b54b2dfc762db9cb8bf1ae28f056a88e75acdab6e8418df8dcdc"
 dependencies = [
  "anyhow",
  "rand",
@@ -897,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "21.1.0"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec43c9c5ae7ec7b6ac9e263b6d5b9e3781aa05ba3a1c05f6e70701c5c6600665"
+checksum = "2675a71212ed39a806e415b0dbf4702879ff288ec7f5ee996dda42a135512b50"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,10 @@ members = [
 rust-version = "1.74.0"
 
 [workspace.dependencies.soroban-env-host]
-version = "=21.1.0"
+version = "=21.2.0"
 
 [workspace.dependencies.soroban-simulation]
-version = "=21.1.0"
+version = "=21.2.0"
 
 [workspace.dependencies]
 base64 = "0.22.0"


### PR DESCRIPTION
### What
Update stellar-xdr, soroban-env-*

### Why
To get a release of the stellar-rpc-client using a newer stellar-xdr for use in the stellar-cli.