### PR TITLE
Add CI concurrency group for some workflows

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main, release/** ]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_protected == 'true' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main, release/** ]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_protected == 'true' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   integration:
     name: System tests

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -4,6 +4,10 @@ on:
     branches: [ main, release/** ]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_protected == 'true' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   # Optional: allow read access to pull request. Use with `only-new-issues` option.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main, release/** ]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_protected == 'true' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/soroban-rpc.yml
+++ b/.github/workflows/soroban-rpc.yml
@@ -9,6 +9,10 @@ on:
     branches: [ main, release/** ]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_protected == 'true' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Unit tests


### PR DESCRIPTION
### What

Add CI concurrency group limiting to one build per branch, canceling any older runs.

### Why

See discussion [here](https://stellarfoundation.slack.com/archives/C02B04RMK/p1721777179370309). Goal is to reduce cost and limit CI resource usage. This change will make it so that CI runs are canceled when new commits are pushed, except on protected branches (ex. `main`) 

Note that the only workflow that is actually costing us money is `e2e`. Since this repo is public, all workflows that run on standard github runners (which is everything else) are free. So if for some reason we still want/like the runs for the other workflows to keep going when new commits are pushed, we could eliminate the changes there and just keep the `e2e` workflow changes. 
