### PR TITLE
Add packfile library design doc

### DIFF
--- a/design-docs/packfile-library.md
+++ b/design-docs/packfile-library.md
@@ -2,16 +2,39 @@
 
 ## Problem
 
-We need to store large collections of variable-length items (events, compressed bitmaps, ledgers) in immutable files and read individual items by ordinal index with minimal I/O. The files are written once and read many times over their lifetime.
+We need to store large collections of variable-length **items** (opaque byte blobs) in immutable files. Items are appended sequentially during a write phase, then the file is sealed and never modified. Reads need to fetch individual items efficiently — given an item's position in the sequence (0, 1, 2, ...), return its bytes.
 
-A flat file is the natural fit: write items sequentially, keep an offset table at the end, look up any item by index. This is simple, fast, and well-suited to immutable data. General-purpose storage engines like RocksDB or SQLite add key management, transactions, and mutable write paths that we don't need — overhead without benefit for immutable, ordinal-indexed data.
+The two main read patterns are scattered point lookups (hundreds or thousands of potentially non-contiguous items per query) and sequential scans (all items in order). The storage may have a limited I/O budget (e.g. EBS volumes with a fixed number of operations per second) or high per-request latency (e.g. S3 range GETs). Minimizing the number of I/O operations per query is critical.
 
-Packfile is an implementation of this approach. It handles the details that a naive implementation gets wrong or leaves to the caller: record grouping for compression, compact index encoding, parallel block processing, SHA-256 content hashing, CRC32C integrity checks, and safe concurrent reads.
+Packfile is designed around this constraint:
 
-Two packages:
+- **Minimize I/O operations per query.** Opening a file and looking up any item should require as few I/O operations as possible. Ideally, one I/O on open, then one I/O per item lookup.
+- **Concurrent reads.** All read methods must be safe for parallel use. On storage with limited I/O budgets or high per-request latency, issuing reads sequentially is far too slow. Parallel reads are required to keep query latency manageable.
+- **Immutable after write.** Files are written once, sealed, then read-only. No updates, no deletes.
 
-- **`packfile`** — item-level random access to immutable files. Handles record grouping, zstd compression, CRC32C integrity, content hashing, and parallel I/O. Uses a thin CGo wrapper (`zstd/`) for compression — the pure-Go zstd implementation is 4x slower on our workloads.
-- **`intpack`** — integer compression using Frame of Reference (FOR) encoding. Pure Go, no external dependencies. General-purpose codec — not packfile-specific.
+Non-goals:
+- **Key-based lookup.** Items are accessed by their position in the sequence, not by key.
+- **Mutability.** No append-after-finalize.
+- **Chunk management.** Directory layout, rotation, and tiering are caller concerns.
+
+## Concepts
+
+On disk, items are grouped into **records**. `ItemsPerRecord` controls how many items go into each record.
+
+Records can be stored in one of three formats: **Compressed** (zstd with built-in integrity, the default), **Uncompressed** (raw bytes with CRC32C integrity check), or **Raw** (raw bytes, no integrity check).
+
+The file ends with a compact **offset index** that maps each record to its byte position on disk. When a file is opened, the offset index is loaded into memory. After that, looking up any item is a single read to fetch the record containing it — no further index I/O. This is how packfile achieves the "one I/O on open, one I/O per lookup" goal.
+
+`ItemsPerRecord` is the key configuration choice because it directly controls the size of the offset index:
+
+- A larger `ItemsPerRecord` (e.g. 128, the default) means fewer records, which means a smaller offset index. With compression enabled, it also gives the compressor more context, improving compression for small items. The cost is that reading one item requires reading and decoding its entire record, extracting the requested item, and discarding the rest.
+- `ItemsPerRecord=1` stores each item as its own record. The offset index is larger (one entry per item), but each read fetches exactly what's needed.
+
+The offset index has `ceil(totalItems / ItemsPerRecord)` entries, at most 4 bytes each but typically much less — the entries are compressed, so when records are similar in size each entry is closer to 1-2 bytes. Use `4 * ceil(totalItems / ItemsPerRecord)` as a conservative upper bound.
+
+Choose `ItemsPerRecord` so the index fits within your I/O budget — for example, on storage where each I/O reads up to 256 KB, keep the index under 256 KB. You can check the actual index size of a written file via `Trailer().IndexSize`. See [Index Encoding](#index-encoding) for how the offset index is encoded.
+
+A packfile can optionally include a **content hash** — a SHA-256 digest computed over all items at write time — which can later be used to verify the file's integrity. See `ContentHash` in the API reference.
 
 ## Usage
 
@@ -20,82 +43,77 @@ Error handling omitted for clarity. All functions return errors.
 ### Writing
 
 ```go
-w, _ := packfile.Create("events-00042.pack", packfile.WriterOptions{
-    RecordSize:  128,         // items per record (default 128)
-    Concurrency: 4,           // parallel block-processing goroutines
-    ContentHash: true,        // compute SHA-256 content hash
+w, _ := packfile.Create("output.pack", packfile.WriterOptions{
+    ItemsPerRecord: 128,  // items per record (default 128)
+    Concurrency:    4,    // parallel compression goroutines
+    ContentHash:    true, // compute SHA-256 content hash
 })
 defer w.Close() // removes file if Finish was not called
 
-for _, event := range events {
-    w.Append(event)
+for _, item := range items {
+    w.AppendItem(item)
 }
 
-w.Finish(nil) // flushes partial record, writes index + trailer, fsyncs
+w.Finish(nil) // seal the file (nil = no app data)
 ```
 
-Items are appended in order. `Finish` flushes any partial record, writes the offset index, optional app data, and a 64-byte trailer, then fsyncs. `Close` after `Finish` is a no-op; `Close` without `Finish` removes the incomplete file.
-
-Multi-part items (e.g., fingerprint + bitmap data) can be appended as a single logical item:
-
-```go
-w.Append(fingerprint[:], bitmapData) // concatenated as one entry
-```
+Items are appended in order. `Finish` seals the file and fsyncs. `Close` after `Finish` is a no-op; `Close` without `Finish` removes the incomplete file.
 
 ### Reading: Point Lookup
 
 ```go
-r := packfile.Open("events-00042.pack")
+r := packfile.Open("output.pack")
 defer r.Close()
 
-r.ReadItem(42, func(event []byte) error {
-    processEvent(event) // valid only for the duration of this call — copy if needed
+r.ReadItem(42, func(data []byte) error {
+    // data is borrowed — copy if you need to keep it after this callback returns
+    process(data)
     return nil
 })
 ```
 
-`Open` returns immediately — all I/O runs in a background goroutine. `ReadItem` maps the item index to its record, reads and decodes the record, and passes the item to the callback. The entry slice is borrowed from an internal decoder buffer and must not be retained after the callback returns.
+`Open` returns immediately — file I/O runs in a background goroutine. The first read call blocks until the file is ready. `ReadItem` fetches a single item by position and passes it to the callback.
 
 ### Reading: Sequential Scan
 
 ```go
-r := packfile.Open("events-00042.pack")
+r := packfile.Open("output.pack")
 defer r.Close()
 
-for event, err := range r.ReadRange(0, 1000) {
+for data, err := range r.ReadRange(0, 1000) {
     if err != nil {
         return err
     }
-    processEvent(event) // valid only until next iteration — copy if needed
+    // data is valid only until the next iteration — copy if needed
+    process(data)
 }
 ```
 
-Safe to break early. No cleanup required. Each yielded `[]byte` is valid only until the next iteration.
+Safe to break early. No cleanup required.
 
-### Reading: Scattered Access
+### Reading: Multiple Items
 
-A bitmap query produces a set of item indices scattered across the file. `ReadItems` reads them with parallel I/O, calling a callback for each item:
+`ReadItems` is like `ReadItem` but fetches many items at once using parallel I/O. You pass the positions of the items you want (sorted, no duplicates). The callback is called concurrently from multiple goroutines — `idx` tells you which element in your positions slice the data corresponds to:
 
 ```go
-r := packfile.Open("events-00042.pack", packfile.WithConcurrency(8))
+r := packfile.Open("output.pack", packfile.WithConcurrency(8))
 defer r.Close()
 
-// indices from bitmap intersection — sorted, unique, possibly non-contiguous
-indices := bitmapResult.ToSortedSlice()
+// fetch items at positions 42, 1000, 500000, and 8700000
+positions := []int{42, 1000, 500_000, 8_700_000}
 
-results := make([][]byte, len(indices))
-r.ReadItems(ctx, indices, func(pos int, entry []byte) error {
-    results[pos] = bytes.Clone(entry) // copy — entry is borrowed
+results := make([][]byte, len(positions))
+r.ReadItems(ctx, positions, func(idx int, data []byte) error {
+    results[idx] = bytes.Clone(data) // copy — data is borrowed
     return nil
 })
+// results[0] = item at position 42, results[1] = item at position 1000, etc.
 ```
-
-`ReadItems` groups indices by record, then partitions consecutive records into I/O batches (≤ 1MB each). Workers claim batches via an atomic counter. The callback is called concurrently from multiple goroutines in arbitrary order; `pos` identifies which index the entry corresponds to.
 
 ### Content Hash Verification
 
 ```go
-r := packfile.Open("events-00042.pack")
+r := packfile.Open("output.pack")
 defer r.Close()
 
 hash, ok, _ := r.ContentHash() // stored SHA-256, if present
@@ -104,232 +122,6 @@ if ok {
 }
 ```
 
-### Key-Based Access
-
-Packfile indexes by ordinal position, not by key. For keyed data, the caller provides its own key → ordinal mapping. Any mapping works: a hash table, a sorted array with binary search, or a perfect hash function. Packfile doesn't know or care how the ordinal was determined.
-
-Example using a minimal perfect hash function (MPHF) for bitmap storage:
-
-```go
-// Write — one bitmap per MPHF slot, batched into records
-w, _ := packfile.Create("bitmaps.pack", packfile.WriterOptions{RecordSize: 128})
-for slot := 0; slot < mphf.Len(); slot++ {
-    w.Append(bitmapData[slot])
-}
-w.Finish(nil)
-
-// Read — MPHF gives ordinal, packfile gives data
-r := packfile.Open("bitmaps.pack")
-defer r.Close()
-
-slot := mphf.Lookup("USD")
-r.ReadItem(slot, func(data []byte) error {
-    bitmap.UnmarshalBinary(data) // data is borrowed — copy if needed
-    return nil
-})
-```
-
-## Goals
-
-- **O(1) random access by ordinal index.** Every `ReadItem` call maps index to record via arithmetic, then reads and decodes a single record.
-- **Minimal I/O.** The full index loads in one disk read on open (~112KB for 68K records). After that, one disk read per record, exact size, no over-read.
-- **Compact index.** Index size depends on max record size, not file size. A file with 20KB records uses 15-bit deltas whether the file is 500MB or 50GB.
-- **Immutable after write.** No updates, no deletes. Simple, safe, predictable.
-- **Concurrent reads.** All `Reader` methods are safe for concurrent use. No locks in the read path.
-
-## Non-Goals
-
-- **Key-based lookup.** Packfile is indexed by ordinal position, not by key. Key-based access is built on top by the caller (see usage example above).
-- **Mutability.** No append-after-finalize, no updates, no deletes.
-- **Chunk management.** Directory layout, chunk-to-sequence mapping, rotation are caller concerns.
-- **Caching.** No built-in LRU. Callers manage their own pool of open `Reader` instances.
-
-## How It Works
-
-Items are grouped into fixed-size **records** (default 128 items per record). Small items like events don't compress well individually, but 128 of them together do. Large items like ledgers are stored one per record since they compress well on their own. Each record is compressed and written as a contiguous block on disk.
-
-An **offset index** at the end of the file maps record numbers to byte offsets. On open, the entire index is decoded into a flat `[]int64` array. Looking up item `i` is arithmetic: `offsets[i / RecordSize]` gives the record's byte offset, then a single disk read + decode extracts the item.
-
-When a record contains multiple items, the reader needs to know where each item starts within the decompressed data. A compact **FOR index** appended to each multi-item record stores these byte lengths. The FOR index is always uncompressed and carries its own CRC32C — it can be verified without decompressing the payload. Single-item records skip the FOR index entirely.
-
----
-
-## File Format
-
-Everything below is internal to the library. Callers don't need to know this — it's here for contributors and the curious.
-
-Reads throughout this section use `pread` — positioned read at a specific file offset without moving a file pointer — which is safe for concurrent use and maps to Go's `os.File.ReadAt`.
-
-### Layout
-
-```
-┌──────────────────────────────────┐  offset 0
-│ record 0                         │
-│ record 1                         │
-│ ...                              │
-│ record N-1                       │
-├──────────────────────────────────┤  indexBase
-│ offset index (FOR groups)        │
-│ CRC32C (4 bytes)                 │
-├──────────────────────────────────┤  (optional)
-│ app data                         │
-├──────────────────────────────────┤
-│ trailer (64 bytes)               │
-└──────────────────────────────────┘  EOF
-```
-
-### Records
-
-Each record contains up to `RecordSize` items. When a record contains multiple items (`RecordSize > 1`), the items are concatenated into a payload, and a **FOR index** is appended. The FOR index encodes each item's byte length and carries its own CRC32C — it is always uncompressed regardless of the record format, and is stripped from the raw record bytes before any format-specific processing.
-
-```
-Multi-item record on-disk layout:
-
-  Compressed:   [zstd(payload)][FOR_index]
-  Uncompressed: [payload][4B CRC_items][FOR_index]
-  Raw:          [payload][FOR_index]
-
-FOR_index = [packed residuals][1B W][4B min LE][4B CRC32C]
-  where CRC32C covers [packed][W][min]
-```
-
-The last 9 bytes of any multi-item record are always `[1B W][4B min][4B CRC]` — fixed offsets from the tail regardless of packed content. The decoder strips and verifies the FOR index from the raw bytes before decompression, enabling early corruption detection without paying decompression cost.
-
-**Single-item records** (`RecordSize=1`): The FOR index is omitted entirely — the item's length equals the decompressed payload length.
-
-```
-Single-item record layout (RecordSize=1):
-  Compressed:   [zstd(item)]
-  Uncompressed: [item][4B CRC_items]
-  Raw:          [item]
-```
-
-**Compressed records** (default): The payload is zstd-compressed. Integrity is provided by zstd's built-in content checksum (xxHash64), verified automatically during decompression. The FOR index (appended after compression) has its own CRC32C.
-
-**Uncompressed records** (`Format: Uncompressed`): The payload is stored as-is with a 4-byte CRC32C. The FOR index has its own CRC32C. The item CRC covers only the payload bytes (not the FOR index).
-
-**Raw records** (`Format: Raw`): The payload is stored as-is with no integrity wrapper. The FOR index still has its own CRC32C.
-
-### Content Hash
-
-When `ContentHash: true`, the writer computes a chunked SHA-256 over the logical item stream:
-
-```
-chunkDigest_i = SHA-256([4B len][item_{i*K}] ... [4B len][item_{i*K+K-1}])
-finalHash     = SHA-256(chunkDigest_0 || ... || chunkDigest_M)
-K = RecordSize
-```
-
-The hash is independent of compression and format — same items in the same order with the same RecordSize always produce the same hash. Note that changing RecordSize changes the chunk boundaries and therefore the hash.
-
-### Trailer (64 bytes at EOF)
-
-```
-Offset  Size  Type      Field
-0       4     uint32    magic (0x534C4348)
-4       1     uint8     version (1)
-5       1     uint8     flags
-6       4     uint32    recordCount
-10      4     uint32    totalItems
-14      4     uint32    recordSize
-18      4     uint32    indexSize (all groups + 4-byte CRC32C)
-22      4     uint32    appDataSize (0 if none)
-26      32    [32]byte  contentHash (zeroed if flagContentHash not set)
-58      2     -         reserved (zero)
-60      4     uint32    CRC32C of trailer[0:60]
-```
-
-Flags (uint8):
-- Bit 0 (`flagNoCompression`): records are not zstd-compressed (Uncompressed format with CRC32C, or Raw when combined with Bit 2)
-- Bit 1 (`flagContentHash`): trailer contains a 32-byte SHA-256 content hash
-- Bit 2 (`flagNoCRC`): per-record CRC32C is omitted (only valid with flagNoCompression; this combination is the Raw format)
-
-The `Checksum` at offset 60 covers `trailer[0:60]`. The reader validates flags against `knownFlags` and rejects files with unknown flag bits.
-
-### Index Encoding
-
-The offset index maps record numbers to byte positions. A naive approach stores absolute byte offsets, but offset size grows with file size — a 50GB file needs 36-bit offsets even if records are only 6KB.
-
-Packfile stores **record sizes** (deltas between consecutive offsets) instead. Deltas depend on the maximum record size, not total file size. A file with 20KB records uses 15-bit deltas whether the file is 500MB or 50GB.
-
-Deltas are encoded using **Frame of Reference (FOR)** compression in groups of 128. FOR subtracts a per-group minimum from every value, then bit-packs the residuals at the minimum bit width needed. Each group is self-contained:
-
-```
-FOR Group (ceil(128 × W / 8) + 5 bytes):
-
-  [00-XX]  residuals: 128 packed integers, W bits each
-           residual[j] = delta[j] - groupMin
-
-  [XX]     W: uint8, bit width of residuals (bits.Len32 of max residual)
-
-  [XX+1 .. XX+4]  groupMin: uint32 LE, minimum delta in this group
-```
-
-Width and minimum are always the final 5 bytes. A group where all records are between 5,000 and 5,200 bytes needs only 8 bits for residuals (range of 200), regardless of the absolute delta magnitude.
-
-On open, all groups are decoded into a flat `[]int64` offset table. Resolving item `i`:
-
-```
-recordIdx = i / RecordSize
-localIdx  = i % RecordSize
-offset    = offsets[recordIdx]
-```
-
-Each `ReadItem` is an array lookup + single disk read + decode.
-
-The group size (128) is a library constant, independent of RecordSize. If it changes, the format version is bumped.
-
-### Integrity
-
-**Index checksum:** CRC32C of the raw index bytes (all FOR groups). Verified on open before decoding. After decoding, the reader also asserts that the running offset sum equals `indexBase` — an independent structural invariant that catches encode/decode logic bugs.
-
-**Trailer checksum:** CRC32C of `trailer[0:60]` protects all structural fields. App data has no packfile-level integrity check — callers are responsible for their own app data integrity.
-
-**Trailer validation:** On open: flags against `knownFlags`, `recordSize > 0`, `ceil(totalItems / recordSize) == recordCount`.
-
-**Record checksums:** Compressed records use zstd's built-in content checksum (xxHash64), verified during decompression. Uncompressed records use a trailing CRC32C. Raw records have no per-record integrity — use only when items are already checksummed.
-
-**Content hash verification:** `Verify(ctx)` recomputes the SHA-256 content hash by streaming all items and compares to the stored hash.
-
-### Edge Cases
-
-**Last group:** If `RecordCount` is not a multiple of 128, remaining residual slots are zero-padded. The reader respects `RecordCount` and never accesses padding.
-
-**Last record:** If `TotalItems` is not a multiple of `RecordSize`, the last record contains fewer items.
-
-**Zero items:** Valid. No records. Index section is just 4 bytes (CRC32C of empty payload).
-
-**Single item:** One record, one group, one delta.
-
----
-
-## Implementation Notes
-
-### Read Path
-
-**Non-blocking Open.** `Open` returns a `*Reader` immediately. A background goroutine performs all I/O: open, stat, speculative read, trailer parse, CRC verification, index decode, app data read. A `sync.OnceValue` drains the result on the first query call. Errors are deferred to query time — `Open` itself never fails. This enables overlapped initialization: start loading an MPHF or opening other files while the goroutine runs.
-
-**Speculative Read.** On open, one pread of the last `min(256KB, fileSize)` bytes. This usually captures the trailer, app data, and index in one IOP. If the tail exceeds 256KB, a single fallback read fetches the rest.
-
-**ReadItem.** Maps item index to record index (`i / RecordSize`), gets a pooled decoder, reads the record via `ReadAt`, decodes (decompresses + extracts item sizes), and passes the item to the callback as a borrowed slice. Returns the decoder to the pool after the callback.
-
-**ReadRange.** Coalesces consecutive records that fit in a pooled 1MB buffer into single `ReadAt` calls. Oversized records (> 1MB) get one-off allocations.
-
-**ReadItems.** Single-pass partition of sorted indices into I/O batches (consecutive records ≤ 1MB). Workers (up to `concurrency` goroutines) claim batches via an atomic counter, read with a single `ReadAt`, decode, and call `fn(pos, entry)` directly. No channels, no reorder goroutine. On error or cancellation, an atomic flag stops remaining workers.
-
-**Decoder Pool.** `sync.Pool` of decoder instances, each owning a `ZSTD_DCtx` allocated via CGo. Decoders are stateless between calls.
-
-**Concurrency.** Safe for concurrent use after `Open`. The offset table and metadata are immutable. All read methods use stateless `ReadAt` (pread) with pooled resources.
-
-### Write Path
-
-**Create.** Opens the file directly at `path` with `O_EXCL` (fails if exists, unless `Overwrite` is set). `Finish` writes remaining items, the offset index, app data, trailer, then fsyncs. `Close` without `Finish` removes the incomplete file.
-
-**Parallel Pipeline.** When `Concurrency > 1`, the writer runs a streaming pipeline: `Append` accumulates items → `Flush` sends records to `workCh` → N block workers compress/CRC/hash in parallel → writer goroutine reorders by block ID and writes sequentially.
-
-**BytesPerSync.** Optional background writeback via `sync_file_range(SYNC_FILE_RANGE_WRITE)` on Linux (no-op elsewhere). Spreads I/O so the final fsync has less to flush.
-
-**Index Decode OOM Guard.** Before decoding, validates that `recordCount` is plausible given `indexSize`. Each FOR group of up to 128 records requires at least 6 bytes. This prevents crafted trailers from causing huge allocations.
 
 ## API Reference
 
@@ -340,8 +132,8 @@ package packfile
 
 // WriterOptions configures how the packfile is written.
 type WriterOptions struct {
-    // RecordSize is the number of items per record. 0 defaults to 128.
-    RecordSize int
+    // ItemsPerRecord is the number of items per record. 0 defaults to 128.
+    ItemsPerRecord int
 
     // Format controls record encoding. Default (zero value) is Compressed.
     // Compressed: zstd with built-in integrity.
@@ -349,9 +141,8 @@ type WriterOptions struct {
     // Raw: raw records with no integrity wrapper.
     Format RecordFormat
 
-    // Concurrency sets the number of block-processing goroutines.
-    // 0 or 1 means serial. Ignored when Format is not Compressed
-    // and ContentHash is false (nothing to parallelize).
+    // Concurrency sets the number of parallel compression goroutines.
+    // 0 or 1 means serial.
     Concurrency int
 
     // ContentHash enables SHA-256 content hashing over the logical item stream.
@@ -376,9 +167,10 @@ type Writer struct{ /* unexported */ }
 // exists unless Overwrite is set.
 func Create(path string, opts WriterOptions) (*Writer, error)
 
-// Append adds a single logical item. Parts are concatenated as one entry.
-// Flushes a record when RecordSize items accumulate.
-func (w *Writer) Append(parts ...[]byte) error
+// AppendItem adds a single item. If multiple byte slices are passed,
+// they are concatenated into one item.
+// Flushes a record when ItemsPerRecord items accumulate.
+func (w *Writer) AppendItem(parts ...[]byte) error
 
 // Finish flushes any partial record, writes index + optional app data + trailer,
 // fsyncs, and closes the file. appData is optional caller-injected data stored
@@ -398,10 +190,10 @@ func (w *Writer) Close() error
 // Safe for concurrent use by multiple goroutines.
 type Reader struct{ /* unexported */ }
 
-// Open returns a Reader immediately. All file I/O (open, stat, speculative
-// read, trailer parse, index decode, app data read) runs in a background
-// goroutine. Open never fails; errors are deferred to the first method that
-// needs the result. Close must always be called.
+// Open returns a Reader immediately. File I/O runs in a background goroutine;
+// the first read call blocks until the file is ready. Open never fails;
+// errors are deferred to the first method that needs the result.
+// Close must always be called.
 func Open(path string, opts ...ReaderOption) *Reader
 
 // WithConcurrency sets the max parallel goroutines for ReadItems.
@@ -411,28 +203,26 @@ func WithConcurrency(n int) ReaderOption
 // TotalItems returns the total number of logical items in the packfile.
 func (r *Reader) TotalItems() (int, error)
 
-// ReadItem reads a single item by global index and passes it to fn.
+// ReadItem reads a single item by position and passes it to fn.
 // The []byte passed to fn is borrowed and must not be retained after fn
-// returns — copy if needed. Returns ErrIndexRange if index is out of
-// [0, TotalItems).
-func (r *Reader) ReadItem(index int, fn func([]byte) error) error
+// returns — copy if needed. Returns ErrPositionOutOfRange if position is
+// out of [0, TotalItems).
+func (r *Reader) ReadItem(position int, fn func([]byte) error) error
 
 // ReadRange returns an iterator over count contiguous items starting at start.
 // Each yielded []byte is valid only until the next iteration — copy if you
 // need to retain it. Safe to break early. Thread-safe.
 func (r *Reader) ReadRange(start, count int) iter.Seq2[[]byte, error]
 
-// ReadItems reads items at scattered indices with parallel I/O and calls
-// fn for each item. fn receives the position in the original indices slice
-// and a borrowed entry slice valid only for the duration of the call — copy
-// if needed.
+// ReadItems reads items at the given positions with parallel I/O and calls
+// fn for each item. fn receives the index in the positions slice and a
+// borrowed data slice valid only for the duration of the call — copy if needed.
 //
 // fn is called concurrently from multiple goroutines, in arbitrary order.
-// The pos argument identifies which index the entry corresponds to.
 //
-// indices must be sorted ascending with no duplicates.
-// Panics if any index is out of range or indices are not sorted/unique.
-func (r *Reader) ReadItems(ctx context.Context, indices []int, fn func(pos int, entry []byte) error) error
+// positions must be sorted ascending with no duplicates.
+// Panics if any position is out of range or positions are not sorted/unique.
+func (r *Reader) ReadItems(ctx context.Context, positions []int, fn func(idx int, data []byte) error) error
 
 // ContentHash returns the SHA-256 content hash stored in the trailer, if present.
 func (r *Reader) ContentHash() ([32]byte, bool, error)
@@ -445,8 +235,11 @@ func (r *Reader) Verify(ctx context.Context) error
 // AppData returns the app data section, or nil if appDataSize == 0.
 func (r *Reader) AppData() ([]byte, error)
 
+// Trailer returns the parsed trailer fields (record count, total items, etc.).
 func (r *Reader) Trailer() (Trailer, error)
 
+// Close releases all resources. Safe to call multiple times.
+// Must always be called, even if no read methods were called.
 func (r *Reader) Close() error
 ```
 
@@ -459,24 +252,212 @@ var (
     ErrVersion             = fmt.Errorf("%w: unsupported version", ErrCorrupt)
     ErrChecksum            = fmt.Errorf("%w: checksum mismatch", ErrCorrupt)
     ErrSize                = fmt.Errorf("%w: file size inconsistent with trailer", ErrCorrupt)
-    ErrIndexRange          = errors.New("packfile: item index out of range")
+    ErrPositionOutOfRange  = errors.New("packfile: position out of range")
     ErrContentHashMismatch = errors.New("packfile: content hash mismatch")
 )
 ```
 
-### intpack
+## File Format
 
-```go
-package intpack
+Everything below is internal to the library. Callers don't need to know this — it's here for contributors and the curious.
 
-// EncodeGroup FOR-encodes values into one group: [packed residuals][1B W][4B min LE].
-// W = bits.Len32(max - min), clamped to min 1. Pure codec — no CRC, no trailer.
-// Panics if len(values) == 0.
-func EncodeGroup(values []uint32) []byte
+**Terminology quick reference:**
 
-// DecodeGroup FOR-decodes one group of n values from the tail of buf.
-// buf must end at the last byte of [min] (the byte before any trailing CRC or other data).
-// Returns decoded values (written into dst[0:n], reallocating if cap(dst) < n),
-// bytes consumed from the tail, and any error.
-func DecodeGroup(buf []byte, n int, dst []uint32) (values []uint32, consumed int, err error)
+| Term | Meaning |
+|---|---|
+| **Item** | One opaque byte blob — the unit the caller writes and reads |
+| **Record** | A group of 1 to `ItemsPerRecord` items, stored as one contiguous blob on disk |
+| **Payload** | The concatenated raw bytes of all items in a record, before compression |
+| **Item size index** | FOR-encoded byte lengths appended to each multi-item record, so the reader can find individual items within the decompressed payload |
+| **Offset index** | The file-level table at the end of the file mapping each record to its byte position on disk |
+| **FOR group** | A batch of integers (up to 128) encoded together using Frame of Reference compression |
+| **W** | Bit width needed to store the largest residual in a FOR group |
+| **min** | The smallest value in a FOR group, subtracted from all values before bit-packing |
+
+Reads throughout this section use `pread` — positioned read at a specific file offset without moving a file pointer — which is safe for concurrent use and maps to Go's `os.File.ReadAt`.
+
+### Layout
+
 ```
+┌──────────────────────────────────┐  offset 0
+│ record 0                         │
+│ record 1                         │
+│ ...                              │
+│ record N-1                       │
+├──────────────────────────────────┤  indexBase
+│ offset index                     │
+│ CRC32C (4 bytes)                 │
+├──────────────────────────────────┤  (optional)
+│ app data                         │
+├──────────────────────────────────┤
+│ trailer (64 bytes)               │
+└──────────────────────────────────┘  EOF
+```
+
+### FOR Encoding
+
+Both the offset index and the per-record item size index use **[Frame of Reference (FOR)](https://lemire.me/blog/2012/02/08/effective-compression-using-frame-of-reference-and-delta-coding/)** encoding, so this section explains the encoding before either is described.
+
+FOR encodes a group of unsigned integers compactly. It subtracts the group's minimum value from every value, then bit-packs the residuals at the minimum bit width needed. Each group is self-contained:
+
+```
+FOR Group (ceil(N × W / 8) + 5 bytes):
+
+  [00-XX]  residuals: N packed integers, W bits each
+           residual[j] = value[j] - min
+
+  [XX]     W: uint8, bit width needed (bits.Len32 of max residual)
+
+  [XX+1 .. XX+4]  min: uint32 LE, minimum value in this group
+```
+
+Width and minimum are always the final 5 bytes. For example, a group where all values are between 5,000 and 5,200 needs only 8 bits per residual (range of 200), regardless of the absolute magnitude.
+
+### Index Encoding
+
+The offset index maps record numbers to byte positions. Rather than storing absolute offsets (which grow with file size), the index stores **record byte sizes** — the difference between consecutive offsets. These are encoded using FOR in groups of 128.
+
+A file with 20KB records uses ~15-bit values whether the file is 500MB or 50GB, because the values are record sizes, not file offsets.
+
+On open, all groups are decoded into a flat `[]int64` offset table. Resolving item `i`:
+
+```
+recordIdx = i / ItemsPerRecord
+localIdx  = i % ItemsPerRecord
+offset    = offsets[recordIdx]
+```
+
+Each `ReadItem` is an array lookup + single disk read + decode.
+
+The FOR group size for the offset index is 128 — a library constant, independent of `ItemsPerRecord`. If it changes, the format version is bumped.
+
+### Records
+
+Each record contains up to `ItemsPerRecord` items.
+
+**Multi-item records** (`ItemsPerRecord > 1`): Items are concatenated into a payload. An **item size index** is appended after the payload — a single FOR group encoding each item's byte length, followed by a CRC32C of the FOR data. The item size index is always uncompressed regardless of the record format, and is stripped from the raw record bytes before any format-specific processing.
+
+```
+Multi-item record on-disk layout:
+
+  Compressed:   [zstd(payload)][item_sizes]
+  Uncompressed: [payload][4B CRC_items][item_sizes]
+  Raw:          [payload][item_sizes]
+
+item_sizes = [FOR-encoded item lengths][4B CRC32C]
+```
+
+The decoder strips and verifies the item size index from the tail of the record before decompression, enabling early corruption detection without paying decompression cost.
+
+**Single-item records** (`ItemsPerRecord=1`): The item size index is omitted entirely — the item is the entire payload.
+
+```
+Single-item record layout (ItemsPerRecord=1):
+  Compressed:   [zstd(item)]
+  Uncompressed: [item][4B CRC_items]
+  Raw:          [item]
+```
+
+**Compressed records** (default): The payload is zstd-compressed. Integrity is provided by zstd's built-in content checksum (xxHash64), verified automatically during decompression.
+
+**Uncompressed records** (`Format: Uncompressed`): The payload is stored as-is with a 4-byte CRC32C covering only the payload bytes.
+
+**Raw records** (`Format: Raw`): The payload is stored as-is with no integrity wrapper.
+
+### Content Hash
+
+When `ContentHash: true`, the writer computes a chunked SHA-256 over the logical item stream. Each record's items are hashed together into a digest, then all digests are hashed into the final hash:
+
+```
+// Example with ItemsPerRecord=128:
+record_0_digest = SHA-256([4B len][item_0][4B len][item_1]...[4B len][item_127])
+record_1_digest = SHA-256([4B len][item_128]...[4B len][item_255])
+...
+finalHash = SHA-256(record_0_digest || record_1_digest || ...)
+```
+
+The hash is independent of compression and format — same items in the same order with the same `ItemsPerRecord` always produce the same hash. Note that changing `ItemsPerRecord` changes the chunk boundaries and therefore the hash.
+
+### Trailer (64 bytes at EOF)
+
+```
+Offset  Size  Type      Field
+0       4     uint32    magic (0x534C4348)
+4       1     uint8     version (1)
+5       1     uint8     flags
+6       4     uint32    recordCount
+10      4     uint32    totalItems
+14      4     uint32    itemsPerRecord
+18      4     uint32    indexSize (offset index bytes + 4-byte CRC32C)
+22      4     uint32    appDataSize (0 if none)
+26      32    [32]byte  contentHash (zeroed if flagContentHash not set)
+58      2     uint16    indexForGroupSize (FOR group size for offset index)
+60      4     uint32    CRC32C of trailer[0:60]
+```
+
+Flags (uint8):
+- Bit 0 (`flagNoCompression`): records are not zstd-compressed (Uncompressed format with CRC32C, or Raw when combined with Bit 2)
+- Bit 1 (`flagContentHash`): trailer contains a 32-byte SHA-256 content hash
+- Bit 2 (`flagNoCRC`): per-record CRC32C is omitted (only valid with flagNoCompression; this combination is the Raw format)
+
+The `Checksum` at offset 60 covers `trailer[0:60]`. The reader validates flags against `knownFlags` and rejects files with unknown flag bits.
+
+### Integrity
+
+**Index checksum:** CRC32C of the raw offset index bytes. Verified on open before decoding. After decoding, the reader also asserts that the running offset sum equals `indexBase` — an independent structural invariant that catches encode/decode logic bugs.
+
+**Trailer checksum:** CRC32C of `trailer[0:60]` protects all structural fields. App data has no packfile-level integrity check — callers are responsible for their own app data integrity.
+
+**Trailer validation:** On open: flags against `knownFlags`, `itemsPerRecord > 0`, `ceil(totalItems / itemsPerRecord) == recordCount`.
+
+**Record checksums:** Compressed records use zstd's built-in content checksum (xxHash64), verified during decompression. Uncompressed records use a trailing CRC32C. Raw records have no per-record integrity — use only when items are already checksummed.
+
+**Content hash verification:** `Verify(ctx)` recomputes the SHA-256 content hash by streaming all items and compares to the stored hash.
+
+### Edge Cases
+
+**Last group:** If `recordCount` is not a multiple of 128, remaining residual slots in the last FOR group are zero-padded. The reader respects `recordCount` and never accesses padding.
+
+**Last record:** If `totalItems` is not a multiple of `ItemsPerRecord`, the last record contains fewer items.
+
+**Zero items:** Valid. No records. Index section is just 4 bytes (CRC32C of empty payload).
+
+**Single item:** One record, one FOR group, one value.
+
+---
+
+## Implementation Notes
+
+### Read Path
+
+**Non-blocking Open.** `Open` returns a `*Reader` immediately. A background goroutine performs all I/O: open, stat, speculative read, trailer parse, CRC verification, index decode, app data read. A `sync.OnceValue` drains the result on the first query call. Errors are deferred to query time — `Open` itself never fails. This enables overlapped initialization: the caller can open multiple files or perform other setup while the goroutine runs.
+
+**Speculative Read.** On open, one pread of the last `min(256KB, fileSize)` bytes. If the offset index fits within this range, the trailer, app data, and index are all loaded in a single I/O operation. Otherwise, a fallback read fetches the rest.
+
+**Index Decode OOM Guard.** Before decoding the offset index, validates that `recordCount` is plausible given `indexSize`. Each FOR group of up to 128 records requires at least 6 bytes. This prevents crafted trailers from causing huge allocations.
+
+**ReadItem.** Given `ReadItem(42, fn)` on a file with `ItemsPerRecord=128`:
+
+1. Record number = `42 / 128 = 0`, local position = `42 % 128 = 42`
+2. Look up record 0's byte offset from the in-memory offset table (array access)
+3. One `pread` fetches the entire record from disk
+4. Decode: strip and verify the item size index, decompress if needed
+5. Extract item 42 from the decoded payload, pass to `fn`
+
+All of steps 2-5 are a single I/O operation. A pooled decoder is used and returned after the callback.
+
+**ReadRange.** Coalesces consecutive records that fit in a pooled 1MB buffer into single `ReadAt` calls. Oversized records (> 1MB) get one-off allocations.
+
+**ReadItems.** Single-pass partition of sorted positions into I/O batches (consecutive records ≤ 1MB). Workers (up to `concurrency` goroutines) claim batches via an atomic counter, read with a single `ReadAt`, decode, and call `fn(idx, data)` directly. No channels, no reorder goroutine. On error or cancellation, an atomic flag stops remaining workers.
+
+**Decoder Pool.** `sync.Pool` of decoder instances, each owning a `ZSTD_DCtx` allocated via CGo. Decoders are stateless between calls.
+
+**Concurrency.** Safe for concurrent use after `Open`. The offset table and metadata are immutable. All read methods use stateless `ReadAt` (pread) with pooled resources.
+
+### Write Path
+
+**Create.** Opens the file directly at `path` with `O_EXCL` (fails if exists, unless `Overwrite` is set). `Finish` writes remaining items, the offset index, app data, trailer, then fsyncs. `Close` without `Finish` removes the incomplete file.
+
+**Parallel Pipeline.** When `Concurrency > 1`, the writer runs a streaming pipeline: `AppendItem` accumulates items → flush sends records to workers → N block workers compress/CRC/hash in parallel → writer goroutine reorders by block ID and writes sequentially.
+
+**BytesPerSync.** Optional background writeback via `sync_file_range(SYNC_FILE_RANGE_WRITE)` on Linux (no-op elsewhere). Spreads I/O so the final fsync has less to flush.

--- a/design-docs/packfile-library.md
+++ b/design-docs/packfile-library.md
@@ -296,7 +296,7 @@ Reads throughout this section use `pread` — positioned read at a specific file
 
 ### FOR Encoding
 
-Both the offset index and the per-record item size index use **[Frame of Reference (FOR)](https://lemire.me/blog/2012/02/08/effective-compression-using-frame-of-reference-and-delta-coding/)** encoding, so this section explains the encoding before either is described.
+Both the offset index and the per-record item size index use **[Frame of Reference (FOR)](https://lemire.me/blog/2012/02/08/effective-compression-using-frame-of-reference-and-delta-coding/)** encoding.
 
 FOR encodes a group of unsigned integers compactly. It subtracts the group's minimum value from every value, then bit-packs the residuals at the minimum bit width needed. Each group is self-contained:
 
@@ -315,7 +315,7 @@ Width and minimum are always the final 5 bytes. For example, a group where all v
 
 ### Index Encoding
 
-The offset index maps record numbers to byte positions. Rather than storing absolute offsets (which grow with file size), the index stores **record byte sizes** — the difference between consecutive offsets. These are encoded using FOR in groups of 128.
+The offset index maps record numbers to byte positions. Rather than storing absolute offsets (which grow with file size), the index stores **record byte sizes**. These are encoded using FOR in groups of 128.
 
 A file with 20KB records uses ~15-bit values whether the file is 500MB or 50GB, because the values are record sizes, not file offsets.
 
@@ -363,6 +363,73 @@ Single-item record layout (ItemsPerRecord=1):
 **Uncompressed records** (`Format: Uncompressed`): The payload is stored as-is with a 4-byte CRC32C covering only the payload bytes.
 
 **Raw records** (`Format: Raw`): The payload is stored as-is with no integrity wrapper.
+
+### Worked Example
+
+Here's how records, item size indexes, and the offset index compose into a complete file. Compressed payload sizes are approximate (marked ≈); FOR encoding math is exact.
+
+5 items with sizes [120, 95, 200, 80, 150] bytes.
+
+**With `ItemsPerRecord=2`** (3 records):
+
+```
+Record 0: items 0,1
+  payload = 120 + 95 = 215 bytes → zstd ≈ 180 bytes
+  item_sizes = FOR([120, 95]):
+    min=95, residuals=[25, 0], W=5
+    ceil(2×5/8)=2B packed + 1B W + 4B min + 4B CRC = 11 bytes
+  on disk: [zstd(payload) ≈ 180 B][item_sizes (11 B)] ≈ 191 B
+
+Record 1: items 2,3
+  payload = 200 + 80 = 280 bytes → zstd ≈ 235 bytes
+  item_sizes = FOR([200, 80]):
+    min=80, residuals=[120, 0], W=7
+    ceil(2×7/8)=2B packed + 1B W + 4B min + 4B CRC = 11 bytes
+  on disk: [zstd(payload) ≈ 235 B][item_sizes (11 B)] ≈ 246 B
+
+Record 2: item 4 only (partial last record)
+  payload = 150 bytes → zstd ≈ 125 bytes
+  on disk: [zstd(payload) ≈ 125 B] ≈ 125 B
+  no item_sizes — single-item record
+
+Offset index stores record byte sizes: [191, 246, 125]
+  FOR group: min=125, residuals=[66, 121, 0], W=7
+  ceil(3×7/8)=3B packed + 1B W + 4B min + 4B CRC = 12 bytes
+
+File layout:
+  0       Record 0  (≈ 191 B)
+  191     Record 1  (≈ 246 B)
+  437     Record 2  (≈ 125 B)
+  562     Offset index (12 B)
+  574     Trailer (64 B)
+  638     EOF
+```
+
+**With `ItemsPerRecord=1`** (5 records, same items):
+
+```
+Record 0: [zstd(120 B)] ≈ 100 B    no item_sizes —
+Record 1: [zstd(95 B)]  ≈ 82 B     every record is
+Record 2: [zstd(200 B)] ≈ 165 B    single-item
+Record 3: [zstd(80 B)]  ≈ 70 B
+Record 4: [zstd(150 B)] ≈ 125 B
+
+Offset index stores: [100, 82, 165, 70, 125]
+  FOR group: min=70, residuals=[30, 12, 95, 0, 55], W=7
+  ceil(5×7/8)=5B packed + 1B W + 4B min + 4B CRC = 14 bytes
+
+File layout:
+  0       Record 0  (≈ 100 B)
+  100     Record 1  (≈ 82 B)
+  182     Record 2  (≈ 165 B)
+  347     Record 3  (≈ 70 B)
+  417     Record 4  (≈ 125 B)
+  542     Offset index (14 B)
+  556     Trailer (64 B)
+  620     EOF
+```
+
+Key difference: with `ItemsPerRecord=2`, each multi-item record carries an item size index so the reader can find individual items inside the decompressed payload. With `ItemsPerRecord=1`, that disappears entirely — each read fetches exactly one item, no slicing needed. The tradeoff is 5 index entries instead of 3.
 
 ### Content Hash
 

--- a/design-docs/packfile-library.md
+++ b/design-docs/packfile-library.md
@@ -240,9 +240,9 @@ Offset  Size  Type      Field
 ```
 
 Flags (uint8):
-- Bit 0 (`flagNoCompression`): records are uncompressed with CRC32C
+- Bit 0 (`flagNoCompression`): records are not zstd-compressed (Uncompressed format with CRC32C, or Raw when combined with Bit 2)
 - Bit 1 (`flagContentHash`): trailer contains a 32-byte SHA-256 content hash
-- Bit 2 (`flagNoCRC`): per-record CRC32C is omitted (only with flagNoCompression)
+- Bit 2 (`flagNoCRC`): per-record CRC32C is omitted (only valid with flagNoCompression; this combination is the Raw format)
 
 The `Checksum` at offset 60 covers `trailer[0:60]`. The reader validates flags against `knownFlags` and rejects files with unknown flag bits.
 
@@ -459,7 +459,7 @@ var (
     ErrVersion             = fmt.Errorf("%w: unsupported version", ErrCorrupt)
     ErrChecksum            = fmt.Errorf("%w: checksum mismatch", ErrCorrupt)
     ErrSize                = fmt.Errorf("%w: file size inconsistent with trailer", ErrCorrupt)
-    ErrIndexRange          = errors.New("packfile: record index out of range")
+    ErrIndexRange          = errors.New("packfile: item index out of range")
     ErrContentHashMismatch = errors.New("packfile: content hash mismatch")
 )
 ```

--- a/design-docs/packfile-library.md
+++ b/design-docs/packfile-library.md
@@ -252,7 +252,7 @@ The offset index maps record numbers to byte positions. A naive approach stores 
 
 Packfile stores **record sizes** (deltas between consecutive offsets) instead. Deltas depend on the maximum record size, not total file size. A file with 20KB records uses 15-bit deltas whether the file is 500MB or 50GB.
 
-Deltas are encoded using **Frame of Reference (FOR) compression** in groups of 128. FOR subtracts a per-group minimum from every value, then bit-packs the residuals at the minimum bit width needed. Each group is self-contained:
+Deltas are encoded using **Frame of Reference (FOR)** compression in groups of 128. FOR subtracts a per-group minimum from every value, then bit-packs the residuals at the minimum bit width needed. Each group is self-contained:
 
 ```
 FOR Group (ceil(128 × W / 8) + 5 bytes):
@@ -285,7 +285,7 @@ The group size (128) is a library constant, independent of RecordSize. If it cha
 
 **Trailer checksum:** CRC32C of `trailer[0:60]` protects all structural fields. App data has no packfile-level integrity check — callers are responsible for their own app data integrity.
 
-**Trailer validation:** On open: flags against `knownFlags`, `recordSize > 0`, `ceil(totalItems / recordsize) == recordCount`.
+**Trailer validation:** On open: flags against `knownFlags`, `recordSize > 0`, `ceil(totalItems / recordSize) == recordCount`.
 
 **Record checksums:** Compressed records use zstd's built-in content checksum (xxHash64), verified during decompression. Uncompressed records use a trailing CRC32C. Raw records have no per-record integrity — use only when items are already checksummed.
 

--- a/design-docs/packfile-library.md
+++ b/design-docs/packfile-library.md
@@ -1,0 +1,482 @@
+# Packfile Library Design
+
+## Problem
+
+We need to store large collections of variable-length items (events, compressed bitmaps, ledgers) in immutable files and read individual items by ordinal index with minimal I/O. The files are written once and read many times over their lifetime.
+
+A flat file is the natural fit: write items sequentially, keep an offset table at the end, look up any item by index. This is simple, fast, and well-suited to immutable data. General-purpose storage engines like RocksDB or SQLite add key management, transactions, and mutable write paths that we don't need — overhead without benefit for immutable, ordinal-indexed data.
+
+Packfile is an implementation of this approach. It handles the details that a naive implementation gets wrong or leaves to the caller: record grouping for compression, compact index encoding, parallel block processing, SHA-256 content hashing, CRC32C integrity checks, and safe concurrent reads.
+
+Two packages:
+
+- **`packfile`** — item-level random access to immutable files. Handles record grouping, zstd compression, CRC32C integrity, content hashing, and parallel I/O. Uses a thin CGo wrapper (`zstd/`) for compression — the pure-Go zstd implementation is 4x slower on our workloads.
+- **`intpack`** — integer compression using Frame of Reference (FOR) encoding. Pure Go, no external dependencies. General-purpose codec — not packfile-specific.
+
+## Usage
+
+Error handling omitted for clarity. All functions return errors.
+
+### Writing
+
+```go
+w, _ := packfile.Create("events-00042.pack", packfile.WriterOptions{
+    RecordSize:  128,         // items per record (default 128)
+    Concurrency: 4,           // parallel block-processing goroutines
+    ContentHash: true,        // compute SHA-256 content hash
+})
+defer w.Close() // removes file if Finish was not called
+
+for _, event := range events {
+    w.Append(event)
+}
+
+w.Finish(nil) // flushes partial record, writes index + trailer, fsyncs
+```
+
+Items are appended in order. `Finish` flushes any partial record, writes the offset index, optional app data, and a 64-byte trailer, then fsyncs. `Close` after `Finish` is a no-op; `Close` without `Finish` removes the incomplete file.
+
+Multi-part items (e.g., fingerprint + bitmap data) can be appended as a single logical item:
+
+```go
+w.Append(fingerprint[:], bitmapData) // concatenated as one entry
+```
+
+### Reading: Point Lookup
+
+```go
+r := packfile.Open("events-00042.pack")
+defer r.Close()
+
+r.ReadItem(42, func(event []byte) error {
+    processEvent(event) // valid only for the duration of this call — copy if needed
+    return nil
+})
+```
+
+`Open` returns immediately — all I/O runs in a background goroutine. `ReadItem` maps the item index to its record, reads and decodes the record, and passes the item to the callback. The entry slice is borrowed from an internal decoder buffer and must not be retained after the callback returns.
+
+### Reading: Sequential Scan
+
+```go
+r := packfile.Open("events-00042.pack")
+defer r.Close()
+
+for event, err := range r.ReadRange(0, 1000) {
+    if err != nil {
+        return err
+    }
+    processEvent(event) // valid only until next iteration — copy if needed
+}
+```
+
+Safe to break early. No cleanup required. Each yielded `[]byte` is valid only until the next iteration.
+
+### Reading: Scattered Access
+
+A bitmap query produces a set of item indices scattered across the file. `ReadItems` reads them with parallel I/O, calling a callback for each item:
+
+```go
+r := packfile.Open("events-00042.pack", packfile.WithConcurrency(8))
+defer r.Close()
+
+// indices from bitmap intersection — sorted, unique, possibly non-contiguous
+indices := bitmapResult.ToSortedSlice()
+
+results := make([][]byte, len(indices))
+r.ReadItems(ctx, indices, func(pos int, entry []byte) error {
+    results[pos] = bytes.Clone(entry) // copy — entry is borrowed
+    return nil
+})
+```
+
+`ReadItems` groups indices by record, then partitions consecutive records into I/O batches (≤ 1MB each). Workers claim batches via an atomic counter. The callback is called concurrently from multiple goroutines in arbitrary order; `pos` identifies which index the entry corresponds to.
+
+### Content Hash Verification
+
+```go
+r := packfile.Open("events-00042.pack")
+defer r.Close()
+
+hash, ok, _ := r.ContentHash() // stored SHA-256, if present
+if ok {
+    err := r.Verify(ctx) // recompute and compare
+}
+```
+
+### Key-Based Access
+
+Packfile indexes by ordinal position, not by key. For keyed data, the caller provides its own key → ordinal mapping. Any mapping works: a hash table, a sorted array with binary search, or a perfect hash function. Packfile doesn't know or care how the ordinal was determined.
+
+Example using a minimal perfect hash function (MPHF) for bitmap storage:
+
+```go
+// Write — one bitmap per MPHF slot, batched into records
+w, _ := packfile.Create("bitmaps.pack", packfile.WriterOptions{RecordSize: 128})
+for slot := 0; slot < mphf.Len(); slot++ {
+    w.Append(bitmapData[slot])
+}
+w.Finish(nil)
+
+// Read — MPHF gives ordinal, packfile gives data
+r := packfile.Open("bitmaps.pack")
+defer r.Close()
+
+slot := mphf.Lookup("USD")
+r.ReadItem(slot, func(data []byte) error {
+    bitmap.UnmarshalBinary(data) // data is borrowed — copy if needed
+    return nil
+})
+```
+
+## Goals
+
+- **O(1) random access by ordinal index.** Every `ReadItem` call maps index to record via arithmetic, then reads and decodes a single record.
+- **Minimal I/O.** The full index loads in one disk read on open (~112KB for 68K records). After that, one disk read per record, exact size, no over-read.
+- **Compact index.** Index size depends on max record size, not file size. A file with 20KB records uses 15-bit deltas whether the file is 500MB or 50GB.
+- **Immutable after write.** No updates, no deletes. Simple, safe, predictable.
+- **Concurrent reads.** All `Reader` methods are safe for concurrent use. No locks in the read path.
+
+## Non-Goals
+
+- **Key-based lookup.** Packfile is indexed by ordinal position, not by key. Key-based access is built on top by the caller (see usage example above).
+- **Mutability.** No append-after-finalize, no updates, no deletes.
+- **Chunk management.** Directory layout, chunk-to-sequence mapping, rotation are caller concerns.
+- **Caching.** No built-in LRU. Callers manage their own pool of open `Reader` instances.
+
+## How It Works
+
+Items are grouped into fixed-size **records** (default 128 items per record). Small items like events don't compress well individually, but 128 of them together do. Large items like ledgers are stored one per record since they compress well on their own. Each record is compressed and written as a contiguous block on disk.
+
+An **offset index** at the end of the file maps record numbers to byte offsets. On open, the entire index is decoded into a flat `[]int64` array. Looking up item `i` is arithmetic: `offsets[i / RecordSize]` gives the record's byte offset, then a single disk read + decode extracts the item.
+
+When a record contains multiple items, the reader needs to know where each item starts within the decompressed data. A compact **FOR index** appended to each multi-item record stores these byte lengths. The FOR index is always uncompressed and carries its own CRC32C — it can be verified without decompressing the payload. Single-item records skip the FOR index entirely.
+
+---
+
+## File Format
+
+Everything below is internal to the library. Callers don't need to know this — it's here for contributors and the curious.
+
+Reads throughout this section use `pread` — positioned read at a specific file offset without moving a file pointer — which is safe for concurrent use and maps to Go's `os.File.ReadAt`.
+
+### Layout
+
+```
+┌──────────────────────────────────┐  offset 0
+│ record 0                         │
+│ record 1                         │
+│ ...                              │
+│ record N-1                       │
+├──────────────────────────────────┤  indexBase
+│ offset index (FOR groups)        │
+│ CRC32C (4 bytes)                 │
+├──────────────────────────────────┤  (optional)
+│ app data                         │
+├──────────────────────────────────┤
+│ trailer (64 bytes)               │
+└──────────────────────────────────┘  EOF
+```
+
+### Records
+
+Each record contains up to `RecordSize` items. When a record contains multiple items (`RecordSize > 1`), the items are concatenated into a payload, and a **FOR index** is appended. The FOR index encodes each item's byte length and carries its own CRC32C — it is always uncompressed regardless of the record format, and is stripped from the raw record bytes before any format-specific processing.
+
+```
+Multi-item record on-disk layout:
+
+  Compressed:   [zstd(payload)][FOR_index]
+  Uncompressed: [payload][4B CRC_items][FOR_index]
+  Raw:          [payload][FOR_index]
+
+FOR_index = [packed residuals][1B W][4B min LE][4B CRC32C]
+  where CRC32C covers [packed][W][min]
+```
+
+The last 9 bytes of any multi-item record are always `[1B W][4B min][4B CRC]` — fixed offsets from the tail regardless of packed content. The decoder strips and verifies the FOR index from the raw bytes before decompression, enabling early corruption detection without paying decompression cost.
+
+**Single-item records** (`RecordSize=1`): The FOR index is omitted entirely — the item's length equals the decompressed payload length.
+
+```
+Single-item record layout (RecordSize=1):
+  Compressed:   [zstd(item)]
+  Uncompressed: [item][4B CRC_items]
+  Raw:          [item]
+```
+
+**Compressed records** (default): The payload is zstd-compressed. Integrity is provided by zstd's built-in content checksum (xxHash64), verified automatically during decompression. The FOR index (appended after compression) has its own CRC32C.
+
+**Uncompressed records** (`Format: Uncompressed`): The payload is stored as-is with a 4-byte CRC32C. The FOR index has its own CRC32C. The item CRC covers only the payload bytes (not the FOR index).
+
+**Raw records** (`Format: Raw`): The payload is stored as-is with no integrity wrapper. The FOR index still has its own CRC32C.
+
+### Content Hash
+
+When `ContentHash: true`, the writer computes a chunked SHA-256 over the logical item stream:
+
+```
+chunkDigest_i = SHA-256([4B len][item_{i*K}] ... [4B len][item_{i*K+K-1}])
+finalHash     = SHA-256(chunkDigest_0 || ... || chunkDigest_M)
+K = RecordSize
+```
+
+The hash is independent of compression and format — same items in the same order with the same RecordSize always produce the same hash. Note that changing RecordSize changes the chunk boundaries and therefore the hash.
+
+### Trailer (64 bytes at EOF)
+
+```
+Offset  Size  Type      Field
+0       4     uint32    magic (0x534C4348)
+4       1     uint8     version (1)
+5       1     uint8     flags
+6       4     uint32    recordCount
+10      4     uint32    totalItems
+14      4     uint32    recordSize
+18      4     uint32    indexSize (all groups + 4-byte CRC32C)
+22      4     uint32    appDataSize (0 if none)
+26      32    [32]byte  contentHash (zeroed if flagContentHash not set)
+58      2     -         reserved (zero)
+60      4     uint32    CRC32C of trailer[0:60]
+```
+
+Flags (uint8):
+- Bit 0 (`flagNoCompression`): records are uncompressed with CRC32C
+- Bit 1 (`flagContentHash`): trailer contains a 32-byte SHA-256 content hash
+- Bit 2 (`flagNoCRC`): per-record CRC32C is omitted (only with flagNoCompression)
+
+The `Checksum` at offset 60 covers `trailer[0:60]`. The reader validates flags against `knownFlags` and rejects files with unknown flag bits.
+
+### Index Encoding
+
+The offset index maps record numbers to byte positions. A naive approach stores absolute byte offsets, but offset size grows with file size — a 50GB file needs 36-bit offsets even if records are only 6KB.
+
+Packfile stores **record sizes** (deltas between consecutive offsets) instead. Deltas depend on the maximum record size, not total file size. A file with 20KB records uses 15-bit deltas whether the file is 500MB or 50GB.
+
+Deltas are encoded using **Frame of Reference (FOR) compression** in groups of 128. FOR subtracts a per-group minimum from every value, then bit-packs the residuals at the minimum bit width needed. Each group is self-contained:
+
+```
+FOR Group (ceil(128 × W / 8) + 5 bytes):
+
+  [00-XX]  residuals: 128 packed integers, W bits each
+           residual[j] = delta[j] - groupMin
+
+  [XX]     W: uint8, bit width of residuals (bits.Len32 of max residual)
+
+  [XX+1 .. XX+4]  groupMin: uint32 LE, minimum delta in this group
+```
+
+Width and minimum are always the final 5 bytes. A group where all records are between 5,000 and 5,200 bytes needs only 8 bits for residuals (range of 200), regardless of the absolute delta magnitude.
+
+On open, all groups are decoded into a flat `[]int64` offset table. Resolving item `i`:
+
+```
+recordIdx = i / RecordSize
+localIdx  = i % RecordSize
+offset    = offsets[recordIdx]
+```
+
+Each `ReadItem` is an array lookup + single disk read + decode.
+
+The group size (128) is a library constant, independent of RecordSize. If it changes, the format version is bumped.
+
+### Integrity
+
+**Index checksum:** CRC32C of the raw index bytes (all FOR groups). Verified on open before decoding. After decoding, the reader also asserts that the running offset sum equals `indexBase` — an independent structural invariant that catches encode/decode logic bugs.
+
+**Trailer checksum:** CRC32C of `trailer[0:60]` protects all structural fields. App data has no packfile-level integrity check — callers are responsible for their own app data integrity.
+
+**Trailer validation:** On open: flags against `knownFlags`, `recordSize > 0`, `ceil(totalItems / recordsize) == recordCount`.
+
+**Record checksums:** Compressed records use zstd's built-in content checksum (xxHash64), verified during decompression. Uncompressed records use a trailing CRC32C. Raw records have no per-record integrity — use only when items are already checksummed.
+
+**Content hash verification:** `Verify(ctx)` recomputes the SHA-256 content hash by streaming all items and compares to the stored hash.
+
+### Edge Cases
+
+**Last group:** If `RecordCount` is not a multiple of 128, remaining residual slots are zero-padded. The reader respects `RecordCount` and never accesses padding.
+
+**Last record:** If `TotalItems` is not a multiple of `RecordSize`, the last record contains fewer items.
+
+**Zero items:** Valid. No records. Index section is just 4 bytes (CRC32C of empty payload).
+
+**Single item:** One record, one group, one delta.
+
+---
+
+## Implementation Notes
+
+### Read Path
+
+**Non-blocking Open.** `Open` returns a `*Reader` immediately. A background goroutine performs all I/O: open, stat, speculative read, trailer parse, CRC verification, index decode, app data read. A `sync.OnceValue` drains the result on the first query call. Errors are deferred to query time — `Open` itself never fails. This enables overlapped initialization: start loading an MPHF or opening other files while the goroutine runs.
+
+**Speculative Read.** On open, one pread of the last `min(256KB, fileSize)` bytes. This usually captures the trailer, app data, and index in one IOP. If the tail exceeds 256KB, a single fallback read fetches the rest.
+
+**ReadItem.** Maps item index to record index (`i / RecordSize`), gets a pooled decoder, reads the record via `ReadAt`, decodes (decompresses + extracts item sizes), and passes the item to the callback as a borrowed slice. Returns the decoder to the pool after the callback.
+
+**ReadRange.** Coalesces consecutive records that fit in a pooled 1MB buffer into single `ReadAt` calls. Oversized records (> 1MB) get one-off allocations.
+
+**ReadItems.** Single-pass partition of sorted indices into I/O batches (consecutive records ≤ 1MB). Workers (up to `concurrency` goroutines) claim batches via an atomic counter, read with a single `ReadAt`, decode, and call `fn(pos, entry)` directly. No channels, no reorder goroutine. On error or cancellation, an atomic flag stops remaining workers.
+
+**Decoder Pool.** `sync.Pool` of decoder instances, each owning a `ZSTD_DCtx` allocated via CGo. Decoders are stateless between calls.
+
+**Concurrency.** Safe for concurrent use after `Open`. The offset table and metadata are immutable. All read methods use stateless `ReadAt` (pread) with pooled resources.
+
+### Write Path
+
+**Create.** Opens the file directly at `path` with `O_EXCL` (fails if exists, unless `Overwrite` is set). `Finish` writes remaining items, the offset index, app data, trailer, then fsyncs. `Close` without `Finish` removes the incomplete file.
+
+**Parallel Pipeline.** When `Concurrency > 1`, the writer runs a streaming pipeline: `Append` accumulates items → `Flush` sends records to `workCh` → N block workers compress/CRC/hash in parallel → writer goroutine reorders by block ID and writes sequentially.
+
+**BytesPerSync.** Optional background writeback via `sync_file_range(SYNC_FILE_RANGE_WRITE)` on Linux (no-op elsewhere). Spreads I/O so the final fsync has less to flush.
+
+**Index Decode OOM Guard.** Before decoding, validates that `recordCount` is plausible given `indexSize`. Each FOR group of up to 128 records requires at least 6 bytes. This prevents crafted trailers from causing huge allocations.
+
+## API Reference
+
+### Writer
+
+```go
+package packfile
+
+// WriterOptions configures how the packfile is written.
+type WriterOptions struct {
+    // RecordSize is the number of items per record. 0 defaults to 128.
+    RecordSize int
+
+    // Format controls record encoding. Default (zero value) is Compressed.
+    // Compressed: zstd with built-in integrity.
+    // Uncompressed: raw records with CRC32C integrity.
+    // Raw: raw records with no integrity wrapper.
+    Format RecordFormat
+
+    // Concurrency sets the number of block-processing goroutines.
+    // 0 or 1 means serial. Ignored when Format is not Compressed
+    // and ContentHash is false (nothing to parallelize).
+    Concurrency int
+
+    // ContentHash enables SHA-256 content hashing over the logical item stream.
+    ContentHash bool
+
+    // BytesPerSync initiates background writeback of dirty pages every N bytes
+    // written. On Linux this uses sync_file_range(SYNC_FILE_RANGE_WRITE) which
+    // is non-blocking — it tells the kernel to start flushing without waiting.
+    // This spreads I/O across the write phase so the final fdatasync in Finish()
+    // has less data to flush. 0 disables (default).
+    BytesPerSync int
+
+    // Overwrite allows Create to replace an existing file.
+    // When false (default), fails if the file already exists.
+    Overwrite bool
+}
+
+// Writer creates a new packfile. Items must be appended in order.
+type Writer struct{ /* unexported */ }
+
+// Create starts writing a new packfile at path. Fails if the file already
+// exists unless Overwrite is set.
+func Create(path string, opts WriterOptions) (*Writer, error)
+
+// Append adds a single logical item. Parts are concatenated as one entry.
+// Flushes a record when RecordSize items accumulate.
+func (w *Writer) Append(parts ...[]byte) error
+
+// Finish flushes any partial record, writes index + optional app data + trailer,
+// fsyncs, and closes the file. appData is optional caller-injected data stored
+// between the index and trailer; pass nil for no app data.
+func (w *Writer) Finish(appData []byte) error
+
+// Close releases resources. If Finish was not called, the incomplete file
+// is removed. If Finish was called, Close is a no-op. Safe to call multiple
+// times. Idiomatic usage: defer w.Close() with Finish as the last action.
+func (w *Writer) Close() error
+```
+
+### Reader
+
+```go
+// Reader provides random access to items in a packfile.
+// Safe for concurrent use by multiple goroutines.
+type Reader struct{ /* unexported */ }
+
+// Open returns a Reader immediately. All file I/O (open, stat, speculative
+// read, trailer parse, index decode, app data read) runs in a background
+// goroutine. Open never fails; errors are deferred to the first method that
+// needs the result. Close must always be called.
+func Open(path string, opts ...ReaderOption) *Reader
+
+// WithConcurrency sets the max parallel goroutines for ReadItems.
+// Values less than 1 are clamped to 1. Default 8.
+func WithConcurrency(n int) ReaderOption
+
+// TotalItems returns the total number of logical items in the packfile.
+func (r *Reader) TotalItems() (int, error)
+
+// ReadItem reads a single item by global index and passes it to fn.
+// The []byte passed to fn is borrowed and must not be retained after fn
+// returns — copy if needed. Returns ErrIndexRange if index is out of
+// [0, TotalItems).
+func (r *Reader) ReadItem(index int, fn func([]byte) error) error
+
+// ReadRange returns an iterator over count contiguous items starting at start.
+// Each yielded []byte is valid only until the next iteration — copy if you
+// need to retain it. Safe to break early. Thread-safe.
+func (r *Reader) ReadRange(start, count int) iter.Seq2[[]byte, error]
+
+// ReadItems reads items at scattered indices with parallel I/O and calls
+// fn for each item. fn receives the position in the original indices slice
+// and a borrowed entry slice valid only for the duration of the call — copy
+// if needed.
+//
+// fn is called concurrently from multiple goroutines, in arbitrary order.
+// The pos argument identifies which index the entry corresponds to.
+//
+// indices must be sorted ascending with no duplicates.
+// Panics if any index is out of range or indices are not sorted/unique.
+func (r *Reader) ReadItems(ctx context.Context, indices []int, fn func(pos int, entry []byte) error) error
+
+// ContentHash returns the SHA-256 content hash stored in the trailer, if present.
+func (r *Reader) ContentHash() ([32]byte, bool, error)
+
+// Verify recomputes the SHA-256 content hash by streaming all items and
+// compares it to the hash stored in the trailer. Returns nil if no hash is
+// stored or if the hash matches.
+func (r *Reader) Verify(ctx context.Context) error
+
+// AppData returns the app data section, or nil if appDataSize == 0.
+func (r *Reader) AppData() ([]byte, error)
+
+func (r *Reader) Trailer() (Trailer, error)
+
+func (r *Reader) Close() error
+```
+
+### Errors
+
+```go
+var (
+    ErrCorrupt             = errors.New("packfile: corrupt file")
+    ErrMagic               = fmt.Errorf("%w: invalid magic number", ErrCorrupt)
+    ErrVersion             = fmt.Errorf("%w: unsupported version", ErrCorrupt)
+    ErrChecksum            = fmt.Errorf("%w: checksum mismatch", ErrCorrupt)
+    ErrSize                = fmt.Errorf("%w: file size inconsistent with trailer", ErrCorrupt)
+    ErrIndexRange          = errors.New("packfile: record index out of range")
+    ErrContentHashMismatch = errors.New("packfile: content hash mismatch")
+)
+```
+
+### intpack
+
+```go
+package intpack
+
+// EncodeGroup FOR-encodes values into one group: [packed residuals][1B W][4B min LE].
+// W = bits.Len32(max - min), clamped to min 1. Pure codec — no CRC, no trailer.
+// Panics if len(values) == 0.
+func EncodeGroup(values []uint32) []byte
+
+// DecodeGroup FOR-decodes one group of n values from the tail of buf.
+// buf must end at the last byte of [min] (the byte before any trailing CRC or other data).
+// Returns decoded values (written into dst[0:n], reallocating if cap(dst) < n),
+// bytes consumed from the tail, and any error.
+func DecodeGroup(buf []byte, n int, dst []uint32) (values []uint32, consumed int, err error)
+```


### PR DESCRIPTION
## Summary
- Adds a design document for a compact, immutable file format that provides O(1) random access to ordinal-indexed data (events, bitmaps, ledgers) with minimal I/O
- This is a building block for a full history implementation of RPC (v2)
- The doc covers the file format, read/write paths, integrity model, and API reference
- The goal is to align on this design before proceeding with implementation — please flag any concerns or blockers so we can address them during the design stage

**Note:** This PR targets `main` for now but will be retargeted to the full history RPC / v2 branch once we align on that before merging.

## Further reading
- Reference implementation: [`packfile`](https://github.com/tamirms/event-analysis/tree/main/packfile), [`intpack`](https://github.com/tamirms/event-analysis/tree/main/intpack)
- [Benchmarks](https://github.com/tamirms/event-analysis/blob/main/BENCHMARKS.md) — packfile vs RocksDB sstable across write throughput, sequential/random reads, compression efficiency, and bitmap indexing
- [Format comparison](https://github.com/tamirms/event-analysis/blob/main/FORMAT-COMPARISON.md) — technical evaluation of packfile vs RocksDB sstable across performance, code complexity, dependencies, and suitability for remote storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)