### PR TITLE
Fix failure to check error result from BuildEventsJSONFromTransaction()

### DIFF
--- a/cmd/stellar-rpc/internal/methods/get_transactions.go
+++ b/cmd/stellar-rpc/internal/methods/get_transactions.go
@@ -157,7 +157,7 @@ func (h transactionsRPCHandler) processTransactionsInLedger(
 			txInfo.DiagnosticEventsJSON = diagEvents
 
 			txInfo.Events, convErr = BuildEventsJSONFromTransaction(tx)
-			if err != nil {
+			if convErr != nil {
 				return nil, false, &jrpc2.Error{
 					Code:    jrpc2.InternalError,
 					Message: convErr.Error(),


### PR DESCRIPTION
### What

Fixes a `nil == nil` error checking bug.

### Why

An error value is assigned to `convErr`, but the stale/confirmed-nil variable `err` is checked instead. This leads to never checking the return status of `BuildEventsJSONFromTransaction()` in the `getTransactions` endpoint, which can plausibly return an error.

### Known limitations

N/A
