### PR TITLE
simulate-transaction: remove confusing Cost field in response

### DIFF
--- a/cmd/soroban-rpc/internal/integrationtest/simulate_transaction_test.go
+++ b/cmd/soroban-rpc/internal/integrationtest/simulate_transaction_test.go
@@ -32,8 +32,6 @@ func TestSimulateTransactionSucceeds(t *testing.T) {
 	contractHashBytes := xdr.ScBytes(contractHash[:])
 	expectedXdr := xdr.ScVal{Type: xdr.ScValTypeScvBytes, Bytes: &contractHashBytes}
 	require.Greater(t, result.LatestLedger, uint32(0))
-	require.Greater(t, result.Cost.CPUInstructions, uint64(0))
-	require.Greater(t, result.Cost.MemoryBytes, uint64(0))
 
 	expectedTransactionData := xdr.SorobanTransactionData{
 		Resources: xdr.SorobanResources{

--- a/cmd/soroban-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/simulate_transaction.go
@@ -25,7 +25,8 @@ type SimulateTransactionRequest struct {
 	Format         string                    `json:"xdrFormat,omitempty"`
 }
 
-// SimulateHostFunctionResult contains the simulation result of each HostFunction within the single InvokeHostFunctionOp allowed in a Transaction
+// SimulateHostFunctionResult contains the simulation result of each HostFunction within the single
+// InvokeHostFunctionOp allowed in a Transaction
 type SimulateHostFunctionResult struct {
 	AuthXDR  *[]string         `json:"auth,omitempty"`
 	AuthJSON []json.RawMessage `json:"authJson,omitempty"`

--- a/cmd/soroban-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/soroban-rpc/internal/methods/simulate_transaction.go
@@ -25,13 +25,7 @@ type SimulateTransactionRequest struct {
 	Format         string                    `json:"xdrFormat,omitempty"`
 }
 
-type SimulateTransactionCost struct {
-	CPUInstructions uint64 `json:"cpuInsns,string"`
-	MemoryBytes     uint64 `json:"memBytes,string"`
-}
-
-// SimulateHostFunctionResult contains the simulation result of each HostFunction
-// within the single InvokeHostFunctionOp allowed in a Transaction
+// SimulateHostFunctionResult contains the simulation result of each HostFunction within the single InvokeHostFunctionOp allowed in a Transaction
 type SimulateHostFunctionResult struct {
 	AuthXDR  *[]string         `json:"auth,omitempty"`
 	AuthJSON []json.RawMessage `json:"authJson,omitempty"`
@@ -217,8 +211,6 @@ type SimulateTransactionResponse struct {
 	MinResourceFee int64 `json:"minResourceFee,string,omitempty"`
 	// an array of the individual host function call results
 	Results []SimulateHostFunctionResult `json:"results,omitempty"`
-	// the effective cpu and memory cost of the invoked transaction execution.
-	Cost SimulateTransactionCost `json:"cost,omitempty"`
 	// If present, it indicates that a prior RestoreFootprint is required
 	RestorePreamble *RestorePreamble `json:"restorePreamble,omitempty"`
 	// If present, it indicates how the state (ledger entries) will change as a result of the transaction execution.
@@ -392,13 +384,9 @@ func NewSimulateTransactionHandler(logger *log.Entry, ledgerEntryReader db.Ledge
 		}
 
 		simResp := SimulateTransactionResponse{
-			Error:          result.Error,
-			Results:        results,
-			MinResourceFee: result.MinFee,
-			Cost: SimulateTransactionCost{
-				CPUInstructions: result.CPUInstructions,
-				MemoryBytes:     result.MemoryBytes,
-			},
+			Error:           result.Error,
+			Results:         results,
+			MinResourceFee:  result.MinFee,
 			LatestLedger:    latestLedger,
 			RestorePreamble: restorePreamble,
 			StateChanges:    stateChanges,


### PR DESCRIPTION
### What

Remove confusing Cost field in simulate-transaction's response.

### Why

Closes https://github.com/stellar/soroban-rpc/issues/66

### Known limitations

It's a breaking change, which should be released with protocol 22
