### PR TITLE
Add intpack FOR encoding and packfile offset index codec

### DIFF
--- a/cmd/stellar-rpc/internal/intpack/intpack.go
+++ b/cmd/stellar-rpc/internal/intpack/intpack.go
@@ -52,8 +52,8 @@ func DecodeGroup(buf []byte, n int, dst []uint32) ([]uint32, int, error) {
 	}
 
 	width := uint64(buf[len(buf)-footerSize])
-	if width > 32 {
-		return dst, 0, fmt.Errorf("intpack: invalid FOR width %d (max 32)", width)
+	if width == 0 || width > 32 {
+		return dst, 0, fmt.Errorf("intpack: invalid FOR width %d (must be 1..32)", width)
 	}
 
 	groupMin := binary.LittleEndian.Uint32(buf[len(buf)-footerSize+1:])
@@ -103,18 +103,11 @@ func packResiduals(buf []byte, values []uint32, minVal uint32, width uint8) {
 // Safe to call with any packed length — elements near the boundary where an
 // 8-byte read would exceed len(packed) are decoded using a zero-padded copy.
 //
+// Caller must ensure w is in [1, 32] — DecodeGroup validates this.
 // The uint64-to-int and uint64-to-uint32 conversions are safe:
 //   - bytePos is bounded by len(packed) which fits in int
 //   - (raw>>shift)&mask is bounded by width <= 32 bits, fits in uint32
 func unpackResiduals(packed []byte, n int, w uint64, groupMin uint32, values []uint32) {
-	if w == 0 {
-		for i := range values {
-			values[i] = groupMin
-		}
-
-		return
-	}
-
 	mask := uint64((1 << w) - 1)
 
 	// When len(packed) < 7, safeLimit is negative — all reads use the

--- a/cmd/stellar-rpc/internal/intpack/intpack.go
+++ b/cmd/stellar-rpc/internal/intpack/intpack.go
@@ -6,8 +6,10 @@
 //
 //	[packed residuals][1-byte width][4-byte minimum (little-endian)]
 //
-// Width and minimum are always the final 5 bytes, so callers can locate
-// metadata from the tail of any buffer without knowing the packed size upfront.
+// Width and minimum are always the final 5 bytes, so the group can be located
+// from the end of a buffer without a separate length field. This is useful when
+// a FOR group is appended after variable-length data — the decoder can strip
+// the group from the tail, then recover the preceding data's boundary.
 package intpack
 
 import (
@@ -17,20 +19,23 @@ import (
 	"slices"
 )
 
+const (
+	footerSize    = 5 // 1-byte width + 4-byte minimum (little-endian)
+	writeOverhang = 7 // extra bytes for safe 8-byte writes near the end of the packed region
+)
+
 // EncodeGroup FOR-encodes values into one group.
 // Panics if len(values) == 0.
 func EncodeGroup(values []uint32) []byte {
 	minVal, width := rangeWidth(values)
 	packSize := (int(width)*len(values) + 7) / 8
 
-	// 5 bytes for the footer (1-byte width + 4-byte minimum),
-	// 7 bytes of overshoot for safe 8-byte writes during bit-packing.
-	buf := make([]byte, packSize+5+7)
+	buf := make([]byte, packSize+footerSize+writeOverhang)
 	packResiduals(buf, values, minVal, width)
 	buf[packSize] = width
 	binary.LittleEndian.PutUint32(buf[packSize+1:], minVal)
 
-	return buf[:packSize+5]
+	return buf[:packSize+footerSize]
 }
 
 // DecodeGroup FOR-decodes one group of n values from the tail of buf.
@@ -42,25 +47,25 @@ func DecodeGroup(buf []byte, n int, dst []uint32) ([]uint32, int, error) {
 		return dst, 0, fmt.Errorf("intpack: FOR decode n must be > 0, got %d", n)
 	}
 
-	if len(buf) < 5 {
-		return dst, 0, fmt.Errorf("intpack: FOR decode buf too short (%d bytes, need >= 5)", len(buf))
+	if len(buf) < footerSize {
+		return dst, 0, fmt.Errorf("intpack: FOR decode buf too short (%d bytes, need >= %d)", len(buf), footerSize)
 	}
 
-	width := uint64(buf[len(buf)-5])
+	width := uint64(buf[len(buf)-footerSize])
 	if width > 32 {
 		return dst, 0, fmt.Errorf("intpack: invalid FOR width %d (max 32)", width)
 	}
 
-	groupMin := binary.LittleEndian.Uint32(buf[len(buf)-4:])
+	groupMin := binary.LittleEndian.Uint32(buf[len(buf)-footerSize+1:])
 	packSize := (int(width)*n + 7) / 8
 
-	consumed := packSize + 5
+	consumed := packSize + footerSize
 	if len(buf) < consumed {
 		return dst, 0, fmt.Errorf("intpack: FOR decode buf too short for payload (%d bytes, need >= %d)", len(buf), consumed)
 	}
 
 	dst = ensureCapU32(dst, n)
-	unpackResiduals(buf[len(buf)-5-packSize:len(buf)-5], n, width, groupMin, dst)
+	unpackResiduals(buf[len(buf)-footerSize-packSize:len(buf)-footerSize], n, width, groupMin, dst)
 
 	return dst, consumed, nil
 }
@@ -96,7 +101,7 @@ func packResiduals(buf []byte, values []uint32, minVal uint32, width uint8) {
 
 // unpackResiduals unpacks n bit-packed residuals from packed and adds groupMin.
 // Safe to call with any packed length — elements near the boundary where an
-// 8-byte read would exceed len(packed) are decoded byte-by-byte.
+// 8-byte read would exceed len(packed) are decoded using a zero-padded copy.
 //
 // The uint64-to-int and uint64-to-uint32 conversions are safe:
 //   - bytePos is bounded by len(packed) which fits in int
@@ -113,7 +118,7 @@ func unpackResiduals(packed []byte, n int, w uint64, groupMin uint32, values []u
 	mask := uint64((1 << w) - 1)
 
 	// When len(packed) < 7, safeLimit is negative — all reads use the
-	// byte-by-byte fallback path since int(bytePos) is always >= 0.
+	// fallback path since int(bytePos) is always >= 0.
 	safeLimit := len(packed) - 7
 
 	for j := range n {
@@ -125,9 +130,12 @@ func unpackResiduals(packed []byte, n int, w uint64, groupMin uint32, values []u
 		if int(bytePos) < safeLimit { //nolint:gosec // bytePos bounded by packed length
 			raw = binary.LittleEndian.Uint64(packed[bytePos:])
 		} else {
-			for k := 0; k < 8 && int(bytePos)+k < len(packed); k++ { //nolint:gosec // bytePos bounded by packed length
-				raw |= uint64(packed[int(bytePos)+k]) << (k * 8) //nolint:gosec // bytePos bounded by packed length
-			}
+			// Near the boundary: copy remaining bytes into a zero-padded
+			// buffer so Uint64 can read a full 8 bytes safely.
+			var tail [8]byte
+
+			copy(tail[:], packed[bytePos:])
+			raw = binary.LittleEndian.Uint64(tail[:])
 		}
 
 		values[j] = groupMin + uint32((raw>>shift)&mask) //nolint:gosec // masked to width <= 32 bits

--- a/cmd/stellar-rpc/internal/intpack/intpack.go
+++ b/cmd/stellar-rpc/internal/intpack/intpack.go
@@ -1,0 +1,143 @@
+// Package intpack provides Frame-of-Reference (FOR) integer encoding for
+// groups of uint32 values. Values are encoded as bit-packed residuals relative
+// to the group minimum, requiring only ceil(log2(max-min)) bits per value.
+//
+// On-disk layout per group:
+//
+//	[packed residuals][1-byte width][4-byte minimum (little-endian)]
+//
+// Width and minimum are always the final 5 bytes, so callers can locate
+// metadata from the tail of any buffer without knowing the packed size upfront.
+package intpack
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/bits"
+	"slices"
+)
+
+// EncodeGroup FOR-encodes values into one group.
+// Panics if len(values) == 0.
+func EncodeGroup(values []uint32) []byte {
+	minVal, width := rangeWidth(values)
+	packSize := (int(width)*len(values) + 7) / 8
+
+	// 5 bytes for the footer (1-byte width + 4-byte minimum),
+	// 7 bytes of overshoot for safe 8-byte writes during bit-packing.
+	buf := make([]byte, packSize+5+7)
+	packResiduals(buf, values, minVal, width)
+	buf[packSize] = width
+	binary.LittleEndian.PutUint32(buf[packSize+1:], minVal)
+
+	return buf[:packSize+5]
+}
+
+// DecodeGroup FOR-decodes one group of n values from the tail of buf.
+// The encoded group must be at the end of buf, but buf may contain
+// additional data before it. Returns decoded values (written into dst[0:n],
+// reallocating if cap(dst) < n), bytes consumed from the tail, and any error.
+func DecodeGroup(buf []byte, n int, dst []uint32) ([]uint32, int, error) {
+	if n <= 0 {
+		return dst, 0, fmt.Errorf("intpack: FOR decode n must be > 0, got %d", n)
+	}
+
+	if len(buf) < 5 {
+		return dst, 0, fmt.Errorf("intpack: FOR decode buf too short (%d bytes, need >= 5)", len(buf))
+	}
+
+	width := uint64(buf[len(buf)-5])
+	if width > 32 {
+		return dst, 0, fmt.Errorf("intpack: invalid FOR width %d (max 32)", width)
+	}
+
+	groupMin := binary.LittleEndian.Uint32(buf[len(buf)-4:])
+	packSize := (int(width)*n + 7) / 8
+
+	consumed := packSize + 5
+	if len(buf) < consumed {
+		return dst, 0, fmt.Errorf("intpack: FOR decode buf too short for payload (%d bytes, need >= %d)", len(buf), consumed)
+	}
+
+	dst = ensureCapU32(dst, n)
+	unpackResiduals(buf[len(buf)-5-packSize:len(buf)-5], n, width, groupMin, dst)
+
+	return dst, consumed, nil
+}
+
+// rangeWidth computes the minimum value and the bit width needed to
+// FOR-encode values. Width is clamped to at least 1.
+// bits.Len32 returns at most 32, which always fits in uint8.
+func rangeWidth(values []uint32) (uint32, uint8) {
+	minVal := slices.Min(values)
+	maxVal := slices.Max(values)
+
+	width := uint8(bits.Len32(maxVal - minVal)) //nolint:gosec // bits.Len32 returns [0,32], fits in uint8
+	if width == 0 {
+		width = 1
+	}
+
+	return minVal, width
+}
+
+// packResiduals bit-packs (values[i] - minVal) into buf using 8-byte
+// read-modify-writes. buf must be at least 7 bytes longer than the packed
+// payload to allow safe overshoot at the boundary.
+func packResiduals(buf []byte, values []uint32, minVal uint32, width uint8) {
+	for j, v := range values {
+		residual := uint64(v - minVal)
+		bitPos := uint64(j) * uint64(width)
+		bytePos := bitPos / 8
+		shift := bitPos % 8
+		existing := binary.LittleEndian.Uint64(buf[bytePos:])
+		binary.LittleEndian.PutUint64(buf[bytePos:], existing|(residual<<shift))
+	}
+}
+
+// unpackResiduals unpacks n bit-packed residuals from packed and adds groupMin.
+// Safe to call with any packed length — elements near the boundary where an
+// 8-byte read would exceed len(packed) are decoded byte-by-byte.
+//
+// The uint64-to-int and uint64-to-uint32 conversions are safe:
+//   - bytePos is bounded by len(packed) which fits in int
+//   - (raw>>shift)&mask is bounded by width <= 32 bits, fits in uint32
+func unpackResiduals(packed []byte, n int, w uint64, groupMin uint32, values []uint32) {
+	if w == 0 {
+		for i := range values {
+			values[i] = groupMin
+		}
+
+		return
+	}
+
+	mask := uint64((1 << w) - 1)
+
+	// When len(packed) < 7, safeLimit is negative — all reads use the
+	// byte-by-byte fallback path since int(bytePos) is always >= 0.
+	safeLimit := len(packed) - 7
+
+	for j := range n {
+		bitPos := uint64(j) * w
+		bytePos := bitPos / 8
+		shift := bitPos % 8
+
+		var raw uint64
+		if int(bytePos) < safeLimit { //nolint:gosec // bytePos bounded by packed length
+			raw = binary.LittleEndian.Uint64(packed[bytePos:])
+		} else {
+			for k := 0; k < 8 && int(bytePos)+k < len(packed); k++ { //nolint:gosec // bytePos bounded by packed length
+				raw |= uint64(packed[int(bytePos)+k]) << (k * 8) //nolint:gosec // bytePos bounded by packed length
+			}
+		}
+
+		values[j] = groupMin + uint32((raw>>shift)&mask) //nolint:gosec // masked to width <= 32 bits
+	}
+}
+
+func ensureCapU32(s []uint32, n int) []uint32 {
+	if cap(s) < n {
+		return make([]uint32, n)
+	}
+
+	return s[:n]
+}

--- a/cmd/stellar-rpc/internal/intpack/intpack_test.go
+++ b/cmd/stellar-rpc/internal/intpack/intpack_test.go
@@ -138,16 +138,14 @@ func TestDecodeGroupWithPrefix(t *testing.T) {
 	require.Equal(t, values, decoded)
 }
 
-func TestDecodeGroupWidth0(t *testing.T) {
-	// Craft a buffer with width=0: all values are equal to groupMin.
-	// Layout: [0 packed bytes][width=0][min=42 LE]
+func TestDecodeGroupWidth0Rejected(t *testing.T) {
+	// The encoder clamps width to >=1, so width=0 is treated as corruption
+	// on decode. Layout: [0 packed bytes][width=0][min=42 LE]
 	var buf [5]byte
 
 	buf[0] = 0 // width = 0
 	binary.LittleEndian.PutUint32(buf[1:], 42)
 
-	decoded, consumed, err := DecodeGroup(buf[:], 3, nil)
-	require.NoError(t, err)
-	require.Equal(t, 5, consumed)
-	require.Equal(t, []uint32{42, 42, 42}, decoded)
+	_, _, err := DecodeGroup(buf[:], 3, nil)
+	require.Error(t, err)
 }

--- a/cmd/stellar-rpc/internal/intpack/intpack_test.go
+++ b/cmd/stellar-rpc/internal/intpack/intpack_test.go
@@ -1,0 +1,153 @@
+package intpack
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGroupRoundTrip(t *testing.T) {
+	values := []uint32{10, 20, 30, 40, 50}
+	encoded := EncodeGroup(values)
+
+	decoded, consumed, err := DecodeGroup(encoded, len(values), nil)
+	require.NoError(t, err)
+	require.Equal(t, len(encoded), consumed)
+	require.Equal(t, values, decoded)
+}
+
+func TestWidth32(t *testing.T) {
+	values := []uint32{0, math.MaxUint32}
+	encoded := EncodeGroup(values)
+
+	decoded, consumed, err := DecodeGroup(encoded, len(values), nil)
+	require.NoError(t, err)
+	require.Equal(t, len(encoded), consumed)
+	require.Equal(t, values, decoded)
+}
+
+func TestDecodeGroupErrors(t *testing.T) {
+	// Invalid width (> 32): set the 5th-from-last byte to 33.
+	data := make([]byte, 12)
+	data[len(data)-5] = 33 // width = 33
+
+	_, _, err := DecodeGroup(data, 1, nil)
+	require.Error(t, err)
+
+	// Data too short (< 5 bytes).
+	_, _, err = DecodeGroup([]byte{1, 2, 3, 4}, 1, nil)
+	require.Error(t, err)
+
+	// n <= 0.
+	_, _, err = DecodeGroup(data, 0, nil)
+	require.Error(t, err)
+
+	_, _, err = DecodeGroup(data, -1, nil)
+	require.Error(t, err)
+
+	// Truncated payload: valid footer but packed residuals cut short.
+	// Encode 128 values (width=7, packSize=112), then keep only last 6 bytes
+	// (1 packed byte + 1-byte width + 4-byte min). DecodeGroup needs 112+5=117 bytes.
+	vals := make([]uint32, 128)
+	for i := range vals {
+		vals[i] = uint32(i)
+	}
+
+	encoded := EncodeGroup(vals)
+	truncated := encoded[len(encoded)-6:] // [1 packed byte][width][min]
+
+	_, _, err = DecodeGroup(truncated, 128, nil)
+	require.Error(t, err)
+}
+
+func TestRoundTrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []uint32
+	}{
+		{"uniform", []uint32{100, 100, 100, 100}},
+		{"ascending", []uint32{10, 20, 30, 40, 50}},
+		{"single", []uint32{42}},
+		{"wide_range", []uint32{0, 1, 1000000}},
+		{"max_group", func() []uint32 {
+			v := make([]uint32, 128)
+			for i := range v {
+				v[i] = uint32(i * 7)
+			}
+
+			return v
+		}()},
+	}
+
+	var dst []uint32
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded := EncodeGroup(tt.values)
+
+			var err error
+
+			dst, _, err = DecodeGroup(encoded, len(tt.values), dst)
+			require.NoError(t, err)
+			require.Equal(t, tt.values, dst)
+		})
+	}
+}
+
+func TestDecodeGroupBufferReuse(t *testing.T) {
+	sizes1 := []uint32{10, 20, 30}
+	encoded1 := EncodeGroup(sizes1)
+
+	dst, _, err := DecodeGroup(encoded1, len(sizes1), nil)
+	require.NoError(t, err)
+
+	sizes2 := []uint32{100, 200, 300, 400, 500}
+	encoded2 := EncodeGroup(sizes2)
+
+	dst, _, err = DecodeGroup(encoded2, len(sizes2), dst)
+	require.NoError(t, err)
+	require.Equal(t, sizes2, dst)
+}
+
+func TestEncodeGroupLayout(t *testing.T) {
+	sizes := []uint32{100, 200, 300}
+	encoded := EncodeGroup(sizes)
+
+	// The last 5 bytes are [W][min(4)].
+	// W = bits.Len32(300-100) = bits.Len32(200) = 8.
+	require.Equal(t, uint8(8), encoded[len(encoded)-5])
+	require.Equal(t, uint32(100), binary.LittleEndian.Uint32(encoded[len(encoded)-4:]))
+}
+
+func TestDecodeGroupWithPrefix(t *testing.T) {
+	values := []uint32{5, 10, 15}
+	encoded := EncodeGroup(values)
+
+	buf := make([]byte, 20+len(encoded))
+	for i := range buf[:20] {
+		buf[i] = 0xAB
+	}
+
+	copy(buf[20:], encoded)
+
+	decoded, consumed, err := DecodeGroup(buf, len(values), nil)
+	require.NoError(t, err)
+	require.Equal(t, len(encoded), consumed)
+	require.Equal(t, values, decoded)
+}
+
+func TestDecodeGroupWidth0(t *testing.T) {
+	// Craft a buffer with width=0: all values are equal to groupMin.
+	// Layout: [0 packed bytes][width=0][min=42 LE]
+	var buf [5]byte
+
+	buf[0] = 0 // width = 0
+	binary.LittleEndian.PutUint32(buf[1:], 42)
+
+	decoded, consumed, err := DecodeGroup(buf[:], 3, nil)
+	require.NoError(t, err)
+	require.Equal(t, 5, consumed)
+	require.Equal(t, []uint32{42, 42, 42}, decoded)
+}

--- a/cmd/stellar-rpc/internal/packfile/index.go
+++ b/cmd/stellar-rpc/internal/packfile/index.go
@@ -1,0 +1,163 @@
+package packfile
+
+// Offset index codec for packfiles. The offset index maps record numbers to
+// byte positions on disk. Rather than storing absolute offsets (which grow with
+// file size), the index stores record byte sizes encoded as FOR groups of up
+// to 128 values, with a trailing CRC32C over the entire index section.
+//
+// This builds on the low-level FOR codec in the intpack package.
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"math"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/intpack"
+)
+
+const groupSize = 128 // values per FOR group in the offset index
+
+var (
+	ErrCorrupt  = errors.New("packfile: corrupt file")
+	ErrChecksum = fmt.Errorf("%w: checksum mismatch", ErrCorrupt)
+)
+
+var crc32cTable = crc32.MakeTable(crc32.Castagnoli) //nolint:gochecknoglobals // immutable lookup table
+
+func crc32c(b []byte) uint32 { return crc32.Checksum(b, crc32cTable) }
+
+// decodeIndex decodes a FOR-encoded offset index with CRC32C integrity.
+// Returns recordCount+1 offsets: offsets[i] is the start byte of record i,
+// and offsets[recordCount] equals indexBase.
+func decodeIndex(buf []byte, recordCount int, indexSize int, indexBase int64) ([]int64, error) {
+	if recordCount < 0 {
+		return nil, fmt.Errorf("%w: negative recordCount %d", ErrCorrupt, recordCount)
+	}
+
+	if indexSize < 4 {
+		return nil, fmt.Errorf("%w: index too small (%d bytes)", ErrCorrupt, indexSize)
+	}
+
+	if len(buf) < indexSize {
+		return nil, fmt.Errorf("%w: buffer length %d < indexSize %d", ErrCorrupt, len(buf), indexSize)
+	}
+
+	buf = buf[:indexSize]
+
+	// Sanity-check recordCount against indexSize to prevent OOM from crafted trailers.
+	// Each FOR group of up to 128 records requires at least 6 bytes
+	// (1 byte packed + 1-byte width + 4-byte minimum).
+	maxGroups := (indexSize - 4) / 6 // subtract CRC, divide by min group size
+
+	maxRecords := maxGroups * groupSize
+	if recordCount > maxRecords {
+		return nil, fmt.Errorf("%w: recordCount %d implausible for indexSize %d", ErrCorrupt, recordCount, indexSize)
+	}
+
+	// Verify CRC32C over raw index bytes (all groups, excluding trailing 4-byte CRC).
+	payloadLen := indexSize - 4
+
+	storedCRC := binary.LittleEndian.Uint32(buf[payloadLen:])
+	if storedCRC != crc32c(buf[:payloadLen]) {
+		return nil, ErrChecksum
+	}
+
+	// Groups are stored forward on disk but decoded backward: each group's metadata
+	// (width, min) is at its tail, so intpack.DecodeGroup naturally reads from the end of
+	// its window. Iterating backward lets us shrink the window after each group.
+	groupCount := (recordCount + groupSize - 1) / groupSize
+	deltas := make([]uint32, recordCount)
+	pos := payloadLen
+
+	for g := groupCount - 1; g >= 0; g-- {
+		base := g * groupSize
+
+		limit := groupSize
+		if g == groupCount-1 && recordCount%groupSize != 0 {
+			limit = recordCount % groupSize
+		}
+
+		_, consumed, err := intpack.DecodeGroup(buf[:pos], limit, deltas[base:base+limit])
+		if err != nil {
+			return nil, fmt.Errorf("%w: index group %d: %w", ErrCorrupt, g, err)
+		}
+
+		pos -= consumed
+	}
+
+	if pos != 0 {
+		return nil, fmt.Errorf("%w: index has %d unconsumed bytes after decoding all groups", ErrCorrupt, pos)
+	}
+
+	// Forward prefix-sum to build absolute offsets from deltas.
+	offsets := make([]int64, recordCount+1)
+
+	offset := int64(0)
+	for i, d := range deltas {
+		offsets[i] = offset
+		offset += int64(d)
+	}
+
+	// Structural sanity check: running sum must arrive at indexBase.
+	if offset != indexBase {
+		return nil, fmt.Errorf("%w: final offset %d != indexBase %d", ErrCorrupt, offset, indexBase)
+	}
+
+	offsets[recordCount] = indexBase
+
+	return offsets, nil
+}
+
+// encodeIndex encodes record offsets into a FOR-128 index section with CRC32C.
+// offsets must have recordCount+1 entries where offsets[i+1] >= offsets[i],
+// and the last entry is the end-of-data offset.
+// Returns the index bytes including the trailing CRC32C.
+func encodeIndex(offsets []int64) ([]byte, error) {
+	if len(offsets) == 0 {
+		return nil, errors.New("packfile: offsets must have at least one entry")
+	}
+
+	if offsets[0] != 0 {
+		return nil, fmt.Errorf("packfile: first offset must be 0, got %d", offsets[0])
+	}
+
+	recordCount := len(offsets) - 1
+	if recordCount > math.MaxUint32 {
+		return nil, fmt.Errorf("packfile: record count %d exceeds uint32 max", recordCount)
+	}
+
+	var buf bytes.Buffer
+
+	deltas := make([]uint32, 0, groupSize)
+	for g := 0; g*groupSize < recordCount; g++ {
+		base := g * groupSize
+		end := min(base+groupSize, recordCount)
+
+		deltas = deltas[:0]
+
+		for j := base; j < end; j++ {
+			d := offsets[j+1] - offsets[j]
+			if d < 0 {
+				return nil, fmt.Errorf("packfile: offsets not monotonically increasing at index %d", j)
+			}
+
+			if d > math.MaxUint32 {
+				return nil, fmt.Errorf("packfile: record size delta %d exceeds 4GB", d)
+			}
+
+			deltas = append(deltas, uint32(d))
+		}
+
+		buf.Write(intpack.EncodeGroup(deltas))
+	}
+
+	// Append CRC32C over raw index bytes.
+	var crcBuf [4]byte
+	binary.LittleEndian.PutUint32(crcBuf[:], crc32c(buf.Bytes()))
+	buf.Write(crcBuf[:])
+
+	return buf.Bytes(), nil
+}

--- a/cmd/stellar-rpc/internal/packfile/index.go
+++ b/cmd/stellar-rpc/internal/packfile/index.go
@@ -48,8 +48,7 @@ func decodeIndex(buf []byte, recordCount int, indexSize int, indexBase int64) ([
 	buf = buf[:indexSize]
 
 	// Sanity-check recordCount against indexSize to prevent OOM from crafted trailers.
-	// Each FOR group of up to 128 records requires at least 6 bytes
-	// (1 byte packed + 1-byte width + 4-byte minimum).
+	// Each FOR group requires at least 6 bytes (1 byte packed + 5-byte footer).
 	maxGroups := (indexSize - 4) / 6 // subtract CRC, divide by min group size
 
 	maxRecords := maxGroups * groupSize

--- a/cmd/stellar-rpc/internal/packfile/index_test.go
+++ b/cmd/stellar-rpc/internal/packfile/index_test.go
@@ -1,0 +1,171 @@
+package packfile
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIndexRoundTrip(t *testing.T) {
+	tests := []struct {
+		name    string
+		offsets []int64
+	}{
+		{"single record", []int64{0, 1000}},
+		{"few records", []int64{0, 1000, 2500, 5000}},
+		{"uniform sizes", func() []int64 {
+			offsets := make([]int64, 101)
+			for i := range offsets {
+				offsets[i] = int64(i) * 4096
+			}
+
+			return offsets
+		}()},
+		{"variable sizes", []int64{0, 100, 5000, 5100, 50000, 50001}},
+		{"exceeds one group", func() []int64 {
+			offsets := make([]int64, 200+1) // 200 records = 2 groups
+			for i := range offsets {
+				offsets[i] = int64(i) * 6400
+			}
+
+			return offsets
+		}()},
+		{"exactly one group", func() []int64 {
+			offsets := make([]int64, 128+1)
+			for i := range offsets {
+				offsets[i] = int64(i) * 1024
+			}
+
+			return offsets
+		}()},
+		{"partial last group", func() []int64 {
+			offsets := make([]int64, 129+1) // 129 records = 1 full + 1 partial
+			for i := range offsets {
+				offsets[i] = int64(i) * 2048
+			}
+
+			return offsets
+		}()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded, err := encodeIndex(tt.offsets)
+			require.NoError(t, err)
+
+			recordCount := len(tt.offsets) - 1
+			indexBase := tt.offsets[recordCount]
+
+			decoded, err := decodeIndex(encoded, recordCount, len(encoded), indexBase)
+			require.NoError(t, err)
+			require.Equal(t, tt.offsets, decoded)
+		})
+	}
+}
+
+func TestIndexCRCCorruption(t *testing.T) {
+	offsets := []int64{0, 1000, 2000, 3000}
+
+	encoded, err := encodeIndex(offsets)
+	require.NoError(t, err)
+
+	// Corrupt a byte in the payload (before the CRC).
+	encoded[0] ^= 0xFF
+
+	_, err = decodeIndex(encoded, 3, len(encoded), 3000)
+	require.ErrorIs(t, err, ErrChecksum)
+}
+
+func TestIndexCorruptCRCBytes(t *testing.T) {
+	offsets := []int64{0, 1000, 2000, 3000}
+
+	encoded, err := encodeIndex(offsets)
+	require.NoError(t, err)
+
+	// Corrupt the CRC itself.
+	crcOffset := len(encoded) - 4
+	binary.LittleEndian.PutUint32(encoded[crcOffset:], 0xDEADBEEF)
+
+	_, err = decodeIndex(encoded, 3, len(encoded), 3000)
+	require.ErrorIs(t, err, ErrChecksum)
+}
+
+func TestIndexTooSmall(t *testing.T) {
+	_, err := decodeIndex([]byte{1, 2, 3}, 1, 3, 100)
+	require.ErrorIs(t, err, ErrCorrupt)
+}
+
+func TestIndexImplausibleRecordCount(t *testing.T) {
+	// indexSize=10 means payload=6 bytes, max 1 group of 128 records.
+	// Requesting 200 records should fail the OOM guard.
+	buf := make([]byte, 10)
+
+	_, err := decodeIndex(buf, 200, 10, 0)
+	require.ErrorIs(t, err, ErrCorrupt)
+}
+
+func TestIndexBaseMismatch(t *testing.T) {
+	offsets := []int64{0, 1000, 2000, 3000}
+
+	encoded, err := encodeIndex(offsets)
+	require.NoError(t, err)
+
+	// Pass wrong indexBase — should fail structural check.
+	_, err = decodeIndex(encoded, 3, len(encoded), 9999)
+	require.ErrorIs(t, err, ErrCorrupt)
+}
+
+func TestIndexNegativeRecordCount(t *testing.T) {
+	_, err := decodeIndex(make([]byte, 10), -1, 10, 0)
+	require.ErrorIs(t, err, ErrCorrupt)
+}
+
+func TestIndexBufferTooSmall(t *testing.T) {
+	_, err := decodeIndex(make([]byte, 5), 1, 10, 0)
+	require.ErrorIs(t, err, ErrCorrupt)
+}
+
+func TestIndexEncodeEmptyOffsets(t *testing.T) {
+	_, err := encodeIndex([]int64{})
+	require.Error(t, err)
+}
+
+func TestIndexEncodeNonZeroStart(t *testing.T) {
+	_, err := encodeIndex([]int64{100, 200})
+	require.Error(t, err)
+}
+
+func TestIndexNonMonotonicOffsets(t *testing.T) {
+	_, err := encodeIndex([]int64{0, 1000, 500})
+	require.Error(t, err)
+}
+
+func TestIndexZeroRecords(t *testing.T) {
+	offsets := []int64{0}
+
+	encoded, err := encodeIndex(offsets)
+	require.NoError(t, err)
+
+	decoded, err := decodeIndex(encoded, 0, len(encoded), 0)
+	require.NoError(t, err)
+	require.Equal(t, []int64{0}, decoded)
+}
+
+func TestIndexDeltaExceedsUint32(t *testing.T) {
+	_, err := encodeIndex([]int64{0, math.MaxUint32 + 1})
+	require.Error(t, err)
+}
+
+func TestIndexLargeDelta(t *testing.T) {
+	// Delta near MaxUint32 exercises width=32 in the FOR encoder.
+	offsets := []int64{0, math.MaxUint32}
+
+	encoded, err := encodeIndex(offsets)
+	require.NoError(t, err)
+
+	decoded, err := decodeIndex(encoded, 1, len(encoded), math.MaxUint32)
+	require.NoError(t, err)
+	require.Equal(t, offsets, decoded)
+}


### PR DESCRIPTION
## Summary

First in a series of PRs checking in the packfile implementation for full history RPC v2. See #633 for the full design doc.

This PR adds two packages:

**intpack** (`intpack.go`) — A standalone [Frame of Reference](https://lemire.me/blog/2012/02/08/effective-compression-using-frame-of-reference-and-delta-coding/) integer codec. Encodes groups of uint32 values by subtracting the group minimum and bit-packing residuals at the minimum bit width needed. Each encoded group ends with a 1-byte width and 4-byte minimum, so callers can locate the metadata from the tail without knowing the packed size. Used by the packfile offset index (this PR), per-record item size indexes (later PR), and the event store app data encoding.

**Offset index codec** (`index.go`) — Builds on intpack to encode/decode the file-level index that maps record numbers to byte positions on disk. Rather than storing absolute offsets (which grow with file size), the index stores record byte sizes as FOR groups of up to 128 values with a trailing CRC32C. On open, all groups are decoded into a flat `[]int64` offset table for O(1) lookup. Includes an OOM guard that validates record count against index size before allocating, and a structural invariant check (prefix-sum must equal the known index base offset).

## Test plan
- [x] `intpack_test.go` — roundtrip encoding/decoding, full uint32 range (width 32), error cases (invalid width, truncated payload, n<=0), buffer reuse, binary layout verification, decoding with prefix data, crafted width-0 input
- [x] `index_test.go` — roundtrip with various sizes (single record, multi-group, partial last group), CRC corruption detection, implausible record count rejection, index base mismatch detection, negative record count, buffer too small, non-monotonic offsets, zero records, empty offsets, non-zero start, delta exceeding uint32, large deltas near MaxUint32

🤖 Generated with [Claude Code](https://claude.com/claude-code)
