### PR TITLE
Update core and host versions

### DIFF
--- a/.github/workflows/stellar-rpc.yml
+++ b/.github/workflows/stellar-rpc.yml
@@ -96,10 +96,10 @@ jobs:
       STELLAR_RPC_INTEGRATION_TESTS_ENABLED: true
       STELLAR_RPC_INTEGRATION_TESTS_CORE_MAX_SUPPORTED_PROTOCOL: ${{ matrix.protocol-version }}
       STELLAR_RPC_INTEGRATION_TESTS_CAPTIVE_CORE_BIN: /usr/bin/stellar-core
-      PROTOCOL_24_CORE_DEBIAN_PKG_VERSION: 24.1.0-2804.rc1.5a7035d49.focal
-      PROTOCOL_24_CORE_DOCKER_IMG: stellar/unsafe-stellar-core:24.1.0-2804.rc1.5a7035d49.focal
-      PROTOCOL_25_CORE_DEBIAN_PKG_VERSION: 24.1.0-2804.rc1.5a7035d49.focal
-      PROTOCOL_25_CORE_DOCKER_IMG: stellar/unsafe-stellar-core:24.1.0-2804.rc1.5a7035d49.focal
+      PROTOCOL_24_CORE_DEBIAN_PKG_VERSION: 24.1.1-2896.bc46d6004.jammy
+      PROTOCOL_24_CORE_DOCKER_IMG: stellar/unsafe-stellar-core:24.1.1-2896.bc46d6004.jammy
+      PROTOCOL_25_CORE_DEBIAN_PKG_VERSION: 24.1.1-2896.bc46d6004.jammy
+      PROTOCOL_25_CORE_DOCKER_IMG: stellar/unsafe-stellar-core:24.1.1-2896.bc46d6004.jammy
 
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ version = "=24.0.0"
 [workspace.dependencies.soroban-env-host-curr]
 package = "soroban-env-host"
 git = "https://github.com/stellar/rs-soroban-env.git"
-rev = "0a0c2df704edeb3cdafabfcc759eddccd6775337"
+rev = "cf58d535ab05d02802a5e804a95524650f8c62c7"
 
 [workspace.dependencies.soroban-simulation-prev]
 package = "soroban-simulation"
@@ -25,7 +25,7 @@ version = "=24.0.0"
 [workspace.dependencies.soroban-simulation-curr]
 package = "soroban-simulation"
 git = "https://github.com/stellar/rs-soroban-env.git"
-rev = "0a0c2df704edeb3cdafabfcc759eddccd6775337"
+rev = "cf58d535ab05d02802a5e804a95524650f8c62c7"
 
 [workspace.dependencies.stellar-xdr]
 git = "https://github.com/stellar/rs-stellar-xdr.git"


### PR DESCRIPTION
### What

There is a new [host version](https://github.com/stellar/rs-soroban-env/commit/cf58d535ab05d02802a5e804a95524650f8c62c7) with the bn254 fixes which has been included in the latest P25 core build (24.1.1-2896.bc46d6004.jammy).

This PR updates rpc to use those versions of core and rs-soroban-env.
