### PR TITLE
Update docker pipeline to use jammy instead of focal

### DIFF
--- a/cmd/stellar-rpc/docker/Dockerfile
+++ b/cmd/stellar-rpc/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-bullseye as build
+FROM golang:1.24-bookworm AS build
 ARG RUST_TOOLCHAIN_VERSION=stable
 ARG REPOSITORY_VERSION
 
@@ -12,9 +12,9 @@ ENV CARGO_HOME=/rust/.cargo
 ENV RUSTUP_HOME=/rust/.rust
 ENV PATH="/usr/local/go/bin:$CARGO_HOME/bin:${PATH}"
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update
-RUN apt-get install -y build-essential jq
-RUN apt-get clean
+RUN apt update
+RUN apt install -y build-essential jq
+RUN apt clean
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_TOOLCHAIN_VERSION
 
@@ -26,16 +26,22 @@ RUN mv stellar-rpc /bin/stellar-rpc
 FROM ubuntu:22.04
 ARG STELLAR_CORE_VERSION
 ENV STELLAR_CORE_VERSION=${STELLAR_CORE_VERSION:-*}
-ENV STELLAR_CORE_BINARY_PATH /usr/bin/stellar-core
+ENV STELLAR_CORE_BINARY_PATH=/usr/bin/stellar-core
 ENV DEBIAN_FRONTEND=noninteractive
 
 # ca-certificates are required to make tls connections
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl jq wget gnupg apt-utils
-RUN wget -qO - https://apt.stellar.org/SDF.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true apt-key add -
-RUN echo "deb https://apt.stellar.org focal stable" >/etc/apt/sources.list.d/SDF.list
-RUN echo "deb https://apt.stellar.org focal unstable" >/etc/apt/sources.list.d/SDF-unstable.list
-RUN apt-get update && apt-get install -y stellar-core=${STELLAR_CORE_VERSION}
-RUN apt-get clean
+RUN apt update && apt install -y --no-install-recommends ca-certificates curl wget gnupg apt-utils
+RUN curl -sSL https://apt.stellar.org/SDF.asc | gpg --dearmor >/etc/apt/trusted.gpg.d/SDF.gpg
+RUN echo "deb https://apt.stellar.org jammy stable" >/etc/apt/sources.list.d/SDF.list
+RUN echo "deb https://apt.stellar.org jammy unstable" >/etc/apt/sources.list.d/SDF-unstable.list
+
+# install llvm-19 so that core can be installed
+RUN wget -O /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key
+RUN echo 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main' > /etc/apt/sources.list.d/llvm.list
+RUN echo 'deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main' >> /etc/apt/sources.list.d/llvm.list
+
+RUN apt update && apt install -y stellar-core=${STELLAR_CORE_VERSION}
+RUN apt clean
 
 # Copy the binary from the build stage
 COPY --from=build /bin/stellar-rpc /app/stellar-rpc

--- a/cmd/stellar-rpc/docker/Dockerfile.release
+++ b/cmd/stellar-rpc/docker/Dockerfile.release
@@ -8,16 +8,13 @@ ENV STELLAR_CORE_BINARY_PATH /usr/bin/stellar-core
 ENV DEBIAN_FRONTEND=noninteractive
 
 # ca-certificates are required to make tls connections
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl jq wget gnupg apt-utils gpg && \
+RUN apt update && apt install -y --no-install-recommends ca-certificates curl jq wget gnupg apt-utils gpg && \
     curl -sSL https://apt.stellar.org/SDF.asc | gpg --dearmor >/etc/apt/trusted.gpg.d/SDF.gpg && \
-    echo "deb https://apt.stellar.org focal stable" >/etc/apt/sources.list.d/SDF.list && \
-    echo "deb https://apt.stellar.org focal testing" >/etc/apt/sources.list.d/SDF-testing.list && \
-    echo "deb https://apt.stellar.org focal unstable" >/etc/apt/sources.list.d/SDF-unstable.list && \
-    apt-get update && \
-    apt-get install -y stellar-core=${STELLAR_CORE_VERSION} stellar-rpc=${STELLAR_RPC_VERSION} && \
-    apt-get clean
-
-# TODO: for backwards compatibility, remove when fully deprecating the soroban-rpc name
-RUN ln -s /usr/bin/stellar-rpc /usr/bin/stellar-soroban-rpc
+    echo "deb https://apt.stellar.org jammy stable" >/etc/apt/sources.list.d/SDF.list && \
+    echo "deb https://apt.stellar.org jammy testing" >/etc/apt/sources.list.d/SDF-testing.list && \
+    echo "deb https://apt.stellar.org jammy unstable" >/etc/apt/sources.list.d/SDF-unstable.list && \
+    apt update && \
+    apt install -y stellar-core=${STELLAR_CORE_VERSION} stellar-rpc=${STELLAR_RPC_VERSION} && \
+    apt clean
 
 ENTRYPOINT ["/usr/bin/stellar-rpc"]

--- a/cmd/stellar-rpc/docker/Makefile
+++ b/cmd/stellar-rpc/docker/Makefile
@@ -24,9 +24,10 @@ endif
 
 docker-build:
 	$(SUDO) docker build --pull --platform linux/amd64 $(DOCKER_OPTS) \
-	--label org.opencontainers.image.created="$(BUILD_DATE)" \
-	--build-arg STELLAR_CORE_VERSION=$(STELLAR_CORE_VERSION) --build-arg STELLAR_RPC_VERSION=$(STELLAR_RPC_VERSION_PACKAGE_VERSION) \
-	-t $(TAG) -f Dockerfile.release .
+		--label org.opencontainers.image.created="$(BUILD_DATE)" \
+		--build-arg STELLAR_CORE_VERSION=$(STELLAR_CORE_VERSION) \
+		--build-arg STELLAR_RPC_VERSION=$(STELLAR_RPC_VERSION_PACKAGE_VERSION) \
+		-t $(TAG) -f Dockerfile.release .
 
 docker-push:
 	$(SUDO) docker push $(TAG)


### PR DESCRIPTION
### What
This is ported directly from the `protocol-25` branch (see #537, #535, and #534).

### Why
The Jenkins pipeline uses `main` when bundling docker so the changes on that branch weren't being used :(

### Known limitations
n/a