### PR TITLE
Improve startup by eliminating unnecessary migration ranges

### DIFF
--- a/cmd/soroban-rpc/internal/db/event.go
+++ b/cmd/soroban-rpc/internal/db/event.go
@@ -311,8 +311,8 @@ type eventTableMigration struct {
 	writer      EventWriter
 }
 
-func (e *eventTableMigration) ApplicableRange() *LedgerSeqRange {
-	return &LedgerSeqRange{
+func (e *eventTableMigration) ApplicableRange() LedgerSeqRange {
+	return LedgerSeqRange{
 		First: e.firstLedger,
 		Last:  e.lastLedger,
 	}
@@ -326,7 +326,7 @@ func newEventTableMigration(
 	_ context.Context,
 	logger *log.Entry,
 	passphrase string,
-	ledgerSeqRange *LedgerSeqRange,
+	ledgerSeqRange LedgerSeqRange,
 ) migrationApplierFactory {
 	return migrationApplierFactoryF(func(db *DB) (MigrationApplier, error) {
 		migration := eventTableMigration{

--- a/cmd/soroban-rpc/internal/db/migration.go
+++ b/cmd/soroban-rpc/internal/db/migration.go
@@ -137,7 +137,7 @@ func newGuardedDataMigration(
 		return nil, err
 	}
 	if previouslyMigrated {
-		//nolint:nilnil A sentinel value here would be stupid
+		//nolint:nilnil // a sentinel value here would be stupid
 		return nil, nil
 	}
 	applier, err := factory.New(db)
@@ -212,7 +212,7 @@ func BuildMigrations(
 	//
 	// Add new migrations here:
 	//
-	var currentMigrations = map[string]migrationApplierF{
+	currentMigrations := map[string]migrationApplierF{
 		transactionsMigrationName: newTransactionTableMigration,
 		eventsMigrationName:       newEventTableMigration,
 	}

--- a/cmd/soroban-rpc/internal/db/migration.go
+++ b/cmd/soroban-rpc/internal/db/migration.go
@@ -205,18 +205,14 @@ func BuildMigrations(
 	}
 
 	//
-	// Add new migrations here:
+	// Add new DB migrations here:
 	//
 	currentMigrations := map[string]migrationApplierF{
 		transactionsMigrationName: newTransactionTableMigration,
 		eventsMigrationName:       newEventTableMigration,
 	}
 
-	mm := MultiMigration{
-		migrations: make([]Migration, 0, len(currentMigrations)),
-		db:         db,
-	}
-
+	migrations := make([]Migration, 0, len(currentMigrations))
 	for migrationName, migrationFunc := range currentMigrations {
 		migrationLogger := logger.WithField("migration", migrationName)
 		factory := migrationFunc(
@@ -237,8 +233,11 @@ func BuildMigrations(
 			continue
 		}
 
-		mm.Append(guardedM)
+		migrations = append(migrations, guardedM)
 	}
 
-	return mm, nil
+	return MultiMigration{
+		migrations: migrations,
+		db:         db,
+	}, nil
 }

--- a/cmd/soroban-rpc/internal/db/migration.go
+++ b/cmd/soroban-rpc/internal/db/migration.go
@@ -14,12 +14,6 @@ const (
 	eventsMigrationName       = "EventsTable"
 )
 
-// Add new migrations here:
-var CurrentMigrations = map[string]migrationApplierF{
-	transactionsMigrationName: newTransactionTableMigration,
-	eventsMigrationName:       newEventTableMigration,
-}
-
 type LedgerSeqRange struct {
 	First uint32
 	Last  uint32
@@ -143,6 +137,7 @@ func newGuardedDataMigration(
 		return nil, err
 	}
 	if previouslyMigrated {
+		//nolint:nilnil A sentinel value here would be stupid
 		return nil, nil
 	}
 	applier, err := factory.New(db)
@@ -214,8 +209,16 @@ func BuildMigrations(
 		return MultiMigration{}, applicableRange, errors.Join(err, db.Rollback())
 	}
 
-	migrations := make([]Migration, 0, len(CurrentMigrations))
-	for migrationName, migrationFunc := range CurrentMigrations {
+	//
+	// Add new migrations here:
+	//
+	var currentMigrations = map[string]migrationApplierF{
+		transactionsMigrationName: newTransactionTableMigration,
+		eventsMigrationName:       newEventTableMigration,
+	}
+
+	migrations := make([]Migration, 0, len(currentMigrations))
+	for migrationName, migrationFunc := range currentMigrations {
 		migrationLogger := logger.WithField("migration", migrationName)
 		factory := migrationFunc(
 			ctx,

--- a/cmd/soroban-rpc/internal/db/transaction.go
+++ b/cmd/soroban-rpc/internal/db/transaction.go
@@ -255,8 +255,8 @@ type transactionTableMigration struct {
 	writer      TransactionWriter
 }
 
-func (t *transactionTableMigration) ApplicableRange() *LedgerSeqRange {
-	return &LedgerSeqRange{
+func (t *transactionTableMigration) ApplicableRange() LedgerSeqRange {
+	return LedgerSeqRange{
 		First: t.firstLedger,
 		Last:  t.lastLedger,
 	}
@@ -270,7 +270,7 @@ func newTransactionTableMigration(
 	ctx context.Context,
 	logger *log.Entry,
 	passphrase string,
-	ledgerSeqRange *LedgerSeqRange,
+	ledgerSeqRange LedgerSeqRange,
 ) migrationApplierFactory {
 	return migrationApplierFactoryF(func(db *DB) (MigrationApplier, error) {
 		// Truncate the table, since it may contain data, causing insert conflicts later on.

--- a/cmd/soroban-rpc/internal/feewindow/feewindow.go
+++ b/cmd/soroban-rpc/internal/feewindow/feewindow.go
@@ -2,6 +2,7 @@
 package feewindow
 
 import (
+	"context"
 	"errors"
 	"io"
 	"slices"
@@ -194,3 +195,34 @@ func (fw *FeeWindows) IngestFees(meta xdr.LedgerCloseMeta) error {
 	}
 	return nil
 }
+
+func (fw *FeeWindows) AsMigration(seqRange db.LedgerSeqRange) db.Migration {
+	return &feeWindowMigration{
+		firstLedger: seqRange.First,
+		lastLedger:  seqRange.Last,
+		windows:     fw,
+	}
+}
+
+type feeWindowMigration struct {
+	firstLedger uint32
+	lastLedger  uint32
+	windows     *FeeWindows
+}
+
+func (fw *feeWindowMigration) ApplicableRange() db.LedgerSeqRange {
+	return db.LedgerSeqRange{
+		First: fw.firstLedger,
+		Last:  fw.lastLedger,
+	}
+}
+
+func (fw *feeWindowMigration) Apply(_ context.Context, meta xdr.LedgerCloseMeta) error {
+	return fw.windows.IngestFees(meta)
+}
+
+func (fw *feeWindowMigration) Commit(_ context.Context) error {
+	return nil // no-op
+}
+
+var _ db.Migration = &feeWindowMigration{}

--- a/cmd/soroban-rpc/internal/feewindow/feewindow.go
+++ b/cmd/soroban-rpc/internal/feewindow/feewindow.go
@@ -225,4 +225,5 @@ func (fw *feeWindowMigration) Commit(_ context.Context) error {
 	return nil // no-op
 }
 
+// ensure we conform to the migration interface
 var _ db.Migration = &feeWindowMigration{}

--- a/cmd/soroban-rpc/internal/feewindow/feewindow.go
+++ b/cmd/soroban-rpc/internal/feewindow/feewindow.go
@@ -133,9 +133,9 @@ type FeeWindows struct {
 	db                        *db.DB
 }
 
-func NewFeeWindows(classicRetention uint32, sorobanRetetion uint32, networkPassPhrase string, db *db.DB) *FeeWindows {
+func NewFeeWindows(classicRetention uint32, sorobanRetention uint32, networkPassPhrase string, db *db.DB) *FeeWindows {
 	return &FeeWindows{
-		SorobanInclusionFeeWindow: NewFeeWindow(sorobanRetetion),
+		SorobanInclusionFeeWindow: NewFeeWindow(sorobanRetention),
 		ClassicFeeWindow:          NewFeeWindow(classicRetention),
 		networkPassPhrase:         networkPassPhrase,
 		db:                        db,


### PR DESCRIPTION
### What
Speed up startup time in "already migrated" cases by eliminating unnecessary ledger range traversals.

Specifically, this includes the following changes:
 * Fee stats windows cannot exceed the history retention window, as this doesn't make sense.
 * Migrations that are already applied are not added to the list of "multi-migrations".
 * Fee stats window building conforms to the migration interface to simplify code.
 * `LedgerSeqRange` has been refactored to always use a value reference.

As a result, if all migrations have occurred, the traversal only occurs over the fee window.

This reduces startup times in a fully-loaded (24hr) database that needs no migrations **from ~1m40s to ~1s**.

### Why
Previously, startup would take a significant amount of time doing nothing because it would loop over a large ledger range and check whether or not a migration was necessary for that ledger. If migrations were already done, it would move on to the next ledger.

In this version, we instead appropriately calculate the ledger range to traverse by only expanding the ledger range if a migration has *not* already completed.

### Known limitations
n/a, tested at length locally