### PR TITLE
Merge v25.0.1 back into `main`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## Unreleased
 
 
+## [v25.0.1](https://github.com/stellar/stellar-rpc/compare/v25.0.0...v25.0.1)
+
+### Fixed
+- Add batched event inserts to avoid SQLite bind variable limit when a transaction contains more than 3K events ([#608](https://github.com/stellar/stellar-rpc/pull/608)).
+
+
 ## [v25.0.0](https://github.com/stellar/stellar-rpc/compare/v24.0.0...v25.0.0): Protocol 25
 
 ### Breaking Changes
@@ -17,7 +23,7 @@ go get -u github.com/stellar/go-stellar-sdk/protocols/rpc
 - Added `--backfill` configuration parameter providing synchronous backfilling of `HISTORY_RETENTION_WINDOW` ledgers to the local DB prior to RPC starting. For one week of ledgers (approximately 150Gb), this can be expected to complete in under three hours and use <3 Gb of memory (less than core itself). To use this, one must enable a datastore and `SERVE_LEDGERS_FROM_DATASTORE`, which also enables `getLedger` ([#571](https://github.com/stellar/stellar-rpc/pull/571)).
 - Expanded `getLatestLedger` endpoint to also return `closeTime`, `headerXdr`, and `metadataXdr` ([#554](https://github.com/stellar/stellar-rpc/pull/554)).
 - Added `soroban-env-host` info to `version` command ([#550](https://github.com/stellar/stellar-rpc/pull/550)).
-- Added `--network` configuration parameter, allowing users to specify a default Stellar network (`testnet`, `pubnet`, or `futurenet`) ([#540](https://github.com/stellar/stellar-rpc/pull/540), [#543](https://github.com/stellar/stellar-rpc/pull/543)).
+- Added a new `--network` configuration parameter, allowing users to specify a default Stellar network (`testnet`, `pubnet`, or `futurenet`) ([#540](https://github.com/stellar/stellar-rpc/pull/540), [#543](https://github.com/stellar/stellar-rpc/pull/543)).
 - Simulation has been updated to support Protocol 25 ([#548](https://github.com/stellar/stellar-rpc/pull/548)).
 
 ### Fixed

--- a/cmd/stellar-rpc/internal/db/event.go
+++ b/cmd/stellar-rpc/internal/db/event.go
@@ -208,26 +208,36 @@ func (eventHandler *eventHandler) InsertEvents(lcm xdr.LedgerCloseMeta) error {
 			}
 		}
 
-		query := sq.Insert(eventTableName).
-			Columns(
-				"id",
-				"contract_id",
-				"event_type",
-				"event_data",
-				"ledger_close_time",
-				"transaction_hash",
-				"topic1", "topic2", "topic3", "topic4",
-			)
+		// Batch inserts to avoid exceeding SQLite's SQLITE_MAX_VARIABLE_NUMBER
+		// limit (32,767 by default). With 10 bind variables per event, we cap
+		// each INSERT at 1000 events (10,000 bind variables) to stay well
+		// within the limit.
+		const maxEventsPerBatch = 1000
 
-		for _, event := range insertableEvents {
-			query, err = insertEvents(query, lcm, event)
-			if err != nil {
-				return err
+		for batchStart := 0; batchStart < len(insertableEvents); batchStart += maxEventsPerBatch {
+			batchEnd := batchStart + maxEventsPerBatch
+			if batchEnd > len(insertableEvents) {
+				batchEnd = len(insertableEvents)
 			}
-		}
 
-		if len(insertableEvents) > 0 { // don't run empty insert
-			// Ignore the last inserted ID as it is not needed
+			query := sq.Insert(eventTableName).
+				Columns(
+					"id",
+					"contract_id",
+					"event_type",
+					"event_data",
+					"ledger_close_time",
+					"transaction_hash",
+					"topic1", "topic2", "topic3", "topic4",
+				)
+
+			for _, event := range insertableEvents[batchStart:batchEnd] {
+				query, err = insertEvents(query, lcm, event)
+				if err != nil {
+					return err
+				}
+			}
+
 			_, err = query.RunWith(eventHandler.stmtCache).Exec()
 			if err != nil {
 				return err


### PR DESCRIPTION
### What
This runs `git merge -S main` into the `release/v25.0.1` branch and resolves the conflicts in the `CHANGELOG.md`.

### Why
The patch was built on top of the `v25.0.0` tag and we need to merge it back upstream for the next release.

### Known limitations
n/a