### PR TITLE
Add events table migration

### DIFF
--- a/cmd/soroban-rpc/internal/daemon/daemon.go
+++ b/cmd/soroban-rpc/internal/daemon/daemon.go
@@ -39,6 +39,7 @@ const (
 	defaultReadTimeout                    = 5 * time.Second
 	defaultShutdownGracePeriod            = 10 * time.Second
 	inMemoryInitializationLedgerLogPeriod = 1_000_000
+	firstLedger                           = 2
 )
 
 type Daemon struct {
@@ -310,7 +311,7 @@ func (d *Daemon) mustInitializeStorage(cfg *config.Config) *feewindow.FeeWindows
 		d.logger.WithError(err).Fatal("failed to get latest ledger sequence: %w", err)
 	}
 	maxFeeRetentionWindow := max(cfg.ClassicFeeStatsLedgerRetentionWindow, cfg.SorobanFeeStatsLedgerRetentionWindow)
-	ledgerSeqRange := &db.LedgerSeqRange{FirstLedgerSeq: 2, LastLedgerSeq: latestLedger}
+	ledgerSeqRange := &db.LedgerSeqRange{FirstLedgerSeq: firstLedger, LastLedgerSeq: latestLedger}
 	if latestLedger > maxFeeRetentionWindow {
 		ledgerSeqRange.FirstLedgerSeq = latestLedger - maxFeeRetentionWindow
 	}

--- a/cmd/soroban-rpc/internal/daemon/daemon.go
+++ b/cmd/soroban-rpc/internal/daemon/daemon.go
@@ -321,7 +321,7 @@ func (d *Daemon) mustInitializeStorage(cfg *config.Config) *feewindow.FeeWindows
 	defer func() {
 		err = d.db.Commit()
 		if err != nil {
-			d.logger.WithError(err).Fatal("could not commit database transaction")
+			d.logger.WithError(err).Fatal("could not commit database transaction: ", d.db.Rollback())
 		}
 	}()
 

--- a/cmd/soroban-rpc/internal/daemon/daemon.go
+++ b/cmd/soroban-rpc/internal/daemon/daemon.go
@@ -315,6 +315,8 @@ func (d *Daemon) mustInitializeStorage(cfg *config.Config) *feewindow.FeeWindows
 	if latestLedger > maxFeeRetentionWindow {
 		ledgerSeqRange.FirstLedgerSeq = latestLedger - maxFeeRetentionWindow
 	}
+
+	// Combine the ledger range for fees, events and transactions
 	ledgerSeqRange = ledgerSeqRange.Merge(applicableRange)
 
 	// Apply migration for fee stats in-memory store

--- a/cmd/soroban-rpc/internal/daemon/daemon.go
+++ b/cmd/soroban-rpc/internal/daemon/daemon.go
@@ -346,53 +346,58 @@ func (d *Daemon) mustInitializeStorage(cfg *config.Config) *feewindow.FeeWindows
 		d.logger.WithError(err).Fatal("could not obtain txmeta cache from the database")
 	}
 
+	err = d.db.Begin(readTxMetaCtx)
+	if err != nil {
+		d.logger.WithError(err).Fatal("could not begin db transaction")
+	}
+	defer func() {
+		commitErr := d.db.Commit()
+		if commitErr != nil {
+			d.logger.WithError(commitErr).Fatal("could not commit migrations")
+		}
+	}()
+
 	dataMigrations, err := db.BuildMigrations(readTxMetaCtx, d.logger, d.db, cfg.NetworkPassphrase, ledgerSeqRange)
 	if err != nil {
 		d.logger.WithError(err).Fatal("could not build migrations")
 	}
 
 	// Apply migration for events and transactions tables
-	for _, migrationFactory := range dataMigrations {
-		guardedMigration, err := db.NewGuardedDataMigration(
-			readTxMetaCtx,
-			migrationFactory.MigrationName,
-			migrationFactory.Logger,
-			migrationFactory.Factory,
-			migrationFactory.DB,
-		)
-		if err != nil {
-			d.logger.WithError(err).Fatal("could not create guarded migration for: ",
-				migrationFactory.MigrationName)
-		}
-
-		err = db.NewLedgerReader(d.db).StreamLedgerRange(
-			readTxMetaCtx,
-			ledgerSeqRange.FirstLedgerSeq,
-			ledgerSeqRange.LastLedgerSeq,
-			func(txMeta xdr.LedgerCloseMeta) error {
-				currentSeq = txMeta.LedgerSequence()
-				if err := guardedMigration.Apply(readTxMetaCtx, txMeta); err != nil {
-					d.logger.WithError(err).Fatal("could not apply migration for ledger: ",
-						currentSeq, " and table: ", migrationFactory.MigrationName)
-				}
-				return nil
-			})
-		if err != nil {
-			d.logger.WithError(err).Fatal("could not obtain txmeta cache from the database for: ",
-				migrationFactory.MigrationName)
-		}
-		if err = guardedMigration.Commit(readTxMetaCtx); err != nil {
-			d.logger.WithError(err).Fatal("could not commit migration for: ", migrationFactory.MigrationName)
-		}
-	}
-
-	if currentSeq != 0 {
-		d.logger.WithFields(supportlog.F{
-			"seq": currentSeq,
-		}).Info("finished initializing in-memory store and applying DB data migrations")
-	}
-
-	return feeWindows
+	//guardedMigration, err := db.NewGuardedDataMigration(
+	//	readTxMetaCtx,
+	//	migrationFactory.MigrationName,
+	//	migrationFactory.Logger,
+	//	migrationFactory.Factory,
+	//	migrationFactory.DB,
+	//)
+	//if err != nil {
+	//	d.logger.WithError(err).Fatal("could not create guarded migration for: ",
+	//		migrationFactory.MigrationName)
+	//}
+	//
+	//err = db.NewLedgerReader(d.db).StreamLedgerRange(
+	//	readTxMetaCtx,
+	//	ledgerSeqRange.FirstLedgerSeq,
+	//	ledgerSeqRange.LastLedgerSeq,
+	//	func(txMeta xdr.LedgerCloseMeta) error {
+	//		currentSeq = txMeta.LedgerSequence()
+	//		if err := guardedMigration.Apply(readTxMetaCtx, txMeta); err != nil {
+	//			d.logger.WithError(err).Fatal("could not apply migration for ledger: ",
+	//				currentSeq, " and table: ", migrationFactory.MigrationName)
+	//		}
+	//		return nil
+	//	})
+	//if err != nil {
+	//	d.logger.WithError(err).Fatal("could not obtain txmeta cache from the database")
+	//}
+	//
+	//if currentSeq != 0 {
+	//	d.logger.WithFields(supportlog.F{
+	//		"seq": currentSeq,
+	//	}).Info("finished initializing in-memory store and applying DB data migrations")
+	//}
+	//
+	//return feeWindows
 }
 
 func (d *Daemon) Run() {

--- a/cmd/soroban-rpc/internal/daemon/daemon.go
+++ b/cmd/soroban-rpc/internal/daemon/daemon.go
@@ -332,7 +332,7 @@ func (d *Daemon) mustInitializeStorage(cfg *config.Config) *feewindow.FeeWindows
 			migrationFactory.DB,
 		)
 		if err != nil {
-			d.logger.WithError(err).Fatal("could not create guarded migration for: %s",
+			d.logger.WithError(err).Fatal("could not create guarded migration for: %w",
 				migrationFactory.MigrationName)
 		}
 
@@ -368,7 +368,7 @@ func (d *Daemon) mustInitializeStorage(cfg *config.Config) *feewindow.FeeWindows
 			d.logger.WithError(err).Fatal("could not obtain txmeta cache from the database")
 		}
 		if err := guardedMigration.Commit(readTxMetaCtx); err != nil {
-			d.logger.WithError(err).Fatal("could not commit migration for: %s",
+			d.logger.WithError(err).Fatal("could not commit migration for: %w",
 				migrationFactory.MigrationName)
 		}
 	}

--- a/cmd/soroban-rpc/internal/daemon/daemon.go
+++ b/cmd/soroban-rpc/internal/daemon/daemon.go
@@ -39,7 +39,6 @@ const (
 	defaultReadTimeout                    = 5 * time.Second
 	defaultShutdownGracePeriod            = 10 * time.Second
 	inMemoryInitializationLedgerLogPeriod = 1_000_000
-	firstLedger                           = 2
 )
 
 type Daemon struct {

--- a/cmd/soroban-rpc/internal/db/event.go
+++ b/cmd/soroban-rpc/internal/db/event.go
@@ -319,6 +319,7 @@ func (e *eventTableMigration) Apply(_ context.Context, meta xdr.LedgerCloseMeta)
 }
 
 func newEventTableMigration(
+	_ context.Context,
 	logger *log.Entry,
 	passphrase string,
 	ledgerSeqRange *LedgerSeqRange,

--- a/cmd/soroban-rpc/internal/db/event.go
+++ b/cmd/soroban-rpc/internal/db/event.go
@@ -245,24 +245,20 @@ func (e *eventTableMigration) Apply(_ context.Context, meta xdr.LedgerCloseMeta)
 
 func newEventTableMigration(
 	logger *log.Entry,
-	retentionWindow uint32,
 	passphrase string,
+	ledgerSeqRange *LedgerSeqRange,
 ) migrationApplierFactory {
 	return migrationApplierFactoryF(func(db *DB, latestLedger uint32) (MigrationApplier, error) {
-		firstLedgerToMigrate := firstLedger
 		writer := &eventHandler{
 			log:        logger,
 			db:         db,
 			stmtCache:  sq.NewStmtCache(db.GetTx()),
 			passphrase: passphrase,
 		}
-		if latestLedger > retentionWindow {
-			firstLedgerToMigrate = latestLedger - retentionWindow
-		}
 
 		migration := eventTableMigration{
-			firstLedger: firstLedgerToMigrate,
-			lastLedger:  latestLedger,
+			firstLedger: ledgerSeqRange.FirstLedgerSeq,
+			lastLedger:  ledgerSeqRange.LastLedgerSeq,
 			writer:      writer,
 		}
 		return &migration, nil

--- a/cmd/soroban-rpc/internal/db/event.go
+++ b/cmd/soroban-rpc/internal/db/event.go
@@ -324,18 +324,16 @@ func newEventTableMigration(
 	passphrase string,
 	ledgerSeqRange *LedgerSeqRange,
 ) migrationApplierFactory {
-	return migrationApplierFactoryF(func(db *DB, latestLedger uint32) (MigrationApplier, error) {
-		writer := &eventHandler{
-			log:        logger,
-			db:         db,
-			stmtCache:  sq.NewStmtCache(db.GetTx()),
-			passphrase: passphrase,
-		}
-
+	return migrationApplierFactoryF(func(db *DB) (MigrationApplier, error) {
 		migration := eventTableMigration{
 			firstLedger: ledgerSeqRange.FirstLedgerSeq,
 			lastLedger:  ledgerSeqRange.LastLedgerSeq,
-			writer:      writer,
+			writer: &eventHandler{
+				log:        logger,
+				db:         db,
+				stmtCache:  sq.NewStmtCache(db.GetTx()),
+				passphrase: passphrase,
+			},
 		}
 		return &migration, nil
 	})

--- a/cmd/soroban-rpc/internal/db/migration.go
+++ b/cmd/soroban-rpc/internal/db/migration.go
@@ -204,7 +204,7 @@ func BuildMigrations(ctx context.Context, logger *log.Entry, db *DB, cfg *config
 
 	m1, err := newGuardedDataMigration(ctx, migrationName, logger, factory, db)
 	if err != nil {
-		return nil, fmt.Errorf("creating guarded transaction migration: %w", err)
+		return nil, fmt.Errorf("could not create guarded transaction migration: %w", err)
 	}
 	migrations = append(migrations, m1)
 
@@ -216,7 +216,7 @@ func BuildMigrations(ctx context.Context, logger *log.Entry, db *DB, cfg *config
 	)
 	m2, err := newGuardedDataMigration(ctx, eventMigrationName, logger, eventFactory, db)
 	if err != nil {
-		return nil, fmt.Errorf("creating guarded transaction migration: %w", err)
+		return nil, fmt.Errorf("could not create guarded event migration: %w", err)
 	}
 	migrations = append(migrations, m2)
 

--- a/cmd/soroban-rpc/internal/db/migration.go
+++ b/cmd/soroban-rpc/internal/db/migration.go
@@ -170,7 +170,9 @@ func GetMigrationLedgerRange(ctx context.Context, db *DB, retentionWindow uint32
 	}, nil
 }
 
-func BuildMigrations(ctx context.Context, logger *log.Entry, db *DB, networkPassphrase string, ledgerSeqRange *LedgerSeqRange) ([]MigrationFactory, error) {
+func BuildMigrations(ctx context.Context, logger *log.Entry, db *DB, networkPassphrase string,
+	ledgerSeqRange *LedgerSeqRange,
+) ([]MigrationFactory, error) {
 	var migrations []MigrationFactory
 
 	transactionFactory := newTransactionTableMigration(

--- a/cmd/soroban-rpc/internal/db/migration.go
+++ b/cmd/soroban-rpc/internal/db/migration.go
@@ -50,13 +50,13 @@ type MigrationApplier interface {
 	Apply(ctx context.Context, meta xdr.LedgerCloseMeta) error
 }
 
+type migrationApplierF func(context.Context, *log.Entry, string, *LedgerSeqRange) migrationApplierFactory
+
 type migrationApplierFactory interface {
 	New(db *DB) (MigrationApplier, error)
 }
 
 type migrationApplierFactoryF func(db *DB) (MigrationApplier, error)
-
-type migrationApplierF func(context.Context, *log.Entry, string, *LedgerSeqRange) migrationApplierFactory
 
 func (m migrationApplierFactoryF) New(db *DB) (MigrationApplier, error) {
 	return m(db)

--- a/cmd/soroban-rpc/internal/db/migration.go
+++ b/cmd/soroban-rpc/internal/db/migration.go
@@ -12,6 +12,7 @@ import (
 const (
 	transactionsMigrationName = "TransactionsTable"
 	eventsMigrationName       = "EventsTable"
+	numMigrations             = 2
 )
 
 type LedgerSeqRange struct {
@@ -197,7 +198,7 @@ func GetMigrationLedgerRange(ctx context.Context, db *DB, retentionWindow uint32
 func BuildMigrations(ctx context.Context, logger *log.Entry, db *DB, networkPassphrase string,
 	ledgerSeqRange *LedgerSeqRange,
 ) (MultiMigration, error) {
-	migrations := make(MultiMigration, 0, 2)
+	migrations := make(MultiMigration, 0, numMigrations)
 
 	migrationNameToFunc := map[string]migrationApplierF{
 		transactionsMigrationName: newTransactionTableMigration,

--- a/cmd/soroban-rpc/internal/db/migration.go
+++ b/cmd/soroban-rpc/internal/db/migration.go
@@ -137,8 +137,9 @@ func (g *guardedMigration) ApplicableRange() *LedgerSeqRange {
 
 func (g *guardedMigration) Commit(ctx context.Context) error {
 	if g.alreadyMigrated {
-		return nil
+		return g.Rollback(ctx)
 	}
+
 	err := setMetaBool(ctx, g.db, g.guardMetaKey, true)
 	if err != nil {
 		return errors.Join(err, g.Rollback(ctx))

--- a/cmd/soroban-rpc/internal/db/migration.go
+++ b/cmd/soroban-rpc/internal/db/migration.go
@@ -12,7 +12,6 @@ import (
 const (
 	transactionsMigrationName = "TransactionsTable"
 	eventsMigrationName       = "EventsTable"
-	numMigrations             = 2
 )
 
 type LedgerSeqRange struct {
@@ -181,12 +180,12 @@ func GetMigrationLedgerRange(ctx context.Context, db *DB, retentionWindow uint32
 func BuildMigrations(ctx context.Context, logger *log.Entry, db *DB, networkPassphrase string,
 	ledgerSeqRange *LedgerSeqRange,
 ) (MultiMigration, error) {
-	migrations := make(MultiMigration, 0, numMigrations)
-
 	migrationNameToFunc := map[string]migrationApplierF{
 		transactionsMigrationName: newTransactionTableMigration,
 		eventsMigrationName:       newEventTableMigration,
 	}
+
+	migrations := make(MultiMigration, 0, len(migrationNameToFunc))
 
 	for migrationName, migrationFunc := range migrationNameToFunc {
 		migrationLogger := logger.WithField("migration", migrationName)

--- a/cmd/soroban-rpc/internal/ingest/service_test.go
+++ b/cmd/soroban-rpc/internal/ingest/service_test.go
@@ -67,7 +67,7 @@ func TestIngestion(t *testing.T) {
 	config := Config{
 		Logger:            supportlog.New(),
 		DB:                mockDB,
-		FeeWindows:        feewindow.NewFeeWindows(1, 1, network.TestNetworkPassphrase),
+		FeeWindows:        feewindow.NewFeeWindows(1, 1, network.TestNetworkPassphrase, nil),
 		LedgerBackend:     mockLedgerBackend,
 		Daemon:            daemon,
 		NetworkPassPhrase: network.TestNetworkPassphrase,


### PR DESCRIPTION
### What

Closes #257 

- Add migration for events table.
- Move db transaction logic for migration out of `guardedMigration`.

### Why

- We are moving events from in-memory to db, hence the migration support.
- Sqlite DB cannot handle two concurrent db transactions, so we need to have a common transaction for both migrations instead of individual ones. Having per migration db tx leads to `database is locked` error.

### Known limitations

NA
