### PR TITLE
Use llvm-20 to create rpc release image

### DIFF
--- a/cmd/stellar-rpc/docker/Dockerfile.release
+++ b/cmd/stellar-rpc/docker/Dockerfile.release
@@ -14,10 +14,10 @@ RUN curl -sSL https://apt.stellar.org/SDF.asc | gpg --dearmor >/etc/apt/trusted.
     echo "deb https://apt.stellar.org jammy testing" >/etc/apt/sources.list.d/SDF-testing.list && \
     echo "deb https://apt.stellar.org jammy unstable" >/etc/apt/sources.list.d/SDF-unstable.list
 
-# install llvm-19 so that core can be installed
+# install llvm-20 so that core can be installed
 RUN wget -O /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key
-RUN echo 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main' > /etc/apt/sources.list.d/llvm.list
-RUN echo 'deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main' >> /etc/apt/sources.list.d/llvm.list
+RUN echo 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main' > /etc/apt/sources.list.d/llvm.list
+RUN echo 'deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main' >> /etc/apt/sources.list.d/llvm.list
 
 RUN apt update && \
     apt install -y stellar-core=${STELLAR_CORE_VERSION} stellar-rpc=${STELLAR_RPC_VERSION} && \


### PR DESCRIPTION
### What

I updated the llvm version in https://github.com/stellar/stellar-rpc/pull/548 which targeted the protocol-25 branch. However, I was not able to create a protocol 25 docker image for rpc because the jenkins job uses the Dockerfile.release file from the main branch. After updating Dockerfile.release so that it includes the updates from the protocol-25 branch I should be able to successfully create and publish the docker image.


https://buildmeister-v3.stellar-ops.com/job/Platform/job/soroban-rpc-docker-builder/139/console
 