### PR TITLE
Cap fee stats retention window at 1000 ledgers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - Added `--backfill` configuration parameter providing synchronous backfilling of `HISTORY_RETENTION_WINDOW` ledgers to the local DB prior to RPC starting. For one week of ledgers (approximately 150Gb), this can be expected to complete in under three hours and use <3 Gb of memory (less than core itself). To use this, one must enable a datastore and `SERVE_LEDGERS_FROM_DATASTORE`, which also enables `getLedger` ([#571](https://github.com/stellar/stellar-rpc/pull/571)).
 
+### Changed
+- Fee stats retention windows (`classic-fee-stats-retention-window` and `soroban-fee-stats-retention-window`) are now capped at 1000 ledgers. Previously, very large values caused O(n^2) startup time ([#630](https://github.com/stellar/stellar-rpc/pull/630)).
+
 ### Fixed
 - Fixes a race condition in `getTransaction` in which the `LatestLedger` field would sometimes be earlier than the transaction's `Ledger` field ([#619](https://github.com/stellar/stellar-rpc/pull/619)).
 - `simulateTransaction` will now reject smart contract transaction requests that contain a memo ([#588](https://github.com/stellar/stellar-rpc/pull/588)).

--- a/cmd/stellar-rpc/internal/config/option_test.go
+++ b/cmd/stellar-rpc/internal/config/option_test.go
@@ -105,6 +105,31 @@ func TestValidatePositiveInt(t *testing.T) {
 	require.NoError(t, o.Validate(o))
 }
 
+func TestValidateFeeStatsRetentionWindow(t *testing.T) {
+	var val uint32
+	o := &Option{
+		Name:      "soroban-fee-stats-retention-window",
+		ConfigKey: &val,
+		Validate:  feeStatsRetentionWindowValidator,
+	}
+
+	// zero is rejected (positive check)
+	require.NoError(t, o.setValue(uint32(0)))
+	require.ErrorContains(t, o.Validate(o), "must be positive")
+
+	// valid: default value
+	require.NoError(t, o.setValue(uint32(50)))
+	require.NoError(t, o.Validate(o))
+
+	// valid: at the cap
+	require.NoError(t, o.setValue(uint32(MaxFeeStatsRetentionWindow)))
+	require.NoError(t, o.Validate(o))
+
+	// invalid: exceeds cap
+	require.NoError(t, o.setValue(uint32(MaxFeeStatsRetentionWindow+1)))
+	require.ErrorContains(t, o.Validate(o), "cannot exceed 1000 ledgers")
+}
+
 func TestUnassignableField(t *testing.T) {
 	var co Option
 	var b bool

--- a/cmd/stellar-rpc/internal/config/options.go
+++ b/cmd/stellar-rpc/internal/config/options.go
@@ -26,6 +26,12 @@ const (
 	OneDayOfLedgers   = 17280
 	SevenDayOfLedgers = OneDayOfLedgers * 7
 
+	// MaxFeeStatsRetentionWindow is the maximum allowed fee stats retention
+	// window (~55 minutes). Larger windows cause slow startup due to
+	// O(n^2) fee distribution recomputation and provide no meaningful
+	// improvement in fee estimates.
+	MaxFeeStatsRetentionWindow = 1000
+
 	defaultHTTPEndpoint             = "localhost:8000"
 	defaultCaptiveCoreHTTPPort      = 11626 // regular queries like /info
 	defaultCaptiveCoreHTTPQueryPort = 11628
@@ -315,14 +321,14 @@ func (cfg *Config) options() Options {
 			Usage:        "configures classic fee stats retention window expressed in number of ledgers",
 			ConfigKey:    &cfg.ClassicFeeStatsLedgerRetentionWindow,
 			DefaultValue: uint32(10),
-			Validate:     positive,
+			Validate:     feeStatsRetentionWindowValidator,
 		},
 		{
 			Name:         "soroban-fee-stats-retention-window",
 			Usage:        "configures soroban inclusion fee stats retention window expressed in number of ledgers",
 			ConfigKey:    &cfg.SorobanFeeStatsLedgerRetentionWindow,
 			DefaultValue: uint32(50),
-			Validate:     positive,
+			Validate:     feeStatsRetentionWindowValidator,
 		},
 		{
 			Name:         "max-events-limit",
@@ -709,6 +715,23 @@ func required(option *Option) error {
 	}
 
 	return missingRequiredOptionError{strErr: fmt.Sprintf("%s is required.%s", option.Name, advice), usage: option.Usage}
+}
+
+func feeStatsRetentionWindowValidator(option *Option) error {
+	if err := positive(option); err != nil {
+		return err
+	}
+	ptr, ok := option.ConfigKey.(*uint32)
+	if !ok {
+		return fmt.Errorf("%s is not a uint32", option.Name)
+	}
+	v := *ptr
+	if v > MaxFeeStatsRetentionWindow {
+		return fmt.Errorf(
+			"%s cannot exceed %d ledgers (got %d)",
+			option.Name, MaxFeeStatsRetentionWindow, v)
+	}
+	return nil
 }
 
 func positive(option *Option) error {


### PR DESCRIPTION
## Summary
- Adds a `MaxFeeStatsRetentionWindow` constant (1000 ledgers, ~55 minutes) and validates `classic-fee-stats-retention-window` and `soroban-fee-stats-retention-window` against it at startup
- A user reported ~3 hour startup times on mainnet after setting both fee stats windows to 241,920 (same as their history retention window). The root cause is that `AppendLedgerFees` recomputes the fee distribution (collect all fees + sort) on every ledger during init, making startup O(n²) in the fee window size
- Fee percentile estimates don't meaningfully improve beyond a few hundred ledgers, so there's no reason to allow very large values

🤖 Generated with [Claude Code](https://claude.com/claude-code)