### PR TITLE
Add thin CGo zstd wrapper for packfile compression

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -1,8 +1,38 @@
 name: 'Setup the Go environment'
-description: 'Installs go and restores/saves the build/module cache'
+description: 'Installs go, libzstd, and restores/saves the build/module cache'
+inputs:
+  go-arch:
+    description: 'Target Go architecture (used for libzstd cache key when cross-compiling)'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
+    - name: Cache libzstd
+      if: runner.os == 'Linux'
+      id: cache-zstd
+      uses: actions/cache@v4
+      with:
+        path: ~/.zstd
+        key: libzstd-1.5.7-${{ runner.os }}-${{ inputs.go-arch || runner.arch }}-${{ hashFiles('scripts/install-zstd.sh') }}
+
+    - name: Build libzstd from source
+      if: runner.os == 'Linux' && steps.cache-zstd.outputs.cache-hit != 'true'
+      shell: bash
+      run: PREFIX="$HOME/.zstd" ./scripts/install-zstd.sh
+
+    - name: Install libzstd (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: ./scripts/install-zstd.sh
+
+    - name: Configure CGO for libzstd
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        echo "CGO_CFLAGS=-I$HOME/.zstd/include" >> $GITHUB_ENV
+        echo "CGO_LDFLAGS=-L$HOME/.zstd/lib" >> $GITHUB_ENV
+
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
@@ -52,4 +82,3 @@ runs:
     - if: github.ref_protected
       shell: bash
       run: ${{ steps.variables.outputs.SUDO }} rm -rf ${{ steps.variables.outputs.GOMODCACHE }} ${{ steps.variables.outputs.GOCACHE  }}
-

--- a/.github/workflows/stellar-rpc.yml
+++ b/.github/workflows/stellar-rpc.yml
@@ -57,15 +57,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-go
 
-      # Use cross-compiler for linux aarch64
+      # Install cross-compiler before setup-go so that libzstd is built
+      # for the target architecture (CC is picked up by install-zstd.sh).
       - if: matrix.rust_target == 'aarch64-unknown-linux-gnu'
         name: Install aarch64 cross-compilation toolchain
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-10-aarch64-linux-gnu
           echo 'CC=aarch64-linux-gnu-gcc-10' >> $GITHUB_ENV
+
+      - uses: ./.github/actions/setup-go
+        with:
+          go-arch: ${{ matrix.go_arch }}
 
       - run: |
           rustup target add ${{ matrix.rust_target }}

--- a/cmd/stellar-rpc/docker/Dockerfile
+++ b/cmd/stellar-rpc/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm AS build
+FROM golang:1.25-trixie AS build
 ARG RUST_TOOLCHAIN_VERSION=stable
 ARG REPOSITORY_VERSION
 
@@ -13,7 +13,7 @@ ENV RUSTUP_HOME=/rust/.rust
 ENV PATH="/usr/local/go/bin:$CARGO_HOME/bin:${PATH}"
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update
-RUN apt install -y build-essential jq
+RUN apt install -y build-essential jq libzstd-dev pkg-config
 RUN apt clean
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_TOOLCHAIN_VERSION

--- a/cmd/stellar-rpc/internal/zstd/zstd.go
+++ b/cmd/stellar-rpc/internal/zstd/zstd.go
@@ -1,0 +1,253 @@
+// Package zstd provides compression and decompression using system libzstd
+// via a thin CGO wrapper (~60 lines of C calls).
+//
+// We wrote this instead of using existing Go zstd bindings because:
+//
+//   - klauspost/compress (pure Go): ~92 MB/s compress on our 28KB blocks at
+//     level 3. System C libzstd: ~365 MB/s. 4x slower.
+//
+//   - DataDog/zstd: by default compiles vendored C zstd without -O2, giving
+//     only ~49 MB/s. With -tags external_libzstd it links system libzstd
+//     (~236 MB/s) but the build tag is easy to forget. Worse, the vendored C
+//     symbols cause ELF symbol interposition on Linux: when linked in the same
+//     binary as RocksDB (which also uses libzstd), RocksDB's calls to
+//     ZSTD_compress2 resolve to the unoptimized vendored copy, making RocksDB
+//     5x slower. macOS is immune (Mach-O two-level namespace).
+//
+// This wrapper links system libzstd directly. On Linux it statically links
+// libzstd.a; on macOS it dynamically links via pkg-config (homebrew). No build
+// tags, no vendored code, no interposition risk. Requires libzstd >= 1.5.7
+// (enforced at compile time and runtime). Compressor and Decompressor are not
+// safe for concurrent use — each goroutine should own its own instance.
+package zstd
+
+/*
+#cgo darwin pkg-config: libzstd
+#cgo darwin CFLAGS: -I/opt/homebrew/include -I/usr/local/include
+#cgo darwin LDFLAGS: -L/opt/homebrew/lib -L/usr/local/lib
+#cgo linux LDFLAGS: -l:libzstd.a
+#include <zstd.h>
+
+#if ZSTD_VERSION_NUMBER < 10507
+#error "libzstd >= 1.5.7 required"
+#endif
+*/
+import "C"
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"runtime"
+	"sync"
+	"unsafe"
+)
+
+var versionCheck sync.Once //nolint:gochecknoglobals // one-time runtime version check
+
+func checkVersion() {
+	versionCheck.Do(func() {
+		const minVersion = 10507 // 1.5.7
+
+		v := uint(C.ZSTD_versionNumber())
+		if v < minVersion {
+			panic(fmt.Sprintf("zstd: runtime library version %d.%d.%d < required 1.5.7",
+				v/10000, (v/100)%100, v%100))
+		}
+	})
+}
+
+const zstdLevel = 3
+
+// Compressor holds a reusable zstd compression context and output buffer.
+// Not safe for concurrent use — each goroutine should own one.
+type Compressor struct {
+	ctx     *C.ZSTD_CCtx
+	scratch []byte
+}
+
+// CompressorOption configures a Compressor.
+type CompressorOption func(*compressorConfig)
+
+type compressorConfig struct {
+	checksum bool
+}
+
+// WithoutChecksum disables the zstd content checksum.
+// Use when the caller provides its own integrity check (e.g., CRC32C).
+func WithoutChecksum() CompressorOption {
+	return func(cfg *compressorConfig) { cfg.checksum = false }
+}
+
+// NewCompressor creates a new Compressor. By default content checksums are enabled.
+func NewCompressor(opts ...CompressorOption) *Compressor {
+	checkVersion()
+	cfg := compressorConfig{checksum: true}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	ctx := C.ZSTD_createCCtx()
+	if ctx == nil {
+		panic("zstd: ZSTD_createCCtx returned NULL (out of memory)")
+	}
+	if rc := C.ZSTD_CCtx_setParameter(ctx, C.ZSTD_c_compressionLevel, zstdLevel); C.ZSTD_isError(rc) != 0 {
+		C.ZSTD_freeCCtx(ctx)
+		panic("zstd: set compression level: " + C.GoString(C.ZSTD_getErrorName(rc)))
+	}
+	var flag C.int
+	if cfg.checksum {
+		flag = 1
+	}
+	if rc := C.ZSTD_CCtx_setParameter(ctx, C.ZSTD_c_checksumFlag, flag); C.ZSTD_isError(rc) != 0 {
+		C.ZSTD_freeCCtx(ctx)
+		panic("zstd: set checksum flag: " + C.GoString(C.ZSTD_getErrorName(rc)))
+	}
+	c := &Compressor{ctx: ctx}
+	// Safety net for C memory: when sync.Pool evicts items, there's no cleanup
+	// callback, so the finalizer ensures the C context is eventually freed.
+	runtime.SetFinalizer(c, (*Compressor).Close)
+
+	return c
+}
+
+// Encode compresses data, reusing internal buffers.
+// The returned slice is valid until the next call to Encode.
+func (c *Compressor) Encode(data []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	if c.ctx == nil {
+		return nil, errors.New("zstd: Encode called on closed Compressor")
+	}
+	boundSize := C.ZSTD_compressBound(C.size_t(len(data)))
+	if boundSize > C.size_t(math.MaxInt) {
+		return nil, fmt.Errorf("zstd: input too large (compressBound=%d exceeds max int)", uint64(boundSize))
+	}
+
+	bound := int(boundSize)
+	if cap(c.scratch) < bound {
+		c.scratch = make([]byte, bound)
+	} else {
+		c.scratch = c.scratch[:bound]
+	}
+
+	n := C.ZSTD_compress2(c.ctx,
+		unsafe.Pointer(&c.scratch[0]), C.size_t(bound),
+		unsafe.Pointer(&data[0]), C.size_t(len(data)))
+	if C.ZSTD_isError(n) != 0 {
+		return nil, fmt.Errorf("zstd: compress: %s", C.GoString(C.ZSTD_getErrorName(n)))
+	}
+	return c.scratch[:int(n)], nil
+}
+
+// Close frees the compression context.
+func (c *Compressor) Close() {
+	if c.ctx != nil {
+		C.ZSTD_freeCCtx(c.ctx)
+		c.ctx = nil
+	}
+}
+
+// Encode compresses data with zstd level 3 and content checksum.
+// Allocates per call. Use Compressor for hot paths.
+func Encode(data []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	c := NewCompressor()
+	defer c.Close()
+	out, err := c.Encode(data)
+	if err != nil {
+		return nil, err
+	}
+	// Copy since the slice is backed by c.scratch.
+	result := make([]byte, len(out))
+	copy(result, out)
+	return result, nil
+}
+
+// Decompressor holds a reusable zstd decompression context.
+// Not safe for concurrent use — each goroutine should own one.
+type Decompressor struct {
+	ctx *C.ZSTD_DCtx
+}
+
+// NewDecompressor creates a new Decompressor.
+func NewDecompressor() *Decompressor {
+	checkVersion()
+	ctx := C.ZSTD_createDCtx()
+	if ctx == nil {
+		panic("zstd: ZSTD_createDCtx returned NULL (out of memory)")
+	}
+	d := &Decompressor{ctx: ctx}
+	runtime.SetFinalizer(d, (*Decompressor).Close)
+
+	return d
+}
+
+// Decode decompresses src into dst, returning the result.
+// dst is reused if large enough. Frames must include the decompressed size
+// in the header (standard for ZSTD_compress2). Streaming frames without a
+// content size use a fixed 4x estimate and will fail if the actual ratio exceeds that.
+func (d *Decompressor) Decode(dst, src []byte) ([]byte, error) {
+	if len(src) == 0 {
+		return dst[:0], nil
+	}
+	if d.ctx == nil {
+		return nil, errors.New("zstd: Decode called on closed Decompressor")
+	}
+
+	// Get decompressed size from frame header.
+	// ZSTD_getFrameContentSize returns an unsigned 64-bit int with two sentinel values:
+	//   ZSTD_CONTENTSIZE_UNKNOWN (0xFFFFFFFFFFFFFFFF) — size not in header
+	//   ZSTD_CONTENTSIZE_ERROR   (0xFFFFFFFFFFFFFFFE) — corrupt/invalid frame
+	fcs := C.ZSTD_getFrameContentSize(
+		unsafe.Pointer(&src[0]), C.size_t(len(src)))
+	var size int
+	switch fcs {
+	case C.ZSTD_CONTENTSIZE_ERROR:
+		return nil, errors.New("zstd: zstd frame header invalid")
+	case C.ZSTD_CONTENTSIZE_UNKNOWN:
+		// Our Compressor always writes content size (ZSTD_compress2 default).
+		// This path only triggers for externally-produced streaming frames.
+		size = len(src) * 4 // fallback estimate
+	default:
+		if fcs > math.MaxInt {
+			return nil, fmt.Errorf("zstd: frame claims decompressed size %d (exceeds addressable memory)", uint64(fcs))
+		}
+		size = int(fcs)
+		if size == 0 {
+			return dst[:0], nil
+		}
+	}
+	if cap(dst) < size {
+		dst = make([]byte, size)
+	} else {
+		dst = dst[:size]
+	}
+
+	n := C.ZSTD_decompressDCtx(d.ctx,
+		unsafe.Pointer(&dst[0]), C.size_t(len(dst)),
+		unsafe.Pointer(&src[0]), C.size_t(len(src)))
+	if C.ZSTD_isError(n) != 0 {
+		return nil, fmt.Errorf("zstd: zstd decompress: %s",
+			C.GoString(C.ZSTD_getErrorName(n)))
+	}
+	return dst[:int(n)], nil
+}
+
+// Close frees the decompression context.
+func (d *Decompressor) Close() {
+	if d.ctx != nil {
+		C.ZSTD_freeDCtx(d.ctx)
+		d.ctx = nil
+	}
+}
+
+// Decode decompresses src into dst, returning the result.
+// Allocates a context per call. Use Decompressor for hot paths.
+func Decode(dst, src []byte) ([]byte, error) {
+	d := NewDecompressor()
+	defer d.Close()
+	return d.Decode(dst, src)
+}

--- a/cmd/stellar-rpc/internal/zstd/zstd_test.go
+++ b/cmd/stellar-rpc/internal/zstd/zstd_test.go
@@ -1,0 +1,330 @@
+package zstd
+
+import (
+	"bytes"
+	"crypto/rand"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTrip(t *testing.T) {
+	data := make([]byte, 10000)
+	rand.Read(data)
+
+	compressed, err := Encode(data)
+	require.NoError(t, err)
+
+	decompressed, err := Decode(nil, compressed)
+	require.NoError(t, err)
+	require.Equal(t, data, decompressed)
+}
+
+func TestCorruptData(t *testing.T) {
+	data := make([]byte, 1000)
+	rand.Read(data)
+
+	compressed, err := Encode(data)
+	require.NoError(t, err)
+
+	// Truncate to half — should always fail.
+	truncated := compressed[:len(compressed)/2]
+
+	_, err = Decode(nil, truncated)
+	require.Error(t, err)
+
+	// Zero out the frame header — should always fail.
+	corrupted := make([]byte, len(compressed))
+	copy(corrupted, compressed)
+
+	for i := range min(8, len(corrupted)) {
+		corrupted[i] = 0
+	}
+
+	_, err = Decode(nil, corrupted)
+	require.Error(t, err)
+}
+
+// TestEmptyInput verifies that nil and zero-length inputs produce nil/empty
+// output without touching C code (which would SIGSEGV on a nil pointer).
+func TestEmptyInput(t *testing.T) {
+	got, err := Encode(nil)
+	require.NoError(t, err)
+	require.Nil(t, got)
+
+	got, err = Encode([]byte{})
+	require.NoError(t, err)
+	require.Nil(t, got)
+
+	// Decode with nil dst.
+	got, err = Decode(nil, nil)
+	require.NoError(t, err)
+	require.Empty(t, got)
+
+	// Decode with pre-allocated dst: returned slice should reuse dst's backing array.
+	dst := make([]byte, 0, 64)
+
+	got, err = Decode(dst, nil)
+	require.NoError(t, err)
+	require.Empty(t, got)
+	require.Equal(t, cap(dst), cap(got), "Decode(dst, nil) did not reuse dst backing array")
+}
+
+// TestOneByte exercises the minimum-size input boundary.
+func TestOneByte(t *testing.T) {
+	data := []byte{0x42}
+
+	compressed, err := Encode(data)
+	require.NoError(t, err)
+	require.NotEmpty(t, compressed)
+
+	got, err := Decode(nil, compressed)
+	require.NoError(t, err)
+	require.Equal(t, data, got)
+}
+
+// TestContextReuse verifies that Compressor and Decompressor produce correct
+// results across multiple calls with varying payload sizes and compressibility.
+func TestContextReuse(t *testing.T) {
+	payloads := [][]byte{
+		bytes.Repeat([]byte{0}, 4096), // highly compressible
+		make([]byte, 1),               // minimal
+		make([]byte, 100000),          // large random
+		{0xDE, 0xAD},                  // tiny
+		make([]byte, 8192),            // medium random
+	}
+	// Fill random payloads.
+	rand.Read(payloads[2])
+	rand.Read(payloads[4])
+
+	c := NewCompressor()
+	defer c.Close()
+
+	d := NewDecompressor()
+	defer d.Close()
+
+	var dst []byte
+
+	for i, data := range payloads {
+		compressed, err := c.Encode(data)
+		require.NoError(t, err, "iteration %d", i)
+
+		// Copy compressed data before next Encode overwrites scratch.
+		saved := make([]byte, len(compressed))
+		copy(saved, compressed)
+
+		dst, err = d.Decode(dst, saved)
+		require.NoError(t, err, "iteration %d", i)
+		require.Equal(t, data, dst, "iteration %d", i)
+	}
+}
+
+// TestScratchAliasing verifies the aliasing contract: the slice returned by
+// Compressor.Encode shares the internal scratch buffer, so a saved copy must
+// be used if the result is needed after the next Encode call.
+func TestScratchAliasing(t *testing.T) {
+	c := NewCompressor()
+	defer c.Close()
+
+	data1 := make([]byte, 4096)
+	rand.Read(data1)
+
+	out1, err := c.Encode(data1)
+	require.NoError(t, err)
+
+	saved := make([]byte, len(out1))
+	copy(saved, out1)
+
+	got, err := Decode(nil, saved)
+	require.NoError(t, err)
+	require.Equal(t, data1, got)
+
+	// Second encode with different data reuses scratch.
+	data2 := make([]byte, 8192)
+	rand.Read(data2)
+
+	out2, err := c.Encode(data2)
+	require.NoError(t, err)
+
+	saved2 := make([]byte, len(out2))
+	copy(saved2, out2)
+
+	got, err = Decode(nil, saved2)
+	require.NoError(t, err)
+	require.Equal(t, data2, got)
+}
+
+// TestDstBufferReuse verifies that Decode reuses a pre-allocated dst buffer
+// when it is large enough, avoiding allocation.
+func TestDstBufferReuse(t *testing.T) {
+	data := make([]byte, 5000)
+	rand.Read(data)
+
+	compressed, err := Encode(data)
+	require.NoError(t, err)
+
+	// Pre-allocate dst larger than needed.
+	dst := make([]byte, 0, 10000)
+	ptrBefore := &dst[:1][0]
+
+	got, err := Decode(dst, compressed)
+	require.NoError(t, err)
+	require.Equal(t, data, got)
+
+	ptrAfter := &got[:1][0]
+	require.Equal(t, ptrBefore, ptrAfter, "Decode allocated new buffer instead of reusing dst")
+}
+
+// TestCloseIdempotent verifies that calling Close twice does not panic or
+// double-free the C context.
+func TestCloseIdempotent(_ *testing.T) {
+	c := NewCompressor()
+	c.Close()
+	c.Close() // must not panic or double-free
+
+	d := NewDecompressor()
+	d.Close()
+	d.Close() // must not panic or double-free
+}
+
+// TestChecksumDetectsBitFlip verifies that the xxhash64 content checksum
+// (enabled via ZSTD_c_checksumFlag) catches single-bit corruption in the
+// compressed payload.
+func TestChecksumDetectsBitFlip(t *testing.T) {
+	data := make([]byte, 4096)
+	rand.Read(data)
+
+	compressed, err := Encode(data)
+	require.NoError(t, err)
+
+	// Flip a bit in the middle of the compressed data (block area),
+	// leaving magic and frame header intact.
+	corrupted := make([]byte, len(compressed))
+	copy(corrupted, compressed)
+
+	flipIdx := len(corrupted) / 2
+	corrupted[flipIdx] ^= 0x01
+
+	_, err = Decode(nil, corrupted)
+	require.Error(t, err)
+}
+
+// TestWithoutChecksum verifies that WithoutChecksum produces valid frames
+// and that bit flips in the compressed payload are NOT detected (no checksum).
+func TestWithoutChecksum(t *testing.T) {
+	data := make([]byte, 4096)
+	rand.Read(data)
+
+	c := NewCompressor(WithoutChecksum())
+	defer c.Close()
+
+	compressed, err := c.Encode(data)
+	require.NoError(t, err)
+
+	saved := make([]byte, len(compressed))
+	copy(saved, compressed)
+
+	got, err := Decode(nil, saved)
+	require.NoError(t, err)
+	require.Equal(t, data, got)
+
+	// Without checksum, a bit flip in the block area may decode without error
+	// (producing wrong data) rather than being caught.
+	corrupted := make([]byte, len(saved))
+	copy(corrupted, saved)
+	corrupted[len(corrupted)/2] ^= 0x01
+
+	result, err := Decode(nil, corrupted)
+	if err == nil && bytes.Equal(result, data) {
+		t.Fatal("bit-flipped data decoded to identical output — checksum may still be enabled")
+	}
+	// Either err != nil (zstd block structure broken) or result != data (silent corruption).
+	// Both are acceptable without checksum; the key is we don't guarantee detection.
+}
+
+// TestConcurrentInstances verifies that independent Compressor/Decompressor
+// instances work correctly from multiple goroutines simultaneously.
+func TestConcurrentInstances(t *testing.T) {
+	const (
+		goroutines = 8
+		iterations = 100
+	)
+
+	payloads := make([][]byte, goroutines)
+	for i := range payloads {
+		payloads[i] = make([]byte, 1000+i*500)
+		rand.Read(payloads[i])
+	}
+
+	var wg sync.WaitGroup
+
+	wg.Add(goroutines)
+
+	for g := range goroutines {
+		go func() {
+			defer wg.Done()
+
+			c := NewCompressor()
+			defer c.Close()
+
+			d := NewDecompressor()
+			defer d.Close()
+
+			var dst []byte
+
+			for range iterations {
+				compressed, err := c.Encode(payloads[g])
+				if err != nil {
+					t.Errorf("goroutine %d: Encode: %v", g, err)
+					return
+				}
+
+				saved := make([]byte, len(compressed))
+				copy(saved, compressed)
+
+				dst, err = d.Decode(dst, saved)
+				if err != nil {
+					t.Errorf("goroutine %d: Decode: %v", g, err)
+					return
+				}
+
+				if !bytes.Equal(dst, payloads[g]) {
+					t.Errorf("goroutine %d: round-trip mismatch", g)
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestEncodeAfterClose verifies that calling Encode on a closed Compressor
+// returns an error instead of passing a nil C pointer (which would SIGSEGV).
+func TestEncodeAfterClose(t *testing.T) {
+	c := NewCompressor()
+	c.Close()
+
+	_, err := c.Encode([]byte("should error"))
+	require.Error(t, err)
+}
+
+// TestDecodeAfterClose verifies that calling Decode on a closed Decompressor
+// returns an error instead of crashing.
+func TestDecodeAfterClose(t *testing.T) {
+	d := NewDecompressor()
+	d.Close()
+
+	_, err := d.Decode(nil, []byte("dummy"))
+	require.Error(t, err)
+}
+
+// TestDecodeNonZstdData verifies that garbage bytes are rejected cleanly
+// with an error, not a crash.
+func TestDecodeNonZstdData(t *testing.T) {
+	garbage := []byte("this is not zstd compressed data at all")
+
+	_, err := Decode(nil, garbage)
+	require.Error(t, err)
+}

--- a/scripts/install-zstd.sh
+++ b/scripts/install-zstd.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Install libzstd 1.5.7 for the packfile CGo wrapper.
+# Works on Linux and macOS. On Linux, builds from source and installs
+# headers + static library to PREFIX (default /usr/local).
+#
+# Usage:
+#   ./scripts/install-zstd.sh                                  # install to /usr/local (needs write access)
+#   PREFIX=$HOME/.zstd ./scripts/install-zstd.sh                 # user-local install (no root needed)
+#   CC=aarch64-linux-gnu-gcc-10 PREFIX=$HOME/.zstd/aarch64 ./scripts/install-zstd.sh   # cross-compile
+#
+set -euo pipefail
+
+ZSTD_VERSION=1.5.7
+ZSTD_SHA256=eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3
+PREFIX="${PREFIX:-/usr/local}"
+
+case "$(uname -s)" in
+  Darwin)
+    if command -v brew &>/dev/null; then
+      brew install zstd
+    else
+      echo "error: homebrew not found, install zstd manually" >&2
+      exit 1
+    fi
+    ;;
+  Linux)
+    WORKDIR=$(mktemp -d)
+    trap 'rm -rf "$WORKDIR"' EXIT
+
+    curl -sSfL -o "$WORKDIR/zstd.tar.gz" \
+      "https://github.com/facebook/zstd/releases/download/v${ZSTD_VERSION}/zstd-${ZSTD_VERSION}.tar.gz"
+    echo "${ZSTD_SHA256}  $WORKDIR/zstd.tar.gz" | sha256sum -c
+
+    tar xzf "$WORKDIR/zstd.tar.gz" -C "$WORKDIR"
+    make -j"$(nproc)" -C "$WORKDIR/zstd-${ZSTD_VERSION}" lib-release
+    make -C "$WORKDIR/zstd-${ZSTD_VERSION}/lib" install PREFIX="$PREFIX"
+    ;;
+  *)
+    echo "error: unsupported OS $(uname -s)" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

Second in a series of PRs checking in the packfile implementation for full history RPC v2. See #633 for the design doc and #649 for the first PR (FOR encoding + offset index).

This PR adds a thin CGo wrapper around system libzstd (>= 1.5.7) for compression and decompression, and updates build infrastructure to provide the required library version.

**Why a custom wrapper instead of existing Go bindings?** (see `zstd.go` package doc for details)
- **klauspost/compress (pure Go):** ~4x slower than system libzstd on our 28KB blocks at level 3
- **DataDog/zstd:** vendored C symbols cause ELF symbol interposition with RocksDB on Linux, making RocksDB 5x slower

**Why 1.5.7?** Benchmarked on representative production data (28KB blocks of 128 events):

| | libzstd 1.5.5 | libzstd 1.5.7 | Change |
|---|---|---|---|
| Compress | 717 MB/s | 766 MB/s | **+6.9%** (p=0.000, n=10) |
| Decompress | 3.43 GB/s | 3.65 GB/s | **+6.3%** (p=0.000, n=10) |

**Linking strategy:**
- Linux: statically linked via `#cgo linux LDFLAGS: -l:libzstd.a` — the binary carries libzstd 1.5.7 baked in, no runtime dependency. This applies to Docker builds, CI, and the Jenkins .deb package pipeline (which uses our Dockerfile).
- macOS: dynamically linked via pkg-config/homebrew for local development.

**Build infrastructure changes:**
- Dockerfile: switch build stage from `golang:1.25-bookworm` to `golang:1.25-trixie` (Debian 13 ships libzstd 1.5.7 in default repos), add `libzstd-dev` and `pkg-config`
- CI: build libzstd 1.5.7 from source in the `setup-go` action on Linux (with SHA256 verification); install via brew on macOS

## Test plan
- [x] Roundtrip compression/decompression
- [x] Corrupt data detection (truncated, header-corrupted, bit-flipped)
- [x] Empty/nil input handling (no SIGSEGV on nil C pointer)
- [x] Context reuse across multiple calls with varying payloads
- [x] Scratch buffer aliasing contract
- [x] dst buffer reuse (no unnecessary allocation)
- [x] Close idempotency (no double-free)
- [x] Checksum detection of single-bit corruption
- [x] WithoutChecksum option
- [x] Concurrent independent instances
- [x] Encode/Decode after Close returns error

🤖 Generated with [Claude Code](https://claude.com/claude-code)