### PR TITLE
fix: update soroban deps to prerelease

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,8 @@ version = "=21.2.0"
 
 [workspace.dependencies.soroban-env-host-curr]
 package = "soroban-env-host"
-version = "=22.0.0"
-git = "https://github.com/stellar/rs-soroban-env"
-rev = "0497816694bef2b103494c8c61b7c8a06a72c7d3"
+version = "=22.0.0-rc.2"
+
 
 [workspace.dependencies.soroban-simulation-prev]
 package = "soroban-simulation"
@@ -25,14 +24,10 @@ version = "=21.2.0"
 
 [workspace.dependencies.soroban-simulation-curr]
 package = "soroban-simulation"
-version = "=22.0.0"
-git = "https://github.com/stellar/rs-soroban-env"
-rev = "0497816694bef2b103494c8c61b7c8a06a72c7d3"
+version = "=22.0.0-rc.2"
 
 [workspace.dependencies.stellar-xdr]
-version = "=22.0.0"
-git = "https://github.com/stellar/rs-stellar-xdr.git"
-rev = "b5516843b6379e4e29520bf2ba156484f62edc46"
+version = "=22.0.0-rc.1.1"
 features = [ "serde" ]
 
 [workspace.dependencies]


### PR DESCRIPTION
When testing out the procotol22 branch with quickstart, I got an XDR length error, which suggests that this is perhaps out of date with the xdr of the sdk. So I updated here. However, I'm getting the following error.

```
error: failed to select a version for k256.
    ... required by package soroban-env-host v22.0.0-rc.2
    ... which satisfies dependency soroban-env-host-curr = "=22.0.0-rc.2" of package preflight v21.4.0 (/Users/willem/c/s/soroban-rpc/cmd/soroban-rpc/lib/preflight)
versions that meet the requirements ^0.13.3 are: 0.13.4, 0.13.3
all possible versions conflict with previously selected packages.
  previously selected package k256 v0.13.1
    ... which satisfies dependency k256 = "=0.13.1" of package soroban-env-host v21.2.0
    ... which satisfies dependency soroban-env-host-prev = "=21.2.0" of package preflight v21.4.0 (/Users/willem/c/s/soroban-rpc/cmd/soroban-rpc/lib/preflight)
```