### PR TITLE
Merge v25.0.0 release branch back into mainline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+
+## [v25.0.0](https://github.com/stellar/stellar-rpc/compare/v24.0.0...v25.0.0): Protocol 25
+
 ### Breaking Changes
 * The RPC client and schema definitions have been moved to the unified Stellar Go SDK. Please install them from there, instead:
 
@@ -14,9 +17,12 @@ go get -u github.com/stellar/go-stellar-sdk/protocols/rpc
 - Expanded `getLatestLedger` endpoint to also return `closeTime`, `headerXdr`, and `metadataXdr` ([#554](https://github.com/stellar/stellar-rpc/pull/554)).
 - Added `soroban-env-host` info to `version` command ([#550](https://github.com/stellar/stellar-rpc/pull/550)).
 - Added a new `--network` configuration parameter, allowing users to specify a default Stellar network (`testnet`, `pubnet`, or `futurenet`) ([#540](https://github.com/stellar/stellar-rpc/pull/540), [#543](https://github.com/stellar/stellar-rpc/pull/543)).
+- Simulation has been updated to support Protocol 25 ([#548](https://github.com/stellar/stellar-rpc/pull/548)).
 
 ### Fixed
 - `version` command now works consistently on MacOS ([#550](https://github.com/stellar/stellar-rpc/pull/550)).
+- JSON-RPC methods now accept `params: {}` ([#551](https://github.com/stellar/stellar-rpc/issues/551)).
+
 
 ## [v24.0.0](https://github.com/stellar/stellar-rpc/compare/v23.0.4...v24.0.0): Protocol 24
 


### PR DESCRIPTION
Self-explanatory: we just needed some changelog updates.