### PR TITLE
Fix instructions in subcommand README

### DIFF
--- a/cmd/stellar-rpc/README.md
+++ b/cmd/stellar-rpc/README.md
@@ -33,8 +33,6 @@ testnet release candidates from the [testing repository.](https://apt.stellar.or
 ```bash
 git clone https://github.com/stellar/stellar-rpc.git
 cd stellar-rpc
-git fetch --tags
-git checkout tags/v20.3.3 -b soroban-testnet-release
 ```
 - Build stellar-rpc target:
 ```bash


### PR DESCRIPTION
### What
Removes the tag checkout, `main` is fine.

### Why
The instructions are misleading and out of date.

### Known limitations
n/a