### PR TITLE
Add hash to getTransactions response

### DIFF
--- a/cmd/soroban-rpc/internal/db/transaction.go
+++ b/cmd/soroban-rpc/internal/db/transaction.go
@@ -25,6 +25,7 @@ const (
 var ErrNoTransaction = errors.New("no transaction with this hash exists")
 
 type Transaction struct {
+	TransactionHash  string
 	Result           []byte   // XDR encoded xdr.TransactionResult
 	Meta             []byte   // XDR encoded xdr.TransactionMeta
 	Envelope         []byte   // XDR encoded xdr.TransactionEnvelope
@@ -223,6 +224,7 @@ func ParseTransaction(lcm xdr.LedgerCloseMeta, ingestTx ingest.LedgerTransaction
 		Sequence:  lcm.LedgerSequence(),
 		CloseTime: lcm.LedgerCloseTime(),
 	}
+	tx.TransactionHash = ingestTx.Result.TransactionHash.HexString()
 
 	if tx.Result, err = ingestTx.Result.Result.MarshalBinary(); err != nil {
 		return tx, fmt.Errorf("couldn't encode transaction Result: %w", err)

--- a/cmd/soroban-rpc/internal/methods/get_transactions.go
+++ b/cmd/soroban-rpc/internal/methods/get_transactions.go
@@ -58,6 +58,8 @@ func (req GetTransactionsRequest) isValid(maxLimit uint, ledgerRange ledgerbucke
 type TransactionInfo struct {
 	// Status is one of: TransactionSuccess, TransactionFailed.
 	Status string `json:"status"`
+	// TransactionHash is the hex encoded hash of the transaction.
+	TransactionHash string `json:"txHash"`
 	// ApplicationOrder is the index of the transaction among all the transactions
 	// for that ledger.
 	ApplicationOrder int32 `json:"applicationOrder"`
@@ -194,6 +196,7 @@ func (h transactionsRPCHandler) processTransactionsInLedger(
 		}
 
 		txInfo := TransactionInfo{
+			TransactionHash:  tx.TransactionHash,
 			ApplicationOrder: tx.ApplicationOrder,
 			FeeBump:          tx.FeeBump,
 			Ledger:           tx.Ledger.Sequence,

--- a/cmd/soroban-rpc/internal/methods/get_transactions.go
+++ b/cmd/soroban-rpc/internal/methods/get_transactions.go
@@ -58,7 +58,8 @@ func (req GetTransactionsRequest) isValid(maxLimit uint, ledgerRange ledgerbucke
 type TransactionInfo struct {
 	// Status is one of: TransactionSuccess, TransactionFailed.
 	Status string `json:"status"`
-	// TransactionHash is the hex encoded hash of the transaction.
+	// TransactionHash is the hex encoded hash of the transaction. Note that for fee-bump transaction
+	// this will be the hash of the fee-bump transaction instead of the inner transaction hash.
 	TransactionHash string `json:"txHash"`
 	// ApplicationOrder is the index of the transaction among all the transactions
 	// for that ledger.

--- a/cmd/soroban-rpc/internal/methods/get_transactions_test.go
+++ b/cmd/soroban-rpc/internal/methods/get_transactions_test.go
@@ -20,6 +20,19 @@ const (
 	NetworkPassphrase string = "passphrase"
 )
 
+var expectedTransactionInfo = TransactionInfo{
+	Status:              "SUCCESS",
+	TransactionHash:     "b0d0b35dcaed0152d62fbbaa28ed3fa4991c87e7e169a8fca2687b17ee26ca2d",
+	ApplicationOrder:    1,
+	FeeBump:             false,
+	Ledger:              1,
+	LedgerCloseTime:     125,
+	EnvelopeXDR:         "AAAAAgAAAQCAAAAAAAAAAD8MNL+TrQ2ZcdBMzJD3BVEcg4qtlzSkovsNegP8f+iaAAAAAQAAAAD///+dAAAAAAAAAAAAAAAAAAAAAAAAAAA=", //nolint:lll
+	ResultMetaXDR:       "AAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAA",
+	ResultXDR:           "AAAAAAAAAGQAAAAAAAAAAAAAAAA=",
+	DiagnosticEventsXDR: []string{},
+}
+
 // createTestLedger Creates a test ledger with 2 transactions
 func createTestLedger(sequence uint32) xdr.LedgerCloseMeta {
 	sequence -= 100
@@ -70,6 +83,9 @@ func TestGetTransactions_DefaultLimit(t *testing.T) {
 
 	// assert transactions result
 	assert.Len(t, response.Transactions, 10)
+
+	// assert the transaction structure. We will match only 1 tx for sanity purposes.
+	assert.Equal(t, expectedTransactionInfo, response.Transactions[0])
 }
 
 func TestGetTransactions_DefaultLimitExceedsLatestLedger(t *testing.T) {
@@ -104,6 +120,9 @@ func TestGetTransactions_DefaultLimitExceedsLatestLedger(t *testing.T) {
 
 	// assert transactions result
 	assert.Len(t, response.Transactions, 6)
+
+	// assert the transaction structure. We will match only 1 tx for sanity purposes.
+	assert.Equal(t, expectedTransactionInfo, response.Transactions[0])
 }
 
 func TestGetTransactions_CustomLimit(t *testing.T) {
@@ -143,6 +162,9 @@ func TestGetTransactions_CustomLimit(t *testing.T) {
 	assert.Len(t, response.Transactions, 2)
 	assert.Equal(t, uint32(1), response.Transactions[0].Ledger)
 	assert.Equal(t, uint32(1), response.Transactions[1].Ledger)
+
+	// assert the transaction structure. We will match only 1 tx for sanity purposes.
+	assert.Equal(t, expectedTransactionInfo, response.Transactions[0])
 }
 
 func TestGetTransactions_CustomLimitAndCursor(t *testing.T) {


### PR DESCRIPTION
### What

Closes #263 

Add TransactionHash to getTransactions response.

### Why

While users can parse the hash from within the envelope XDR, this makes it easier to get it directly from the response.

### Known limitations

NA
