### PR TITLE
Fix BeforeJSON/AfterJSON swap in AddLedgerEntryChangeJSON

### DIFF
--- a/cmd/stellar-rpc/internal/methods/simulate_transaction.go
+++ b/cmd/stellar-rpc/internal/methods/simulate_transaction.go
@@ -117,7 +117,7 @@ func AddLedgerEntryChangeJSON(l *protocol.LedgerEntryChange, diff preflight.XDRD
 	}
 
 	if afterPresent {
-		l.BeforeJSON, err = xdr2json.ConvertBytes(xdr.LedgerEntry{}, diff.After)
+		l.AfterJSON, err = xdr2json.ConvertBytes(xdr.LedgerEntry{}, diff.After)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION

### What

After was incorrectly assigned to l.BeforeJSON instead of l.AfterJSON, causing JSON-format simulation responses to return the post-transaction state in the before field and a null after field for updated ledger entries. The XDR path was correct.

Also update the test to use distinct Before/After data for the update case and assert both fields directly, so this class of bug is caught.


### Known limitations

[N/A]
