### PR TITLE
Fix --log-format parsing

### DIFF
--- a/cmd/soroban-rpc/internal/config/options.go
+++ b/cmd/soroban-rpc/internal/config/options.go
@@ -121,11 +121,9 @@ func (cfg *Config) options() Options {
 				case nil:
 					return nil
 				case string:
-					return fmt.Errorf(
-						"could not parse %s: %w",
-						option.Name,
-						cfg.LogFormat.UnmarshalText([]byte(v)),
-					)
+					if err := cfg.LogFormat.UnmarshalText([]byte(v)); err != nil {
+						return fmt.Errorf("could not parse %s: %w", option.Name, err)
+					}
 				case LogFormat:
 					cfg.LogFormat = v
 				case *LogFormat:


### PR DESCRIPTION
I broke it at https://github.com/stellar/soroban-rpc/pull/228

It turns out that `github.com/stellar/go/support/errors.Wrapf` returns nil if the error is nil (which is different to how `errors.Errorf` behaves).

I have looked at both https://github.com/stellar/soroban-rpc/pull/228 and https://github.com/stellar/soroban-rpc/pull/224 and this is the only instance in which we replaced `Wrapf` by `Errorf` where we don't first check the error for `nil`.
