### PR TITLE
refactor: use strings.Builder to improve performance

### DIFF
--- a/cmd/stellar-rpc/internal/config/option.go
+++ b/cmd/stellar-rpc/internal/config/option.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -35,12 +36,13 @@ func (options Options) Validate() error {
 	}
 	if len(missingOptions) > 0 {
 		// we had one or more missing options, combine these all into a single error.
-		errString := "The following required configuration parameters are missing:"
+		var errString strings.Builder
+		errString.WriteString("The following required configuration parameters are missing:")
 		for _, missingOpt := range missingOptions {
-			errString += "\n*\t" + missingOpt.strErr
-			errString += "\n \t" + missingOpt.usage
+			errString.WriteString("\n*\t" + missingOpt.strErr)
+			errString.WriteString("\n \t" + missingOpt.usage)
 		}
-		return &missingRequiredOptionError{strErr: errString}
+		return &missingRequiredOptionError{strErr: errString.String()}
 	}
 	return nil
 }

--- a/cmd/stellar-rpc/internal/integrationtest/infrastructure/test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/infrastructure/test.go
@@ -467,11 +467,11 @@ func (i *Test) generateCaptiveCoreCfgForDaemon() {
 }
 
 func (i *Test) generateRPCConfigFile(rpcConfig rpcConfig) {
-	cfgFileContents := ""
+	var cfgFileContents strings.Builder
 	for k, v := range rpcConfig.toMap() {
-		cfgFileContents += fmt.Sprintf("%s=%q\n", k, v)
+		cfgFileContents.WriteString(fmt.Sprintf("%s=%q\n", k, v))
 	}
-	err := os.WriteFile(filepath.Join(i.rpcConfigFilesDir, "stellar-rpc.config"), []byte(cfgFileContents), 0o666)
+	err := os.WriteFile(filepath.Join(i.rpcConfigFilesDir, "stellar-rpc.config"), []byte(cfgFileContents.String()), 0o666)
 	require.NoError(i.t, err)
 }
 

--- a/cmd/stellar-rpc/internal/jsonrpc.go
+++ b/cmd/stellar-rpc/internal/jsonrpc.go
@@ -136,14 +136,14 @@ func logResponse(logger *log.Entry, reqID string, duration time.Duration, status
 }
 
 func toSnakeCase(s string) string {
-	var result string
+	var result strings.Builder
 	for _, v := range s {
 		if unicode.IsUpper(v) {
-			result += "_"
+			result.WriteString("_")
 		}
-		result += string(v)
+		result.WriteString(string(v))
 	}
-	return strings.ToLower(result)
+	return strings.ToLower(result.String())
 }
 
 // NewJSONRPCHandler constructs a Handler instance


### PR DESCRIPTION
### What

use strings.Builder to improve performance

### Why

strings.Builder has fewer memory allocations and better performance.
More info: [golang/go#75190](https://github.com/golang/go/issues/75190)

### Known limitations

N
