### PR TITLE
Fix underscore casing of the deprecated field

### DIFF
--- a/cmd/soroban-rpc/internal/methods/get_version_info.go
+++ b/cmd/soroban-rpc/internal/methods/get_version_info.go
@@ -22,7 +22,7 @@ type GetVersionInfoResponse struct {
 	//nolint:tagliatelle
 	CommitHashDeprecated string `json:"commit_hash"`
 	//nolint:tagliatelle
-	BuildTimestampDeprecated string `json:"build_timestamp"`
+	BuildTimestampDeprecated string `json:"build_time_stamp"`
 	//nolint:tagliatelle
 	CaptiveCoreVersionDeprecated string `json:"captive_core_version"`
 	//nolint:tagliatelle


### PR DESCRIPTION
### What
Rename JSON encoding of the field.

### Why
With the release of v22.0.0, we fixed incorrect fields and dropped fields that were deprecated. Then, we reintroduced them after the fact. As a result of that, we "restored" the deprecated field of `getVersionInfo` `build_time_stamp` as `build_timestamp`.

### Known limitations
This is strictly a bug so we do not treat it as an API change.