### PR TITLE
Update actions/setup-go to v6

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: '1.24'
         # unfortunately we cannot use the provided caching because it uses the


### PR DESCRIPTION
Update actions/setup-go to v6.

Versions of actions/setup-go prior to v4 no longer work due to changes in the Go download URLs (see https://github.com/actions/setup-go/issues/688). While updating repos affected by that, figured may as well update all repos using any version earlier than the latest.