### PR TITLE
Statically-set maximum event cursor overflows

### DIFF
--- a/cmd/soroban-rpc/internal/db/cursor.go
+++ b/cmd/soroban-rpc/internal/db/cursor.go
@@ -129,9 +129,9 @@ var (
 	// MaxCursor is the largest possible cursor
 	//nolint:gochecknoglobals
 	MaxCursor = Cursor{
-		Ledger: math.MaxUint32,
-		Tx:     math.MaxUint32,
-		Op:     math.MaxUint32,
+		Ledger: math.MaxInt32,
+		Tx:     math.MaxInt32,
+		Op:     math.MaxInt32,
 		Event:  math.MaxUint32,
 	}
 )

--- a/cmd/soroban-rpc/internal/methods/get_events.go
+++ b/cmd/soroban-rpc/internal/methods/get_events.go
@@ -446,10 +446,8 @@ func (h eventsRPCHandler) getEvents(ctx context.Context, request GetEventsReques
 		}
 	}
 	endLedger := start.Ledger + LedgerScanLimit
-
 	// endLedger should not exceed ledger retention window
 	endLedger = min(ledgerRange.LastLedger.Sequence+1, endLedger)
-
 	if request.EndLedger != 0 {
 		endLedger = min(request.EndLedger, endLedger)
 	}


### PR DESCRIPTION
### What
Change max cursor.

### Why
TOIDs use int32 not uint32 so the set value will overflow. Found this while debugging an unrelated event cursor issue.