### PR TITLE
Fix lint error in /methods and remove usage of internal error package

### DIFF
--- a/cmd/soroban-rpc/internal/integrationtest/metrics_test.go
+++ b/cmd/soroban-rpc/internal/integrationtest/metrics_test.go
@@ -2,13 +2,13 @@ package integrationtest
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"net/http"
 	"net/url"
 	"runtime"
 	"testing"
 
+	"github.com/pkg/errors"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/cmd/soroban-rpc/internal/integrationtest/metrics_test.go
+++ b/cmd/soroban-rpc/internal/integrationtest/metrics_test.go
@@ -2,6 +2,7 @@ package integrationtest
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"io"
 	"net/http"
 	"net/url"
@@ -11,8 +12,6 @@ import (
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/stellar/go/support/errors"
 
 	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/config"
 	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/integrationtest/infrastructure"

--- a/cmd/soroban-rpc/internal/methods/get_events.go
+++ b/cmd/soroban-rpc/internal/methods/get_events.go
@@ -8,10 +8,10 @@ import (
 	"time"
 
 	"github.com/creachadair/jrpc2"
+	"github.com/pkg/errors"
 
 	"github.com/stellar/go/strkey"
 	"github.com/stellar/go/support/collections/set"
-	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
 

--- a/cmd/soroban-rpc/internal/methods/get_events.go
+++ b/cmd/soroban-rpc/internal/methods/get_events.go
@@ -600,7 +600,5 @@ func NewGetEventsHandler(
 		logger:       logger,
 		ledgerReader: ledgerReader,
 	}
-	return NewHandler(func(ctx context.Context, request GetEventsRequest) (GetEventsResponse, error) {
-		return eventsHandler.getEvents(ctx, request)
-	})
+	return NewHandler(eventsHandler.getEvents)
 }

--- a/cmd/soroban-rpc/internal/methods/get_events.go
+++ b/cmd/soroban-rpc/internal/methods/get_events.go
@@ -119,7 +119,7 @@ func (g *GetEventsRequest) Valid(maxLimit uint) error {
 	// Validate the paging limit (if it exists)
 	if g.Pagination != nil && g.Pagination.Cursor != nil {
 		if g.StartLedger != 0 || g.EndLedger != 0 {
-			return errors.New("ledger ranges and cursor cannot both be set") //nolint:forbidigo
+			return errors.New("ledger ranges and cursor cannot both be set")
 		}
 	} else if g.StartLedger <= 0 {
 		return errors.New("startLedger must be positive")

--- a/cmd/soroban-rpc/internal/methods/get_events.go
+++ b/cmd/soroban-rpc/internal/methods/get_events.go
@@ -80,7 +80,7 @@ func (e eventTypeSet) matches(event xdr.ContractEvent) bool {
 	if len(e) == 0 {
 		return true
 	}
-	_, ok := e[eventTypeFromXDR[event.Type]]
+	_, ok := e[getEventTypeFromEventTypeXDR()[event.Type]]
 	return ok
 }
 
@@ -160,10 +160,12 @@ const (
 	EventTypeDiagnostic = "diagnostic"
 )
 
-var eventTypeFromXDR = map[xdr.ContractEventType]string{
-	xdr.ContractEventTypeSystem:     EventTypeSystem,
-	xdr.ContractEventTypeContract:   EventTypeContract,
-	xdr.ContractEventTypeDiagnostic: EventTypeDiagnostic,
+func getEventTypeFromEventTypeXDR() map[xdr.ContractEventType]string {
+	return map[xdr.ContractEventType]string{
+		xdr.ContractEventTypeSystem:     EventTypeSystem,
+		xdr.ContractEventTypeContract:   EventTypeContract,
+		xdr.ContractEventTypeDiagnostic: EventTypeDiagnostic,
+	}
 }
 
 func getEventTypeXDRFromEventType() map[string]xdr.ContractEventType {
@@ -523,7 +525,7 @@ func eventInfoForEvent(
 		return EventInfo{}, errors.New("unknown event version")
 	}
 
-	eventType, ok := eventTypeFromXDR[event.Event.Type]
+	eventType, ok := getEventTypeFromEventTypeXDR()[event.Event.Type]
 	if !ok {
 		return EventInfo{}, fmt.Errorf("unknown XDR ContractEventType type: %d", event.Event.Type)
 	}

--- a/cmd/soroban-rpc/internal/methods/get_ledger_entry.go
+++ b/cmd/soroban-rpc/internal/methods/get_ledger_entry.go
@@ -14,14 +14,14 @@ import (
 	"github.com/stellar/soroban-rpc/cmd/soroban-rpc/internal/xdr2json"
 )
 
-// Deprecated. Use GetLedgerEntriesRequest instead.
+// GetLedgerEntryRequest Deprecated: Use GetLedgerEntriesRequest instead.
 // TODO(https://github.com/stellar/soroban-tools/issues/374) remove after getLedgerEntries is deployed.
 type GetLedgerEntryRequest struct {
 	Key    string `json:"key"`
 	Format string `json:"xdrFormat"`
 }
 
-// Deprecated. Use GetLedgerEntriesResponse instead.
+// GetLedgerEntryResponse Deprecated: Use GetLedgerEntriesResponse instead.
 // TODO(https://github.com/stellar/soroban-tools/issues/374) remove after getLedgerEntries is deployed.
 type GetLedgerEntryResponse struct {
 	EntryXDR  string          `json:"xdr"`
@@ -35,7 +35,7 @@ type GetLedgerEntryResponse struct {
 }
 
 // NewGetLedgerEntryHandler returns a json rpc handler to retrieve the specified ledger entry from stellar core
-// Deprecated. use NewGetLedgerEntriesHandler instead.
+// Deprecated: use NewGetLedgerEntriesHandler instead
 // TODO(https://github.com/stellar/soroban-tools/issues/374) remove after getLedgerEntries is deployed.
 func NewGetLedgerEntryHandler(logger *log.Entry, ledgerEntryReader db.LedgerEntryReader) jrpc2.Handler {
 	return NewHandler(func(ctx context.Context, request GetLedgerEntryRequest) (GetLedgerEntryResponse, error) {

--- a/cmd/soroban-rpc/internal/methods/get_transactions_test.go
+++ b/cmd/soroban-rpc/internal/methods/get_transactions_test.go
@@ -69,7 +69,7 @@ func TestGetTransactions_DefaultLimit(t *testing.T) {
 	assert.Equal(t, toid.New(5, 2, 1).String(), response.Cursor)
 
 	// assert transactions result
-	assert.Len(t, 10, len(response.Transactions))
+	assert.Len(t, response.Transactions, 10)
 }
 
 func TestGetTransactions_DefaultLimitExceedsLatestLedger(t *testing.T) {
@@ -179,7 +179,7 @@ func TestGetTransactions_CustomLimitAndCursor(t *testing.T) {
 	assert.Equal(t, toid.New(3, 1, 1).String(), response.Cursor)
 
 	// assert transactions result
-	assert.Len(t, 3, len(response.Transactions))
+	assert.Len(t, response.Transactions, 3)
 	assert.Equal(t, uint32(2), response.Transactions[0].Ledger)
 	assert.Equal(t, uint32(2), response.Transactions[1].Ledger)
 	assert.Equal(t, uint32(3), response.Transactions[2].Ledger)

--- a/cmd/soroban-rpc/internal/methods/get_transactions_test.go
+++ b/cmd/soroban-rpc/internal/methods/get_transactions_test.go
@@ -69,7 +69,7 @@ func TestGetTransactions_DefaultLimit(t *testing.T) {
 	assert.Equal(t, toid.New(5, 2, 1).String(), response.Cursor)
 
 	// assert transactions result
-	assert.Equal(t, 10, len(response.Transactions))
+	assert.Len(t, 10, len(response.Transactions))
 }
 
 func TestGetTransactions_DefaultLimitExceedsLatestLedger(t *testing.T) {
@@ -179,7 +179,7 @@ func TestGetTransactions_CustomLimitAndCursor(t *testing.T) {
 	assert.Equal(t, toid.New(3, 1, 1).String(), response.Cursor)
 
 	// assert transactions result
-	assert.Equal(t, 3, len(response.Transactions))
+	assert.Len(t, 3, len(response.Transactions))
 	assert.Equal(t, uint32(2), response.Transactions[0].Ledger)
 	assert.Equal(t, uint32(2), response.Transactions[1].Ledger)
 	assert.Equal(t, uint32(3), response.Transactions[2].Ledger)

--- a/cmd/soroban-rpc/internal/methods/handler_test.go
+++ b/cmd/soroban-rpc/internal/methods/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/creachadair/jrpc2"
 	"github.com/creachadair/jrpc2/handler"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type Request struct {
@@ -15,7 +16,7 @@ type Request struct {
 
 func TestNewHandlerNoArrayParameters(t *testing.T) {
 	callCount := 0
-	f := func(ctx context.Context, request Request) error {
+	f := func(_ context.Context, request Request) error {
 		callCount++
 		assert.Equal(t, "bar", request.Parameter)
 		return nil
@@ -27,15 +28,15 @@ func TestNewHandlerNoArrayParameters(t *testing.T) {
 "params": { "parameter": "bar" }
 }`
 	requests, err := jrpc2.ParseRequests([]byte(objectRequest))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, requests, 1)
 	finalObjectRequest := requests[0].ToRequest()
 
 	// object parameters should work with our handlers
 	customHandler := NewHandler(f)
 	_, err = customHandler(context.Background(), finalObjectRequest)
-	assert.NoError(t, err)
-	assert.Equal(t, 1, callCount)
+	require.NoError(t, err)
+	require.Equal(t, 1, callCount)
 
 	arrayRequest := `{
 "jsonrpc": "2.0",
@@ -44,17 +45,17 @@ func TestNewHandlerNoArrayParameters(t *testing.T) {
 "params": ["bar"]
 }`
 	requests, err = jrpc2.ParseRequests([]byte(arrayRequest))
-	assert.NoError(t, err)
-	assert.Len(t, requests, 1)
+	require.NoError(t, err)
+	require.Len(t, requests, 1)
 	finalArrayRequest := requests[0].ToRequest()
 
 	// Array requests should work with the normal handler, but not with our handlers
 	stdHandler := handler.New(f)
 	_, err = stdHandler(context.Background(), finalArrayRequest)
-	assert.NoError(t, err)
-	assert.Equal(t, 2, callCount)
+	require.NoError(t, err)
+	require.Equal(t, 2, callCount)
 
 	_, err = customHandler(context.Background(), finalArrayRequest)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid parameters")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid parameters")
 }

--- a/cmd/soroban-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/simulate_transaction.go
@@ -30,7 +30,8 @@ type SimulateTransactionCost struct {
 	MemoryBytes     uint64 `json:"memBytes,string"`
 }
 
-// SimulateHostFunctionResult contains the simulation result of each HostFunction within the single InvokeHostFunctionOp allowed in a Transaction
+// SimulateHostFunctionResult contains the simulation result of each HostFunction
+// within the single InvokeHostFunctionOp allowed in a Transaction
 type SimulateHostFunctionResult struct {
 	AuthXDR  []string          `json:"auth,omitempty"`
 	AuthJSON []json.RawMessage `json:"authJson,omitempty"`
@@ -213,12 +214,16 @@ type SimulateTransactionResponse struct {
 	EventsXDR  []string          `json:"events,omitempty"` // DiagnosticEvent XDR in base64
 	EventsJSON []json.RawMessage `json:"eventsJson,omitempty"`
 
-	MinResourceFee  int64                        `json:"minResourceFee,string,omitempty"`
-	Results         []SimulateHostFunctionResult `json:"results,omitempty"`         // an array of the individual host function call results
-	Cost            SimulateTransactionCost      `json:"cost,omitempty"`            // the effective cpu and memory cost of the invoked transaction execution.
-	RestorePreamble *RestorePreamble             `json:"restorePreamble,omitempty"` // If present, it indicates that a prior RestoreFootprint is required
-	StateChanges    []LedgerEntryChange          `json:"stateChanges,omitempty"`    // If present, it indicates how the state (ledger entries) will change as a result of the transaction execution.
-	LatestLedger    uint32                       `json:"latestLedger"`
+	MinResourceFee int64 `json:"minResourceFee,string,omitempty"`
+	// an array of the individual host function call results
+	Results []SimulateHostFunctionResult `json:"results,omitempty"`
+	// the effective cpu and memory cost of the invoked transaction execution.
+	Cost SimulateTransactionCost `json:"cost,omitempty"`
+	// If present, it indicates that a prior RestoreFootprint is required
+	RestorePreamble *RestorePreamble `json:"restorePreamble,omitempty"`
+	// If present, it indicates how the state (ledger entries) will change as a result of the transaction execution.
+	StateChanges []LedgerEntryChange `json:"stateChanges,omitempty"`
+	LatestLedger uint32              `json:"latestLedger"`
 }
 
 type PreflightGetter interface {
@@ -260,7 +265,8 @@ func NewSimulateTransactionHandler(logger *log.Entry, ledgerEntryReader db.Ledge
 		case xdr.OperationTypeExtendFootprintTtl, xdr.OperationTypeRestoreFootprint:
 			if txEnvelope.Type != xdr.EnvelopeTypeEnvelopeTypeTx && txEnvelope.V1.Tx.Ext.V != 1 {
 				return SimulateTransactionResponse{
-					Error: "To perform a SimulateTransaction for ExtendFootprintTtl or RestoreFootprint operations, SorobanTransactionData must be provided",
+					Error: "To perform a SimulateTransaction for ExtendFootprintTtl or RestoreFootprint operations," +
+						" SorobanTransactionData must be provided",
 				}
 			}
 			footprint = txEnvelope.V1.Tx.Ext.SorobanData.Resources.Footprint
@@ -374,7 +380,7 @@ func NewSimulateTransactionHandler(logger *log.Entry, ledgerEntryReader db.Ledge
 		}
 
 		stateChanges := make([]LedgerEntryChange, len(result.LedgerEntryDiff))
-		for i := 0; i < len(stateChanges); i++ {
+		for i := range stateChanges {
 			if err := stateChanges[i].FromXDRDiff(result.LedgerEntryDiff[i], request.Format); err != nil {
 				return SimulateTransactionResponse{
 					Error:        err.Error(),

--- a/cmd/soroban-rpc/internal/methods/util_test.go
+++ b/cmd/soroban-rpc/internal/methods/util_test.go
@@ -83,10 +83,10 @@ func createMockLedgerCloseMeta(ledgerSequence uint32) xdr.LedgerCloseMeta {
 func NewTestDB(tb testing.TB) *db.DB {
 	tmp := tb.TempDir()
 	dbPath := path.Join(tmp, "db.sqlite")
-	db, err := db.OpenSQLiteDB(dbPath)
+	dbConn, err := db.OpenSQLiteDB(dbPath)
 	require.NoError(tb, err)
 	tb.Cleanup(func() {
-		require.NoError(tb, db.Close())
+		require.NoError(tb, dbConn.Close())
 	})
-	return db
+	return dbConn
 }


### PR DESCRIPTION
This diff does following: 

- Remove usage of internal error
- Fix lint errors in `/methods `
