### PR TITLE
Use `TransactionInfo` within `GetTransactionResponse`

### DIFF
--- a/cmd/soroban-rpc/internal/methods/get_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/get_transaction.go
@@ -29,8 +29,6 @@ const (
 
 // GetTransactionResponse is the response for the Soroban-RPC getTransaction() endpoint
 type GetTransactionResponse struct {
-	// Status is one of: TransactionSuccess, TransactionNotFound, or TransactionFailed.
-	Status string `json:"status"`
 	// LatestLedger is the latest ledger stored in Soroban-RPC.
 	LatestLedger uint32 `json:"latestLedger"`
 	// LatestLedgerCloseTime is the unix timestamp of when the latest ledger was closed.
@@ -41,27 +39,7 @@ type GetTransactionResponse struct {
 	OldestLedgerCloseTime int64 `json:"oldestLedgerCloseTime,string"`
 
 	// The fields below are only present if Status is not TransactionNotFound.
-
-	// ApplicationOrder is the index of the transaction among all the transactions
-	// for that ledger.
-	ApplicationOrder int32 `json:"applicationOrder,omitempty"`
-	// FeeBump indicates whether the transaction is a feebump transaction
-	FeeBump bool `json:"feeBump,omitempty"`
-	// EnvelopeXdr is the TransactionEnvelope XDR value.
-	EnvelopeXdr string `json:"envelopeXdr,omitempty"`
-	// ResultXdr is the TransactionResult XDR value.
-	ResultXdr string `json:"resultXdr,omitempty"`
-	// ResultMetaXdr is the TransactionMeta XDR value.
-	ResultMetaXdr string `json:"resultMetaXdr,omitempty"`
-
-	// Ledger is the sequence of the ledger which included the transaction.
-	Ledger uint32 `json:"ledger,omitempty"`
-	// LedgerCloseTime is the unix timestamp of when the transaction was included in the ledger.
-	LedgerCloseTime int64 `json:"createdAt,string,omitempty"`
-
-	// DiagnosticEventsXDR is present only if Status is equal to TransactionFailed.
-	// DiagnosticEventsXDR is a base64-encoded slice of xdr.DiagnosticEvent
-	DiagnosticEventsXDR []string `json:"diagnosticEventsXdr,omitempty"`
+	TransactionInfo
 }
 
 type GetTransactionRequest struct {

--- a/cmd/soroban-rpc/internal/methods/get_transaction_test.go
+++ b/cmd/soroban-rpc/internal/methods/get_transaction_test.go
@@ -33,7 +33,10 @@ func TestGetTransaction(t *testing.T) {
 	hash := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	tx, err := GetTransaction(ctx, log, store, ledgerReader, GetTransactionRequest{hash})
 	require.NoError(t, err)
-	require.Equal(t, GetTransactionResponse{Status: TransactionStatusNotFound}, tx)
+	require.Equal(t, GetTransactionResponse{
+		TransactionInfo: TransactionInfo{
+			Status: TransactionStatusNotFound,
+		}}, tx)
 
 	meta := txMeta(1, true)
 	require.NoError(t, store.InsertTransactions(meta))
@@ -50,19 +53,21 @@ func TestGetTransaction(t *testing.T) {
 	expectedTxMeta, err := xdr.MarshalBase64(meta.V1.TxProcessing[0].TxApplyProcessing)
 	require.NoError(t, err)
 	require.Equal(t, GetTransactionResponse{
-		Status:                TransactionStatusSuccess,
 		LatestLedger:          101,
 		LatestLedgerCloseTime: 2625,
 		OldestLedger:          101,
 		OldestLedgerCloseTime: 2625,
-		ApplicationOrder:      1,
-		FeeBump:               false,
-		EnvelopeXdr:           expectedEnvelope,
-		ResultXdr:             expectedTxResult,
-		ResultMetaXdr:         expectedTxMeta,
-		Ledger:                101,
-		LedgerCloseTime:       2625,
-		DiagnosticEventsXDR:   []string{},
+		TransactionInfo: TransactionInfo{
+			Status:              TransactionStatusSuccess,
+			ApplicationOrder:    1,
+			FeeBump:             false,
+			EnvelopeXdr:         expectedEnvelope,
+			ResultXdr:           expectedTxResult,
+			ResultMetaXdr:       expectedTxMeta,
+			Ledger:              101,
+			LedgerCloseTime:     2625,
+			DiagnosticEventsXDR: []string{},
+		},
 	}, tx)
 
 	// ingest another (failed) transaction
@@ -73,19 +78,21 @@ func TestGetTransaction(t *testing.T) {
 	tx, err = GetTransaction(ctx, log, store, ledgerReader, GetTransactionRequest{hash})
 	require.NoError(t, err)
 	require.Equal(t, GetTransactionResponse{
-		Status:                TransactionStatusSuccess,
 		LatestLedger:          102,
 		LatestLedgerCloseTime: 2650,
 		OldestLedger:          101,
 		OldestLedgerCloseTime: 2625,
-		ApplicationOrder:      1,
-		FeeBump:               false,
-		EnvelopeXdr:           expectedEnvelope,
-		ResultXdr:             expectedTxResult,
-		ResultMetaXdr:         expectedTxMeta,
-		Ledger:                101,
-		LedgerCloseTime:       2625,
-		DiagnosticEventsXDR:   []string{},
+		TransactionInfo: TransactionInfo{
+			Status:              TransactionStatusSuccess,
+			ApplicationOrder:    1,
+			FeeBump:             false,
+			EnvelopeXdr:         expectedEnvelope,
+			ResultXdr:           expectedTxResult,
+			ResultMetaXdr:       expectedTxMeta,
+			Ledger:              101,
+			LedgerCloseTime:     2625,
+			DiagnosticEventsXDR: []string{},
+		},
 	}, tx)
 
 	// the new transaction should also be there
@@ -102,19 +109,21 @@ func TestGetTransaction(t *testing.T) {
 	tx, err = GetTransaction(ctx, log, store, ledgerReader, GetTransactionRequest{hash})
 	require.NoError(t, err)
 	require.Equal(t, GetTransactionResponse{
-		Status:                TransactionStatusFailed,
 		LatestLedger:          102,
 		LatestLedgerCloseTime: 2650,
 		OldestLedger:          101,
 		OldestLedgerCloseTime: 2625,
-		ApplicationOrder:      1,
-		FeeBump:               false,
-		EnvelopeXdr:           expectedEnvelope,
-		ResultXdr:             expectedTxResult,
-		ResultMetaXdr:         expectedTxMeta,
-		Ledger:                102,
-		LedgerCloseTime:       2650,
-		DiagnosticEventsXDR:   []string{},
+		TransactionInfo: TransactionInfo{
+			Status:              TransactionStatusFailed,
+			ApplicationOrder:    1,
+			FeeBump:             false,
+			EnvelopeXdr:         expectedEnvelope,
+			ResultXdr:           expectedTxResult,
+			ResultMetaXdr:       expectedTxMeta,
+			Ledger:              102,
+			LedgerCloseTime:     2650,
+			DiagnosticEventsXDR: []string{},
+		},
 	}, tx)
 
 	// Test Txn with events
@@ -139,19 +148,21 @@ func TestGetTransaction(t *testing.T) {
 	tx, err = GetTransaction(ctx, log, store, ledgerReader, GetTransactionRequest{hash})
 	require.NoError(t, err)
 	require.Equal(t, GetTransactionResponse{
-		Status:                TransactionStatusSuccess,
+		TransactionInfo: TransactionInfo{
+			Status:              TransactionStatusSuccess,
+			ApplicationOrder:    1,
+			FeeBump:             false,
+			EnvelopeXdr:         expectedEnvelope,
+			ResultXdr:           expectedTxResult,
+			ResultMetaXdr:       expectedTxMeta,
+			Ledger:              103,
+			LedgerCloseTime:     2675,
+			DiagnosticEventsXDR: []string{expectedEventsMeta},
+		},
 		LatestLedger:          103,
 		LatestLedgerCloseTime: 2675,
 		OldestLedger:          101,
 		OldestLedgerCloseTime: 2625,
-		ApplicationOrder:      1,
-		FeeBump:               false,
-		EnvelopeXdr:           expectedEnvelope,
-		ResultXdr:             expectedTxResult,
-		ResultMetaXdr:         expectedTxMeta,
-		Ledger:                103,
-		LedgerCloseTime:       2675,
-		DiagnosticEventsXDR:   []string{expectedEventsMeta},
 	}, tx)
 }
 

--- a/cmd/soroban-rpc/internal/methods/get_transaction_test.go
+++ b/cmd/soroban-rpc/internal/methods/get_transaction_test.go
@@ -36,7 +36,8 @@ func TestGetTransaction(t *testing.T) {
 	require.Equal(t, GetTransactionResponse{
 		TransactionInfo: TransactionInfo{
 			Status: TransactionStatusNotFound,
-		}}, tx)
+		},
+	}, tx)
 
 	meta := txMeta(1, true)
 	require.NoError(t, store.InsertTransactions(meta))

--- a/cmd/soroban-rpc/internal/methods/get_transactions.go
+++ b/cmd/soroban-rpc/internal/methods/get_transactions.go
@@ -72,7 +72,7 @@ type TransactionInfo struct {
 	// Ledger is the sequence of the ledger which included the transaction.
 	Ledger uint32 `json:"ledger"`
 	// LedgerCloseTime is the unix timestamp of when the transaction was included in the ledger.
-	LedgerCloseTime int64 `json:"createdAt"`
+	LedgerCloseTime int64 `json:"createdAt,string"`
 }
 
 // GetTransactionsResponse encapsulates the response structure for getTransactions queries.


### PR DESCRIPTION
**WARNING**: This is a breaking API change; see _Known limitations_, below.

### What
Use `TransactionInfo` (from the `getTransactions()` handler) as part of the `getTransaction()` handler.

### Why
One is a subset of the other, and this makes it easier for both the code and documentation to reflect that.

It also guarantees that the endpoints don't diverge in the future.

This is partially related to #124, where I realized I was duplicating work by parsing out the transaction fields separately for each endpoint: this would make the work more streamlined.

### Known limitations
According to the [CI integration test runs](https://github.com/stellar/soroban-rpc/actions/runs/9967582043/job/27541488475?pr=251), this breaks `getTransaction`'s integration tests because `createdAt` is encoded as an `int64` rather than a `string` in the schema for `getTransactions`. We need to change this for JavaScript which is a breaking API change.