### PR TITLE
backfill config loader + validation pipeline (#684)

### DIFF
--- a/cmd/stellar-rpc/internal/fullhistory/backfill/cmd.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/cmd.go
@@ -1,9 +1,5 @@
 // Package backfill implements the offline full-history backfill pipeline
 // and owns its CLI wiring.
-//
-// This slice (#684) fills in the subcommand body with config loading + the
-// full pre-DAG validation pipeline. DAG construction and execution land in
-// subsequent slices (#687 DAG engine, #691–#696 task implementations).
 package backfill
 
 import (
@@ -16,47 +12,43 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/backfill/config"
 )
 
-// NewCmd builds the `full-history-backfill` subcommand. The subcommand is
-// an offline ingest entry point — it loads a TOML config, merges CLI
-// flags, runs every pre-DAG validation rule, and prints the resolved
-// configuration for operator inspection. DAG construction is not yet
-// wired (slice #687).
+// NewCmd builds the `full-history-backfill` subcommand. It loads a TOML
+// config, merges CLI flags, runs every pre-DAG validation rule, and
+// prints the resolved configuration. DAG construction lands in #687.
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "full-history-backfill",
 		Short: "Offline backfill of historical Stellar ledger data",
 		RunE:  runBackfill,
 	}
-	// Six operator-facing flags from the design doc's CLI table, plus
-	// two logging-overrides (--log-level / --log-format) that complete
-	// the #684 scope. Their defaults match the help-text contract the
-	// scaffolding slice (#699 / #680) already advertised.
 	cmd.Flags().String("config", "", "Path to TOML configuration file (required)")
 	cmd.Flags().Uint32("start-ledger", 0, "First ledger to ingest (inclusive, >= 2)")
 	cmd.Flags().Uint32("end-ledger", 0, "Last ledger to ingest (inclusive, > start-ledger)")
 	cmd.Flags().Int("workers", 0, "Concurrent DAG task slots (0 = GOMAXPROCS)")
 	cmd.Flags().Int("max-retries", 3, "Max retries per task before marking failed")
 	cmd.Flags().Bool("verify-recsplit", true, "Run RecSplit verify phase after build")
-	cmd.Flags().String("log-level", "", "Log level override (debug/info/warn/error); overrides [LOGGING].LEVEL when non-empty")
-	cmd.Flags().String("log-format", "", "Log format override (text/json); overrides [LOGGING].FORMAT when non-empty")
+	cmd.Flags().String(
+		"log-level", "",
+		"Log level override (debug/info/warn/error); overrides [LOGGING].LEVEL when non-empty",
+	)
+	cmd.Flags().String(
+		"log-format", "",
+		"Log format override (text/json); overrides [LOGGING].FORMAT when non-empty",
+	)
 
+	// MarkFlagRequired errors only on a typo'd flag name — that's a
+	// programmer bug, not an operator error; panic so it shows up at
+	// startup rather than silently swallowed.
 	if err := cmd.MarkFlagRequired("config"); err != nil {
-		// MarkFlagRequired only errors when the named flag is missing;
-		// if that happens it means the registration above has a typo
-		// and this is a programming bug, not an operator error —
-		// panic surfaces it at startup.
 		panic(err)
 	}
 	return cmd
 }
 
-// runBackfill is the RunE body. Pipeline order follows the design-doc
-// "Validation before DAG construction" section: TOML-struct validation
-// first, then CLI-flag merge (which also widens the range to chunk
-// boundaries), then CLI-range validation, then the meta-store
-// immutability check, then the BSB availability probe. Every step that
-// fails returns a wrapped error so cobra exits non-zero and the operator
-// sees the specific offending rule.
+// runBackfill is the pipeline: load TOML → validate → merge flags →
+// validate flags → immutability check → BSB availability → summary.
+// Each step wraps its error so operators see the specific rule that
+// failed.
 func runBackfill(cmd *cobra.Command, _ []string) error {
 	flags, err := readFlags(cmd)
 	if err != nil {
@@ -68,60 +60,49 @@ func runBackfill(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	// Step 1: TOML-level validation (required fields, path defaults).
 	if err := cfg.Validate(); err != nil {
 		return fmt.Errorf("config validation failed: %w", err)
 	}
 
-	// Step 2: merge CLI flags (also widens the range to chunk boundaries).
 	cfg.ApplyFlags(flags.cli)
 
-	// Step 3: CLI-range validation (start/end/workers/max-retries).
 	if err := cfg.ValidateFlags(flags.cli); err != nil {
 		return fmt.Errorf("flag validation failed: %w", err)
 	}
 
-	// Step 4: CHUNKS_PER_TXHASH_INDEX immutability. The stub store used
-	// here is in-memory; the real RocksDB-backed store lands in #689 and
-	// drops in at this exact call site without the subcommand changing.
-	store := config.NewStubConfigStore()
-	if err := cfg.ValidateAgainstConfigStore(store); err != nil {
-		return fmt.Errorf("meta-store validation failed: %w", err)
+	// In-memory Store — swapped for the RocksDB-backed store from
+	// slice #689 (e.g., metastore.NewStore(cfg.MetaStore.Path)) when
+	// that lands. ValidateAgainstStore's signature does not change;
+	// only this construction line does.
+	if err := cfg.ValidateAgainstStore(config.NewInMemoryStore()); err != nil {
+		return fmt.Errorf("store validation failed: %w", err)
 	}
 
-	// Step 5: BSB availability. Stub probe returns math.MaxUint32 so this
-	// check is effectively a no-op until slice #688 lands the real probe.
-	probe := config.NewStubBSBAvailabilityProbe()
-	if err := cfg.ValidateAgainstBSB(probe); err != nil {
+	// No-op BSB probe — swapped for the GCS-backed probe from slice
+	// #688 (e.g., bsb.NewProbe(cfg.Backfill.BSB)) when that lands.
+	// ValidateAgainstBSB's signature does not change; only this
+	// construction line does.
+	if err := cfg.ValidateAgainstBSB(config.NewNopBSBAvailabilityProbe()); err != nil {
 		return fmt.Errorf("BSB availability check failed: %w", err)
 	}
 
-	// Resolved config is now fully populated. Print the summary to the
-	// command's Out stream so both interactive operators and tests see
-	// the same bytes.
 	printSummary(cmd.OutOrStdout(), cfg)
 	return nil
 }
 
-// collectedFlags bundles every flag the subcommand reads so runBackfill
-// does not juggle eight return values inline. configPath is broken out
-// separately because it drives the file I/O before any cli.*-derived
-// work can happen.
 type collectedFlags struct {
 	configPath string
 	cli        config.CLIFlags
 }
 
-// readFlags reads every flag we registered in NewCmd. Each `_ = err`
-// result from Get<T> is harmless because the flag names match verbatim
-// what NewCmd declared — a typo here would be a programmer error caught
-// by cmd_test.go's smoke test.
+// readFlags pulls every registered flag off cmd. A Get<T> error here
+// would mean the flag name is misspelled relative to NewCmd — caught
+// by cmd_test.go's registration check.
 func readFlags(cmd *cobra.Command) (collectedFlags, error) {
 	configPath, err := cmd.Flags().GetString("config")
 	if err != nil {
 		return collectedFlags{}, fmt.Errorf("read --config flag: %w", err)
 	}
-
 	startLedger, err := cmd.Flags().GetUint32("start-ledger")
 	if err != nil {
 		return collectedFlags{}, fmt.Errorf("read --start-ledger flag: %w", err)
@@ -165,9 +146,9 @@ func readFlags(cmd *cobra.Command) (collectedFlags, error) {
 	}, nil
 }
 
-// loadConfig reads the TOML file at path and parses it. Errors are
-// wrapped so the operator gets a clear "file couldn't be read" vs
-// "file parsed but schema was wrong" distinction.
+// loadConfig reads + parses the TOML file at path. Wrapped errors let
+// the operator distinguish "can't read file" from "file parsed but
+// schema was wrong".
 func loadConfig(path string) (*config.Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -180,10 +161,7 @@ func loadConfig(path string) (*config.Config, error) {
 	return cfg, nil
 }
 
-// printSummary writes a human-legible summary of the resolved Config to
-// w. Chosen layout: labeled single-line key/value pairs grouped by
-// concern (range, execution, storage, BSB, logging). Keeps operator
-// review quick without shelling out to a TOML pretty-printer.
+// printSummary writes a labeled dump of the resolved Config to w.
 func printSummary(w io.Writer, cfg *config.Config) {
 	fmt.Fprintln(w, "full-history-backfill: config validated and expanded")
 	fmt.Fprintln(w, "─── Range ─────────────────────────────────────────────")

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/cmd.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/cmd.go
@@ -70,18 +70,17 @@ func runBackfill(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("flag validation failed: %w", err)
 	}
 
-	// In-memory Store — swapped for the RocksDB-backed store from
-	// slice #689 (e.g., metastore.NewStore(cfg.MetaStore.Path)) when
-	// that lands. ValidateAgainstStore's signature does not change;
-	// only this construction line does.
+	// We currently use an in-memory store here. A RocksDB-backed store
+	// will replace this constructor call as part of #689; the call to
+	// ValidateAgainstStore itself does not change.
 	if err := cfg.ValidateAgainstStore(config.NewInMemoryStore()); err != nil {
 		return fmt.Errorf("store validation failed: %w", err)
 	}
 
-	// No-op BSB probe — swapped for the GCS-backed probe from slice
-	// #688 (e.g., bsb.NewProbe(cfg.Backfill.BSB)) when that lands.
-	// ValidateAgainstBSB's signature does not change; only this
-	// construction line does.
+	// We currently use a no-op BSB probe (every ledger is reported as
+	// available). A real GCS-backed probe will replace this constructor
+	// call as part of #688; the call to ValidateAgainstBSB itself does
+	// not change.
 	if err := cfg.ValidateAgainstBSB(config.NewNopBSBAvailabilityProbe()); err != nil {
 		return fmt.Errorf("BSB availability check failed: %w", err)
 	}

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/cmd.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/cmd.go
@@ -1,32 +1,217 @@
 // Package backfill implements the offline full-history backfill pipeline
 // and owns its CLI wiring.
+//
+// This slice (#684) fills in the subcommand body with config loading + the
+// full pre-DAG validation pipeline. DAG construction and execution land in
+// subsequent slices (#687 DAG engine, #691–#696 task implementations).
 package backfill
 
 import (
 	"fmt"
+	"io"
+	"os"
 
 	"github.com/spf13/cobra"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/backfill/config"
 )
 
-// NewCmd builds the `full-history-backfill` subcommand, an offline ingest
-// entry point whose body is wired up in subsequent slices.
+// NewCmd builds the `full-history-backfill` subcommand. The subcommand is
+// an offline ingest entry point — it loads a TOML config, merges CLI
+// flags, runs every pre-DAG validation rule, and prints the resolved
+// configuration for operator inspection. DAG construction is not yet
+// wired (slice #687).
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "full-history-backfill",
 		Short: "Offline backfill of historical Stellar ledger data",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			_, err := fmt.Fprintln(cmd.OutOrStdout(), "full-history-backfill: not yet implemented")
-			return err
-		},
+		RunE:  runBackfill,
 	}
+	// Six operator-facing flags from the design doc's CLI table, plus
+	// two logging-overrides (--log-level / --log-format) that complete
+	// the #684 scope. Their defaults match the help-text contract the
+	// scaffolding slice (#699 / #680) already advertised.
 	cmd.Flags().String("config", "", "Path to TOML configuration file (required)")
 	cmd.Flags().Uint32("start-ledger", 0, "First ledger to ingest (inclusive, >= 2)")
 	cmd.Flags().Uint32("end-ledger", 0, "Last ledger to ingest (inclusive, > start-ledger)")
 	cmd.Flags().Int("workers", 0, "Concurrent DAG task slots (0 = GOMAXPROCS)")
 	cmd.Flags().Int("max-retries", 3, "Max retries per task before marking failed")
 	cmd.Flags().Bool("verify-recsplit", true, "Run RecSplit verify phase after build")
+	cmd.Flags().String("log-level", "", "Log level override (debug/info/warn/error); overrides [LOGGING].LEVEL when non-empty")
+	cmd.Flags().String("log-format", "", "Log format override (text/json); overrides [LOGGING].FORMAT when non-empty")
+
 	if err := cmd.MarkFlagRequired("config"); err != nil {
+		// MarkFlagRequired only errors when the named flag is missing;
+		// if that happens it means the registration above has a typo
+		// and this is a programming bug, not an operator error —
+		// panic surfaces it at startup.
 		panic(err)
 	}
 	return cmd
+}
+
+// runBackfill is the RunE body. Pipeline order follows the design-doc
+// "Validation before DAG construction" section: TOML-struct validation
+// first, then CLI-flag merge (which also widens the range to chunk
+// boundaries), then CLI-range validation, then the meta-store
+// immutability check, then the BSB availability probe. Every step that
+// fails returns a wrapped error so cobra exits non-zero and the operator
+// sees the specific offending rule.
+func runBackfill(cmd *cobra.Command, _ []string) error {
+	flags, err := readFlags(cmd)
+	if err != nil {
+		return err
+	}
+
+	cfg, err := loadConfig(flags.configPath)
+	if err != nil {
+		return err
+	}
+
+	// Step 1: TOML-level validation (required fields, path defaults).
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("config validation failed: %w", err)
+	}
+
+	// Step 2: merge CLI flags (also widens the range to chunk boundaries).
+	cfg.ApplyFlags(flags.cli)
+
+	// Step 3: CLI-range validation (start/end/workers/max-retries).
+	if err := cfg.ValidateFlags(flags.cli); err != nil {
+		return fmt.Errorf("flag validation failed: %w", err)
+	}
+
+	// Step 4: CHUNKS_PER_TXHASH_INDEX immutability. The stub store used
+	// here is in-memory; the real RocksDB-backed store lands in #689 and
+	// drops in at this exact call site without the subcommand changing.
+	store := config.NewStubConfigStore()
+	if err := cfg.ValidateAgainstConfigStore(store); err != nil {
+		return fmt.Errorf("meta-store validation failed: %w", err)
+	}
+
+	// Step 5: BSB availability. Stub probe returns math.MaxUint32 so this
+	// check is effectively a no-op until slice #688 lands the real probe.
+	probe := config.NewStubBSBAvailabilityProbe()
+	if err := cfg.ValidateAgainstBSB(probe); err != nil {
+		return fmt.Errorf("BSB availability check failed: %w", err)
+	}
+
+	// Resolved config is now fully populated. Print the summary to the
+	// command's Out stream so both interactive operators and tests see
+	// the same bytes.
+	printSummary(cmd.OutOrStdout(), cfg)
+	return nil
+}
+
+// collectedFlags bundles every flag the subcommand reads so runBackfill
+// does not juggle eight return values inline. configPath is broken out
+// separately because it drives the file I/O before any cli.*-derived
+// work can happen.
+type collectedFlags struct {
+	configPath string
+	cli        config.CLIFlags
+}
+
+// readFlags reads every flag we registered in NewCmd. Each `_ = err`
+// result from Get<T> is harmless because the flag names match verbatim
+// what NewCmd declared — a typo here would be a programmer error caught
+// by cmd_test.go's smoke test.
+func readFlags(cmd *cobra.Command) (collectedFlags, error) {
+	configPath, err := cmd.Flags().GetString("config")
+	if err != nil {
+		return collectedFlags{}, fmt.Errorf("read --config flag: %w", err)
+	}
+
+	startLedger, err := cmd.Flags().GetUint32("start-ledger")
+	if err != nil {
+		return collectedFlags{}, fmt.Errorf("read --start-ledger flag: %w", err)
+	}
+	endLedger, err := cmd.Flags().GetUint32("end-ledger")
+	if err != nil {
+		return collectedFlags{}, fmt.Errorf("read --end-ledger flag: %w", err)
+	}
+	workers, err := cmd.Flags().GetInt("workers")
+	if err != nil {
+		return collectedFlags{}, fmt.Errorf("read --workers flag: %w", err)
+	}
+	maxRetries, err := cmd.Flags().GetInt("max-retries")
+	if err != nil {
+		return collectedFlags{}, fmt.Errorf("read --max-retries flag: %w", err)
+	}
+	verifyRecSplit, err := cmd.Flags().GetBool("verify-recsplit")
+	if err != nil {
+		return collectedFlags{}, fmt.Errorf("read --verify-recsplit flag: %w", err)
+	}
+	logLevel, err := cmd.Flags().GetString("log-level")
+	if err != nil {
+		return collectedFlags{}, fmt.Errorf("read --log-level flag: %w", err)
+	}
+	logFormat, err := cmd.Flags().GetString("log-format")
+	if err != nil {
+		return collectedFlags{}, fmt.Errorf("read --log-format flag: %w", err)
+	}
+
+	return collectedFlags{
+		configPath: configPath,
+		cli: config.CLIFlags{
+			StartLedger:    startLedger,
+			EndLedger:      endLedger,
+			Workers:        workers,
+			MaxRetries:     maxRetries,
+			VerifyRecSplit: verifyRecSplit,
+			LogLevel:       logLevel,
+			LogFormat:      logFormat,
+		},
+	}, nil
+}
+
+// loadConfig reads the TOML file at path and parses it. Errors are
+// wrapped so the operator gets a clear "file couldn't be read" vs
+// "file parsed but schema was wrong" distinction.
+func loadConfig(path string) (*config.Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read config file %q: %w", path, err)
+	}
+	cfg, err := config.ParseConfig(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse config file %q: %w", path, err)
+	}
+	return cfg, nil
+}
+
+// printSummary writes a human-legible summary of the resolved Config to
+// w. Chosen layout: labeled single-line key/value pairs grouped by
+// concern (range, execution, storage, BSB, logging). Keeps operator
+// review quick without shelling out to a TOML pretty-printer.
+func printSummary(w io.Writer, cfg *config.Config) {
+	fmt.Fprintln(w, "full-history-backfill: config validated and expanded")
+	fmt.Fprintln(w, "─── Range ─────────────────────────────────────────────")
+	fmt.Fprintf(w, "  effective start ledger : %d\n", cfg.EffectiveStartLedger)
+	fmt.Fprintf(w, "  effective end ledger   : %d\n", cfg.EffectiveEndLedger)
+	fmt.Fprintf(w, "  chunks-per-txhash-index: %d\n", cfg.Backfill.ChunksPerTxHashIndex)
+
+	fmt.Fprintln(w, "─── Execution ─────────────────────────────────────────")
+	fmt.Fprintf(w, "  workers        : %d\n", cfg.Workers)
+	fmt.Fprintf(w, "  max-retries    : %d\n", cfg.MaxRetries)
+	fmt.Fprintf(w, "  verify-recsplit: %t\n", cfg.VerifyRecSplit)
+
+	fmt.Fprintln(w, "─── Storage paths ─────────────────────────────────────")
+	fmt.Fprintf(w, "  meta store  : %s\n", cfg.MetaStore.Path)
+	fmt.Fprintf(w, "  ledgers     : %s\n", cfg.ImmutableStorage.Ledgers.Path)
+	fmt.Fprintf(w, "  events      : %s\n", cfg.ImmutableStorage.Events.Path)
+	fmt.Fprintf(w, "  txhash raw  : %s\n", cfg.ImmutableStorage.TxHashRaw.Path)
+	fmt.Fprintf(w, "  txhash index: %s\n", cfg.ImmutableStorage.TxHashIndex.Path)
+
+	fmt.Fprintln(w, "─── BSB ───────────────────────────────────────────────")
+	fmt.Fprintf(w, "  bucket-path: %s\n", cfg.Backfill.BSB.BucketPath)
+	fmt.Fprintf(w, "  buffer-size: %d\n", cfg.Backfill.BSB.BufferSize)
+	fmt.Fprintf(w, "  num-workers: %d\n", cfg.Backfill.BSB.NumWorkers)
+
+	fmt.Fprintln(w, "─── Logging ───────────────────────────────────────────")
+	fmt.Fprintf(w, "  level : %s\n", cfg.Logging.Level)
+	fmt.Fprintf(w, "  format: %s\n", cfg.Logging.Format)
+
+	fmt.Fprintln(w, "───────────────────────────────────────────────────────")
+	fmt.Fprintln(w, "DAG construction + execution not yet wired (see slices #687, #691–#696).")
 }

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/cmd_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/cmd_test.go
@@ -2,35 +2,177 @@ package backfill
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewCmd_Placeholder(t *testing.T) {
+// minimalValidTOML returns a TOML payload the full validation pipeline
+// accepts. Kept local to cmd_test.go so the subcommand test remains
+// self-contained and does not reach into the config package's internal
+// test helpers.
+const minimalValidTOML = `
+[SERVICE]
+DEFAULT_DATA_DIR = "/data/stellar-rpc"
+
+[BACKFILL.BSB]
+BUCKET_PATH = "bucket"
+`
+
+// writeTOMLFile writes body to a fresh temp file and returns the path.
+// t.TempDir handles cleanup, so each test gets an isolated directory.
+func writeTOMLFile(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "backfill.toml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write temp TOML: %v", err)
+	}
+	return path
+}
+
+// TestNewCmd_Flags verifies that every flag #684's design doc calls for is
+// registered. Drives the command from construction to the flag inventory
+// — if a flag gets accidentally dropped, this test catches it before any
+// operator runs hit "unknown flag" at the CLI.
+func TestNewCmd_Flags(t *testing.T) {
 	cmd := NewCmd()
 
 	require.Equal(t, "full-history-backfill", cmd.Use)
 
-	for _, name := range []string{
+	wanted := []string{
 		"config",
 		"start-ledger",
 		"end-ledger",
 		"workers",
 		"max-retries",
 		"verify-recsplit",
-	} {
+		"log-level",
+		"log-format",
+	}
+	for _, name := range wanted {
 		require.NotNilf(t, cmd.Flags().Lookup(name), "missing flag: %s", name)
 	}
+}
 
+// TestNewCmd_ValidConfig_PrintsSummary exercises the golden path: a TOML
+// file that validates successfully → subcommand exits 0 and prints the
+// expected summary fields to stdout. Assertion is substring-match, so a
+// cosmetic layout change in printSummary does not break the test.
+func TestNewCmd_ValidConfig_PrintsSummary(t *testing.T) {
+	configPath := writeTOMLFile(t, minimalValidTOML)
+
+	cmd := NewCmd()
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 	cmd.SetArgs([]string{
-		"--config", "/dev/null",
+		"--config", configPath,
 		"--start-ledger", "2",
-		"--end-ledger", "10002",
+		"--end-ledger", "10001", // chunk 0's last ledger
+		"--workers", "4",
 	})
+
 	require.NoError(t, cmd.Execute())
-	require.Contains(t, out.String(), "not yet implemented")
+
+	// Range fields populated and surfaced.
+	for _, want := range []string{
+		"effective start ledger : 2",
+		"effective end ledger   : 10001",
+		"chunks-per-txhash-index: 1000",
+		"workers        : 4",
+		"max-retries    : 3", // default from flag registration
+		"verify-recsplit: true",
+		"bucket-path: bucket",
+		"meta store  : /data/stellar-rpc/meta/rocksdb", // path default resolved
+	} {
+		require.Containsf(t, out.String(), want, "summary missing %q; full output:\n%s", want, out.String())
+	}
+}
+
+// TestNewCmd_InvalidConfig_ReturnsError covers the failure branches at
+// the subcommand layer — each table case exercises a distinct rule.
+// We rely on cobra surfacing RunE errors as non-zero Execute returns,
+// mirroring what the operator sees from the shell.
+func TestNewCmd_InvalidConfig_ReturnsError(t *testing.T) {
+	cases := []struct {
+		name       string
+		toml       string
+		startFlag  string
+		endFlag    string
+		wantErrSub string
+	}{
+		{
+			name:       "start-ledger below minimum",
+			toml:       minimalValidTOML,
+			startFlag:  "1",
+			endFlag:    "10001",
+			wantErrSub: "start-ledger",
+		},
+		{
+			name:       "end-ledger not greater than start-ledger",
+			toml:       minimalValidTOML,
+			startFlag:  "100",
+			endFlag:    "100",
+			wantErrSub: "end-ledger",
+		},
+		{
+			name:       "TOML missing DEFAULT_DATA_DIR",
+			toml:       "[BACKFILL.BSB]\nBUCKET_PATH = \"bucket\"\n",
+			startFlag:  "2",
+			endFlag:    "10001",
+			wantErrSub: "DEFAULT_DATA_DIR",
+		},
+		{
+			name:       "TOML missing [BACKFILL.BSB]",
+			toml:       "[SERVICE]\nDEFAULT_DATA_DIR = \"/data\"\n",
+			startFlag:  "2",
+			endFlag:    "10001",
+			wantErrSub: "BACKFILL.BSB",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath := writeTOMLFile(t, tc.toml)
+
+			cmd := NewCmd()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs([]string{
+				"--config", configPath,
+				"--start-ledger", tc.startFlag,
+				"--end-ledger", tc.endFlag,
+				"--workers", "1",
+			})
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErrSub)
+		})
+	}
+}
+
+// TestNewCmd_MissingConfigFile verifies that a non-existent --config path
+// surfaces a file-not-found error rather than silently proceeding with
+// an empty Config. Realistic operator-error case; catching it fast is
+// the whole point.
+func TestNewCmd_MissingConfigFile(t *testing.T) {
+	cmd := NewCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"--config", "/tmp/does-not-exist-" + t.Name() + ".toml",
+		"--start-ledger", "2",
+		"--end-ledger", "10001",
+		"--workers", "1",
+	})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "read config file")
 }

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/cmd_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/cmd_test.go
@@ -9,10 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// minimalValidTOML returns a TOML payload the full validation pipeline
-// accepts. Kept local to cmd_test.go so the subcommand test remains
-// self-contained and does not reach into the config package's internal
-// test helpers.
 const minimalValidTOML = `
 [SERVICE]
 DEFAULT_DATA_DIR = "/data/stellar-rpc"
@@ -21,46 +17,32 @@ DEFAULT_DATA_DIR = "/data/stellar-rpc"
 BUCKET_PATH = "bucket"
 `
 
-// writeTOMLFile writes body to a fresh temp file and returns the path.
-// t.TempDir handles cleanup, so each test gets an isolated directory.
 func writeTOMLFile(t *testing.T, body string) string {
 	t.Helper()
-	dir := t.TempDir()
-	path := filepath.Join(dir, "backfill.toml")
+	path := filepath.Join(t.TempDir(), "backfill.toml")
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		t.Fatalf("write temp TOML: %v", err)
 	}
 	return path
 }
 
-// TestNewCmd_Flags verifies that every flag #684's design doc calls for is
-// registered. Drives the command from construction to the flag inventory
-// — if a flag gets accidentally dropped, this test catches it before any
-// operator runs hit "unknown flag" at the CLI.
+// TestNewCmd_Flags guards against a flag getting accidentally dropped —
+// operators would otherwise see "unknown flag" at the CLI.
 func TestNewCmd_Flags(t *testing.T) {
 	cmd := NewCmd()
-
 	require.Equal(t, "full-history-backfill", cmd.Use)
 
-	wanted := []string{
-		"config",
-		"start-ledger",
-		"end-ledger",
-		"workers",
-		"max-retries",
-		"verify-recsplit",
-		"log-level",
-		"log-format",
-	}
-	for _, name := range wanted {
+	for _, name := range []string{
+		"config", "start-ledger", "end-ledger", "workers",
+		"max-retries", "verify-recsplit", "log-level", "log-format",
+	} {
 		require.NotNilf(t, cmd.Flags().Lookup(name), "missing flag: %s", name)
 	}
 }
 
-// TestNewCmd_ValidConfig_PrintsSummary exercises the golden path: a TOML
-// file that validates successfully → subcommand exits 0 and prints the
-// expected summary fields to stdout. Assertion is substring-match, so a
-// cosmetic layout change in printSummary does not break the test.
+// TestNewCmd_ValidConfig_PrintsSummary is the golden path: a valid TOML
+// produces exit 0 and a summary containing the resolved fields.
+// Substring assertions tolerate layout changes in printSummary.
 func TestNewCmd_ValidConfig_PrintsSummary(t *testing.T) {
 	configPath := writeTOMLFile(t, minimalValidTOML)
 
@@ -77,25 +59,23 @@ func TestNewCmd_ValidConfig_PrintsSummary(t *testing.T) {
 
 	require.NoError(t, cmd.Execute())
 
-	// Range fields populated and surfaced.
 	for _, want := range []string{
 		"effective start ledger : 2",
 		"effective end ledger   : 10001",
 		"chunks-per-txhash-index: 1000",
 		"workers        : 4",
-		"max-retries    : 3", // default from flag registration
+		"max-retries    : 3",
 		"verify-recsplit: true",
 		"bucket-path: bucket",
-		"meta store  : /data/stellar-rpc/meta/rocksdb", // path default resolved
+		"meta store  : /data/stellar-rpc/meta/rocksdb",
 	} {
 		require.Containsf(t, out.String(), want, "summary missing %q; full output:\n%s", want, out.String())
 	}
 }
 
-// TestNewCmd_InvalidConfig_ReturnsError covers the failure branches at
-// the subcommand layer — each table case exercises a distinct rule.
-// We rely on cobra surfacing RunE errors as non-zero Execute returns,
-// mirroring what the operator sees from the shell.
+// TestNewCmd_InvalidConfig_ReturnsError — each case maps to one
+// validation rule. Cobra surfaces RunE errors as a non-zero Execute
+// return, which is what the operator sees.
 func TestNewCmd_InvalidConfig_ReturnsError(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -136,14 +116,12 @@ func TestNewCmd_InvalidConfig_ReturnsError(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			configPath := writeTOMLFile(t, tc.toml)
-
 			cmd := NewCmd()
 			var out bytes.Buffer
 			cmd.SetOut(&out)
 			cmd.SetErr(&out)
 			cmd.SetArgs([]string{
-				"--config", configPath,
+				"--config", writeTOMLFile(t, tc.toml),
 				"--start-ledger", tc.startFlag,
 				"--end-ledger", tc.endFlag,
 				"--workers", "1",
@@ -156,17 +134,18 @@ func TestNewCmd_InvalidConfig_ReturnsError(t *testing.T) {
 	}
 }
 
-// TestNewCmd_MissingConfigFile verifies that a non-existent --config path
-// surfaces a file-not-found error rather than silently proceeding with
-// an empty Config. Realistic operator-error case; catching it fast is
-// the whole point.
+// TestNewCmd_MissingConfigFile — a non-existent --config path must
+// surface a file-read error, not silently proceed. Uses a guaranteed-
+// missing path under t.TempDir() (the dir exists, the file does not).
 func TestNewCmd_MissingConfigFile(t *testing.T) {
+	missingPath := filepath.Join(t.TempDir(), "does-not-exist.toml")
+
 	cmd := NewCmd()
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 	cmd.SetArgs([]string{
-		"--config", "/tmp/does-not-exist-" + t.Name() + ".toml",
+		"--config", missingPath,
 		"--start-ledger", "2",
 		"--end-ledger", "10001",
 		"--workers", "1",

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/cmd_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/cmd_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,9 +21,7 @@ BUCKET_PATH = "bucket"
 func writeTOMLFile(t *testing.T, body string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "backfill.toml")
-	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
-		t.Fatalf("write temp TOML: %v", err)
-	}
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
 	return path
 }
 
@@ -30,13 +29,13 @@ func writeTOMLFile(t *testing.T, body string) string {
 // operators would otherwise see "unknown flag" at the CLI.
 func TestNewCmd_Flags(t *testing.T) {
 	cmd := NewCmd()
-	require.Equal(t, "full-history-backfill", cmd.Use)
+	assert.Equal(t, "full-history-backfill", cmd.Use)
 
 	for _, name := range []string{
 		"config", "start-ledger", "end-ledger", "workers",
 		"max-retries", "verify-recsplit", "log-level", "log-format",
 	} {
-		require.NotNilf(t, cmd.Flags().Lookup(name), "missing flag: %s", name)
+		assert.NotNilf(t, cmd.Flags().Lookup(name), "missing flag: %s", name)
 	}
 }
 
@@ -57,6 +56,7 @@ func TestNewCmd_ValidConfig_PrintsSummary(t *testing.T) {
 		"--workers", "4",
 	})
 
+	// require — if Execute returns an error, out.String() is meaningless.
 	require.NoError(t, cmd.Execute())
 
 	for _, want := range []string{
@@ -69,7 +69,7 @@ func TestNewCmd_ValidConfig_PrintsSummary(t *testing.T) {
 		"bucket-path: bucket",
 		"meta store  : /data/stellar-rpc/meta/rocksdb",
 	} {
-		require.Containsf(t, out.String(), want, "summary missing %q; full output:\n%s", want, out.String())
+		assert.Containsf(t, out.String(), want, "summary missing %q; full output:\n%s", want, out.String())
 	}
 }
 
@@ -128,8 +128,9 @@ func TestNewCmd_InvalidConfig_ReturnsError(t *testing.T) {
 			})
 
 			err := cmd.Execute()
+			// require — must be non-nil before we can read .Error().
 			require.Error(t, err)
-			require.Contains(t, err.Error(), tc.wantErrSub)
+			assert.Contains(t, err.Error(), tc.wantErrSub)
 		})
 	}
 }
@@ -153,5 +154,5 @@ func TestNewCmd_MissingConfigFile(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "read config file")
+	assert.Contains(t, err.Error(), "read config file")
 }

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/config/config.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/config/config.go
@@ -1,22 +1,8 @@
 // Package config owns the backfill-subcommand's TOML schema, CLI-flag merge
-// layer, and the pre-DAG validation rules listed in design-doc section
+// layer, and the pre-DAG validation rules from design-doc section
 // "Validation before DAG construction".
 //
-// The package splits its responsibilities across three concerns but lives as
-// a single Go package so a future refactor can freely move helpers between
-// them without producing import cycles:
-//
-//   - config.go       — struct schema, ParseConfig, MarshalTOML
-//   - flags.go        — CLIFlags + ApplyFlags (chunk-boundary widening)
-//   - validate.go     — Validate, ValidateFlags, ValidateAgainstConfigStore,
-//     ValidateAgainstBSB
-//   - interfaces.go   — ConfigStore + BSBAvailabilityProbe contracts, plus
-//     no-op stubs used until slices #689 and #688 land the
-//     real RocksDB-backed and BSB-backed implementations.
-//
-// TOML convention: UPPER_SNAKE_CASE keys throughout. pelletier/go-toml (v1)
-// treats TOML keys as case-sensitive per spec, so the struct tags must match
-// the on-disk casing exactly.
+// All TOML keys are UPPER_SNAKE_CASE; TOML is case-sensitive per spec.
 package config
 
 import (
@@ -25,146 +11,82 @@ import (
 	"github.com/pelletier/go-toml"
 )
 
-// Config is the top-level backfill configuration.
-//
-// Field layout mirrors the TOML schema in design-doc section "Configuration":
-// [SERVICE], [BACKFILL] (with nested [BACKFILL.BSB]),
-// [IMMUTABLE_STORAGE.LEDGERS|EVENTS|TXHASH_RAW|TXHASH_INDEX],
-// [LOGGING], [META_STORE]. All keys are UPPER_SNAKE_CASE on disk; Go field
-// names remain idiomatic CamelCase via struct tags.
-//
-// Non-TOML fields populated by ApplyFlags (see flags.go) carry `toml:"-"`
-// so they round-trip cleanly through MarshalTOML.
+// Config is the top-level backfill configuration. Fields whose tag is
+// `toml:"-"` are populated by ApplyFlags after parse and do not round-trip.
 type Config struct {
-	// Service holds the base data directory used as a default root for
-	// any storage paths the operator does not set explicitly.
-	Service ServiceConfig `toml:"SERVICE"`
-
-	// MetaStore is an optional section; when unset, Validate defaults
-	// Path to {DEFAULT_DATA_DIR}/META/ROCKSDB.
-	MetaStore MetaStoreConfig `toml:"META_STORE"`
-
-	// Backfill holds the pipeline-level knobs: CHUNKS_PER_TXHASH_INDEX
-	// (layout-defining; must not change across runs) and the BSB
-	// connection details.
-	Backfill BackfillConfig `toml:"BACKFILL"`
-
-	// ImmutableStorage holds the four per-data-type storage paths that
-	// the design doc lists under [IMMUTABLE_STORAGE.*]. Each defaults to
-	// a sub-directory of DEFAULT_DATA_DIR when Validate resolves defaults.
+	Service          ServiceConfig          `toml:"SERVICE"`
+	MetaStore        MetaStoreConfig        `toml:"META_STORE"`
+	Backfill         BackfillConfig         `toml:"BACKFILL"`
 	ImmutableStorage ImmutableStorageConfig `toml:"IMMUTABLE_STORAGE"`
+	Logging          LoggingConfig          `toml:"LOGGING"`
 
-	// Logging carries the [LOGGING] section. This slice only plumbs the
-	// values through — the logrus bootstrap that consumes them lands in
-	// slice #685 with the pkg/logging rewrite.
-	Logging LoggingConfig `toml:"LOGGING"`
-
-	// --- Fields populated by ApplyFlags — never round-tripped via TOML. ---
-
-	// EffectiveStartLedger / EffectiveEndLedger are the widened range
-	// after chunk-boundary expansion. Always >= the operator-requested
-	// range; never narrower.
 	EffectiveStartLedger uint32 `toml:"-"`
 	EffectiveEndLedger   uint32 `toml:"-"`
-
-	// Workers is the resolved DAG slot count (0 sentinel replaced with
-	// GOMAXPROCS by ApplyFlags).
-	Workers int `toml:"-"`
-
-	// MaxRetries is the resolved per-task retry budget.
-	MaxRetries int `toml:"-"`
-
-	// VerifyRecSplit mirrors the CLI flag.
-	VerifyRecSplit bool `toml:"-"`
+	Workers              int    `toml:"-"`
+	MaxRetries           int    `toml:"-"`
+	VerifyRecSplit       bool   `toml:"-"`
 }
 
-// ServiceConfig carries the single [SERVICE] key — DEFAULT_DATA_DIR — which
-// operators are required to set and which serves as the fall-back root for
-// the meta store, immutable storage trees, and log file paths.
+// ServiceConfig is the [SERVICE] section.
 type ServiceConfig struct {
-	// DefaultDataDir is the base directory; if unset, Validate errors.
+	// DefaultDataDir is the fall-back root for every storage path the
+	// operator does not set explicitly.
 	DefaultDataDir string `toml:"DEFAULT_DATA_DIR"`
 }
 
-// MetaStoreConfig carries the optional [META_STORE] section. Only the
-// RocksDB directory path is operator-visible; RocksDB tuning knobs are
-// hardcoded in the Layer-2 metastore facade (slice #689) per MEMORY.md's
-// decision "tuning knobs NOT in operator TOML".
+// MetaStoreConfig is the optional [META_STORE] section. Defaults to
+// {DEFAULT_DATA_DIR}/meta/rocksdb (lowercase) when absent.
+//
+// RocksDB tuning knobs are intentionally NOT operator-visible here —
+// they are hardcoded in the Layer-2 metastore facade (slice #689).
 type MetaStoreConfig struct {
-	// Path is the meta-store RocksDB directory.
 	Path string `toml:"PATH"`
 }
 
-// BackfillConfig holds the [BACKFILL] section plus its nested [BACKFILL.BSB]
-// table. CHUNKS_PER_TXHASH_INDEX is layout-defining (design doc: "must not
-// change across runs") — immutability is enforced by
-// ValidateAgainstConfigStore against the meta-store key
-// `config:chunks_per_txhash_index`.
+// BackfillConfig is the [BACKFILL] section plus its nested [BACKFILL.BSB].
+//
+// CHUNKS_PER_TXHASH_INDEX is layout-defining: once a backfill run has
+// seeded the meta store with a value, later runs must match it or the
+// on-disk txhash-index boundaries are silently corrupted.
 type BackfillConfig struct {
-	// ChunksPerTxHashIndex controls the cadence of txhash index builds;
-	// defaults to 1_000 (= 10M ledgers per index) when absent.
 	ChunksPerTxHashIndex uint32 `toml:"CHUNKS_PER_TXHASH_INDEX"`
-
-	// BSB is the BufferedStorageBackend configuration — required per the
-	// design doc, hence pointer-valued so absence is distinguishable from
-	// empty-struct.
+	// BSB is pointer-valued so absence is distinguishable from an empty
+	// struct — Validate treats nil as "section missing".
 	BSB *BSBConfig `toml:"BSB"`
 }
 
-// BSBConfig holds the [BACKFILL.BSB] nested table. BUCKET_PATH is the only
-// required key; BUFFER_SIZE and NUM_WORKERS default to 1_000 and 20 when
-// absent or zero (matching the design doc's defaults).
+// BSBConfig is the nested [BACKFILL.BSB] table. BUCKET_PATH is required;
+// BUFFER_SIZE / NUM_WORKERS default to 1000 / 20 when absent.
 type BSBConfig struct {
-	// BucketPath is the remote object-store path (GCS: no gs:// prefix).
 	BucketPath string `toml:"BUCKET_PATH"`
-
-	// BufferSize is the prefetch depth per BSB connection.
-	BufferSize int `toml:"BUFFER_SIZE"`
-
-	// NumWorkers is the download-worker count per BSB connection.
-	NumWorkers int `toml:"NUM_WORKERS"`
+	BufferSize int    `toml:"BUFFER_SIZE"`
+	NumWorkers int    `toml:"NUM_WORKERS"`
 }
 
-// ImmutableStorageConfig mirrors the four sub-sections of [IMMUTABLE_STORAGE]:
-// LEDGERS, EVENTS, TXHASH_RAW, TXHASH_INDEX. Each carries a PATH key that
-// defaults to {DEFAULT_DATA_DIR}/<type> when Validate resolves defaults.
+// ImmutableStorageConfig mirrors the four [IMMUTABLE_STORAGE.*] sub-sections.
 type ImmutableStorageConfig struct {
-	// Ledgers is the per-chunk ledger-pack-file tree root.
-	Ledgers StoragePathConfig `toml:"LEDGERS"`
-
-	// Events is the per-chunk events cold-segment tree root.
-	Events StoragePathConfig `toml:"EVENTS"`
-
-	// TxHashRaw is the per-chunk raw .bin tree root (transient; cleaned
-	// up by CleanupTxHashTask after the RecSplit build).
-	TxHashRaw StoragePathConfig `toml:"TXHASH_RAW"`
-
-	// TxHashIndex is the per-txhash-index RecSplit .idx tree root
-	// (permanent once built).
+	Ledgers     StoragePathConfig `toml:"LEDGERS"`
+	Events      StoragePathConfig `toml:"EVENTS"`
+	TxHashRaw   StoragePathConfig `toml:"TXHASH_RAW"`
 	TxHashIndex StoragePathConfig `toml:"TXHASH_INDEX"`
 }
 
-// StoragePathConfig is the shape shared by all four [IMMUTABLE_STORAGE.*]
-// sub-sections — a single PATH string.
+// StoragePathConfig holds a single PATH string.
 type StoragePathConfig struct {
-	// Path is the filesystem root for this data type.
 	Path string `toml:"PATH"`
 }
 
-// LoggingConfig carries the [LOGGING] section — LEVEL (debug/info/warn/error)
-// and FORMAT (text/json). The logrus bootstrap that consumes these fields
-// lands in slice #685; this slice only plumbs them through parse + flag merge.
+// LoggingConfig is the [LOGGING] section. Values are plumbed through but
+// not consumed in this slice; the logrus bootstrap lands in #685.
 type LoggingConfig struct {
 	// Level is one of "debug", "info", "warn", "error".
 	Level string `toml:"LEVEL"`
-
 	// Format is one of "text", "json".
 	Format string `toml:"FORMAT"`
 }
 
-// ParseConfig decodes a TOML byte slice (typically the contents of the file
-// passed via `--config`) into a Config. Errors are wrapped so the caller can
-// surface them to the operator with context about where parsing failed.
+// ParseConfig decodes a TOML payload (typically the file passed via
+// `--config`) into a Config.
 func ParseConfig(data []byte) (*Config, error) {
 	var cfg Config
 	if err := toml.Unmarshal(data, &cfg); err != nil {
@@ -173,11 +95,9 @@ func ParseConfig(data []byte) (*Config, error) {
 	return &cfg, nil
 }
 
-// MarshalTOML encodes the Config back to TOML bytes. Exists to satisfy the
-// "TOML round-trips" acceptance criterion from #684 — useful for diagnostics
-// ("what config is this backfill actually running with?") and for producing
-// a normalized on-disk form after defaults are resolved. Keys come out in
-// the same UPPER_SNAKE_CASE the struct tags declare.
+// MarshalTOML encodes the Config back to TOML. Useful for diagnostics
+// ("what config is this run actually using?") and to satisfy the
+// parse → marshal → parse round-trip acceptance criterion.
 func (c *Config) MarshalTOML() ([]byte, error) {
 	buf, err := toml.Marshal(*c)
 	if err != nil {

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/config/config.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/config/config.go
@@ -1,0 +1,187 @@
+// Package config owns the backfill-subcommand's TOML schema, CLI-flag merge
+// layer, and the pre-DAG validation rules listed in design-doc section
+// "Validation before DAG construction".
+//
+// The package splits its responsibilities across three concerns but lives as
+// a single Go package so a future refactor can freely move helpers between
+// them without producing import cycles:
+//
+//   - config.go       — struct schema, ParseConfig, MarshalTOML
+//   - flags.go        — CLIFlags + ApplyFlags (chunk-boundary widening)
+//   - validate.go     — Validate, ValidateFlags, ValidateAgainstConfigStore,
+//     ValidateAgainstBSB
+//   - interfaces.go   — ConfigStore + BSBAvailabilityProbe contracts, plus
+//     no-op stubs used until slices #689 and #688 land the
+//     real RocksDB-backed and BSB-backed implementations.
+//
+// TOML convention: UPPER_SNAKE_CASE keys throughout. pelletier/go-toml (v1)
+// treats TOML keys as case-sensitive per spec, so the struct tags must match
+// the on-disk casing exactly.
+package config
+
+import (
+	"fmt"
+
+	"github.com/pelletier/go-toml"
+)
+
+// Config is the top-level backfill configuration.
+//
+// Field layout mirrors the TOML schema in design-doc section "Configuration":
+// [SERVICE], [BACKFILL] (with nested [BACKFILL.BSB]),
+// [IMMUTABLE_STORAGE.LEDGERS|EVENTS|TXHASH_RAW|TXHASH_INDEX],
+// [LOGGING], [META_STORE]. All keys are UPPER_SNAKE_CASE on disk; Go field
+// names remain idiomatic CamelCase via struct tags.
+//
+// Non-TOML fields populated by ApplyFlags (see flags.go) carry `toml:"-"`
+// so they round-trip cleanly through MarshalTOML.
+type Config struct {
+	// Service holds the base data directory used as a default root for
+	// any storage paths the operator does not set explicitly.
+	Service ServiceConfig `toml:"SERVICE"`
+
+	// MetaStore is an optional section; when unset, Validate defaults
+	// Path to {DEFAULT_DATA_DIR}/META/ROCKSDB.
+	MetaStore MetaStoreConfig `toml:"META_STORE"`
+
+	// Backfill holds the pipeline-level knobs: CHUNKS_PER_TXHASH_INDEX
+	// (layout-defining; must not change across runs) and the BSB
+	// connection details.
+	Backfill BackfillConfig `toml:"BACKFILL"`
+
+	// ImmutableStorage holds the four per-data-type storage paths that
+	// the design doc lists under [IMMUTABLE_STORAGE.*]. Each defaults to
+	// a sub-directory of DEFAULT_DATA_DIR when Validate resolves defaults.
+	ImmutableStorage ImmutableStorageConfig `toml:"IMMUTABLE_STORAGE"`
+
+	// Logging carries the [LOGGING] section. This slice only plumbs the
+	// values through — the logrus bootstrap that consumes them lands in
+	// slice #685 with the pkg/logging rewrite.
+	Logging LoggingConfig `toml:"LOGGING"`
+
+	// --- Fields populated by ApplyFlags — never round-tripped via TOML. ---
+
+	// EffectiveStartLedger / EffectiveEndLedger are the widened range
+	// after chunk-boundary expansion. Always >= the operator-requested
+	// range; never narrower.
+	EffectiveStartLedger uint32 `toml:"-"`
+	EffectiveEndLedger   uint32 `toml:"-"`
+
+	// Workers is the resolved DAG slot count (0 sentinel replaced with
+	// GOMAXPROCS by ApplyFlags).
+	Workers int `toml:"-"`
+
+	// MaxRetries is the resolved per-task retry budget.
+	MaxRetries int `toml:"-"`
+
+	// VerifyRecSplit mirrors the CLI flag.
+	VerifyRecSplit bool `toml:"-"`
+}
+
+// ServiceConfig carries the single [SERVICE] key — DEFAULT_DATA_DIR — which
+// operators are required to set and which serves as the fall-back root for
+// the meta store, immutable storage trees, and log file paths.
+type ServiceConfig struct {
+	// DefaultDataDir is the base directory; if unset, Validate errors.
+	DefaultDataDir string `toml:"DEFAULT_DATA_DIR"`
+}
+
+// MetaStoreConfig carries the optional [META_STORE] section. Only the
+// RocksDB directory path is operator-visible; RocksDB tuning knobs are
+// hardcoded in the Layer-2 metastore facade (slice #689) per MEMORY.md's
+// decision "tuning knobs NOT in operator TOML".
+type MetaStoreConfig struct {
+	// Path is the meta-store RocksDB directory.
+	Path string `toml:"PATH"`
+}
+
+// BackfillConfig holds the [BACKFILL] section plus its nested [BACKFILL.BSB]
+// table. CHUNKS_PER_TXHASH_INDEX is layout-defining (design doc: "must not
+// change across runs") — immutability is enforced by
+// ValidateAgainstConfigStore against the meta-store key
+// `config:chunks_per_txhash_index`.
+type BackfillConfig struct {
+	// ChunksPerTxHashIndex controls the cadence of txhash index builds;
+	// defaults to 1_000 (= 10M ledgers per index) when absent.
+	ChunksPerTxHashIndex uint32 `toml:"CHUNKS_PER_TXHASH_INDEX"`
+
+	// BSB is the BufferedStorageBackend configuration — required per the
+	// design doc, hence pointer-valued so absence is distinguishable from
+	// empty-struct.
+	BSB *BSBConfig `toml:"BSB"`
+}
+
+// BSBConfig holds the [BACKFILL.BSB] nested table. BUCKET_PATH is the only
+// required key; BUFFER_SIZE and NUM_WORKERS default to 1_000 and 20 when
+// absent or zero (matching the design doc's defaults).
+type BSBConfig struct {
+	// BucketPath is the remote object-store path (GCS: no gs:// prefix).
+	BucketPath string `toml:"BUCKET_PATH"`
+
+	// BufferSize is the prefetch depth per BSB connection.
+	BufferSize int `toml:"BUFFER_SIZE"`
+
+	// NumWorkers is the download-worker count per BSB connection.
+	NumWorkers int `toml:"NUM_WORKERS"`
+}
+
+// ImmutableStorageConfig mirrors the four sub-sections of [IMMUTABLE_STORAGE]:
+// LEDGERS, EVENTS, TXHASH_RAW, TXHASH_INDEX. Each carries a PATH key that
+// defaults to {DEFAULT_DATA_DIR}/<type> when Validate resolves defaults.
+type ImmutableStorageConfig struct {
+	// Ledgers is the per-chunk ledger-pack-file tree root.
+	Ledgers StoragePathConfig `toml:"LEDGERS"`
+
+	// Events is the per-chunk events cold-segment tree root.
+	Events StoragePathConfig `toml:"EVENTS"`
+
+	// TxHashRaw is the per-chunk raw .bin tree root (transient; cleaned
+	// up by CleanupTxHashTask after the RecSplit build).
+	TxHashRaw StoragePathConfig `toml:"TXHASH_RAW"`
+
+	// TxHashIndex is the per-txhash-index RecSplit .idx tree root
+	// (permanent once built).
+	TxHashIndex StoragePathConfig `toml:"TXHASH_INDEX"`
+}
+
+// StoragePathConfig is the shape shared by all four [IMMUTABLE_STORAGE.*]
+// sub-sections — a single PATH string.
+type StoragePathConfig struct {
+	// Path is the filesystem root for this data type.
+	Path string `toml:"PATH"`
+}
+
+// LoggingConfig carries the [LOGGING] section — LEVEL (debug/info/warn/error)
+// and FORMAT (text/json). The logrus bootstrap that consumes these fields
+// lands in slice #685; this slice only plumbs them through parse + flag merge.
+type LoggingConfig struct {
+	// Level is one of "debug", "info", "warn", "error".
+	Level string `toml:"LEVEL"`
+
+	// Format is one of "text", "json".
+	Format string `toml:"FORMAT"`
+}
+
+// ParseConfig decodes a TOML byte slice (typically the contents of the file
+// passed via `--config`) into a Config. Errors are wrapped so the caller can
+// surface them to the operator with context about where parsing failed.
+func ParseConfig(data []byte) (*Config, error) {
+	var cfg Config
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+	return &cfg, nil
+}
+
+// MarshalTOML encodes the Config back to TOML bytes. Exists to satisfy the
+// "TOML round-trips" acceptance criterion from #684 — useful for diagnostics
+// ("what config is this backfill actually running with?") and for producing
+// a normalized on-disk form after defaults are resolved. Keys come out in
+// the same UPPER_SNAKE_CASE the struct tags declare.
+func (c *Config) MarshalTOML() ([]byte, error) {
+	buf, err := toml.Marshal(*c)
+	if err != nil {
+		return nil, fmt.Errorf("marshal config: %w", err)
+	}
+	return buf, nil
+}

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/config/config_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/config/config_test.go
@@ -1,9 +1,3 @@
-// Package config tests exercise the public parse/validate/apply-flags surface.
-//
-// Tests are intentionally integration-style — they drive behavior through the
-// package's public API (ParseConfig, Validate, ApplyFlags, etc.) rather than
-// poking at struct fields from the inside. This mirrors how the subcommand
-// wires the package and survives internal refactors.
 package config
 
 import (
@@ -11,10 +5,19 @@ import (
 	"testing"
 )
 
-// Cycle 1 — ParseConfig must decode the UPPER_SNAKE_CASE TOML schema's
-// [SERVICE] section and populate Config.Service.DefaultDataDir. TOML-key
-// casing matches the design doc's override of the reference commit's
-// lowercase style; pelletier/go-toml is case-sensitive per spec.
+// minimalValidTOML returns the smallest TOML that parses + validates. Used
+// as a starting point by tests that focus on a specific behavior without
+// re-declaring the full schema.
+func minimalValidTOML() []byte {
+	return []byte(`
+[SERVICE]
+DEFAULT_DATA_DIR = "/data/stellar-rpc"
+
+[BACKFILL.BSB]
+BUCKET_PATH = "bucket"
+`)
+}
+
 func TestParseConfig_ServiceSection(t *testing.T) {
 	data := []byte(`
 [SERVICE]
@@ -25,15 +28,12 @@ DEFAULT_DATA_DIR = "/data/stellar-rpc"
 		t.Fatalf("ParseConfig: %v", err)
 	}
 	if cfg.Service.DefaultDataDir != "/data/stellar-rpc" {
-		t.Errorf("DefaultDataDir = %q, want %q", cfg.Service.DefaultDataDir, "/data/stellar-rpc")
+		t.Errorf("DefaultDataDir = %q", cfg.Service.DefaultDataDir)
 	}
 }
 
-// Cycle 2 — ParseConfig decodes every section of the UPPER_SNAKE_CASE TOML
-// schema from the design doc: [SERVICE], [BACKFILL] (with nested
-// [BACKFILL.BSB]), [IMMUTABLE_STORAGE.*] (four sub-sections),
-// [LOGGING], and optional [META_STORE]. Values asserted here are arbitrary
-// sentinels, chosen so a silently-ignored field shows up as a zero value.
+// TestParseConfig_FullSchema — every section decodes; a silently-ignored
+// field shows up as the zero value of its type.
 func TestParseConfig_FullSchema(t *testing.T) {
 	data := []byte(`
 [SERVICE]
@@ -71,7 +71,6 @@ FORMAT = "json"
 		t.Fatalf("ParseConfig: %v", err)
 	}
 
-	// Spot-check every section.
 	if cfg.Service.DefaultDataDir != "/data/stellar-rpc" {
 		t.Errorf("Service.DefaultDataDir = %q", cfg.Service.DefaultDataDir)
 	}
@@ -113,23 +112,8 @@ FORMAT = "json"
 	}
 }
 
-// minimalValidTOML returns the smallest TOML payload that parses and
-// validates without error — used as a starting point in tests that want to
-// assert a specific piece of behavior without re-declaring the full schema.
-func minimalValidTOML() []byte {
-	return []byte(`
-[SERVICE]
-DEFAULT_DATA_DIR = "/data/stellar-rpc"
-
-[BACKFILL.BSB]
-BUCKET_PATH = "bucket"
-`)
-}
-
-// Cycle 3 — MarshalTOML round-trips cleanly: parse → marshal → parse produces
-// a Config equal to the original. The acceptance criterion from #684 ("TOML
-// round-trips through parser + MarshalTOML") drives this; it verifies no
-// field is silently dropped during marshal (e.g., a missing struct tag).
+// TestConfig_MarshalTOMLRoundTrip — parse → marshal → parse yields an
+// equal Config. Guards against accidentally missing struct tags.
 func TestConfig_MarshalTOMLRoundTrip(t *testing.T) {
 	data := []byte(`
 [SERVICE]
@@ -180,13 +164,8 @@ FORMAT = "json"
 	}
 }
 
-// Cycle 4 — Validate resolves default storage paths under DEFAULT_DATA_DIR
-// when an operator omits the optional [META_STORE] / [IMMUTABLE_STORAGE.*]
-// sections. Exercised path-default rules:
-//   - META_STORE.PATH          → {DEFAULT_DATA_DIR}/meta/rocksdb
-//   - IMMUTABLE_STORAGE.*.PATH → {DEFAULT_DATA_DIR}/<type>
-//   - BACKFILL.CHUNKS_PER_TXHASH_INDEX (== 0)  → 1000
-//   - BSB.BUFFER_SIZE / NUM_WORKERS (<= 0)     → 1000 / 20
+// TestValidate_ResolvesDefaults — Validate fills in every optional path
+// and numeric default when the TOML omits them.
 func TestValidate_ResolvesDefaults(t *testing.T) {
 	cfg, err := ParseConfig(minimalValidTOML())
 	if err != nil {

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/config/config_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/config/config_test.go
@@ -1,0 +1,228 @@
+// Package config tests exercise the public parse/validate/apply-flags surface.
+//
+// Tests are intentionally integration-style — they drive behavior through the
+// package's public API (ParseConfig, Validate, ApplyFlags, etc.) rather than
+// poking at struct fields from the inside. This mirrors how the subcommand
+// wires the package and survives internal refactors.
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Cycle 1 — ParseConfig must decode the UPPER_SNAKE_CASE TOML schema's
+// [SERVICE] section and populate Config.Service.DefaultDataDir. TOML-key
+// casing matches the design doc's override of the reference commit's
+// lowercase style; pelletier/go-toml is case-sensitive per spec.
+func TestParseConfig_ServiceSection(t *testing.T) {
+	data := []byte(`
+[SERVICE]
+DEFAULT_DATA_DIR = "/data/stellar-rpc"
+`)
+	cfg, err := ParseConfig(data)
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if cfg.Service.DefaultDataDir != "/data/stellar-rpc" {
+		t.Errorf("DefaultDataDir = %q, want %q", cfg.Service.DefaultDataDir, "/data/stellar-rpc")
+	}
+}
+
+// Cycle 2 — ParseConfig decodes every section of the UPPER_SNAKE_CASE TOML
+// schema from the design doc: [SERVICE], [BACKFILL] (with nested
+// [BACKFILL.BSB]), [IMMUTABLE_STORAGE.*] (four sub-sections),
+// [LOGGING], and optional [META_STORE]. Values asserted here are arbitrary
+// sentinels, chosen so a silently-ignored field shows up as a zero value.
+func TestParseConfig_FullSchema(t *testing.T) {
+	data := []byte(`
+[SERVICE]
+DEFAULT_DATA_DIR = "/data/stellar-rpc"
+
+[META_STORE]
+PATH = "/ssd0/meta"
+
+[BACKFILL]
+CHUNKS_PER_TXHASH_INDEX = 500
+
+[BACKFILL.BSB]
+BUCKET_PATH = "sdf-ledger-close-meta/v1/ledgers/pubnet"
+BUFFER_SIZE = 250
+NUM_WORKERS = 8
+
+[IMMUTABLE_STORAGE.LEDGERS]
+PATH = "/ssd1/ledgers"
+
+[IMMUTABLE_STORAGE.EVENTS]
+PATH = "/ssd1/events"
+
+[IMMUTABLE_STORAGE.TXHASH_RAW]
+PATH = "/ssd1/txhash/raw"
+
+[IMMUTABLE_STORAGE.TXHASH_INDEX]
+PATH = "/ssd1/txhash/index"
+
+[LOGGING]
+LEVEL = "debug"
+FORMAT = "json"
+`)
+	cfg, err := ParseConfig(data)
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+
+	// Spot-check every section.
+	if cfg.Service.DefaultDataDir != "/data/stellar-rpc" {
+		t.Errorf("Service.DefaultDataDir = %q", cfg.Service.DefaultDataDir)
+	}
+	if cfg.MetaStore.Path != "/ssd0/meta" {
+		t.Errorf("MetaStore.Path = %q", cfg.MetaStore.Path)
+	}
+	if cfg.Backfill.ChunksPerTxHashIndex != 500 {
+		t.Errorf("Backfill.ChunksPerTxHashIndex = %d", cfg.Backfill.ChunksPerTxHashIndex)
+	}
+	if cfg.Backfill.BSB == nil {
+		t.Fatal("Backfill.BSB is nil — [BACKFILL.BSB] did not decode")
+	}
+	if cfg.Backfill.BSB.BucketPath != "sdf-ledger-close-meta/v1/ledgers/pubnet" {
+		t.Errorf("BSB.BucketPath = %q", cfg.Backfill.BSB.BucketPath)
+	}
+	if cfg.Backfill.BSB.BufferSize != 250 {
+		t.Errorf("BSB.BufferSize = %d", cfg.Backfill.BSB.BufferSize)
+	}
+	if cfg.Backfill.BSB.NumWorkers != 8 {
+		t.Errorf("BSB.NumWorkers = %d", cfg.Backfill.BSB.NumWorkers)
+	}
+	if cfg.ImmutableStorage.Ledgers.Path != "/ssd1/ledgers" {
+		t.Errorf("ImmutableStorage.Ledgers.Path = %q", cfg.ImmutableStorage.Ledgers.Path)
+	}
+	if cfg.ImmutableStorage.Events.Path != "/ssd1/events" {
+		t.Errorf("ImmutableStorage.Events.Path = %q", cfg.ImmutableStorage.Events.Path)
+	}
+	if cfg.ImmutableStorage.TxHashRaw.Path != "/ssd1/txhash/raw" {
+		t.Errorf("ImmutableStorage.TxHashRaw.Path = %q", cfg.ImmutableStorage.TxHashRaw.Path)
+	}
+	if cfg.ImmutableStorage.TxHashIndex.Path != "/ssd1/txhash/index" {
+		t.Errorf("ImmutableStorage.TxHashIndex.Path = %q", cfg.ImmutableStorage.TxHashIndex.Path)
+	}
+	if cfg.Logging.Level != "debug" {
+		t.Errorf("Logging.Level = %q", cfg.Logging.Level)
+	}
+	if cfg.Logging.Format != "json" {
+		t.Errorf("Logging.Format = %q", cfg.Logging.Format)
+	}
+}
+
+// minimalValidTOML returns the smallest TOML payload that parses and
+// validates without error — used as a starting point in tests that want to
+// assert a specific piece of behavior without re-declaring the full schema.
+func minimalValidTOML() []byte {
+	return []byte(`
+[SERVICE]
+DEFAULT_DATA_DIR = "/data/stellar-rpc"
+
+[BACKFILL.BSB]
+BUCKET_PATH = "bucket"
+`)
+}
+
+// Cycle 3 — MarshalTOML round-trips cleanly: parse → marshal → parse produces
+// a Config equal to the original. The acceptance criterion from #684 ("TOML
+// round-trips through parser + MarshalTOML") drives this; it verifies no
+// field is silently dropped during marshal (e.g., a missing struct tag).
+func TestConfig_MarshalTOMLRoundTrip(t *testing.T) {
+	data := []byte(`
+[SERVICE]
+DEFAULT_DATA_DIR = "/data/stellar-rpc"
+
+[META_STORE]
+PATH = "/ssd0/meta"
+
+[BACKFILL]
+CHUNKS_PER_TXHASH_INDEX = 500
+
+[BACKFILL.BSB]
+BUCKET_PATH = "bucket"
+BUFFER_SIZE = 250
+NUM_WORKERS = 8
+
+[IMMUTABLE_STORAGE.LEDGERS]
+PATH = "/ssd1/ledgers"
+
+[IMMUTABLE_STORAGE.EVENTS]
+PATH = "/ssd1/events"
+
+[IMMUTABLE_STORAGE.TXHASH_RAW]
+PATH = "/ssd1/txhash/raw"
+
+[IMMUTABLE_STORAGE.TXHASH_INDEX]
+PATH = "/ssd1/txhash/index"
+
+[LOGGING]
+LEVEL = "debug"
+FORMAT = "json"
+`)
+	original, err := ParseConfig(data)
+	if err != nil {
+		t.Fatalf("ParseConfig(original): %v", err)
+	}
+	marshaled, err := original.MarshalTOML()
+	if err != nil {
+		t.Fatalf("MarshalTOML: %v", err)
+	}
+	roundTripped, err := ParseConfig(marshaled)
+	if err != nil {
+		t.Fatalf("ParseConfig(round-tripped):\n%s\nerror: %v", marshaled, err)
+	}
+	if !reflect.DeepEqual(original, roundTripped) {
+		t.Errorf("round-trip mismatch:\noriginal:      %+v\nround-tripped: %+v\nintermediate TOML:\n%s",
+			original, roundTripped, marshaled)
+	}
+}
+
+// Cycle 4 — Validate resolves default storage paths under DEFAULT_DATA_DIR
+// when an operator omits the optional [META_STORE] / [IMMUTABLE_STORAGE.*]
+// sections. Exercised path-default rules:
+//   - META_STORE.PATH          → {DEFAULT_DATA_DIR}/meta/rocksdb
+//   - IMMUTABLE_STORAGE.*.PATH → {DEFAULT_DATA_DIR}/<type>
+//   - BACKFILL.CHUNKS_PER_TXHASH_INDEX (== 0)  → 1000
+//   - BSB.BUFFER_SIZE / NUM_WORKERS (<= 0)     → 1000 / 20
+func TestValidate_ResolvesDefaults(t *testing.T) {
+	cfg, err := ParseConfig(minimalValidTOML())
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	want := map[string]string{
+		"MetaStore.Path":                    "/data/stellar-rpc/meta/rocksdb",
+		"ImmutableStorage.Ledgers.Path":     "/data/stellar-rpc/ledgers",
+		"ImmutableStorage.Events.Path":      "/data/stellar-rpc/events",
+		"ImmutableStorage.TxHashRaw.Path":   "/data/stellar-rpc/txhash/raw",
+		"ImmutableStorage.TxHashIndex.Path": "/data/stellar-rpc/txhash/index",
+	}
+	got := map[string]string{
+		"MetaStore.Path":                    cfg.MetaStore.Path,
+		"ImmutableStorage.Ledgers.Path":     cfg.ImmutableStorage.Ledgers.Path,
+		"ImmutableStorage.Events.Path":      cfg.ImmutableStorage.Events.Path,
+		"ImmutableStorage.TxHashRaw.Path":   cfg.ImmutableStorage.TxHashRaw.Path,
+		"ImmutableStorage.TxHashIndex.Path": cfg.ImmutableStorage.TxHashIndex.Path,
+	}
+	for k, w := range want {
+		if got[k] != w {
+			t.Errorf("%s = %q, want %q", k, got[k], w)
+		}
+	}
+
+	if cfg.Backfill.ChunksPerTxHashIndex != 1000 {
+		t.Errorf("Backfill.ChunksPerTxHashIndex = %d, want 1000", cfg.Backfill.ChunksPerTxHashIndex)
+	}
+	if cfg.Backfill.BSB.BufferSize != 1000 {
+		t.Errorf("BSB.BufferSize = %d, want 1000", cfg.Backfill.BSB.BufferSize)
+	}
+	if cfg.Backfill.BSB.NumWorkers != 20 {
+		t.Errorf("BSB.NumWorkers = %d, want 20", cfg.Backfill.BSB.NumWorkers)
+	}
+}

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/config/flags.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/config/flags.go
@@ -6,91 +6,52 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/geometry"
 )
 
-// Default CLI-flag fall-backs applied when the operator omits a flag (or
-// passes the zero sentinel 0). Named-constant form keeps the defaults out
-// of ApplyFlags' control flow.
-const (
-	// defaultMaxRetries matches the design-doc "--max-retries default 3"
-	// setting, echoed in cmd.go's flag registration.
-	defaultMaxRetries int = 3
-)
+const defaultMaxRetries = 3
 
-// CLIFlags carries the flag values that `cmd.go` hands to the subcommand
-// body. Fields mirror cobra flag names (CamelCase for Go idioms,
-// dash-separated on the wire).
+// CLIFlags carries every flag cmd.go hands to the subcommand body.
 //
-// ApplyFlags consumes CLIFlags and mutates the Config with (a) the widened
-// [EffectiveStartLedger, EffectiveEndLedger] range and (b) the resolved
-// worker count, retry budget, verify-recsplit toggle, and logging overrides.
+// Workers and MaxRetries use 0 as a sentinel for "apply default"; empty
+// LogLevel / LogFormat mean "do not override the TOML value".
 type CLIFlags struct {
-	// StartLedger / EndLedger are the operator-requested range. Widened
-	// outward to chunk boundaries by ApplyFlags.
-	StartLedger uint32
-	EndLedger   uint32
-
-	// Workers is the DAG slot count. 0 → GOMAXPROCS (sentinel convention
-	// already advertised by cmd.go's help text "(0 = GOMAXPROCS)").
-	Workers int
-
-	// MaxRetries is the per-task retry budget. 0 → 3 (design-doc default).
-	MaxRetries int
-
-	// VerifyRecSplit toggles the RecSplit verify pass; defaults true via
-	// cobra's flag registration so the zero value here means "operator
-	// explicitly set false OR flag was never wired" — cmd.go supplies
-	// the real value.
+	StartLedger    uint32
+	EndLedger      uint32
+	Workers        int
+	MaxRetries     int
 	VerifyRecSplit bool
-
-	// LogLevel / LogFormat override the TOML [LOGGING] section when
-	// non-empty. Logrus wiring lands in slice #685; this slice only
-	// merges the values into cfg.Logging.
-	LogLevel  string
-	LogFormat string
+	LogLevel       string
+	LogFormat      string
 }
 
-// ApplyFlags merges CLI flag values into the Config: widens the ledger range
-// outward to chunk boundaries, resolves worker-count and retry defaults,
-// stores the verify-recsplit toggle, and overrides logging fields whenever
-// the operator passed a non-empty value.
+// ApplyFlags merges CLI flag values into c: widens the ledger range to
+// chunk boundaries (outward only — never narrows), resolves default
+// values, and overrides TOML logging fields when the operator passed
+// non-empty values.
 //
-// Assumes Validate has been called first so CHUNKS_PER_TXHASH_INDEX is
-// defaulted — BuildGeometry depends on that. Order matters at the
-// subcommand layer; see cmd.go's Run function.
+// Precondition: Validate has run, so ChunksPerTxHashIndex is populated.
 func (c *Config) ApplyFlags(flags CLIFlags) {
 	geo := c.BuildGeometry()
 
-	// Chunk-boundary expansion. Design-doc rule: start widens DOWN to the
-	// first ledger of its chunk, end widens UP to the last. Never narrows.
-	//
-	// The subtraction `flags.StartLedger - geometry.FirstLedger` is safe
-	// so long as StartLedger >= FirstLedger (2); ValidateFlags enforces
-	// that, but ApplyFlags runs before ValidateFlags in the subcommand
-	// pipeline by design (expansion feeds both the effective range and the
-	// BSB-availability check that follows). Pre-check to avoid underflow.
+	// Chunk-boundary expansion: start widens DOWN, end widens UP.
+	// LedgerToChunkID's subtraction is safe only when the ledger is
+	// >= FirstLedger; ValidateFlags is what finally rejects out-of-range
+	// inputs, so guard here to avoid underflow on bogus values that
+	// slip in before ValidateFlags runs.
 	if flags.StartLedger >= geometry.FirstLedger {
-		startChunkID := (flags.StartLedger - geometry.FirstLedger) / geo.ChunkSize
-		c.EffectiveStartLedger = geo.ChunkFirstLedger(startChunkID)
+		c.EffectiveStartLedger = geo.ChunkFirstLedger(geo.LedgerToChunkID(flags.StartLedger))
 	} else {
-		c.EffectiveStartLedger = flags.StartLedger // ValidateFlags will reject
+		c.EffectiveStartLedger = flags.StartLedger
 	}
-
 	if flags.EndLedger >= geometry.FirstLedger {
-		endChunkID := (flags.EndLedger - geometry.FirstLedger) / geo.ChunkSize
-		c.EffectiveEndLedger = geo.ChunkLastLedger(endChunkID)
+		c.EffectiveEndLedger = geo.ChunkLastLedger(geo.LedgerToChunkID(flags.EndLedger))
 	} else {
-		c.EffectiveEndLedger = flags.EndLedger // ValidateFlags will reject
+		c.EffectiveEndLedger = flags.EndLedger
 	}
 
-	// Workers: 0 sentinel → GOMAXPROCS. Matches the "(0 = GOMAXPROCS)"
-	// help-text contract cmd.go advertises.
 	c.Workers = flags.Workers
 	if c.Workers <= 0 {
 		c.Workers = runtime.GOMAXPROCS(0)
 	}
 
-	// MaxRetries: 0 sentinel → 3. Cobra's flag default is also 3, so the
-	// common path is that flags.MaxRetries arrives already-set; this branch
-	// covers direct programmatic callers (tests, future wrappers).
 	c.MaxRetries = flags.MaxRetries
 	if c.MaxRetries <= 0 {
 		c.MaxRetries = defaultMaxRetries
@@ -98,8 +59,6 @@ func (c *Config) ApplyFlags(flags CLIFlags) {
 
 	c.VerifyRecSplit = flags.VerifyRecSplit
 
-	// Logging overrides: only replace TOML values when the operator
-	// actually passed a value. Empty string means "no CLI override".
 	if flags.LogLevel != "" {
 		c.Logging.Level = flags.LogLevel
 	}
@@ -108,18 +67,15 @@ func (c *Config) ApplyFlags(flags CLIFlags) {
 	}
 }
 
-// BuildGeometry returns a geometry.Geometry wired to this config's
-// CHUNKS_PER_TXHASH_INDEX. ChunkSize remains the global geometry constant
-// (10_000 — a layout invariant, never operator-configurable per the design
-// doc). RangeSize is derived as ChunkSize * ChunksPerTxHashIndex so a
-// non-default operator value produces self-consistent range boundaries.
+// BuildGeometry returns a geometry.Geometry wired to this Config's
+// CHUNKS_PER_TXHASH_INDEX. ChunkSize stays the package constant — it is
+// a layout invariant, not operator-configurable.
 func (c *Config) BuildGeometry() geometry.Geometry {
 	cpi := c.Backfill.ChunksPerTxHashIndex
 	if cpi == 0 {
 		cpi = defaultChunksPerTxHashIndex
 	}
 	return geometry.Geometry{
-		RangeSize:            cpi * geometry.ChunkSize,
 		ChunkSize:            geometry.ChunkSize,
 		ChunksPerTxHashIndex: cpi,
 	}

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/config/flags.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/config/flags.go
@@ -6,11 +6,11 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/geometry"
 )
 
-const defaultMaxRetries = 3
-
 // CLIFlags carries every flag cmd.go hands to the subcommand body.
 //
-// Workers and MaxRetries use 0 as a sentinel for "apply default"; empty
+// Workers uses 0 as the documented GOMAXPROCS sentinel. MaxRetries
+// carries its value literally — cobra's flag default is 3 and 0 is a
+// legitimate operator choice ("no retries, fail fast"). Empty
 // LogLevel / LogFormat mean "do not override the TOML value".
 type CLIFlags struct {
 	StartLedger    uint32
@@ -52,10 +52,11 @@ func (c *Config) ApplyFlags(flags CLIFlags) {
 		c.Workers = runtime.GOMAXPROCS(0)
 	}
 
+	// MaxRetries passes through as-is. cobra registers the default (3)
+	// in cmd.go, so omitted --max-retries already arrives here as 3; an
+	// explicit --max-retries=0 is a legitimate "fail fast" request and
+	// we must not silently rewrite it.
 	c.MaxRetries = flags.MaxRetries
-	if c.MaxRetries <= 0 {
-		c.MaxRetries = defaultMaxRetries
-	}
 
 	c.VerifyRecSplit = flags.VerifyRecSplit
 

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/config/flags.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/config/flags.go
@@ -1,0 +1,126 @@
+package config
+
+import (
+	"runtime"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/geometry"
+)
+
+// Default CLI-flag fall-backs applied when the operator omits a flag (or
+// passes the zero sentinel 0). Named-constant form keeps the defaults out
+// of ApplyFlags' control flow.
+const (
+	// defaultMaxRetries matches the design-doc "--max-retries default 3"
+	// setting, echoed in cmd.go's flag registration.
+	defaultMaxRetries int = 3
+)
+
+// CLIFlags carries the flag values that `cmd.go` hands to the subcommand
+// body. Fields mirror cobra flag names (CamelCase for Go idioms,
+// dash-separated on the wire).
+//
+// ApplyFlags consumes CLIFlags and mutates the Config with (a) the widened
+// [EffectiveStartLedger, EffectiveEndLedger] range and (b) the resolved
+// worker count, retry budget, verify-recsplit toggle, and logging overrides.
+type CLIFlags struct {
+	// StartLedger / EndLedger are the operator-requested range. Widened
+	// outward to chunk boundaries by ApplyFlags.
+	StartLedger uint32
+	EndLedger   uint32
+
+	// Workers is the DAG slot count. 0 → GOMAXPROCS (sentinel convention
+	// already advertised by cmd.go's help text "(0 = GOMAXPROCS)").
+	Workers int
+
+	// MaxRetries is the per-task retry budget. 0 → 3 (design-doc default).
+	MaxRetries int
+
+	// VerifyRecSplit toggles the RecSplit verify pass; defaults true via
+	// cobra's flag registration so the zero value here means "operator
+	// explicitly set false OR flag was never wired" — cmd.go supplies
+	// the real value.
+	VerifyRecSplit bool
+
+	// LogLevel / LogFormat override the TOML [LOGGING] section when
+	// non-empty. Logrus wiring lands in slice #685; this slice only
+	// merges the values into cfg.Logging.
+	LogLevel  string
+	LogFormat string
+}
+
+// ApplyFlags merges CLI flag values into the Config: widens the ledger range
+// outward to chunk boundaries, resolves worker-count and retry defaults,
+// stores the verify-recsplit toggle, and overrides logging fields whenever
+// the operator passed a non-empty value.
+//
+// Assumes Validate has been called first so CHUNKS_PER_TXHASH_INDEX is
+// defaulted — BuildGeometry depends on that. Order matters at the
+// subcommand layer; see cmd.go's Run function.
+func (c *Config) ApplyFlags(flags CLIFlags) {
+	geo := c.BuildGeometry()
+
+	// Chunk-boundary expansion. Design-doc rule: start widens DOWN to the
+	// first ledger of its chunk, end widens UP to the last. Never narrows.
+	//
+	// The subtraction `flags.StartLedger - geometry.FirstLedger` is safe
+	// so long as StartLedger >= FirstLedger (2); ValidateFlags enforces
+	// that, but ApplyFlags runs before ValidateFlags in the subcommand
+	// pipeline by design (expansion feeds both the effective range and the
+	// BSB-availability check that follows). Pre-check to avoid underflow.
+	if flags.StartLedger >= geometry.FirstLedger {
+		startChunkID := (flags.StartLedger - geometry.FirstLedger) / geo.ChunkSize
+		c.EffectiveStartLedger = geo.ChunkFirstLedger(startChunkID)
+	} else {
+		c.EffectiveStartLedger = flags.StartLedger // ValidateFlags will reject
+	}
+
+	if flags.EndLedger >= geometry.FirstLedger {
+		endChunkID := (flags.EndLedger - geometry.FirstLedger) / geo.ChunkSize
+		c.EffectiveEndLedger = geo.ChunkLastLedger(endChunkID)
+	} else {
+		c.EffectiveEndLedger = flags.EndLedger // ValidateFlags will reject
+	}
+
+	// Workers: 0 sentinel → GOMAXPROCS. Matches the "(0 = GOMAXPROCS)"
+	// help-text contract cmd.go advertises.
+	c.Workers = flags.Workers
+	if c.Workers <= 0 {
+		c.Workers = runtime.GOMAXPROCS(0)
+	}
+
+	// MaxRetries: 0 sentinel → 3. Cobra's flag default is also 3, so the
+	// common path is that flags.MaxRetries arrives already-set; this branch
+	// covers direct programmatic callers (tests, future wrappers).
+	c.MaxRetries = flags.MaxRetries
+	if c.MaxRetries <= 0 {
+		c.MaxRetries = defaultMaxRetries
+	}
+
+	c.VerifyRecSplit = flags.VerifyRecSplit
+
+	// Logging overrides: only replace TOML values when the operator
+	// actually passed a value. Empty string means "no CLI override".
+	if flags.LogLevel != "" {
+		c.Logging.Level = flags.LogLevel
+	}
+	if flags.LogFormat != "" {
+		c.Logging.Format = flags.LogFormat
+	}
+}
+
+// BuildGeometry returns a geometry.Geometry wired to this config's
+// CHUNKS_PER_TXHASH_INDEX. ChunkSize remains the global geometry constant
+// (10_000 — a layout invariant, never operator-configurable per the design
+// doc). RangeSize is derived as ChunkSize * ChunksPerTxHashIndex so a
+// non-default operator value produces self-consistent range boundaries.
+func (c *Config) BuildGeometry() geometry.Geometry {
+	cpi := c.Backfill.ChunksPerTxHashIndex
+	if cpi == 0 {
+		cpi = defaultChunksPerTxHashIndex
+	}
+	return geometry.Geometry{
+		RangeSize:            cpi * geometry.ChunkSize,
+		ChunkSize:            geometry.ChunkSize,
+		ChunksPerTxHashIndex: cpi,
+	}
+}

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/config/flags_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/config/flags_test.go
@@ -7,18 +7,13 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/geometry"
 )
 
-// Cycle 6 — ApplyFlags widens the operator-supplied [--start-ledger,
-// --end-ledger] range OUTWARD to the nearest chunk boundaries per the design
-// doc's "Chunk Boundary Expansion" section. Never narrows. Computed from the
-// geometry that BuildGeometry produces for this config (ChunkSize = 10_000,
-// ChunksPerTxHashIndex defaulted to 1000).
+// TestApplyFlags_ChunkBoundaryExpansion — start widens DOWN, end widens
+// UP; never narrows. Four cases cover the combinatorial shape:
 //
-// Four cases cover the combinatorial shape:
-//
-//	(a) both endpoints mid-chunk (canonical example from issue #684 body);
-//	(b) start=FirstLedger (2) and end already chunk-aligned — no widening;
-//	(c) start=FirstLedger (2), end mid-chunk — only end widens;
-//	(d) start mid-chunk, end already chunk-aligned — only start widens.
+//	(a) both endpoints mid-chunk (canonical example from issue body);
+//	(b) both already chunk-aligned — no widening;
+//	(c) start=2, end mid-chunk — only end widens;
+//	(d) start mid-chunk, end chunk-aligned — only start widens.
 func TestApplyFlags_ChunkBoundaryExpansion(t *testing.T) {
 	cases := []struct {
 		name         string
@@ -28,9 +23,8 @@ func TestApplyFlags_ChunkBoundaryExpansion(t *testing.T) {
 		wantEffEnd   uint32
 	}{
 		{
-			// Canonical example from the issue body / design doc:
-			// 5_000_000 falls inside chunk 499 ([4_990_002, 5_000_001]),
-			// 56_337_842 falls inside chunk 5633 ([56_330_002, 56_340_001]).
+			// 5_000_000 is inside chunk 499 ([4_990_002, 5_000_001]);
+			// 56_337_842 is inside chunk 5633 ([56_330_002, 56_340_001]).
 			name:         "both mid-chunk (canonical)",
 			startLedger:  5_000_000,
 			endLedger:    56_337_842,
@@ -38,7 +32,6 @@ func TestApplyFlags_ChunkBoundaryExpansion(t *testing.T) {
 			wantEffEnd:   56_340_001,
 		},
 		{
-			// Chunk-aligned already — widening is a no-op.
 			name:         "start=2, end at chunk-boundary (no widen)",
 			startLedger:  2,
 			endLedger:    10_000_001, // chunk 999's last ledger
@@ -46,8 +39,7 @@ func TestApplyFlags_ChunkBoundaryExpansion(t *testing.T) {
 			wantEffEnd:   10_000_001,
 		},
 		{
-			// Start at absolute minimum, end falls mid-chunk 3
-			// (chunk 3 spans [30_002, 40_001]).
+			// Chunk 3 spans [30_002, 40_001].
 			name:         "start=2, end mid-chunk (widen end only)",
 			startLedger:  2,
 			endLedger:    35_000,
@@ -55,8 +47,7 @@ func TestApplyFlags_ChunkBoundaryExpansion(t *testing.T) {
 			wantEffEnd:   40_001,
 		},
 		{
-			// Start falls mid-chunk 1 (spans [10_002, 20_001]),
-			// end at chunk 5's last ledger (60_001).
+			// Chunk 1 spans [10_002, 20_001]; chunk 5 ends at 60_001.
 			name:         "start mid-chunk, end at chunk-boundary (widen start only)",
 			startLedger:  15_000,
 			endLedger:    60_001,
@@ -88,11 +79,8 @@ func TestApplyFlags_ChunkBoundaryExpansion(t *testing.T) {
 	}
 }
 
-// Cycle 7 — ApplyFlags resolves the "0 sentinel" for Workers to GOMAXPROCS
-// and for MaxRetries to 3, matching the help-text and design-doc contracts.
-// Explicit non-zero values pass through unchanged — this test verifies both
-// directions to guard against a regression where the default clobbered an
-// operator-supplied value.
+// TestApplyFlags_WorkerAndRetryDefaults — 0 sentinels resolve to
+// GOMAXPROCS / 3; explicit values pass through unchanged.
 func TestApplyFlags_WorkerAndRetryDefaults(t *testing.T) {
 	cases := []struct {
 		name           string
@@ -142,10 +130,8 @@ func TestApplyFlags_WorkerAndRetryDefaults(t *testing.T) {
 	}
 }
 
-// Cycle 8 — ApplyFlags merges LogLevel / LogFormat from CLI into
-// cfg.Logging ONLY when the flag value is non-empty. Empty means "operator
-// did not pass --log-level / --log-format, keep whatever the TOML said."
-// Test covers both directions (override and passthrough).
+// TestApplyFlags_LoggingOverride — non-empty CLI values override TOML;
+// empty values leave the TOML values intact.
 func TestApplyFlags_LoggingOverride(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -204,26 +190,24 @@ func TestApplyFlags_LoggingOverride(t *testing.T) {
 	}
 }
 
-// Cycle 12 — BuildGeometry threads CHUNKS_PER_TXHASH_INDEX into
-// geometry.Geometry so downstream callers (ApplyFlags, the DAG engine in
-// slice #687) see a self-consistent range layout. Default case uses 1000,
-// custom case uses a non-round 250 to catch any accidental hard-coded
-// "× 1000" reintroduction.
+// TestBuildGeometry — CHUNKS_PER_TXHASH_INDEX threads into the geometry's
+// LedgersPerIndex. Default (1000 chunks) → 10M ledgers per index; a custom
+// non-round value (250) → 2.5M ledgers per index.
 func TestBuildGeometry(t *testing.T) {
 	cases := []struct {
-		name           string
-		chunksPerIndex uint32
-		wantRangeSize  uint32
+		name              string
+		chunksPerIndex    uint32
+		wantLedgersPerIdx uint32
 	}{
 		{
-			name:           "default CHUNKS_PER_TXHASH_INDEX (1000) → 10M range",
-			chunksPerIndex: 0, // forces default
-			wantRangeSize:  10_000_000,
+			name:              "default (1000) → 10M ledgers per index",
+			chunksPerIndex:    0, // forces default
+			wantLedgersPerIdx: 10_000_000,
 		},
 		{
-			name:           "custom CHUNKS_PER_TXHASH_INDEX (250) → 2.5M range",
-			chunksPerIndex: 250,
-			wantRangeSize:  2_500_000,
+			name:              "custom (250) → 2.5M ledgers per index",
+			chunksPerIndex:    250,
+			wantLedgersPerIdx: 2_500_000,
 		},
 	}
 	for _, tc := range cases {
@@ -232,10 +216,10 @@ func TestBuildGeometry(t *testing.T) {
 			cfg.Backfill.ChunksPerTxHashIndex = tc.chunksPerIndex
 			geo := cfg.BuildGeometry()
 			if geo.ChunkSize != geometry.ChunkSize {
-				t.Errorf("ChunkSize = %d, want %d (layout invariant)", geo.ChunkSize, geometry.ChunkSize)
+				t.Errorf("ChunkSize = %d, want %d", geo.ChunkSize, geometry.ChunkSize)
 			}
-			if geo.RangeSize != tc.wantRangeSize {
-				t.Errorf("RangeSize = %d, want %d", geo.RangeSize, tc.wantRangeSize)
+			if geo.LedgersPerIndex() != tc.wantLedgersPerIdx {
+				t.Errorf("LedgersPerIndex() = %d, want %d", geo.LedgersPerIndex(), tc.wantLedgersPerIdx)
 			}
 		})
 	}

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/config/flags_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/config/flags_test.go
@@ -79,8 +79,9 @@ func TestApplyFlags_ChunkBoundaryExpansion(t *testing.T) {
 	}
 }
 
-// TestApplyFlags_WorkerAndRetryDefaults — 0 sentinels resolve to
-// GOMAXPROCS / 3; explicit values pass through unchanged.
+// TestApplyFlags_WorkerAndRetryDefaults — Workers=0 resolves to
+// GOMAXPROCS (documented sentinel). MaxRetries passes through
+// literally, including 0 (interpreted as "no retries, fail fast").
 func TestApplyFlags_WorkerAndRetryDefaults(t *testing.T) {
 	cases := []struct {
 		name           string
@@ -90,11 +91,11 @@ func TestApplyFlags_WorkerAndRetryDefaults(t *testing.T) {
 		wantMaxRetries int
 	}{
 		{
-			name:           "zero sentinels → GOMAXPROCS and 3",
+			name:           "workers=0 sentinel → GOMAXPROCS; max-retries=0 stays 0",
 			flagWorkers:    0,
 			flagMaxRetries: 0,
 			wantWorkers:    runtime.GOMAXPROCS(0),
-			wantMaxRetries: 3,
+			wantMaxRetries: 0,
 		},
 		{
 			name:           "explicit values pass through",

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/config/flags_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/config/flags_test.go
@@ -1,0 +1,242 @@
+package config
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/geometry"
+)
+
+// Cycle 6 — ApplyFlags widens the operator-supplied [--start-ledger,
+// --end-ledger] range OUTWARD to the nearest chunk boundaries per the design
+// doc's "Chunk Boundary Expansion" section. Never narrows. Computed from the
+// geometry that BuildGeometry produces for this config (ChunkSize = 10_000,
+// ChunksPerTxHashIndex defaulted to 1000).
+//
+// Four cases cover the combinatorial shape:
+//
+//	(a) both endpoints mid-chunk (canonical example from issue #684 body);
+//	(b) start=FirstLedger (2) and end already chunk-aligned — no widening;
+//	(c) start=FirstLedger (2), end mid-chunk — only end widens;
+//	(d) start mid-chunk, end already chunk-aligned — only start widens.
+func TestApplyFlags_ChunkBoundaryExpansion(t *testing.T) {
+	cases := []struct {
+		name         string
+		startLedger  uint32
+		endLedger    uint32
+		wantEffStart uint32
+		wantEffEnd   uint32
+	}{
+		{
+			// Canonical example from the issue body / design doc:
+			// 5_000_000 falls inside chunk 499 ([4_990_002, 5_000_001]),
+			// 56_337_842 falls inside chunk 5633 ([56_330_002, 56_340_001]).
+			name:         "both mid-chunk (canonical)",
+			startLedger:  5_000_000,
+			endLedger:    56_337_842,
+			wantEffStart: 4_990_002,
+			wantEffEnd:   56_340_001,
+		},
+		{
+			// Chunk-aligned already — widening is a no-op.
+			name:         "start=2, end at chunk-boundary (no widen)",
+			startLedger:  2,
+			endLedger:    10_000_001, // chunk 999's last ledger
+			wantEffStart: 2,
+			wantEffEnd:   10_000_001,
+		},
+		{
+			// Start at absolute minimum, end falls mid-chunk 3
+			// (chunk 3 spans [30_002, 40_001]).
+			name:         "start=2, end mid-chunk (widen end only)",
+			startLedger:  2,
+			endLedger:    35_000,
+			wantEffStart: 2,
+			wantEffEnd:   40_001,
+		},
+		{
+			// Start falls mid-chunk 1 (spans [10_002, 20_001]),
+			// end at chunk 5's last ledger (60_001).
+			name:         "start mid-chunk, end at chunk-boundary (widen start only)",
+			startLedger:  15_000,
+			endLedger:    60_001,
+			wantEffStart: 10_002,
+			wantEffEnd:   60_001,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := ParseConfig(minimalValidTOML())
+			if err != nil {
+				t.Fatalf("ParseConfig: %v", err)
+			}
+			if err := cfg.Validate(); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+			cfg.ApplyFlags(CLIFlags{
+				StartLedger: tc.startLedger,
+				EndLedger:   tc.endLedger,
+			})
+			if cfg.EffectiveStartLedger != tc.wantEffStart {
+				t.Errorf("EffectiveStartLedger = %d, want %d", cfg.EffectiveStartLedger, tc.wantEffStart)
+			}
+			if cfg.EffectiveEndLedger != tc.wantEffEnd {
+				t.Errorf("EffectiveEndLedger = %d, want %d", cfg.EffectiveEndLedger, tc.wantEffEnd)
+			}
+		})
+	}
+}
+
+// Cycle 7 — ApplyFlags resolves the "0 sentinel" for Workers to GOMAXPROCS
+// and for MaxRetries to 3, matching the help-text and design-doc contracts.
+// Explicit non-zero values pass through unchanged — this test verifies both
+// directions to guard against a regression where the default clobbered an
+// operator-supplied value.
+func TestApplyFlags_WorkerAndRetryDefaults(t *testing.T) {
+	cases := []struct {
+		name           string
+		flagWorkers    int
+		flagMaxRetries int
+		wantWorkers    int
+		wantMaxRetries int
+	}{
+		{
+			name:           "zero sentinels → GOMAXPROCS and 3",
+			flagWorkers:    0,
+			flagMaxRetries: 0,
+			wantWorkers:    runtime.GOMAXPROCS(0),
+			wantMaxRetries: 3,
+		},
+		{
+			name:           "explicit values pass through",
+			flagWorkers:    40,
+			flagMaxRetries: 7,
+			wantWorkers:    40,
+			wantMaxRetries: 7,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := ParseConfig(minimalValidTOML())
+			if err != nil {
+				t.Fatalf("ParseConfig: %v", err)
+			}
+			if err := cfg.Validate(); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+			cfg.ApplyFlags(CLIFlags{
+				StartLedger: 2,
+				EndLedger:   10_000_001,
+				Workers:     tc.flagWorkers,
+				MaxRetries:  tc.flagMaxRetries,
+			})
+			if cfg.Workers != tc.wantWorkers {
+				t.Errorf("Workers = %d, want %d", cfg.Workers, tc.wantWorkers)
+			}
+			if cfg.MaxRetries != tc.wantMaxRetries {
+				t.Errorf("MaxRetries = %d, want %d", cfg.MaxRetries, tc.wantMaxRetries)
+			}
+		})
+	}
+}
+
+// Cycle 8 — ApplyFlags merges LogLevel / LogFormat from CLI into
+// cfg.Logging ONLY when the flag value is non-empty. Empty means "operator
+// did not pass --log-level / --log-format, keep whatever the TOML said."
+// Test covers both directions (override and passthrough).
+func TestApplyFlags_LoggingOverride(t *testing.T) {
+	cases := []struct {
+		name       string
+		tomlLevel  string
+		tomlFormat string
+		flagLevel  string
+		flagFormat string
+		wantLevel  string
+		wantFormat string
+	}{
+		{
+			name:       "CLI non-empty overrides TOML",
+			tomlLevel:  "info",
+			tomlFormat: "text",
+			flagLevel:  "debug",
+			flagFormat: "json",
+			wantLevel:  "debug",
+			wantFormat: "json",
+		},
+		{
+			name:       "CLI empty leaves TOML intact",
+			tomlLevel:  "warn",
+			tomlFormat: "json",
+			flagLevel:  "",
+			flagFormat: "",
+			wantLevel:  "warn",
+			wantFormat: "json",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{
+				Service: ServiceConfig{DefaultDataDir: "/data"},
+				Backfill: BackfillConfig{
+					BSB: &BSBConfig{BucketPath: "bucket"},
+				},
+				Logging: LoggingConfig{Level: tc.tomlLevel, Format: tc.tomlFormat},
+			}
+			if err := cfg.Validate(); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+			cfg.ApplyFlags(CLIFlags{
+				StartLedger: 2,
+				EndLedger:   10_000_001,
+				LogLevel:    tc.flagLevel,
+				LogFormat:   tc.flagFormat,
+			})
+			if cfg.Logging.Level != tc.wantLevel {
+				t.Errorf("Logging.Level = %q, want %q", cfg.Logging.Level, tc.wantLevel)
+			}
+			if cfg.Logging.Format != tc.wantFormat {
+				t.Errorf("Logging.Format = %q, want %q", cfg.Logging.Format, tc.wantFormat)
+			}
+		})
+	}
+}
+
+// Cycle 12 — BuildGeometry threads CHUNKS_PER_TXHASH_INDEX into
+// geometry.Geometry so downstream callers (ApplyFlags, the DAG engine in
+// slice #687) see a self-consistent range layout. Default case uses 1000,
+// custom case uses a non-round 250 to catch any accidental hard-coded
+// "× 1000" reintroduction.
+func TestBuildGeometry(t *testing.T) {
+	cases := []struct {
+		name           string
+		chunksPerIndex uint32
+		wantRangeSize  uint32
+	}{
+		{
+			name:           "default CHUNKS_PER_TXHASH_INDEX (1000) → 10M range",
+			chunksPerIndex: 0, // forces default
+			wantRangeSize:  10_000_000,
+		},
+		{
+			name:           "custom CHUNKS_PER_TXHASH_INDEX (250) → 2.5M range",
+			chunksPerIndex: 250,
+			wantRangeSize:  2_500_000,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{}
+			cfg.Backfill.ChunksPerTxHashIndex = tc.chunksPerIndex
+			geo := cfg.BuildGeometry()
+			if geo.ChunkSize != geometry.ChunkSize {
+				t.Errorf("ChunkSize = %d, want %d (layout invariant)", geo.ChunkSize, geometry.ChunkSize)
+			}
+			if geo.RangeSize != tc.wantRangeSize {
+				t.Errorf("RangeSize = %d, want %d", geo.RangeSize, tc.wantRangeSize)
+			}
+		})
+	}
+}

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/config/interfaces.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/config/interfaces.go
@@ -1,9 +1,9 @@
 package config
 
 // Store is the key/value contract the CHUNKS_PER_TXHASH_INDEX immutability
-// check runs against. Intentionally narrow (Get + Put only) so the real
-// RocksDB-backed implementation in slice #689 can drop in here without
-// any caller changes in this package or in cmd.go.
+// check runs against. The interface is deliberately narrow (Get + Put
+// only). This slice ships an in-memory implementation; a real
+// RocksDB-backed one will land as part of #689.
 type Store interface {
 	Get(key string) (value string, found bool, err error)
 	Put(key, value string) error
@@ -12,18 +12,19 @@ type Store interface {
 // NewInMemoryStore returns a non-persistent, single-process Store backed
 // by a plain map.
 //
-// Why ship this in #684: the subcommand needs to run the full pre-DAG
-// validation pipeline end-to-end today so operators (and reviewers) can
-// exercise load → validate → expand → summary without first merging the
-// RocksDB-backed Store from #689. With an in-memory store, every run
-// starts fresh — first-run seed writes always fire, so the immutability
-// branch is never actually exercised from the CLI. That is acceptable
-// for this slice because:
-//   - #684's acceptance criteria only require that the immutability
-//     check flows through the Store interface (verified by mock-based
-//     unit tests in validate_test.go).
-//   - #689 swaps this call site for a real RocksDB-backed Store; the
-//     immutability semantics then activate without any changes here.
+// We ship it in this slice so the subcommand can run the full pre-DAG
+// validation pipeline end-to-end today. The real RocksDB-backed store
+// is not yet merged (it will come with #689), so this in-memory one
+// stands in for now. Because every subcommand invocation starts with
+// a fresh map:
+//
+//   - the first-run seed branch of ValidateAgainstStore always fires;
+//   - the match/mismatch branches are never exercised from the CLI.
+//
+// That is fine for this slice — those branches are already covered by
+// mock-based unit tests in validate_test.go. Once #689 lands, the CLI
+// call site switches to the real store and the immutability check
+// becomes load-bearing.
 func NewInMemoryStore() Store {
 	return &inMemoryStore{data: map[string]string{}}
 }
@@ -44,23 +45,20 @@ func (s *inMemoryStore) Put(key, value string) error {
 
 // BSBAvailabilityProbe reports the highest ledger currently retrievable
 // from the BSB backend. ValidateAgainstBSB uses it to reject backfill
-// ranges that extend past what BSB has. Single-method interface so the
-// real BSB-backed implementation in slice #688 drops in here without
-// caller changes.
+// ranges that extend past what BSB has. A real GCS-backed implementation
+// will land as part of #688.
 type BSBAvailabilityProbe interface {
 	MaxAvailableLedger() (uint32, error)
 }
 
 // NewNopBSBAvailabilityProbe returns a probe that treats every ledger as
-// available (returns math.MaxUint32). Effectively a bypass.
+// available (math.MaxUint32). Effectively a bypass.
 //
-// Why ship this in #684: the real probe from slice #688 reaches out to
-// GCS (or the configured object store) to discover the max available
-// ledger — too heavy a dependency for a pipeline-wiring slice whose
-// acceptance criteria are purely about config shape + validation flow.
-// The no-op probe lets the subcommand call ValidateAgainstBSB at the
-// correct point in the pipeline today; #688 swaps this call site for
-// the real probe and the check becomes load-bearing.
+// We ship it in this slice because the real probe would reach out to
+// GCS to discover the max available ledger — too heavy a dependency
+// for a config-shape slice. The no-op keeps the pipeline call order
+// correct today; once #688 lands, the CLI call site switches to the
+// real probe and the availability check becomes load-bearing.
 func NewNopBSBAvailabilityProbe() BSBAvailabilityProbe {
 	return nopBSBAvailabilityProbe{}
 }

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/config/interfaces.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/config/interfaces.go
@@ -1,0 +1,90 @@
+package config
+
+// This file declares the two interfaces that ValidateAgainstConfigStore and
+// ValidateAgainstBSB depend on, plus in-memory stub implementations used by
+// the subcommand until slice #689 (Layer-2 metastore facade) and slice #688
+// (BSB source wrapper) land their real implementations.
+//
+// The stubs are NOT production-grade — they exist solely so the subcommand
+// can wire the full validation pipeline end-to-end today without pulling in
+// pkg/rocksdb or the Stellar SDK's BufferedStorageBackend. MEMORY.md pins
+// the decision: "CHUNKS_PER_TXHASH_INDEX immutability check goes through a
+// ConfigStore interface with a no-op stub impl in this slice. Do NOT import
+// pkg/rocksdb."
+
+// ConfigStore is the narrow interface that ValidateAgainstConfigStore
+// consumes. Exactly two methods: Get (returning value + found + err so the
+// "key absent" case is distinguishable from a real read error) and Put
+// (used on first-run to persist the CHUNKS_PER_TXHASH_INDEX seed value).
+//
+// Slice #689's metastore facade will implement this over the real RocksDB
+// key `config:chunks_per_txhash_index`.
+type ConfigStore interface {
+	// Get retrieves the value for a key. found=false means the key is
+	// absent (first-run semantics); err != nil means the store itself
+	// failed to read (propagate as a hard abort).
+	Get(key string) (value string, found bool, err error)
+
+	// Put writes a key/value pair. Errors propagate as a hard abort —
+	// a subsequent run will retry the same seed value.
+	Put(key, value string) error
+}
+
+// NewStubConfigStore returns an in-memory ConfigStore with no persisted
+// state — suitable for the subcommand wiring in slice #684 where the real
+// RocksDB-backed store lands in #689. Every subcommand invocation sees an
+// empty store, so the CHUNKS_PER_TXHASH_INDEX first-run branch always
+// fires. Callers that want genuine persistence must wait for #689.
+func NewStubConfigStore() ConfigStore {
+	return &stubConfigStore{data: map[string]string{}}
+}
+
+// stubConfigStore is the trivial map-backed impl. Not thread-safe and not
+// persisted across process restarts — intentional, since the real impl
+// lands in #689 with proper locking and fsync semantics.
+type stubConfigStore struct {
+	data map[string]string
+}
+
+// Get reports whether the key exists and returns its value. Never fails —
+// the in-memory map cannot produce an I/O error.
+func (s *stubConfigStore) Get(key string) (string, bool, error) {
+	v, ok := s.data[key]
+	return v, ok, nil
+}
+
+// Put stores the key/value pair. Never fails.
+func (s *stubConfigStore) Put(key, value string) error {
+	s.data[key] = value
+	return nil
+}
+
+// BSBAvailabilityProbe is the narrow interface that ValidateAgainstBSB
+// consumes. Exactly one method: MaxAvailableLedger returns the highest
+// ledger present in the remote object store BSB points at. A real
+// implementation (slice #688) probes GCS/S3; the stub here skips the check
+// entirely by returning math.MaxUint32.
+type BSBAvailabilityProbe interface {
+	// MaxAvailableLedger returns the highest ledger currently retrievable
+	// from the BSB backend.
+	MaxAvailableLedger() (uint32, error)
+}
+
+// NewStubBSBAvailabilityProbe returns a probe that reports "everything is
+// available" — effectively disabling the availability check until slice
+// #688 lands the real BSB-backed probe.
+func NewStubBSBAvailabilityProbe() BSBAvailabilityProbe {
+	return &stubBSBAvailabilityProbe{}
+}
+
+// stubBSBAvailabilityProbe always returns math.MaxUint32, satisfying the
+// "expanded end <= max available" check for any conceivable Stellar ledger.
+type stubBSBAvailabilityProbe struct{}
+
+// MaxAvailableLedger returns the max uint32 so the availability check is
+// effectively a no-op in this slice.
+func (stubBSBAvailabilityProbe) MaxAvailableLedger() (uint32, error) {
+	// math.MaxUint32 — Stellar ledger sequences are uint32 so this is an
+	// unreachable cap in practice.
+	return 0xFFFFFFFF, nil
+}

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/config/interfaces.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/config/interfaces.go
@@ -1,90 +1,72 @@
 package config
 
-// This file declares the two interfaces that ValidateAgainstConfigStore and
-// ValidateAgainstBSB depend on, plus in-memory stub implementations used by
-// the subcommand until slice #689 (Layer-2 metastore facade) and slice #688
-// (BSB source wrapper) land their real implementations.
-//
-// The stubs are NOT production-grade — they exist solely so the subcommand
-// can wire the full validation pipeline end-to-end today without pulling in
-// pkg/rocksdb or the Stellar SDK's BufferedStorageBackend. MEMORY.md pins
-// the decision: "CHUNKS_PER_TXHASH_INDEX immutability check goes through a
-// ConfigStore interface with a no-op stub impl in this slice. Do NOT import
-// pkg/rocksdb."
-
-// ConfigStore is the narrow interface that ValidateAgainstConfigStore
-// consumes. Exactly two methods: Get (returning value + found + err so the
-// "key absent" case is distinguishable from a real read error) and Put
-// (used on first-run to persist the CHUNKS_PER_TXHASH_INDEX seed value).
-//
-// Slice #689's metastore facade will implement this over the real RocksDB
-// key `config:chunks_per_txhash_index`.
-type ConfigStore interface {
-	// Get retrieves the value for a key. found=false means the key is
-	// absent (first-run semantics); err != nil means the store itself
-	// failed to read (propagate as a hard abort).
+// Store is the key/value contract the CHUNKS_PER_TXHASH_INDEX immutability
+// check runs against. Intentionally narrow (Get + Put only) so the real
+// RocksDB-backed implementation in slice #689 can drop in here without
+// any caller changes in this package or in cmd.go.
+type Store interface {
 	Get(key string) (value string, found bool, err error)
-
-	// Put writes a key/value pair. Errors propagate as a hard abort —
-	// a subsequent run will retry the same seed value.
 	Put(key, value string) error
 }
 
-// NewStubConfigStore returns an in-memory ConfigStore with no persisted
-// state — suitable for the subcommand wiring in slice #684 where the real
-// RocksDB-backed store lands in #689. Every subcommand invocation sees an
-// empty store, so the CHUNKS_PER_TXHASH_INDEX first-run branch always
-// fires. Callers that want genuine persistence must wait for #689.
-func NewStubConfigStore() ConfigStore {
-	return &stubConfigStore{data: map[string]string{}}
+// NewInMemoryStore returns a non-persistent, single-process Store backed
+// by a plain map.
+//
+// Why ship this in #684: the subcommand needs to run the full pre-DAG
+// validation pipeline end-to-end today so operators (and reviewers) can
+// exercise load → validate → expand → summary without first merging the
+// RocksDB-backed Store from #689. With an in-memory store, every run
+// starts fresh — first-run seed writes always fire, so the immutability
+// branch is never actually exercised from the CLI. That is acceptable
+// for this slice because:
+//   - #684's acceptance criteria only require that the immutability
+//     check flows through the Store interface (verified by mock-based
+//     unit tests in validate_test.go).
+//   - #689 swaps this call site for a real RocksDB-backed Store; the
+//     immutability semantics then activate without any changes here.
+func NewInMemoryStore() Store {
+	return &inMemoryStore{data: map[string]string{}}
 }
 
-// stubConfigStore is the trivial map-backed impl. Not thread-safe and not
-// persisted across process restarts — intentional, since the real impl
-// lands in #689 with proper locking and fsync semantics.
-type stubConfigStore struct {
+type inMemoryStore struct {
 	data map[string]string
 }
 
-// Get reports whether the key exists and returns its value. Never fails —
-// the in-memory map cannot produce an I/O error.
-func (s *stubConfigStore) Get(key string) (string, bool, error) {
+func (s *inMemoryStore) Get(key string) (string, bool, error) {
 	v, ok := s.data[key]
 	return v, ok, nil
 }
 
-// Put stores the key/value pair. Never fails.
-func (s *stubConfigStore) Put(key, value string) error {
+func (s *inMemoryStore) Put(key, value string) error {
 	s.data[key] = value
 	return nil
 }
 
-// BSBAvailabilityProbe is the narrow interface that ValidateAgainstBSB
-// consumes. Exactly one method: MaxAvailableLedger returns the highest
-// ledger present in the remote object store BSB points at. A real
-// implementation (slice #688) probes GCS/S3; the stub here skips the check
-// entirely by returning math.MaxUint32.
+// BSBAvailabilityProbe reports the highest ledger currently retrievable
+// from the BSB backend. ValidateAgainstBSB uses it to reject backfill
+// ranges that extend past what BSB has. Single-method interface so the
+// real BSB-backed implementation in slice #688 drops in here without
+// caller changes.
 type BSBAvailabilityProbe interface {
-	// MaxAvailableLedger returns the highest ledger currently retrievable
-	// from the BSB backend.
 	MaxAvailableLedger() (uint32, error)
 }
 
-// NewStubBSBAvailabilityProbe returns a probe that reports "everything is
-// available" — effectively disabling the availability check until slice
-// #688 lands the real BSB-backed probe.
-func NewStubBSBAvailabilityProbe() BSBAvailabilityProbe {
-	return &stubBSBAvailabilityProbe{}
+// NewNopBSBAvailabilityProbe returns a probe that treats every ledger as
+// available (returns math.MaxUint32). Effectively a bypass.
+//
+// Why ship this in #684: the real probe from slice #688 reaches out to
+// GCS (or the configured object store) to discover the max available
+// ledger — too heavy a dependency for a pipeline-wiring slice whose
+// acceptance criteria are purely about config shape + validation flow.
+// The no-op probe lets the subcommand call ValidateAgainstBSB at the
+// correct point in the pipeline today; #688 swaps this call site for
+// the real probe and the check becomes load-bearing.
+func NewNopBSBAvailabilityProbe() BSBAvailabilityProbe {
+	return nopBSBAvailabilityProbe{}
 }
 
-// stubBSBAvailabilityProbe always returns math.MaxUint32, satisfying the
-// "expanded end <= max available" check for any conceivable Stellar ledger.
-type stubBSBAvailabilityProbe struct{}
+type nopBSBAvailabilityProbe struct{}
 
-// MaxAvailableLedger returns the max uint32 so the availability check is
-// effectively a no-op in this slice.
-func (stubBSBAvailabilityProbe) MaxAvailableLedger() (uint32, error) {
-	// math.MaxUint32 — Stellar ledger sequences are uint32 so this is an
-	// unreachable cap in practice.
+func (nopBSBAvailabilityProbe) MaxAvailableLedger() (uint32, error) {
 	return 0xFFFFFFFF, nil
 }

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/config/validate.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/config/validate.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -8,33 +9,18 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/geometry"
 )
 
-// ChunksPerTxHashIndexMetaKey is the meta-store key under which the
-// first-run value of CHUNKS_PER_TXHASH_INDEX is persisted. Exported so the
-// metastore facade in slice #689 (Layer-2) and any diagnostic tooling use
-// the same string — redefining the literal in two places is exactly the
-// corruption vector this key is protecting against.
+// ChunksPerTxHashIndexMetaKey is the Store key under which the first-run
+// value of CHUNKS_PER_TXHASH_INDEX is seeded. Exported so the real
+// metastore facade (#689) uses the exact same literal — the whole point
+// of the immutability check is defeated if two sites disagree.
 const ChunksPerTxHashIndexMetaKey = "config:chunks_per_txhash_index"
 
-// Default values for keys that the operator may omit. Grouped here so the
-// single place a number lives is this file, and Validate / ApplyFlags pick
-// them up by name rather than re-typing literals.
-//
-// The path-segment defaults (meta/rocksdb, ledgers, events, txhash/raw,
-// txhash/index) are lowercase because they are filesystem directory names,
-// not TOML keys — TOML-key case (UPPER_SNAKE_CASE) and filesystem-path case
-// are separate concerns. See design-doc section "Directory Structure".
+// Design-doc defaults — one source per value.
 const (
-	// defaultChunksPerTxHashIndex matches the design doc's recommended
-	// default (10M ledgers per txhash index == 1000 chunks × 10K ledgers).
 	defaultChunksPerTxHashIndex uint32 = 1000
+	defaultBSBBufferSize        int    = 1000
+	defaultBSBNumWorkers        int    = 20
 
-	// defaultBSBBufferSize / defaultBSBNumWorkers match the design-doc
-	// defaults for BSB when the operator does not override them.
-	defaultBSBBufferSize int = 1000
-	defaultBSBNumWorkers int = 20
-
-	// Filesystem sub-directory conventions; joined onto DEFAULT_DATA_DIR
-	// to produce default storage paths.
 	defaultMetaStoreSubdir   = "meta/rocksdb"
 	defaultLedgersSubdir     = "ledgers"
 	defaultEventsSubdir      = "events"
@@ -42,43 +28,25 @@ const (
 	defaultTxHashIndexSubdir = "txhash/index"
 )
 
-// Validate enforces the TOML-level constraints (required fields, shape of
-// [BACKFILL.BSB]) and resolves default values for optional fields. It
-// mutates the receiver in place; callers should treat a nil return as
-// "config is now fully resolved and safe to consume."
+// Validate enforces the TOML-level rules (required fields, BSB shape) and
+// fills in defaults for every optional key. Mutates c in place.
 //
-// Validate is the TOML/struct-level half of pre-DAG validation. The CLI-flag
-// half (ValidateFlags) and the meta-store immutability check
-// (ValidateAgainstConfigStore) live alongside so the subcommand can call
-// them in sequence.
-//
-// Rules enforced here (map to design-doc "Validation before DAG
-// construction"):
+// Rules (from design-doc "Validation before DAG construction"):
 //   - DEFAULT_DATA_DIR is required.
-//   - [BACKFILL.BSB] is required and must have BUCKET_PATH.
-//   - CHUNKS_PER_TXHASH_INDEX defaults to 1000 when 0.
-//   - BSB BUFFER_SIZE / NUM_WORKERS default to 1000 / 20 when <= 0.
-//   - Per-type storage paths default under DEFAULT_DATA_DIR when unset.
+//   - [BACKFILL.BSB] is required with BUCKET_PATH.
+//   - Numeric defaults: CHUNKS_PER_TXHASH_INDEX=1000, BUFFER_SIZE=1000, NUM_WORKERS=20.
+//   - Path defaults under DEFAULT_DATA_DIR.
 func (c *Config) Validate() error {
-	// DEFAULT_DATA_DIR is the anchor for every filesystem-path default; if
-	// it is missing, we cannot sensibly fall back to anything.
 	if c.Service.DefaultDataDir == "" {
-		return fmt.Errorf("[SERVICE].DEFAULT_DATA_DIR is required")
+		return errors.New("[SERVICE].DEFAULT_DATA_DIR is required")
 	}
-
-	// BSB is required — backfill has no alternative ledger source. Pointer
-	// nil-check distinguishes "section absent" from "section present but
-	// empty" (latter is caught by BUCKET_PATH check below).
 	if c.Backfill.BSB == nil {
-		return fmt.Errorf("[BACKFILL.BSB] is required")
+		return errors.New("[BACKFILL.BSB] is required")
 	}
 	if c.Backfill.BSB.BucketPath == "" {
-		return fmt.Errorf("[BACKFILL.BSB].BUCKET_PATH is required")
+		return errors.New("[BACKFILL.BSB].BUCKET_PATH is required")
 	}
 
-	// Defaults for path keys the operator omitted. filepath.Join normalizes
-	// separators for the host OS, which matters on Windows-authored TOML
-	// imported onto Linux hosts (and vice versa).
 	if c.MetaStore.Path == "" {
 		c.MetaStore.Path = filepath.Join(c.Service.DefaultDataDir, defaultMetaStoreSubdir)
 	}
@@ -95,8 +63,6 @@ func (c *Config) Validate() error {
 		c.ImmutableStorage.TxHashIndex.Path = filepath.Join(c.Service.DefaultDataDir, defaultTxHashIndexSubdir)
 	}
 
-	// Numeric defaults. 0 is the zero value TOML parse gives us when a key
-	// is absent; treat it as "unset" and fill in the design-doc defaults.
 	if c.Backfill.ChunksPerTxHashIndex == 0 {
 		c.Backfill.ChunksPerTxHashIndex = defaultChunksPerTxHashIndex
 	}
@@ -110,17 +76,14 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-// ValidateFlags enforces the CLI-flag-level rules from design-doc section
-// "Validation before DAG construction":
+// ValidateFlags enforces the CLI-level rules:
 //   - --start-ledger >= FirstLedger (2)
 //   - --end-ledger > --start-ledger
-//   - --workers >= 1
+//   - --workers >= 0 (0 is the documented sentinel for GOMAXPROCS; ApplyFlags resolves it)
 //   - --max-retries >= 0
 //
-// Each error message names the offending flag so the operator can fix the
-// invocation without having to grep validation source code. --verify-recsplit
-// has no numeric constraint — cobra's bool flag type makes parse failures
-// impossible, so there is no rule to enforce here.
+// Error messages name the offending flag so operators do not have to
+// grep source.
 func (c *Config) ValidateFlags(flags CLIFlags) error {
 	if flags.StartLedger < geometry.FirstLedger {
 		return fmt.Errorf("--start-ledger (%d) must be >= %d", flags.StartLedger, geometry.FirstLedger)
@@ -128,8 +91,11 @@ func (c *Config) ValidateFlags(flags CLIFlags) error {
 	if flags.EndLedger <= flags.StartLedger {
 		return fmt.Errorf("--end-ledger (%d) must be > --start-ledger (%d)", flags.EndLedger, flags.StartLedger)
 	}
-	if flags.Workers < 1 {
-		return fmt.Errorf("--workers (%d) must be >= 1", flags.Workers)
+	// Workers is a signed int — cobra allows negative inputs. The 0
+	// sentinel is documented ("0 = GOMAXPROCS"); anything below 0 is
+	// an operator mistake.
+	if flags.Workers < 0 {
+		return fmt.Errorf("--workers (%d) must be >= 0 (0 means GOMAXPROCS)", flags.Workers)
 	}
 	if flags.MaxRetries < 0 {
 		return fmt.Errorf("--max-retries (%d) must be >= 0", flags.MaxRetries)
@@ -137,62 +103,40 @@ func (c *Config) ValidateFlags(flags CLIFlags) error {
 	return nil
 }
 
-// ValidateAgainstConfigStore enforces the design-doc rule that
-// CHUNKS_PER_TXHASH_INDEX is layout-defining and must not change across
-// runs. Three branches (first-run / match / mismatch) map directly to the
-// design-doc section "Validation before DAG construction".
+// ValidateAgainstStore enforces CHUNKS_PER_TXHASH_INDEX immutability. The
+// value gets stringified and stored under ChunksPerTxHashIndexMetaKey on
+// first run; subsequent runs must match or the on-disk layout breaks.
 //
-// Why string-valued (not integer): the meta-store key schema uses string
-// values throughout (chunk-flag values are "1" — see design-doc Meta Store
-// Keys). Staying string-typed at the interface boundary keeps the Layer-2
-// facade in slice #689 from having to special-case one numeric key.
-//
-// Pre-condition: Validate has been called (so CHUNKS_PER_TXHASH_INDEX is
-// already defaulted to 1000 if absent). A caller who skips Validate and
-// passes a raw zero would persist "0" on first-run and lock the store to
-// that value forever — the subcommand's call order guards against this.
-func (c *Config) ValidateAgainstConfigStore(store ConfigStore) error {
+// Pre-condition: Validate has run, so ChunksPerTxHashIndex is populated.
+// Skipping Validate would seed "0" and permanently lock that value.
+func (c *Config) ValidateAgainstStore(store Store) error {
 	current := strconv.FormatUint(uint64(c.Backfill.ChunksPerTxHashIndex), 10)
 
 	stored, found, err := store.Get(ChunksPerTxHashIndexMetaKey)
 	if err != nil {
-		return fmt.Errorf("read %s from config store: %w", ChunksPerTxHashIndexMetaKey, err)
+		return fmt.Errorf("read %s from store: %w", ChunksPerTxHashIndexMetaKey, err)
 	}
 
-	// First-run branch: persist the current value as the seed. Subsequent
-	// runs will compare against this value.
 	if !found {
 		if err := store.Put(ChunksPerTxHashIndexMetaKey, current); err != nil {
-			return fmt.Errorf("seed %s to config store: %w", ChunksPerTxHashIndexMetaKey, err)
+			return fmt.Errorf("seed %s to store: %w", ChunksPerTxHashIndexMetaKey, err)
 		}
 		return nil
 	}
 
-	// Match branch: nothing to do.
 	if stored == current {
 		return nil
 	}
 
-	// Mismatch branch: hard abort. Operator must either revert
-	// CHUNKS_PER_TXHASH_INDEX or start from a fresh data directory.
 	return fmt.Errorf(
-		"CHUNKS_PER_TXHASH_INDEX changed: config-store has %q, config TOML has %q — "+
+		"CHUNKS_PER_TXHASH_INDEX changed: store has %q, config TOML has %q — "+
 			"this value is layout-defining and must not change across runs",
 		stored, current,
 	)
 }
 
-// ValidateAgainstBSB enforces the design-doc rule "expanded end must not
-// exceed BSB-advertised max ledger". Returns:
-//   - nil when the probe reports a max ledger >= EffectiveEndLedger;
-//   - a wrapped probe error when the probe itself fails (operator can fix
-//     credentials / connectivity and retry);
-//   - a hard-abort error naming both values when the expanded range
-//     out-runs BSB's advertised coverage.
-//
-// Pre-condition: ApplyFlags has been called so EffectiveEndLedger holds
-// the widened range; calling ValidateAgainstBSB before ApplyFlags compares
-// against a zero EffectiveEndLedger and always passes — misleading.
+// ValidateAgainstBSB enforces "expanded end must not exceed BSB max
+// available". Requires ApplyFlags to have populated EffectiveEndLedger.
 func (c *Config) ValidateAgainstBSB(probe BSBAvailabilityProbe) error {
 	maxAvailable, err := probe.MaxAvailableLedger()
 	if err != nil {

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/config/validate.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/config/validate.go
@@ -1,0 +1,210 @@
+package config
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/geometry"
+)
+
+// ChunksPerTxHashIndexMetaKey is the meta-store key under which the
+// first-run value of CHUNKS_PER_TXHASH_INDEX is persisted. Exported so the
+// metastore facade in slice #689 (Layer-2) and any diagnostic tooling use
+// the same string — redefining the literal in two places is exactly the
+// corruption vector this key is protecting against.
+const ChunksPerTxHashIndexMetaKey = "config:chunks_per_txhash_index"
+
+// Default values for keys that the operator may omit. Grouped here so the
+// single place a number lives is this file, and Validate / ApplyFlags pick
+// them up by name rather than re-typing literals.
+//
+// The path-segment defaults (meta/rocksdb, ledgers, events, txhash/raw,
+// txhash/index) are lowercase because they are filesystem directory names,
+// not TOML keys — TOML-key case (UPPER_SNAKE_CASE) and filesystem-path case
+// are separate concerns. See design-doc section "Directory Structure".
+const (
+	// defaultChunksPerTxHashIndex matches the design doc's recommended
+	// default (10M ledgers per txhash index == 1000 chunks × 10K ledgers).
+	defaultChunksPerTxHashIndex uint32 = 1000
+
+	// defaultBSBBufferSize / defaultBSBNumWorkers match the design-doc
+	// defaults for BSB when the operator does not override them.
+	defaultBSBBufferSize int = 1000
+	defaultBSBNumWorkers int = 20
+
+	// Filesystem sub-directory conventions; joined onto DEFAULT_DATA_DIR
+	// to produce default storage paths.
+	defaultMetaStoreSubdir   = "meta/rocksdb"
+	defaultLedgersSubdir     = "ledgers"
+	defaultEventsSubdir      = "events"
+	defaultTxHashRawSubdir   = "txhash/raw"
+	defaultTxHashIndexSubdir = "txhash/index"
+)
+
+// Validate enforces the TOML-level constraints (required fields, shape of
+// [BACKFILL.BSB]) and resolves default values for optional fields. It
+// mutates the receiver in place; callers should treat a nil return as
+// "config is now fully resolved and safe to consume."
+//
+// Validate is the TOML/struct-level half of pre-DAG validation. The CLI-flag
+// half (ValidateFlags) and the meta-store immutability check
+// (ValidateAgainstConfigStore) live alongside so the subcommand can call
+// them in sequence.
+//
+// Rules enforced here (map to design-doc "Validation before DAG
+// construction"):
+//   - DEFAULT_DATA_DIR is required.
+//   - [BACKFILL.BSB] is required and must have BUCKET_PATH.
+//   - CHUNKS_PER_TXHASH_INDEX defaults to 1000 when 0.
+//   - BSB BUFFER_SIZE / NUM_WORKERS default to 1000 / 20 when <= 0.
+//   - Per-type storage paths default under DEFAULT_DATA_DIR when unset.
+func (c *Config) Validate() error {
+	// DEFAULT_DATA_DIR is the anchor for every filesystem-path default; if
+	// it is missing, we cannot sensibly fall back to anything.
+	if c.Service.DefaultDataDir == "" {
+		return fmt.Errorf("[SERVICE].DEFAULT_DATA_DIR is required")
+	}
+
+	// BSB is required — backfill has no alternative ledger source. Pointer
+	// nil-check distinguishes "section absent" from "section present but
+	// empty" (latter is caught by BUCKET_PATH check below).
+	if c.Backfill.BSB == nil {
+		return fmt.Errorf("[BACKFILL.BSB] is required")
+	}
+	if c.Backfill.BSB.BucketPath == "" {
+		return fmt.Errorf("[BACKFILL.BSB].BUCKET_PATH is required")
+	}
+
+	// Defaults for path keys the operator omitted. filepath.Join normalizes
+	// separators for the host OS, which matters on Windows-authored TOML
+	// imported onto Linux hosts (and vice versa).
+	if c.MetaStore.Path == "" {
+		c.MetaStore.Path = filepath.Join(c.Service.DefaultDataDir, defaultMetaStoreSubdir)
+	}
+	if c.ImmutableStorage.Ledgers.Path == "" {
+		c.ImmutableStorage.Ledgers.Path = filepath.Join(c.Service.DefaultDataDir, defaultLedgersSubdir)
+	}
+	if c.ImmutableStorage.Events.Path == "" {
+		c.ImmutableStorage.Events.Path = filepath.Join(c.Service.DefaultDataDir, defaultEventsSubdir)
+	}
+	if c.ImmutableStorage.TxHashRaw.Path == "" {
+		c.ImmutableStorage.TxHashRaw.Path = filepath.Join(c.Service.DefaultDataDir, defaultTxHashRawSubdir)
+	}
+	if c.ImmutableStorage.TxHashIndex.Path == "" {
+		c.ImmutableStorage.TxHashIndex.Path = filepath.Join(c.Service.DefaultDataDir, defaultTxHashIndexSubdir)
+	}
+
+	// Numeric defaults. 0 is the zero value TOML parse gives us when a key
+	// is absent; treat it as "unset" and fill in the design-doc defaults.
+	if c.Backfill.ChunksPerTxHashIndex == 0 {
+		c.Backfill.ChunksPerTxHashIndex = defaultChunksPerTxHashIndex
+	}
+	if c.Backfill.BSB.BufferSize <= 0 {
+		c.Backfill.BSB.BufferSize = defaultBSBBufferSize
+	}
+	if c.Backfill.BSB.NumWorkers <= 0 {
+		c.Backfill.BSB.NumWorkers = defaultBSBNumWorkers
+	}
+
+	return nil
+}
+
+// ValidateFlags enforces the CLI-flag-level rules from design-doc section
+// "Validation before DAG construction":
+//   - --start-ledger >= FirstLedger (2)
+//   - --end-ledger > --start-ledger
+//   - --workers >= 1
+//   - --max-retries >= 0
+//
+// Each error message names the offending flag so the operator can fix the
+// invocation without having to grep validation source code. --verify-recsplit
+// has no numeric constraint — cobra's bool flag type makes parse failures
+// impossible, so there is no rule to enforce here.
+func (c *Config) ValidateFlags(flags CLIFlags) error {
+	if flags.StartLedger < geometry.FirstLedger {
+		return fmt.Errorf("--start-ledger (%d) must be >= %d", flags.StartLedger, geometry.FirstLedger)
+	}
+	if flags.EndLedger <= flags.StartLedger {
+		return fmt.Errorf("--end-ledger (%d) must be > --start-ledger (%d)", flags.EndLedger, flags.StartLedger)
+	}
+	if flags.Workers < 1 {
+		return fmt.Errorf("--workers (%d) must be >= 1", flags.Workers)
+	}
+	if flags.MaxRetries < 0 {
+		return fmt.Errorf("--max-retries (%d) must be >= 0", flags.MaxRetries)
+	}
+	return nil
+}
+
+// ValidateAgainstConfigStore enforces the design-doc rule that
+// CHUNKS_PER_TXHASH_INDEX is layout-defining and must not change across
+// runs. Three branches (first-run / match / mismatch) map directly to the
+// design-doc section "Validation before DAG construction".
+//
+// Why string-valued (not integer): the meta-store key schema uses string
+// values throughout (chunk-flag values are "1" — see design-doc Meta Store
+// Keys). Staying string-typed at the interface boundary keeps the Layer-2
+// facade in slice #689 from having to special-case one numeric key.
+//
+// Pre-condition: Validate has been called (so CHUNKS_PER_TXHASH_INDEX is
+// already defaulted to 1000 if absent). A caller who skips Validate and
+// passes a raw zero would persist "0" on first-run and lock the store to
+// that value forever — the subcommand's call order guards against this.
+func (c *Config) ValidateAgainstConfigStore(store ConfigStore) error {
+	current := strconv.FormatUint(uint64(c.Backfill.ChunksPerTxHashIndex), 10)
+
+	stored, found, err := store.Get(ChunksPerTxHashIndexMetaKey)
+	if err != nil {
+		return fmt.Errorf("read %s from config store: %w", ChunksPerTxHashIndexMetaKey, err)
+	}
+
+	// First-run branch: persist the current value as the seed. Subsequent
+	// runs will compare against this value.
+	if !found {
+		if err := store.Put(ChunksPerTxHashIndexMetaKey, current); err != nil {
+			return fmt.Errorf("seed %s to config store: %w", ChunksPerTxHashIndexMetaKey, err)
+		}
+		return nil
+	}
+
+	// Match branch: nothing to do.
+	if stored == current {
+		return nil
+	}
+
+	// Mismatch branch: hard abort. Operator must either revert
+	// CHUNKS_PER_TXHASH_INDEX or start from a fresh data directory.
+	return fmt.Errorf(
+		"CHUNKS_PER_TXHASH_INDEX changed: config-store has %q, config TOML has %q — "+
+			"this value is layout-defining and must not change across runs",
+		stored, current,
+	)
+}
+
+// ValidateAgainstBSB enforces the design-doc rule "expanded end must not
+// exceed BSB-advertised max ledger". Returns:
+//   - nil when the probe reports a max ledger >= EffectiveEndLedger;
+//   - a wrapped probe error when the probe itself fails (operator can fix
+//     credentials / connectivity and retry);
+//   - a hard-abort error naming both values when the expanded range
+//     out-runs BSB's advertised coverage.
+//
+// Pre-condition: ApplyFlags has been called so EffectiveEndLedger holds
+// the widened range; calling ValidateAgainstBSB before ApplyFlags compares
+// against a zero EffectiveEndLedger and always passes — misleading.
+func (c *Config) ValidateAgainstBSB(probe BSBAvailabilityProbe) error {
+	maxAvailable, err := probe.MaxAvailableLedger()
+	if err != nil {
+		return fmt.Errorf("probe BSB for max available ledger: %w", err)
+	}
+	if maxAvailable < c.EffectiveEndLedger {
+		return fmt.Errorf(
+			"BSB does not yet have enough history: expanded end is %d, "+
+				"but BSB advertises max available ledger %d — "+
+				"reduce --end-ledger or wait for more ledgers to land in BSB",
+			c.EffectiveEndLedger, maxAvailable,
+		)
+	}
+	return nil
+}

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/config/validate.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/config/validate.go
@@ -108,8 +108,15 @@ func (c *Config) ValidateFlags(flags CLIFlags) error {
 // first run; subsequent runs must match or the on-disk layout breaks.
 //
 // Pre-condition: Validate has run, so ChunksPerTxHashIndex is populated.
-// Skipping Validate would seed "0" and permanently lock that value.
+// We enforce that explicitly here instead of trusting the caller — a
+// stray first-run invocation without Validate would otherwise seed "0"
+// into the store and permanently lock the layout to that value.
 func (c *Config) ValidateAgainstStore(store Store) error {
+	if c.Backfill.ChunksPerTxHashIndex == 0 {
+		return errors.New(
+			"ValidateAgainstStore precondition violated: CHUNKS_PER_TXHASH_INDEX is 0 " +
+				"— call Validate() first to populate the default")
+	}
 	current := strconv.FormatUint(uint64(c.Backfill.ChunksPerTxHashIndex), 10)
 
 	stored, found, err := store.Get(ChunksPerTxHashIndexMetaKey)

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/config/validate_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/config/validate_test.go
@@ -205,6 +205,22 @@ func TestValidateAgainstStore(t *testing.T) {
 		}
 	})
 
+	t.Run("precondition violation: Validate not called first", func(t *testing.T) {
+		// ChunksPerTxHashIndex defaults to 0 on a freshly-parsed Config.
+		// Skipping Validate leaves it at 0; ValidateAgainstStore must
+		// refuse rather than silently seeding "0" into the store.
+		cfg := &Config{}
+		err := cfg.ValidateAgainstStore(newMockStore())
+		if err == nil {
+			t.Fatal("expected precondition error, got nil")
+		}
+		for _, want := range []string{"precondition", "CHUNKS_PER_TXHASH_INDEX", "Validate()"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q missing substring %q", err.Error(), want)
+			}
+		}
+	})
+
 	t.Run("stored differs from current → hard abort", func(t *testing.T) {
 		cfg := mustValidated(t, 500)
 		store := newMockStore()

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/config/validate_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/config/validate_test.go
@@ -6,25 +6,20 @@ import (
 	"testing"
 )
 
-// mockConfigStore is the test double for the ConfigStore interface. Keeping
-// it local to the test file (rather than reusing the package's stub) gives
-// each test full control over the pre-seeded state — exactly what the
-// mismatch / match / absent branch coverage requires.
-type mockConfigStore struct {
-	data map[string]string
-	// getErr, if non-nil, is returned from Get instead of a lookup —
-	// used by the "Get error propagates" branch.
+// mockStore is the local test double for the Store interface. Kept
+// separate from the package's stub so each test controls pre-seeded
+// state directly.
+type mockStore struct {
+	data   map[string]string
 	getErr error
-	// putErr, if non-nil, is returned from Put — used to verify that
-	// first-run persistence errors propagate.
 	putErr error
 }
 
-func newMockConfigStore() *mockConfigStore {
-	return &mockConfigStore{data: map[string]string{}}
+func newMockStore() *mockStore {
+	return &mockStore{data: map[string]string{}}
 }
 
-func (m *mockConfigStore) Get(key string) (string, bool, error) {
+func (m *mockStore) Get(key string) (string, bool, error) {
 	if m.getErr != nil {
 		return "", false, m.getErr
 	}
@@ -32,7 +27,7 @@ func (m *mockConfigStore) Get(key string) (string, bool, error) {
 	return v, ok, nil
 }
 
-func (m *mockConfigStore) Put(key, value string) error {
+func (m *mockStore) Put(key, value string) error {
 	if m.putErr != nil {
 		return m.putErr
 	}
@@ -40,10 +35,19 @@ func (m *mockConfigStore) Put(key, value string) error {
 	return nil
 }
 
-// Cycle 5 — Validate rejects malformed configs with operator-legible error
-// messages. Table-driven to keep each failure mode named and isolated;
-// substring match on error text lets us verify the error identifies the
-// specific missing/invalid key without over-specifying exact wording.
+// mockBSBProbe is the test double for BSBAvailabilityProbe — a fixed
+// max-ledger value plus an optional injected error.
+type mockBSBProbe struct {
+	maxLedger uint32
+	err       error
+}
+
+func (m mockBSBProbe) MaxAvailableLedger() (uint32, error) {
+	return m.maxLedger, m.err
+}
+
+// TestValidate_RejectsBadConfigs — required-field rules each produce
+// an error that names the offending TOML key.
 func TestValidate_RejectsBadConfigs(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -96,10 +100,9 @@ BUFFER_SIZE = 500
 	}
 }
 
-// Cycle 9 — ValidateFlags rejects out-of-range CLI inputs with an error
-// whose message names the offending flag. Covers four failure modes plus
-// a valid pass-through. Each failure mode maps to a rule from the design
-// doc's "Validation before DAG construction" enumeration.
+// TestValidateFlags — out-of-range CLI inputs produce errors naming the
+// offending flag. Workers=0 is a valid sentinel (resolves to GOMAXPROCS
+// in ApplyFlags); only Workers<0 is rejected.
 func TestValidateFlags(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -109,6 +112,11 @@ func TestValidateFlags(t *testing.T) {
 		{
 			name:       "valid inputs pass",
 			flags:      CLIFlags{StartLedger: 2, EndLedger: 10_000_001, Workers: 40, MaxRetries: 3},
+			wantErrSub: "",
+		},
+		{
+			name:       "workers=0 (GOMAXPROCS sentinel) passes",
+			flags:      CLIFlags{StartLedger: 2, EndLedger: 10_000_001, Workers: 0, MaxRetries: 3},
 			wantErrSub: "",
 		},
 		{
@@ -122,8 +130,8 @@ func TestValidateFlags(t *testing.T) {
 			wantErrSub: "end-ledger",
 		},
 		{
-			name:       "workers < 1",
-			flags:      CLIFlags{StartLedger: 2, EndLedger: 100, Workers: 0, MaxRetries: 3},
+			name:       "workers < 0",
+			flags:      CLIFlags{StartLedger: 2, EndLedger: 100, Workers: -1, MaxRetries: 3},
 			wantErrSub: "workers",
 		},
 		{
@@ -159,15 +167,11 @@ func TestValidateFlags(t *testing.T) {
 	}
 }
 
-// Cycle 10 — ValidateAgainstConfigStore enforces CHUNKS_PER_TXHASH_INDEX
-// immutability. Three branches from the design doc:
-//   - absent: first run; write current value and pass.
-//   - matches: subsequent run with same value; pass.
-//   - mismatches: hard-abort with error naming both stored and current values.
-func TestValidateAgainstConfigStore(t *testing.T) {
+// TestValidateAgainstStore — CHUNKS_PER_TXHASH_INDEX immutability.
+// Three branches: absent (first-run seed), match (pass), mismatch (abort).
+func TestValidateAgainstStore(t *testing.T) {
 	const key = "config:chunks_per_txhash_index"
 
-	// Build a validated config with the caller-specified CHUNKS_PER_TXHASH_INDEX.
 	mustValidated := func(t *testing.T, cpi uint32) *Config {
 		t.Helper()
 		cfg, err := ParseConfig(minimalValidTOML())
@@ -183,8 +187,8 @@ func TestValidateAgainstConfigStore(t *testing.T) {
 
 	t.Run("absent key → first-run seed write, pass", func(t *testing.T) {
 		cfg := mustValidated(t, 1000)
-		store := newMockConfigStore()
-		if err := cfg.ValidateAgainstConfigStore(store); err != nil {
+		store := newMockStore()
+		if err := cfg.ValidateAgainstStore(store); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if got := store.data[key]; got != "1000" {
@@ -194,23 +198,22 @@ func TestValidateAgainstConfigStore(t *testing.T) {
 
 	t.Run("stored matches current → pass", func(t *testing.T) {
 		cfg := mustValidated(t, 1000)
-		store := newMockConfigStore()
+		store := newMockStore()
 		store.data[key] = "1000"
-		if err := cfg.ValidateAgainstConfigStore(store); err != nil {
+		if err := cfg.ValidateAgainstStore(store); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
 
 	t.Run("stored differs from current → hard abort", func(t *testing.T) {
-		cfg := mustValidated(t, 500) // operator changed the config
-		store := newMockConfigStore()
+		cfg := mustValidated(t, 500)
+		store := newMockStore()
 		store.data[key] = "1000" // prior run seeded 1000
-		err := cfg.ValidateAgainstConfigStore(store)
+		err := cfg.ValidateAgainstStore(store)
 		if err == nil {
 			t.Fatal("expected mismatch error, got nil")
 		}
-		// Both the stored and the current values must appear in the
-		// error so the operator can tell what changed.
+		// Error must name both stored and current values and the key name.
 		for _, want := range []string{"1000", "500", "CHUNKS_PER_TXHASH_INDEX"} {
 			if !strings.Contains(err.Error(), want) {
 				t.Errorf("error %q missing substring %q", err.Error(), want)
@@ -219,30 +222,11 @@ func TestValidateAgainstConfigStore(t *testing.T) {
 	})
 }
 
-// mockBSBProbe is the test double for BSBAvailabilityProbe. A fixed max
-// ledger value + optional injected error gives full control over the two
-// happy-path branches and the error-propagation branch.
-type mockBSBProbe struct {
-	maxLedger uint32
-	err       error
-}
-
-func (m mockBSBProbe) MaxAvailableLedger() (uint32, error) {
-	return m.maxLedger, m.err
-}
-
-// Cycle 11 — ValidateAgainstBSB enforces the "expanded end ≤ max available
-// ledger in BSB" rule from the design doc's BSB-Availability Validation
-// section. Three cases:
-//   - probe max ≥ effective end → pass;
-//   - probe max < effective end → error naming both values;
-//   - probe returns error        → propagate (caller decides hard vs soft abort).
-//
-// Pre-condition: ApplyFlags has been called so EffectiveEndLedger is
-// populated. Tests construct the state explicitly to avoid depending on the
-// full pipeline ordering.
+// TestValidateAgainstBSB — three cases: probe reports enough, probe
+// reports not enough, probe errors out.
 func TestValidateAgainstBSB(t *testing.T) {
-	t.Run("probe max >= effective end → pass", func(t *testing.T) {
+	setupCfg := func(t *testing.T) *Config {
+		t.Helper()
 		cfg, err := ParseConfig(minimalValidTOML())
 		if err != nil {
 			t.Fatalf("ParseConfig: %v", err)
@@ -251,25 +235,19 @@ func TestValidateAgainstBSB(t *testing.T) {
 			t.Fatalf("Validate: %v", err)
 		}
 		cfg.ApplyFlags(CLIFlags{StartLedger: 2, EndLedger: 10_000_001, Workers: 1})
+		return cfg
+	}
 
-		probe := mockBSBProbe{maxLedger: 20_000_001}
-		if err := cfg.ValidateAgainstBSB(probe); err != nil {
+	t.Run("probe max >= effective end → pass", func(t *testing.T) {
+		cfg := setupCfg(t)
+		if err := cfg.ValidateAgainstBSB(mockBSBProbe{maxLedger: 20_000_001}); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
 
 	t.Run("probe max < effective end → hard abort", func(t *testing.T) {
-		cfg, err := ParseConfig(minimalValidTOML())
-		if err != nil {
-			t.Fatalf("ParseConfig: %v", err)
-		}
-		if err := cfg.Validate(); err != nil {
-			t.Fatalf("Validate: %v", err)
-		}
-		cfg.ApplyFlags(CLIFlags{StartLedger: 2, EndLedger: 10_000_001, Workers: 1})
-
-		probe := mockBSBProbe{maxLedger: 5_000_000}
-		err = cfg.ValidateAgainstBSB(probe)
+		cfg := setupCfg(t)
+		err := cfg.ValidateAgainstBSB(mockBSBProbe{maxLedger: 5_000_000})
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -281,18 +259,9 @@ func TestValidateAgainstBSB(t *testing.T) {
 	})
 
 	t.Run("probe returns error → propagated", func(t *testing.T) {
-		cfg, err := ParseConfig(minimalValidTOML())
-		if err != nil {
-			t.Fatalf("ParseConfig: %v", err)
-		}
-		if err := cfg.Validate(); err != nil {
-			t.Fatalf("Validate: %v", err)
-		}
-		cfg.ApplyFlags(CLIFlags{StartLedger: 2, EndLedger: 10_000_001, Workers: 1})
-
+		cfg := setupCfg(t)
 		sentinel := errors.New("bsb: connection refused")
-		probe := mockBSBProbe{err: sentinel}
-		err = cfg.ValidateAgainstBSB(probe)
+		err := cfg.ValidateAgainstBSB(mockBSBProbe{err: sentinel})
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/config/validate_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/config/validate_test.go
@@ -1,0 +1,303 @@
+package config
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// mockConfigStore is the test double for the ConfigStore interface. Keeping
+// it local to the test file (rather than reusing the package's stub) gives
+// each test full control over the pre-seeded state — exactly what the
+// mismatch / match / absent branch coverage requires.
+type mockConfigStore struct {
+	data map[string]string
+	// getErr, if non-nil, is returned from Get instead of a lookup —
+	// used by the "Get error propagates" branch.
+	getErr error
+	// putErr, if non-nil, is returned from Put — used to verify that
+	// first-run persistence errors propagate.
+	putErr error
+}
+
+func newMockConfigStore() *mockConfigStore {
+	return &mockConfigStore{data: map[string]string{}}
+}
+
+func (m *mockConfigStore) Get(key string) (string, bool, error) {
+	if m.getErr != nil {
+		return "", false, m.getErr
+	}
+	v, ok := m.data[key]
+	return v, ok, nil
+}
+
+func (m *mockConfigStore) Put(key, value string) error {
+	if m.putErr != nil {
+		return m.putErr
+	}
+	m.data[key] = value
+	return nil
+}
+
+// Cycle 5 — Validate rejects malformed configs with operator-legible error
+// messages. Table-driven to keep each failure mode named and isolated;
+// substring match on error text lets us verify the error identifies the
+// specific missing/invalid key without over-specifying exact wording.
+func TestValidate_RejectsBadConfigs(t *testing.T) {
+	cases := []struct {
+		name       string
+		toml       string
+		wantErrSub string
+	}{
+		{
+			name: "missing DEFAULT_DATA_DIR",
+			toml: `
+[BACKFILL.BSB]
+BUCKET_PATH = "bucket"
+`,
+			wantErrSub: "DEFAULT_DATA_DIR",
+		},
+		{
+			name: "missing [BACKFILL.BSB] section",
+			toml: `
+[SERVICE]
+DEFAULT_DATA_DIR = "/data"
+`,
+			wantErrSub: "BACKFILL.BSB",
+		},
+		{
+			name: "[BACKFILL.BSB] present but BUCKET_PATH empty",
+			toml: `
+[SERVICE]
+DEFAULT_DATA_DIR = "/data"
+
+[BACKFILL.BSB]
+BUFFER_SIZE = 500
+`,
+			wantErrSub: "BUCKET_PATH",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := ParseConfig([]byte(tc.toml))
+			if err != nil {
+				t.Fatalf("ParseConfig: %v", err)
+			}
+			err = cfg.Validate()
+			if err == nil {
+				t.Fatalf("Validate succeeded; wanted error containing %q", tc.wantErrSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrSub) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantErrSub)
+			}
+		})
+	}
+}
+
+// Cycle 9 — ValidateFlags rejects out-of-range CLI inputs with an error
+// whose message names the offending flag. Covers four failure modes plus
+// a valid pass-through. Each failure mode maps to a rule from the design
+// doc's "Validation before DAG construction" enumeration.
+func TestValidateFlags(t *testing.T) {
+	cases := []struct {
+		name       string
+		flags      CLIFlags
+		wantErrSub string // empty → expect nil
+	}{
+		{
+			name:       "valid inputs pass",
+			flags:      CLIFlags{StartLedger: 2, EndLedger: 10_000_001, Workers: 40, MaxRetries: 3},
+			wantErrSub: "",
+		},
+		{
+			name:       "start < FirstLedger (2)",
+			flags:      CLIFlags{StartLedger: 1, EndLedger: 100, Workers: 1},
+			wantErrSub: "start-ledger",
+		},
+		{
+			name:       "end <= start",
+			flags:      CLIFlags{StartLedger: 100, EndLedger: 100, Workers: 1},
+			wantErrSub: "end-ledger",
+		},
+		{
+			name:       "workers < 1",
+			flags:      CLIFlags{StartLedger: 2, EndLedger: 100, Workers: 0, MaxRetries: 3},
+			wantErrSub: "workers",
+		},
+		{
+			name:       "max-retries < 0",
+			flags:      CLIFlags{StartLedger: 2, EndLedger: 100, Workers: 1, MaxRetries: -1},
+			wantErrSub: "max-retries",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := ParseConfig(minimalValidTOML())
+			if err != nil {
+				t.Fatalf("ParseConfig: %v", err)
+			}
+			if err := cfg.Validate(); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+			err = cfg.ValidateFlags(tc.flags)
+			if tc.wantErrSub == "" {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ValidateFlags succeeded; wanted error containing %q", tc.wantErrSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrSub) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantErrSub)
+			}
+		})
+	}
+}
+
+// Cycle 10 — ValidateAgainstConfigStore enforces CHUNKS_PER_TXHASH_INDEX
+// immutability. Three branches from the design doc:
+//   - absent: first run; write current value and pass.
+//   - matches: subsequent run with same value; pass.
+//   - mismatches: hard-abort with error naming both stored and current values.
+func TestValidateAgainstConfigStore(t *testing.T) {
+	const key = "config:chunks_per_txhash_index"
+
+	// Build a validated config with the caller-specified CHUNKS_PER_TXHASH_INDEX.
+	mustValidated := func(t *testing.T, cpi uint32) *Config {
+		t.Helper()
+		cfg, err := ParseConfig(minimalValidTOML())
+		if err != nil {
+			t.Fatalf("ParseConfig: %v", err)
+		}
+		cfg.Backfill.ChunksPerTxHashIndex = cpi
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("Validate: %v", err)
+		}
+		return cfg
+	}
+
+	t.Run("absent key → first-run seed write, pass", func(t *testing.T) {
+		cfg := mustValidated(t, 1000)
+		store := newMockConfigStore()
+		if err := cfg.ValidateAgainstConfigStore(store); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := store.data[key]; got != "1000" {
+			t.Errorf("seed key not persisted: store[%s] = %q", key, got)
+		}
+	})
+
+	t.Run("stored matches current → pass", func(t *testing.T) {
+		cfg := mustValidated(t, 1000)
+		store := newMockConfigStore()
+		store.data[key] = "1000"
+		if err := cfg.ValidateAgainstConfigStore(store); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("stored differs from current → hard abort", func(t *testing.T) {
+		cfg := mustValidated(t, 500) // operator changed the config
+		store := newMockConfigStore()
+		store.data[key] = "1000" // prior run seeded 1000
+		err := cfg.ValidateAgainstConfigStore(store)
+		if err == nil {
+			t.Fatal("expected mismatch error, got nil")
+		}
+		// Both the stored and the current values must appear in the
+		// error so the operator can tell what changed.
+		for _, want := range []string{"1000", "500", "CHUNKS_PER_TXHASH_INDEX"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q missing substring %q", err.Error(), want)
+			}
+		}
+	})
+}
+
+// mockBSBProbe is the test double for BSBAvailabilityProbe. A fixed max
+// ledger value + optional injected error gives full control over the two
+// happy-path branches and the error-propagation branch.
+type mockBSBProbe struct {
+	maxLedger uint32
+	err       error
+}
+
+func (m mockBSBProbe) MaxAvailableLedger() (uint32, error) {
+	return m.maxLedger, m.err
+}
+
+// Cycle 11 — ValidateAgainstBSB enforces the "expanded end ≤ max available
+// ledger in BSB" rule from the design doc's BSB-Availability Validation
+// section. Three cases:
+//   - probe max ≥ effective end → pass;
+//   - probe max < effective end → error naming both values;
+//   - probe returns error        → propagate (caller decides hard vs soft abort).
+//
+// Pre-condition: ApplyFlags has been called so EffectiveEndLedger is
+// populated. Tests construct the state explicitly to avoid depending on the
+// full pipeline ordering.
+func TestValidateAgainstBSB(t *testing.T) {
+	t.Run("probe max >= effective end → pass", func(t *testing.T) {
+		cfg, err := ParseConfig(minimalValidTOML())
+		if err != nil {
+			t.Fatalf("ParseConfig: %v", err)
+		}
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("Validate: %v", err)
+		}
+		cfg.ApplyFlags(CLIFlags{StartLedger: 2, EndLedger: 10_000_001, Workers: 1})
+
+		probe := mockBSBProbe{maxLedger: 20_000_001}
+		if err := cfg.ValidateAgainstBSB(probe); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("probe max < effective end → hard abort", func(t *testing.T) {
+		cfg, err := ParseConfig(minimalValidTOML())
+		if err != nil {
+			t.Fatalf("ParseConfig: %v", err)
+		}
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("Validate: %v", err)
+		}
+		cfg.ApplyFlags(CLIFlags{StartLedger: 2, EndLedger: 10_000_001, Workers: 1})
+
+		probe := mockBSBProbe{maxLedger: 5_000_000}
+		err = cfg.ValidateAgainstBSB(probe)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		for _, want := range []string{"10000001", "5000000"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q missing substring %q", err.Error(), want)
+			}
+		}
+	})
+
+	t.Run("probe returns error → propagated", func(t *testing.T) {
+		cfg, err := ParseConfig(minimalValidTOML())
+		if err != nil {
+			t.Fatalf("ParseConfig: %v", err)
+		}
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("Validate: %v", err)
+		}
+		cfg.ApplyFlags(CLIFlags{StartLedger: 2, EndLedger: 10_000_001, Workers: 1})
+
+		sentinel := errors.New("bsb: connection refused")
+		probe := mockBSBProbe{err: sentinel}
+		err = cfg.ValidateAgainstBSB(probe)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !errors.Is(err, sentinel) {
+			t.Errorf("error %v does not wrap sentinel %v", err, sentinel)
+		}
+	})
+}

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/geometry/geometry.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/geometry/geometry.go
@@ -1,263 +1,110 @@
-// Package geometry provides range and chunk boundary math for Stellar ledger storage.
+// Package geometry holds the chunk and txhash-index boundary math used by
+// the backfill pipeline.
 //
-// These constants and functions define the mapping between ledger sequences,
-// 10M-ledger ranges, and 10K-ledger chunks. They are used by both the backfill
-// pipeline and streaming code.
+// Two concepts:
 //
-// Hierarchy:
+//   - Chunk  — 10_000 ledgers. The atomic unit of ingestion + crash recovery.
+//   - Index  — ChunksPerTxHashIndex chunks (default 1000, = 10M ledgers).
+//     Cadence at which one RecSplit txhash index gets built.
 //
-//	Range (10M ledgers) → 1000 Chunks (10K ledgers each)
-//
-// The Stellar blockchain starts at ledger 2 (FirstLedger), so all formulas
-// offset by 2 to keep boundaries aligned.
-//
-// Example ranges:
-//
-//	Range 0: ledgers [2, 10_000_001]          → chunks [0, 999]
-//	Range 1: ledgers [10_000_002, 20_000_001] → chunks [1000, 1999]
-//	Range 2: ledgers [20_000_002, 30_000_001] → chunks [2000, 2999]
-//
-// Ported verbatim from reference commit 19a9179 (full-history/pkg/geometry/)
-// by slice #684 — the first consumer (chunk-boundary expansion in validation).
+// Ledger sequences start at FirstLedger (2), so every boundary formula
+// offsets by that anchor.
 package geometry
 
-// =============================================================================
-// Range Boundary Constants
-// =============================================================================
+// FirstLedger is the first ledger of the Stellar network.
+const FirstLedger uint32 = 2
 
-const (
-	// FirstLedger is the first ledger in the Stellar blockchain.
-	// All range and chunk boundary math offsets from this value.
-	FirstLedger uint32 = 2
+// ChunkSize is the fixed width of a chunk, in ledgers. Not operator-
+// configurable — the directory tree and packfile format both assume it.
+const ChunkSize uint32 = 10_000
 
-	// ChunkSize is the number of ledgers in each chunk (10,000).
-	// This is the fundamental unit of data — one LFS file per chunk.
-	ChunkSize uint32 = 10_000
-
-	// RangeSize is the number of ledgers in each range (10 million).
-	// Each range contains exactly ChunksPerRange chunks.
-	RangeSize uint32 = 10_000_000
-
-	// ChunksPerRange is the number of chunks in each range.
-	// Derived from RangeSize / ChunkSize (10K), but declared as a constant
-	// to avoid depending on lfs.ChunkSize here.
-	ChunksPerRange uint32 = 1000
-)
-
-// =============================================================================
-// Free Functions (use global constants)
-// =============================================================================
-
-// LedgerToRangeID returns the range ID for a given ledger sequence.
-//
-// Example: LedgerToRangeID(2) = 0, LedgerToRangeID(10_000_002) = 1
-func LedgerToRangeID(ledgerSeq uint32) uint32 {
-	return (ledgerSeq - FirstLedger) / RangeSize
-}
-
-// RangeFirstLedger returns the first ledger sequence (inclusive) in a range.
-//
-// Example: RangeFirstLedger(0) = 2, RangeFirstLedger(1) = 10_000_002
-func RangeFirstLedger(rangeID uint32) uint32 {
-	return (rangeID * RangeSize) + FirstLedger
-}
-
-// RangeLastLedger returns the last ledger sequence (inclusive) in a range.
-//
-// Example: RangeLastLedger(0) = 10_000_001, RangeLastLedger(1) = 20_000_001
-func RangeLastLedger(rangeID uint32) uint32 {
-	return ((rangeID + 1) * RangeSize) + FirstLedger - 1
-}
-
-// RangeFirstChunk returns the first chunk ID in a range.
-//
-// Example: RangeFirstChunk(0) = 0, RangeFirstChunk(1) = 1000
-func RangeFirstChunk(rangeID uint32) uint32 {
-	return rangeID * ChunksPerRange
-}
-
-// RangeLastChunk returns the last chunk ID (inclusive) in a range.
-//
-// Example: RangeLastChunk(0) = 999, RangeLastChunk(1) = 1999
-func RangeLastChunk(rangeID uint32) uint32 {
-	return (rangeID * ChunksPerRange) + ChunksPerRange - 1
-}
-
-// ChunkToRangeID returns the range ID that contains a given chunk.
-//
-// Example: ChunkToRangeID(0) = 0, ChunkToRangeID(999) = 0, ChunkToRangeID(1000) = 1
-func ChunkToRangeID(chunkID uint32) uint32 {
-	return chunkID / ChunksPerRange
-}
-
-// =============================================================================
-// Geometry — Parameterized Range/Chunk Math
-// =============================================================================
-//
-// Geometry encapsulates the range and chunk sizing constants so that production
-// code uses the full 10M-range / 10K-chunk layout while tests can substitute
-// a smaller geometry (e.g., 100-ledger ranges, 10-ledger chunks) for speed.
-//
-// All methods mirror the package-level free functions (LedgerToRangeID, etc.)
-// but compute boundaries from the Geometry values instead of the global constants.
-//
-// Production code should pass DefaultGeometry() through the config chain.
-// Tests should pass TestGeometry() for fast iteration.
-
-// Geometry holds the chunk/range sizing parameters.
+// Geometry bundles the two sizing knobs that define a backfill layout.
+// ChunksPerTxHashIndex is operator-configurable; ChunkSize stays fixed
+// in production but tests substitute a smaller value for speed.
 type Geometry struct {
-	// RangeSize is the number of ledgers in each range.
-	// Production: 10,000,000. Test: 100.
-	RangeSize uint32
-
-	// ChunkSize is the number of ledgers in each chunk.
-	// Production: 10,000. Test: 10.
-	ChunkSize uint32
-
-	// ChunksPerTxHashIndex is the number of chunks in each txhash index group.
-	// Controls the cadence of RecSplit index builds.
-	// Production: 1,000 (10M ledgers per index). Test: 5 (50 ledgers per index).
+	ChunkSize            uint32
 	ChunksPerTxHashIndex uint32
 }
 
-// DefaultGeometry returns the production geometry:
-// 10M-ledger ranges, 10K-ledger chunks, 1000 chunks per index.
+// DefaultGeometry is the production layout: 10_000-ledger chunks,
+// 1_000 chunks per index (10M ledgers per index).
 func DefaultGeometry() Geometry {
-	return Geometry{
-		RangeSize:            RangeSize,
-		ChunkSize:            10_000,
-		ChunksPerTxHashIndex: 1000,
-	}
+	return Geometry{ChunkSize: ChunkSize, ChunksPerTxHashIndex: 1000}
 }
 
-// TestGeometry returns a small geometry suitable for fast unit tests:
-// 100-ledger ranges, 10-ledger chunks, 5 chunks per index (50 ledgers per index).
+// TestGeometry is a downscaled layout for unit tests: 10-ledger chunks,
+// 5 chunks per index (50 ledgers per index).
 func TestGeometry() Geometry {
-	return Geometry{
-		RangeSize:            100,
-		ChunkSize:            10,
-		ChunksPerTxHashIndex: 5,
-	}
+	return Geometry{ChunkSize: 10, ChunksPerTxHashIndex: 5}
 }
 
-// --- Range-level methods ---
-
-// LedgerToRangeID returns the range ID for a given ledger sequence.
-func (g Geometry) LedgerToRangeID(ledgerSeq uint32) uint32 {
-	return (ledgerSeq - FirstLedger) / g.RangeSize
-}
-
-// LedgerToIndexID is an alias for LedgerToRangeID. Use in backfill code
-// where the concept is called "index" rather than "range".
-func (g Geometry) LedgerToIndexID(ledgerSeq uint32) uint32 {
-	return g.LedgerToRangeID(ledgerSeq)
-}
-
-// RangeFirstLedger returns the first ledger sequence (inclusive) in a range.
-func (g Geometry) RangeFirstLedger(rangeID uint32) uint32 {
-	return (rangeID * g.RangeSize) + FirstLedger
-}
-
-// RangeLastLedger returns the last ledger sequence (inclusive) in a range.
-func (g Geometry) RangeLastLedger(rangeID uint32) uint32 {
-	return ((rangeID + 1) * g.RangeSize) + FirstLedger - 1
-}
-
-// RangeFirstChunk returns the first chunk ID in a range.
-func (g Geometry) RangeFirstChunk(rangeID uint32) uint32 {
-	return rangeID * g.ChunksPerTxHashIndex
-}
-
-// RangeLastChunk returns the last chunk ID (inclusive) in a range.
-func (g Geometry) RangeLastChunk(rangeID uint32) uint32 {
-	return (rangeID * g.ChunksPerTxHashIndex) + g.ChunksPerTxHashIndex - 1
-}
-
-// --- Chunk-level methods ---
-
-// ChunkToRangeID returns the range ID that contains a given chunk.
-func (g Geometry) ChunkToRangeID(chunkID uint32) uint32 {
-	return chunkID / g.ChunksPerTxHashIndex
-}
-
-// ChunkFirstLedger returns the first ledger sequence in a chunk.
-func (g Geometry) ChunkFirstLedger(chunkID uint32) uint32 {
-	return (chunkID * g.ChunkSize) + FirstLedger
-}
-
-// ChunkLastLedger returns the last ledger sequence in a chunk.
-func (g Geometry) ChunkLastLedger(chunkID uint32) uint32 {
-	return ((chunkID + 1) * g.ChunkSize) + FirstLedger - 1
-}
-
-// --- Index-level methods ---
-
-// LedgersPerIndex returns the number of ledgers in one txhash index group.
-// Formula: ChunkSize * ChunksPerTxHashIndex.
-// Production (ChunkSize=10000, ChunksPerTxHashIndex=1000): 10,000,000
-// Test (ChunkSize=10, ChunksPerTxHashIndex=5): 50
+// LedgersPerIndex = ChunkSize * ChunksPerTxHashIndex.
 func (g Geometry) LedgersPerIndex() uint32 {
 	return g.ChunkSize * g.ChunksPerTxHashIndex
 }
 
-// IndexID returns the index ID for a given chunk ID.
-// Formula: chunkID / ChunksPerTxHashIndex.
-// Production: IndexID(1500) = 1 (chunk 1500 is in index 1, which covers chunks 1000-1999)
-// Test (ChunksPerTxHashIndex=5): IndexID(7) = 1 (chunk 7 is in index 1, which covers chunks 5-9)
+// --- Chunk-level ---
+
+// LedgerToChunkID returns the chunk ID a ledger falls into.
+func (g Geometry) LedgerToChunkID(ledgerSeq uint32) uint32 {
+	return (ledgerSeq - FirstLedger) / g.ChunkSize
+}
+
+// ChunkFirstLedger returns the first ledger (inclusive) in a chunk.
+func (g Geometry) ChunkFirstLedger(chunkID uint32) uint32 {
+	return (chunkID * g.ChunkSize) + FirstLedger
+}
+
+// ChunkLastLedger returns the last ledger (inclusive) in a chunk.
+func (g Geometry) ChunkLastLedger(chunkID uint32) uint32 {
+	return ((chunkID + 1) * g.ChunkSize) + FirstLedger - 1
+}
+
+// --- Index-level ---
+
+// LedgerToIndexID returns the index ID a ledger falls into.
+func (g Geometry) LedgerToIndexID(ledgerSeq uint32) uint32 {
+	return (ledgerSeq - FirstLedger) / g.LedgersPerIndex()
+}
+
+// IndexID returns the index ID that contains a given chunk.
 func (g Geometry) IndexID(chunkID uint32) uint32 {
 	return chunkID / g.ChunksPerTxHashIndex
 }
 
-// IndexFirstChunk returns the first chunk ID in an index group.
-// Formula: indexID * ChunksPerTxHashIndex.
-// Production: IndexFirstChunk(1) = 1000
-// Test (ChunksPerTxHashIndex=5): IndexFirstChunk(1) = 5
+// IndexFirstChunk returns the first chunk ID in an index.
 func (g Geometry) IndexFirstChunk(indexID uint32) uint32 {
 	return indexID * g.ChunksPerTxHashIndex
 }
 
-// IndexLastChunk returns the last chunk ID (inclusive) in an index group.
-// Formula: (indexID+1)*ChunksPerTxHashIndex - 1.
-// Production: IndexLastChunk(1) = 1999
-// Test (ChunksPerTxHashIndex=5): IndexLastChunk(1) = 9
+// IndexLastChunk returns the last chunk ID (inclusive) in an index.
 func (g Geometry) IndexLastChunk(indexID uint32) uint32 {
 	return (indexID+1)*g.ChunksPerTxHashIndex - 1
 }
 
-// IsLastChunkInIndex reports whether chunkID is the last chunk in its index group.
-// True when (chunkID+1) % ChunksPerTxHashIndex == 0.
-// Completing this chunk should trigger build_txhash_index.
-// Production: IsLastChunkInIndex(999) = true, IsLastChunkInIndex(1000) = false
-// Test (ChunksPerTxHashIndex=5): IsLastChunkInIndex(4) = true, IsLastChunkInIndex(9) = true
-func (g Geometry) IsLastChunkInIndex(chunkID uint32) bool {
-	return (chunkID+1)%g.ChunksPerTxHashIndex == 0
-}
-
-// IndexFirstLedger returns the first ledger sequence in an index group.
-// Formula: IndexFirstChunk(indexID) * ChunkSize + FirstLedger.
-// Production: IndexFirstLedger(1) = 10,000,002
-// Test (ChunkSize=10, ChunksPerTxHashIndex=5): IndexFirstLedger(1) = 52
+// IndexFirstLedger returns the first ledger (inclusive) in an index.
 func (g Geometry) IndexFirstLedger(indexID uint32) uint32 {
 	return g.IndexFirstChunk(indexID)*g.ChunkSize + FirstLedger
 }
 
-// IndexLastLedger returns the last ledger sequence (inclusive) in an index group.
-// Formula: (IndexLastChunk(indexID)+1)*ChunkSize + FirstLedger - 1.
-// Production: IndexLastLedger(1) = 20,000,001
-// Test (ChunkSize=10, ChunksPerTxHashIndex=5): IndexLastLedger(1) = 101
+// IndexLastLedger returns the last ledger (inclusive) in an index.
 func (g Geometry) IndexLastLedger(indexID uint32) uint32 {
 	return (g.IndexLastChunk(indexID)+1)*g.ChunkSize + FirstLedger - 1
 }
 
-// ChunksForIndex returns all chunk IDs in an index group, in ascending order.
-// Used by the DAG builder to enumerate process_chunk dependencies.
-// Production: ChunksForIndex(1) = [1000, 1001, ..., 1999] (len=1000)
-// Test (ChunksPerTxHashIndex=5): ChunksForIndex(1) = [5, 6, 7, 8, 9]
+// IsLastChunkInIndex reports whether completing chunkID should trigger the
+// build_txhash_index task for its index group.
+func (g Geometry) IsLastChunkInIndex(chunkID uint32) bool {
+	return (chunkID+1)%g.ChunksPerTxHashIndex == 0
+}
+
+// ChunksForIndex returns every chunk ID in an index group, ascending.
+// Used by the DAG builder (slice #687) to enumerate process_chunk deps.
 func (g Geometry) ChunksForIndex(indexID uint32) []uint32 {
 	first := g.IndexFirstChunk(indexID)
-	chunks := make([]uint32, g.ChunksPerTxHashIndex)
-	for i := uint32(0); i < g.ChunksPerTxHashIndex; i++ {
-		chunks[i] = first + i
+	out := make([]uint32, g.ChunksPerTxHashIndex)
+	for i := range g.ChunksPerTxHashIndex {
+		out[i] = first + i
 	}
-	return chunks
+	return out
 }

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/geometry/geometry.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/geometry/geometry.go
@@ -1,0 +1,263 @@
+// Package geometry provides range and chunk boundary math for Stellar ledger storage.
+//
+// These constants and functions define the mapping between ledger sequences,
+// 10M-ledger ranges, and 10K-ledger chunks. They are used by both the backfill
+// pipeline and streaming code.
+//
+// Hierarchy:
+//
+//	Range (10M ledgers) → 1000 Chunks (10K ledgers each)
+//
+// The Stellar blockchain starts at ledger 2 (FirstLedger), so all formulas
+// offset by 2 to keep boundaries aligned.
+//
+// Example ranges:
+//
+//	Range 0: ledgers [2, 10_000_001]          → chunks [0, 999]
+//	Range 1: ledgers [10_000_002, 20_000_001] → chunks [1000, 1999]
+//	Range 2: ledgers [20_000_002, 30_000_001] → chunks [2000, 2999]
+//
+// Ported verbatim from reference commit 19a9179 (full-history/pkg/geometry/)
+// by slice #684 — the first consumer (chunk-boundary expansion in validation).
+package geometry
+
+// =============================================================================
+// Range Boundary Constants
+// =============================================================================
+
+const (
+	// FirstLedger is the first ledger in the Stellar blockchain.
+	// All range and chunk boundary math offsets from this value.
+	FirstLedger uint32 = 2
+
+	// ChunkSize is the number of ledgers in each chunk (10,000).
+	// This is the fundamental unit of data — one LFS file per chunk.
+	ChunkSize uint32 = 10_000
+
+	// RangeSize is the number of ledgers in each range (10 million).
+	// Each range contains exactly ChunksPerRange chunks.
+	RangeSize uint32 = 10_000_000
+
+	// ChunksPerRange is the number of chunks in each range.
+	// Derived from RangeSize / ChunkSize (10K), but declared as a constant
+	// to avoid depending on lfs.ChunkSize here.
+	ChunksPerRange uint32 = 1000
+)
+
+// =============================================================================
+// Free Functions (use global constants)
+// =============================================================================
+
+// LedgerToRangeID returns the range ID for a given ledger sequence.
+//
+// Example: LedgerToRangeID(2) = 0, LedgerToRangeID(10_000_002) = 1
+func LedgerToRangeID(ledgerSeq uint32) uint32 {
+	return (ledgerSeq - FirstLedger) / RangeSize
+}
+
+// RangeFirstLedger returns the first ledger sequence (inclusive) in a range.
+//
+// Example: RangeFirstLedger(0) = 2, RangeFirstLedger(1) = 10_000_002
+func RangeFirstLedger(rangeID uint32) uint32 {
+	return (rangeID * RangeSize) + FirstLedger
+}
+
+// RangeLastLedger returns the last ledger sequence (inclusive) in a range.
+//
+// Example: RangeLastLedger(0) = 10_000_001, RangeLastLedger(1) = 20_000_001
+func RangeLastLedger(rangeID uint32) uint32 {
+	return ((rangeID + 1) * RangeSize) + FirstLedger - 1
+}
+
+// RangeFirstChunk returns the first chunk ID in a range.
+//
+// Example: RangeFirstChunk(0) = 0, RangeFirstChunk(1) = 1000
+func RangeFirstChunk(rangeID uint32) uint32 {
+	return rangeID * ChunksPerRange
+}
+
+// RangeLastChunk returns the last chunk ID (inclusive) in a range.
+//
+// Example: RangeLastChunk(0) = 999, RangeLastChunk(1) = 1999
+func RangeLastChunk(rangeID uint32) uint32 {
+	return (rangeID * ChunksPerRange) + ChunksPerRange - 1
+}
+
+// ChunkToRangeID returns the range ID that contains a given chunk.
+//
+// Example: ChunkToRangeID(0) = 0, ChunkToRangeID(999) = 0, ChunkToRangeID(1000) = 1
+func ChunkToRangeID(chunkID uint32) uint32 {
+	return chunkID / ChunksPerRange
+}
+
+// =============================================================================
+// Geometry — Parameterized Range/Chunk Math
+// =============================================================================
+//
+// Geometry encapsulates the range and chunk sizing constants so that production
+// code uses the full 10M-range / 10K-chunk layout while tests can substitute
+// a smaller geometry (e.g., 100-ledger ranges, 10-ledger chunks) for speed.
+//
+// All methods mirror the package-level free functions (LedgerToRangeID, etc.)
+// but compute boundaries from the Geometry values instead of the global constants.
+//
+// Production code should pass DefaultGeometry() through the config chain.
+// Tests should pass TestGeometry() for fast iteration.
+
+// Geometry holds the chunk/range sizing parameters.
+type Geometry struct {
+	// RangeSize is the number of ledgers in each range.
+	// Production: 10,000,000. Test: 100.
+	RangeSize uint32
+
+	// ChunkSize is the number of ledgers in each chunk.
+	// Production: 10,000. Test: 10.
+	ChunkSize uint32
+
+	// ChunksPerTxHashIndex is the number of chunks in each txhash index group.
+	// Controls the cadence of RecSplit index builds.
+	// Production: 1,000 (10M ledgers per index). Test: 5 (50 ledgers per index).
+	ChunksPerTxHashIndex uint32
+}
+
+// DefaultGeometry returns the production geometry:
+// 10M-ledger ranges, 10K-ledger chunks, 1000 chunks per index.
+func DefaultGeometry() Geometry {
+	return Geometry{
+		RangeSize:            RangeSize,
+		ChunkSize:            10_000,
+		ChunksPerTxHashIndex: 1000,
+	}
+}
+
+// TestGeometry returns a small geometry suitable for fast unit tests:
+// 100-ledger ranges, 10-ledger chunks, 5 chunks per index (50 ledgers per index).
+func TestGeometry() Geometry {
+	return Geometry{
+		RangeSize:            100,
+		ChunkSize:            10,
+		ChunksPerTxHashIndex: 5,
+	}
+}
+
+// --- Range-level methods ---
+
+// LedgerToRangeID returns the range ID for a given ledger sequence.
+func (g Geometry) LedgerToRangeID(ledgerSeq uint32) uint32 {
+	return (ledgerSeq - FirstLedger) / g.RangeSize
+}
+
+// LedgerToIndexID is an alias for LedgerToRangeID. Use in backfill code
+// where the concept is called "index" rather than "range".
+func (g Geometry) LedgerToIndexID(ledgerSeq uint32) uint32 {
+	return g.LedgerToRangeID(ledgerSeq)
+}
+
+// RangeFirstLedger returns the first ledger sequence (inclusive) in a range.
+func (g Geometry) RangeFirstLedger(rangeID uint32) uint32 {
+	return (rangeID * g.RangeSize) + FirstLedger
+}
+
+// RangeLastLedger returns the last ledger sequence (inclusive) in a range.
+func (g Geometry) RangeLastLedger(rangeID uint32) uint32 {
+	return ((rangeID + 1) * g.RangeSize) + FirstLedger - 1
+}
+
+// RangeFirstChunk returns the first chunk ID in a range.
+func (g Geometry) RangeFirstChunk(rangeID uint32) uint32 {
+	return rangeID * g.ChunksPerTxHashIndex
+}
+
+// RangeLastChunk returns the last chunk ID (inclusive) in a range.
+func (g Geometry) RangeLastChunk(rangeID uint32) uint32 {
+	return (rangeID * g.ChunksPerTxHashIndex) + g.ChunksPerTxHashIndex - 1
+}
+
+// --- Chunk-level methods ---
+
+// ChunkToRangeID returns the range ID that contains a given chunk.
+func (g Geometry) ChunkToRangeID(chunkID uint32) uint32 {
+	return chunkID / g.ChunksPerTxHashIndex
+}
+
+// ChunkFirstLedger returns the first ledger sequence in a chunk.
+func (g Geometry) ChunkFirstLedger(chunkID uint32) uint32 {
+	return (chunkID * g.ChunkSize) + FirstLedger
+}
+
+// ChunkLastLedger returns the last ledger sequence in a chunk.
+func (g Geometry) ChunkLastLedger(chunkID uint32) uint32 {
+	return ((chunkID + 1) * g.ChunkSize) + FirstLedger - 1
+}
+
+// --- Index-level methods ---
+
+// LedgersPerIndex returns the number of ledgers in one txhash index group.
+// Formula: ChunkSize * ChunksPerTxHashIndex.
+// Production (ChunkSize=10000, ChunksPerTxHashIndex=1000): 10,000,000
+// Test (ChunkSize=10, ChunksPerTxHashIndex=5): 50
+func (g Geometry) LedgersPerIndex() uint32 {
+	return g.ChunkSize * g.ChunksPerTxHashIndex
+}
+
+// IndexID returns the index ID for a given chunk ID.
+// Formula: chunkID / ChunksPerTxHashIndex.
+// Production: IndexID(1500) = 1 (chunk 1500 is in index 1, which covers chunks 1000-1999)
+// Test (ChunksPerTxHashIndex=5): IndexID(7) = 1 (chunk 7 is in index 1, which covers chunks 5-9)
+func (g Geometry) IndexID(chunkID uint32) uint32 {
+	return chunkID / g.ChunksPerTxHashIndex
+}
+
+// IndexFirstChunk returns the first chunk ID in an index group.
+// Formula: indexID * ChunksPerTxHashIndex.
+// Production: IndexFirstChunk(1) = 1000
+// Test (ChunksPerTxHashIndex=5): IndexFirstChunk(1) = 5
+func (g Geometry) IndexFirstChunk(indexID uint32) uint32 {
+	return indexID * g.ChunksPerTxHashIndex
+}
+
+// IndexLastChunk returns the last chunk ID (inclusive) in an index group.
+// Formula: (indexID+1)*ChunksPerTxHashIndex - 1.
+// Production: IndexLastChunk(1) = 1999
+// Test (ChunksPerTxHashIndex=5): IndexLastChunk(1) = 9
+func (g Geometry) IndexLastChunk(indexID uint32) uint32 {
+	return (indexID+1)*g.ChunksPerTxHashIndex - 1
+}
+
+// IsLastChunkInIndex reports whether chunkID is the last chunk in its index group.
+// True when (chunkID+1) % ChunksPerTxHashIndex == 0.
+// Completing this chunk should trigger build_txhash_index.
+// Production: IsLastChunkInIndex(999) = true, IsLastChunkInIndex(1000) = false
+// Test (ChunksPerTxHashIndex=5): IsLastChunkInIndex(4) = true, IsLastChunkInIndex(9) = true
+func (g Geometry) IsLastChunkInIndex(chunkID uint32) bool {
+	return (chunkID+1)%g.ChunksPerTxHashIndex == 0
+}
+
+// IndexFirstLedger returns the first ledger sequence in an index group.
+// Formula: IndexFirstChunk(indexID) * ChunkSize + FirstLedger.
+// Production: IndexFirstLedger(1) = 10,000,002
+// Test (ChunkSize=10, ChunksPerTxHashIndex=5): IndexFirstLedger(1) = 52
+func (g Geometry) IndexFirstLedger(indexID uint32) uint32 {
+	return g.IndexFirstChunk(indexID)*g.ChunkSize + FirstLedger
+}
+
+// IndexLastLedger returns the last ledger sequence (inclusive) in an index group.
+// Formula: (IndexLastChunk(indexID)+1)*ChunkSize + FirstLedger - 1.
+// Production: IndexLastLedger(1) = 20,000,001
+// Test (ChunkSize=10, ChunksPerTxHashIndex=5): IndexLastLedger(1) = 101
+func (g Geometry) IndexLastLedger(indexID uint32) uint32 {
+	return (g.IndexLastChunk(indexID)+1)*g.ChunkSize + FirstLedger - 1
+}
+
+// ChunksForIndex returns all chunk IDs in an index group, in ascending order.
+// Used by the DAG builder to enumerate process_chunk dependencies.
+// Production: ChunksForIndex(1) = [1000, 1001, ..., 1999] (len=1000)
+// Test (ChunksPerTxHashIndex=5): ChunksForIndex(1) = [5, 6, 7, 8, 9]
+func (g Geometry) ChunksForIndex(indexID uint32) []uint32 {
+	first := g.IndexFirstChunk(indexID)
+	chunks := make([]uint32, g.ChunksPerTxHashIndex)
+	for i := uint32(0); i < g.ChunksPerTxHashIndex; i++ {
+		chunks[i] = first + i
+	}
+	return chunks
+}

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/geometry/geometry_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/geometry/geometry_test.go
@@ -1,281 +1,109 @@
 package geometry
 
-import "testing"
+import (
+	"testing"
 
-func TestLedgerToRangeID(t *testing.T) {
-	tests := []struct {
-		name      string
-		ledgerSeq uint32
-		want      uint32
-	}{
-		{"first ledger", 2, 0},
-		{"last ledger in range 0", 10_000_001, 0},
-		{"first ledger in range 1", 10_000_002, 1},
-		{"last ledger in range 1", 20_000_001, 1},
-		{"first ledger in range 2", 20_000_002, 2},
-		{"mid-range 0", 5_000_000, 0},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := LedgerToRangeID(tt.ledgerSeq)
-			if got != tt.want {
-				t.Errorf("LedgerToRangeID(%d) = %d, want %d", tt.ledgerSeq, got, tt.want)
-			}
-		})
-	}
-}
+	"github.com/stretchr/testify/require"
+)
 
-func TestRangeFirstLedger(t *testing.T) {
-	tests := []struct {
-		rangeID uint32
-		want    uint32
-	}{
-		{0, 2},
-		{1, 10_000_002},
-		{2, 20_000_002},
-		{3, 30_000_002},
-	}
-	for _, tt := range tests {
-		got := RangeFirstLedger(tt.rangeID)
-		if got != tt.want {
-			t.Errorf("RangeFirstLedger(%d) = %d, want %d", tt.rangeID, got, tt.want)
-		}
-	}
-}
-
-func TestRangeLastLedger(t *testing.T) {
-	tests := []struct {
-		rangeID uint32
-		want    uint32
-	}{
-		{0, 10_000_001},
-		{1, 20_000_001},
-		{2, 30_000_001},
-	}
-	for _, tt := range tests {
-		got := RangeLastLedger(tt.rangeID)
-		if got != tt.want {
-			t.Errorf("RangeLastLedger(%d) = %d, want %d", tt.rangeID, got, tt.want)
-		}
-	}
-}
-
-func TestRangeFirstChunk(t *testing.T) {
-	tests := []struct {
-		rangeID uint32
-		want    uint32
-	}{
-		{0, 0},
-		{1, 1000},
-		{2, 2000},
-	}
-	for _, tt := range tests {
-		got := RangeFirstChunk(tt.rangeID)
-		if got != tt.want {
-			t.Errorf("RangeFirstChunk(%d) = %d, want %d", tt.rangeID, got, tt.want)
-		}
-	}
-}
-
-func TestRangeLastChunk(t *testing.T) {
-	tests := []struct {
-		rangeID uint32
-		want    uint32
-	}{
-		{0, 999},
-		{1, 1999},
-		{2, 2999},
-	}
-	for _, tt := range tests {
-		got := RangeLastChunk(tt.rangeID)
-		if got != tt.want {
-			t.Errorf("RangeLastChunk(%d) = %d, want %d", tt.rangeID, got, tt.want)
-		}
-	}
-}
-
-func TestChunkToRangeID(t *testing.T) {
-	tests := []struct {
-		chunkID uint32
-		want    uint32
-	}{
-		{0, 0},
-		{999, 0},
-		{1000, 1},
-		{1999, 1},
-		{2000, 2},
-	}
-	for _, tt := range tests {
-		got := ChunkToRangeID(tt.chunkID)
-		if got != tt.want {
-			t.Errorf("ChunkToRangeID(%d) = %d, want %d", tt.chunkID, got, tt.want)
-		}
-	}
-}
-
-// TestRangeRoundTrips verifies that range boundary formulas are consistent.
-func TestRangeRoundTrips(t *testing.T) {
-	for rangeID := uint32(0); rangeID < 5; rangeID++ {
-		first := RangeFirstLedger(rangeID)
-		last := RangeLastLedger(rangeID)
-
-		// First ledger maps back to the same range
-		if got := LedgerToRangeID(first); got != rangeID {
-			t.Errorf("range %d: LedgerToRangeID(first=%d) = %d", rangeID, first, got)
-		}
-		// Last ledger maps back to the same range
-		if got := LedgerToRangeID(last); got != rangeID {
-			t.Errorf("range %d: LedgerToRangeID(last=%d) = %d", rangeID, last, got)
-		}
-		// Range spans exactly RangeSize ledgers
-		if last-first+1 != RangeSize {
-			t.Errorf("range %d: span = %d, want %d", rangeID, last-first+1, RangeSize)
-		}
-		// Chunk round-trip
-		firstChunk := RangeFirstChunk(rangeID)
-		lastChunk := RangeLastChunk(rangeID)
-		if ChunkToRangeID(firstChunk) != rangeID {
-			t.Errorf("range %d: ChunkToRangeID(firstChunk=%d) mismatch", rangeID, firstChunk)
-		}
-		if ChunkToRangeID(lastChunk) != rangeID {
-			t.Errorf("range %d: ChunkToRangeID(lastChunk=%d) mismatch", rangeID, lastChunk)
-		}
-		if lastChunk-firstChunk+1 != ChunksPerRange {
-			t.Errorf("range %d: chunk count = %d, want %d", rangeID, lastChunk-firstChunk+1, ChunksPerRange)
-		}
-	}
-}
-
-// TestRangeContiguity verifies there are no gaps between ranges.
-func TestRangeContiguity(t *testing.T) {
-	for rangeID := uint32(0); rangeID < 5; rangeID++ {
-		lastOfCurrent := RangeLastLedger(rangeID)
-		firstOfNext := RangeFirstLedger(rangeID + 1)
-		if firstOfNext != lastOfCurrent+1 {
-			t.Errorf("gap between range %d (last=%d) and range %d (first=%d)",
-				rangeID, lastOfCurrent, rangeID+1, firstOfNext)
-		}
-		lastChunkOfCurrent := RangeLastChunk(rangeID)
-		firstChunkOfNext := RangeFirstChunk(rangeID + 1)
-		if firstChunkOfNext != lastChunkOfCurrent+1 {
-			t.Errorf("gap between range %d (lastChunk=%d) and range %d (firstChunk=%d)",
-				rangeID, lastChunkOfCurrent, rangeID+1, firstChunkOfNext)
-		}
-	}
-}
-
-// =============================================================================
-// Index-level tests (using TestGeometry: ChunkSize=10, ChunksPerTxHashIndex=5)
-// =============================================================================
-
-func TestLedgersPerIndex(t *testing.T) {
-	g := TestGeometry()
-	if got := g.LedgersPerIndex(); got != 50 {
-		t.Errorf("TestGeometry().LedgersPerIndex() = %d, want 50 (10*5)", got)
-	}
-
+func TestDefaultAndTestGeometry(t *testing.T) {
 	d := DefaultGeometry()
-	if got := d.LedgersPerIndex(); got != 10_000_000 {
-		t.Errorf("DefaultGeometry().LedgersPerIndex() = %d, want 10000000 (10000*1000)", got)
+	require.Equal(t, ChunkSize, d.ChunkSize)
+	require.Equal(t, uint32(1000), d.ChunksPerTxHashIndex)
+	require.Equal(t, uint32(10_000_000), d.LedgersPerIndex())
+
+	tg := TestGeometry()
+	require.Equal(t, uint32(10), tg.ChunkSize)
+	require.Equal(t, uint32(5), tg.ChunksPerTxHashIndex)
+	require.Equal(t, uint32(50), tg.LedgersPerIndex())
+}
+
+func TestChunkBoundaries(t *testing.T) {
+	g := DefaultGeometry()
+	// Chunk 0 spans [2, 10001]. Chunk 499 spans [4_990_002, 5_000_001].
+	require.Equal(t, uint32(2), g.ChunkFirstLedger(0))
+	require.Equal(t, uint32(10_001), g.ChunkLastLedger(0))
+	require.Equal(t, uint32(4_990_002), g.ChunkFirstLedger(499))
+	require.Equal(t, uint32(5_000_001), g.ChunkLastLedger(499))
+}
+
+func TestLedgerToChunkID(t *testing.T) {
+	g := DefaultGeometry()
+	cases := []struct {
+		ledger  uint32
+		wantCID uint32
+	}{
+		{2, 0},
+		{10_001, 0},
+		{10_002, 1},
+		{5_000_000, 499},
+		{5_000_001, 499},
 	}
+	for _, tc := range cases {
+		require.Equalf(t, tc.wantCID, g.LedgerToChunkID(tc.ledger),
+			"LedgerToChunkID(%d)", tc.ledger)
+	}
+}
+
+func TestLedgerToIndexID(t *testing.T) {
+	g := DefaultGeometry()
+	// Index 0 spans ledgers [2, 10_000_001]. Index 1 starts at 10_000_002.
+	require.Equal(t, uint32(0), g.LedgerToIndexID(2))
+	require.Equal(t, uint32(0), g.LedgerToIndexID(10_000_001))
+	require.Equal(t, uint32(1), g.LedgerToIndexID(10_000_002))
+	require.Equal(t, uint32(5), g.LedgerToIndexID(56_337_842))
 }
 
 func TestIndexID(t *testing.T) {
 	g := TestGeometry() // ChunksPerTxHashIndex=5
-	tests := []struct {
-		chunkID uint32
-		want    uint32
-	}{
-		{0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}, // chunks 0-4 → index 0
-		{5, 1}, {6, 1}, {7, 1}, {8, 1}, {9, 1}, // chunks 5-9 → index 1
-		{10, 2}, // chunk 10 → index 2
-	}
-	for _, tt := range tests {
-		if got := g.IndexID(tt.chunkID); got != tt.want {
-			t.Errorf("IndexID(%d) = %d, want %d", tt.chunkID, got, tt.want)
-		}
-	}
+	// Chunks 0-4 → index 0; chunks 5-9 → index 1.
+	require.Equal(t, uint32(0), g.IndexID(0))
+	require.Equal(t, uint32(0), g.IndexID(4))
+	require.Equal(t, uint32(1), g.IndexID(5))
+	require.Equal(t, uint32(1), g.IndexID(9))
+	require.Equal(t, uint32(2), g.IndexID(10))
 }
 
 func TestIndexBoundaries(t *testing.T) {
 	g := TestGeometry() // ChunkSize=10, ChunksPerTxHashIndex=5, FirstLedger=2
-
-	// Index 1: chunks 5-9
-	if got := g.IndexFirstChunk(1); got != 5 {
-		t.Errorf("IndexFirstChunk(1) = %d, want 5", got)
-	}
-	if got := g.IndexLastChunk(1); got != 9 {
-		t.Errorf("IndexLastChunk(1) = %d, want 9", got)
-	}
-
-	// Index 1: ledgers: chunk 5 starts at 5*10+2=52, chunk 9 ends at 10*10+2-1=101
-	if got := g.IndexFirstLedger(1); got != 52 {
-		t.Errorf("IndexFirstLedger(1) = %d, want 52", got)
-	}
-	if got := g.IndexLastLedger(1); got != 101 {
-		t.Errorf("IndexLastLedger(1) = %d, want 101", got)
-	}
+	// Index 1 = chunks 5-9 = ledgers [52, 101].
+	require.Equal(t, uint32(5), g.IndexFirstChunk(1))
+	require.Equal(t, uint32(9), g.IndexLastChunk(1))
+	require.Equal(t, uint32(52), g.IndexFirstLedger(1))
+	require.Equal(t, uint32(101), g.IndexLastLedger(1))
 }
 
 func TestIsLastChunkInIndex(t *testing.T) {
 	g := TestGeometry() // ChunksPerTxHashIndex=5
-
-	trueChunks := []uint32{4, 9, 14}
-	for _, c := range trueChunks {
-		if !g.IsLastChunkInIndex(c) {
-			t.Errorf("IsLastChunkInIndex(%d) = false, want true", c)
-		}
+	for _, c := range []uint32{4, 9, 14} {
+		require.Truef(t, g.IsLastChunkInIndex(c), "chunk %d should be last-in-index", c)
 	}
-
-	falseChunks := []uint32{0, 3, 5, 8}
-	for _, c := range falseChunks {
-		if g.IsLastChunkInIndex(c) {
-			t.Errorf("IsLastChunkInIndex(%d) = true, want false", c)
-		}
+	for _, c := range []uint32{0, 3, 5, 8} {
+		require.Falsef(t, g.IsLastChunkInIndex(c), "chunk %d should NOT be last-in-index", c)
 	}
 }
 
 func TestChunksForIndex(t *testing.T) {
 	g := TestGeometry() // ChunksPerTxHashIndex=5
-	chunks := g.ChunksForIndex(1)
-
-	want := []uint32{5, 6, 7, 8, 9}
-	if len(chunks) != len(want) {
-		t.Fatalf("ChunksForIndex(1) len = %d, want %d", len(chunks), len(want))
-	}
-	for i, c := range chunks {
-		if c != want[i] {
-			t.Errorf("ChunksForIndex(1)[%d] = %d, want %d", i, c, want[i])
-		}
-	}
-
-	if uint32(len(chunks)) != g.ChunksPerTxHashIndex {
-		t.Errorf("len = %d, want ChunksPerTxHashIndex=%d", len(chunks), g.ChunksPerTxHashIndex)
-	}
+	require.Equal(t, []uint32{5, 6, 7, 8, 9}, g.ChunksForIndex(1))
 }
 
+// TestIndexRoundTrip — every chunk in [0, 30) maps to an index that
+// includes it in [IndexFirstChunk, IndexLastChunk].
 func TestIndexRoundTrip(t *testing.T) {
-	g := TestGeometry() // ChunksPerTxHashIndex=5
-
-	for c := uint32(0); c < 30; c++ {
+	g := TestGeometry()
+	for c := range uint32(30) {
 		idx := g.IndexID(c)
-		first := g.IndexFirstChunk(idx)
-		last := g.IndexLastChunk(idx)
-
-		if c < first || c > last {
-			t.Errorf("chunk %d: IndexID=%d, but IndexFirstChunk=%d, IndexLastChunk=%d (out of range)",
-				c, idx, first, last)
-		}
+		require.GreaterOrEqualf(t, c, g.IndexFirstChunk(idx), "chunk %d below IndexFirstChunk(%d)", c, idx)
+		require.LessOrEqualf(t, c, g.IndexLastChunk(idx), "chunk %d above IndexLastChunk(%d)", c, idx)
 	}
 }
 
-func TestIndexCadenceMatchesChunkCount(t *testing.T) {
-	g := TestGeometry() // ChunksPerTxHashIndex=5
-
-	for i := uint32(0); i < 5; i++ {
-		chunks := g.ChunksForIndex(i)
-		if uint32(len(chunks)) != g.ChunksPerTxHashIndex {
-			t.Errorf("ChunksForIndex(%d) len = %d, want %d", i, len(chunks), g.ChunksPerTxHashIndex)
-		}
+// TestIndexContiguity — index i's last ledger + 1 == index i+1's first ledger.
+func TestIndexContiguity(t *testing.T) {
+	g := DefaultGeometry()
+	for i := range uint32(5) {
+		require.Equalf(t, g.IndexLastLedger(i)+1, g.IndexFirstLedger(i+1),
+			"gap between index %d and %d", i, i+1)
 	}
 }

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/geometry/geometry_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/geometry/geometry_test.go
@@ -1,0 +1,281 @@
+package geometry
+
+import "testing"
+
+func TestLedgerToRangeID(t *testing.T) {
+	tests := []struct {
+		name      string
+		ledgerSeq uint32
+		want      uint32
+	}{
+		{"first ledger", 2, 0},
+		{"last ledger in range 0", 10_000_001, 0},
+		{"first ledger in range 1", 10_000_002, 1},
+		{"last ledger in range 1", 20_000_001, 1},
+		{"first ledger in range 2", 20_000_002, 2},
+		{"mid-range 0", 5_000_000, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := LedgerToRangeID(tt.ledgerSeq)
+			if got != tt.want {
+				t.Errorf("LedgerToRangeID(%d) = %d, want %d", tt.ledgerSeq, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRangeFirstLedger(t *testing.T) {
+	tests := []struct {
+		rangeID uint32
+		want    uint32
+	}{
+		{0, 2},
+		{1, 10_000_002},
+		{2, 20_000_002},
+		{3, 30_000_002},
+	}
+	for _, tt := range tests {
+		got := RangeFirstLedger(tt.rangeID)
+		if got != tt.want {
+			t.Errorf("RangeFirstLedger(%d) = %d, want %d", tt.rangeID, got, tt.want)
+		}
+	}
+}
+
+func TestRangeLastLedger(t *testing.T) {
+	tests := []struct {
+		rangeID uint32
+		want    uint32
+	}{
+		{0, 10_000_001},
+		{1, 20_000_001},
+		{2, 30_000_001},
+	}
+	for _, tt := range tests {
+		got := RangeLastLedger(tt.rangeID)
+		if got != tt.want {
+			t.Errorf("RangeLastLedger(%d) = %d, want %d", tt.rangeID, got, tt.want)
+		}
+	}
+}
+
+func TestRangeFirstChunk(t *testing.T) {
+	tests := []struct {
+		rangeID uint32
+		want    uint32
+	}{
+		{0, 0},
+		{1, 1000},
+		{2, 2000},
+	}
+	for _, tt := range tests {
+		got := RangeFirstChunk(tt.rangeID)
+		if got != tt.want {
+			t.Errorf("RangeFirstChunk(%d) = %d, want %d", tt.rangeID, got, tt.want)
+		}
+	}
+}
+
+func TestRangeLastChunk(t *testing.T) {
+	tests := []struct {
+		rangeID uint32
+		want    uint32
+	}{
+		{0, 999},
+		{1, 1999},
+		{2, 2999},
+	}
+	for _, tt := range tests {
+		got := RangeLastChunk(tt.rangeID)
+		if got != tt.want {
+			t.Errorf("RangeLastChunk(%d) = %d, want %d", tt.rangeID, got, tt.want)
+		}
+	}
+}
+
+func TestChunkToRangeID(t *testing.T) {
+	tests := []struct {
+		chunkID uint32
+		want    uint32
+	}{
+		{0, 0},
+		{999, 0},
+		{1000, 1},
+		{1999, 1},
+		{2000, 2},
+	}
+	for _, tt := range tests {
+		got := ChunkToRangeID(tt.chunkID)
+		if got != tt.want {
+			t.Errorf("ChunkToRangeID(%d) = %d, want %d", tt.chunkID, got, tt.want)
+		}
+	}
+}
+
+// TestRangeRoundTrips verifies that range boundary formulas are consistent.
+func TestRangeRoundTrips(t *testing.T) {
+	for rangeID := uint32(0); rangeID < 5; rangeID++ {
+		first := RangeFirstLedger(rangeID)
+		last := RangeLastLedger(rangeID)
+
+		// First ledger maps back to the same range
+		if got := LedgerToRangeID(first); got != rangeID {
+			t.Errorf("range %d: LedgerToRangeID(first=%d) = %d", rangeID, first, got)
+		}
+		// Last ledger maps back to the same range
+		if got := LedgerToRangeID(last); got != rangeID {
+			t.Errorf("range %d: LedgerToRangeID(last=%d) = %d", rangeID, last, got)
+		}
+		// Range spans exactly RangeSize ledgers
+		if last-first+1 != RangeSize {
+			t.Errorf("range %d: span = %d, want %d", rangeID, last-first+1, RangeSize)
+		}
+		// Chunk round-trip
+		firstChunk := RangeFirstChunk(rangeID)
+		lastChunk := RangeLastChunk(rangeID)
+		if ChunkToRangeID(firstChunk) != rangeID {
+			t.Errorf("range %d: ChunkToRangeID(firstChunk=%d) mismatch", rangeID, firstChunk)
+		}
+		if ChunkToRangeID(lastChunk) != rangeID {
+			t.Errorf("range %d: ChunkToRangeID(lastChunk=%d) mismatch", rangeID, lastChunk)
+		}
+		if lastChunk-firstChunk+1 != ChunksPerRange {
+			t.Errorf("range %d: chunk count = %d, want %d", rangeID, lastChunk-firstChunk+1, ChunksPerRange)
+		}
+	}
+}
+
+// TestRangeContiguity verifies there are no gaps between ranges.
+func TestRangeContiguity(t *testing.T) {
+	for rangeID := uint32(0); rangeID < 5; rangeID++ {
+		lastOfCurrent := RangeLastLedger(rangeID)
+		firstOfNext := RangeFirstLedger(rangeID + 1)
+		if firstOfNext != lastOfCurrent+1 {
+			t.Errorf("gap between range %d (last=%d) and range %d (first=%d)",
+				rangeID, lastOfCurrent, rangeID+1, firstOfNext)
+		}
+		lastChunkOfCurrent := RangeLastChunk(rangeID)
+		firstChunkOfNext := RangeFirstChunk(rangeID + 1)
+		if firstChunkOfNext != lastChunkOfCurrent+1 {
+			t.Errorf("gap between range %d (lastChunk=%d) and range %d (firstChunk=%d)",
+				rangeID, lastChunkOfCurrent, rangeID+1, firstChunkOfNext)
+		}
+	}
+}
+
+// =============================================================================
+// Index-level tests (using TestGeometry: ChunkSize=10, ChunksPerTxHashIndex=5)
+// =============================================================================
+
+func TestLedgersPerIndex(t *testing.T) {
+	g := TestGeometry()
+	if got := g.LedgersPerIndex(); got != 50 {
+		t.Errorf("TestGeometry().LedgersPerIndex() = %d, want 50 (10*5)", got)
+	}
+
+	d := DefaultGeometry()
+	if got := d.LedgersPerIndex(); got != 10_000_000 {
+		t.Errorf("DefaultGeometry().LedgersPerIndex() = %d, want 10000000 (10000*1000)", got)
+	}
+}
+
+func TestIndexID(t *testing.T) {
+	g := TestGeometry() // ChunksPerTxHashIndex=5
+	tests := []struct {
+		chunkID uint32
+		want    uint32
+	}{
+		{0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}, // chunks 0-4 → index 0
+		{5, 1}, {6, 1}, {7, 1}, {8, 1}, {9, 1}, // chunks 5-9 → index 1
+		{10, 2}, // chunk 10 → index 2
+	}
+	for _, tt := range tests {
+		if got := g.IndexID(tt.chunkID); got != tt.want {
+			t.Errorf("IndexID(%d) = %d, want %d", tt.chunkID, got, tt.want)
+		}
+	}
+}
+
+func TestIndexBoundaries(t *testing.T) {
+	g := TestGeometry() // ChunkSize=10, ChunksPerTxHashIndex=5, FirstLedger=2
+
+	// Index 1: chunks 5-9
+	if got := g.IndexFirstChunk(1); got != 5 {
+		t.Errorf("IndexFirstChunk(1) = %d, want 5", got)
+	}
+	if got := g.IndexLastChunk(1); got != 9 {
+		t.Errorf("IndexLastChunk(1) = %d, want 9", got)
+	}
+
+	// Index 1: ledgers: chunk 5 starts at 5*10+2=52, chunk 9 ends at 10*10+2-1=101
+	if got := g.IndexFirstLedger(1); got != 52 {
+		t.Errorf("IndexFirstLedger(1) = %d, want 52", got)
+	}
+	if got := g.IndexLastLedger(1); got != 101 {
+		t.Errorf("IndexLastLedger(1) = %d, want 101", got)
+	}
+}
+
+func TestIsLastChunkInIndex(t *testing.T) {
+	g := TestGeometry() // ChunksPerTxHashIndex=5
+
+	trueChunks := []uint32{4, 9, 14}
+	for _, c := range trueChunks {
+		if !g.IsLastChunkInIndex(c) {
+			t.Errorf("IsLastChunkInIndex(%d) = false, want true", c)
+		}
+	}
+
+	falseChunks := []uint32{0, 3, 5, 8}
+	for _, c := range falseChunks {
+		if g.IsLastChunkInIndex(c) {
+			t.Errorf("IsLastChunkInIndex(%d) = true, want false", c)
+		}
+	}
+}
+
+func TestChunksForIndex(t *testing.T) {
+	g := TestGeometry() // ChunksPerTxHashIndex=5
+	chunks := g.ChunksForIndex(1)
+
+	want := []uint32{5, 6, 7, 8, 9}
+	if len(chunks) != len(want) {
+		t.Fatalf("ChunksForIndex(1) len = %d, want %d", len(chunks), len(want))
+	}
+	for i, c := range chunks {
+		if c != want[i] {
+			t.Errorf("ChunksForIndex(1)[%d] = %d, want %d", i, c, want[i])
+		}
+	}
+
+	if uint32(len(chunks)) != g.ChunksPerTxHashIndex {
+		t.Errorf("len = %d, want ChunksPerTxHashIndex=%d", len(chunks), g.ChunksPerTxHashIndex)
+	}
+}
+
+func TestIndexRoundTrip(t *testing.T) {
+	g := TestGeometry() // ChunksPerTxHashIndex=5
+
+	for c := uint32(0); c < 30; c++ {
+		idx := g.IndexID(c)
+		first := g.IndexFirstChunk(idx)
+		last := g.IndexLastChunk(idx)
+
+		if c < first || c > last {
+			t.Errorf("chunk %d: IndexID=%d, but IndexFirstChunk=%d, IndexLastChunk=%d (out of range)",
+				c, idx, first, last)
+		}
+	}
+}
+
+func TestIndexCadenceMatchesChunkCount(t *testing.T) {
+	g := TestGeometry() // ChunksPerTxHashIndex=5
+
+	for i := uint32(0); i < 5; i++ {
+		chunks := g.ChunksForIndex(i)
+		if uint32(len(chunks)) != g.ChunksPerTxHashIndex {
+			t.Errorf("ChunksForIndex(%d) len = %d, want %d", i, len(chunks), g.ChunksPerTxHashIndex)
+		}
+	}
+}

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/geometry/geometry_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/geometry/geometry_test.go
@@ -3,28 +3,28 @@ package geometry
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDefaultAndTestGeometry(t *testing.T) {
 	d := DefaultGeometry()
-	require.Equal(t, ChunkSize, d.ChunkSize)
-	require.Equal(t, uint32(1000), d.ChunksPerTxHashIndex)
-	require.Equal(t, uint32(10_000_000), d.LedgersPerIndex())
+	assert.Equal(t, ChunkSize, d.ChunkSize)
+	assert.Equal(t, uint32(1000), d.ChunksPerTxHashIndex)
+	assert.Equal(t, uint32(10_000_000), d.LedgersPerIndex())
 
 	tg := TestGeometry()
-	require.Equal(t, uint32(10), tg.ChunkSize)
-	require.Equal(t, uint32(5), tg.ChunksPerTxHashIndex)
-	require.Equal(t, uint32(50), tg.LedgersPerIndex())
+	assert.Equal(t, uint32(10), tg.ChunkSize)
+	assert.Equal(t, uint32(5), tg.ChunksPerTxHashIndex)
+	assert.Equal(t, uint32(50), tg.LedgersPerIndex())
 }
 
 func TestChunkBoundaries(t *testing.T) {
 	g := DefaultGeometry()
 	// Chunk 0 spans [2, 10001]. Chunk 499 spans [4_990_002, 5_000_001].
-	require.Equal(t, uint32(2), g.ChunkFirstLedger(0))
-	require.Equal(t, uint32(10_001), g.ChunkLastLedger(0))
-	require.Equal(t, uint32(4_990_002), g.ChunkFirstLedger(499))
-	require.Equal(t, uint32(5_000_001), g.ChunkLastLedger(499))
+	assert.Equal(t, uint32(2), g.ChunkFirstLedger(0))
+	assert.Equal(t, uint32(10_001), g.ChunkLastLedger(0))
+	assert.Equal(t, uint32(4_990_002), g.ChunkFirstLedger(499))
+	assert.Equal(t, uint32(5_000_001), g.ChunkLastLedger(499))
 }
 
 func TestLedgerToChunkID(t *testing.T) {
@@ -40,7 +40,7 @@ func TestLedgerToChunkID(t *testing.T) {
 		{5_000_001, 499},
 	}
 	for _, tc := range cases {
-		require.Equalf(t, tc.wantCID, g.LedgerToChunkID(tc.ledger),
+		assert.Equalf(t, tc.wantCID, g.LedgerToChunkID(tc.ledger),
 			"LedgerToChunkID(%d)", tc.ledger)
 	}
 }
@@ -48,44 +48,44 @@ func TestLedgerToChunkID(t *testing.T) {
 func TestLedgerToIndexID(t *testing.T) {
 	g := DefaultGeometry()
 	// Index 0 spans ledgers [2, 10_000_001]. Index 1 starts at 10_000_002.
-	require.Equal(t, uint32(0), g.LedgerToIndexID(2))
-	require.Equal(t, uint32(0), g.LedgerToIndexID(10_000_001))
-	require.Equal(t, uint32(1), g.LedgerToIndexID(10_000_002))
-	require.Equal(t, uint32(5), g.LedgerToIndexID(56_337_842))
+	assert.Equal(t, uint32(0), g.LedgerToIndexID(2))
+	assert.Equal(t, uint32(0), g.LedgerToIndexID(10_000_001))
+	assert.Equal(t, uint32(1), g.LedgerToIndexID(10_000_002))
+	assert.Equal(t, uint32(5), g.LedgerToIndexID(56_337_842))
 }
 
 func TestIndexID(t *testing.T) {
 	g := TestGeometry() // ChunksPerTxHashIndex=5
 	// Chunks 0-4 → index 0; chunks 5-9 → index 1.
-	require.Equal(t, uint32(0), g.IndexID(0))
-	require.Equal(t, uint32(0), g.IndexID(4))
-	require.Equal(t, uint32(1), g.IndexID(5))
-	require.Equal(t, uint32(1), g.IndexID(9))
-	require.Equal(t, uint32(2), g.IndexID(10))
+	assert.Equal(t, uint32(0), g.IndexID(0))
+	assert.Equal(t, uint32(0), g.IndexID(4))
+	assert.Equal(t, uint32(1), g.IndexID(5))
+	assert.Equal(t, uint32(1), g.IndexID(9))
+	assert.Equal(t, uint32(2), g.IndexID(10))
 }
 
 func TestIndexBoundaries(t *testing.T) {
 	g := TestGeometry() // ChunkSize=10, ChunksPerTxHashIndex=5, FirstLedger=2
 	// Index 1 = chunks 5-9 = ledgers [52, 101].
-	require.Equal(t, uint32(5), g.IndexFirstChunk(1))
-	require.Equal(t, uint32(9), g.IndexLastChunk(1))
-	require.Equal(t, uint32(52), g.IndexFirstLedger(1))
-	require.Equal(t, uint32(101), g.IndexLastLedger(1))
+	assert.Equal(t, uint32(5), g.IndexFirstChunk(1))
+	assert.Equal(t, uint32(9), g.IndexLastChunk(1))
+	assert.Equal(t, uint32(52), g.IndexFirstLedger(1))
+	assert.Equal(t, uint32(101), g.IndexLastLedger(1))
 }
 
 func TestIsLastChunkInIndex(t *testing.T) {
 	g := TestGeometry() // ChunksPerTxHashIndex=5
 	for _, c := range []uint32{4, 9, 14} {
-		require.Truef(t, g.IsLastChunkInIndex(c), "chunk %d should be last-in-index", c)
+		assert.Truef(t, g.IsLastChunkInIndex(c), "chunk %d should be last-in-index", c)
 	}
 	for _, c := range []uint32{0, 3, 5, 8} {
-		require.Falsef(t, g.IsLastChunkInIndex(c), "chunk %d should NOT be last-in-index", c)
+		assert.Falsef(t, g.IsLastChunkInIndex(c), "chunk %d should NOT be last-in-index", c)
 	}
 }
 
 func TestChunksForIndex(t *testing.T) {
 	g := TestGeometry() // ChunksPerTxHashIndex=5
-	require.Equal(t, []uint32{5, 6, 7, 8, 9}, g.ChunksForIndex(1))
+	assert.Equal(t, []uint32{5, 6, 7, 8, 9}, g.ChunksForIndex(1))
 }
 
 // TestIndexRoundTrip — every chunk in [0, 30) maps to an index that
@@ -94,8 +94,8 @@ func TestIndexRoundTrip(t *testing.T) {
 	g := TestGeometry()
 	for c := range uint32(30) {
 		idx := g.IndexID(c)
-		require.GreaterOrEqualf(t, c, g.IndexFirstChunk(idx), "chunk %d below IndexFirstChunk(%d)", c, idx)
-		require.LessOrEqualf(t, c, g.IndexLastChunk(idx), "chunk %d above IndexLastChunk(%d)", c, idx)
+		assert.GreaterOrEqualf(t, c, g.IndexFirstChunk(idx), "chunk %d below IndexFirstChunk(%d)", c, idx)
+		assert.LessOrEqualf(t, c, g.IndexLastChunk(idx), "chunk %d above IndexLastChunk(%d)", c, idx)
 	}
 }
 
@@ -103,7 +103,7 @@ func TestIndexRoundTrip(t *testing.T) {
 func TestIndexContiguity(t *testing.T) {
 	g := DefaultGeometry()
 	for i := range uint32(5) {
-		require.Equalf(t, g.IndexLastLedger(i)+1, g.IndexFirstLedger(i+1),
+		assert.Equalf(t, g.IndexLastLedger(i)+1, g.IndexFirstLedger(i+1),
 			"gap between index %d and %d", i, i+1)
 	}
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Base is temporarily `karthik/backfill-impl/scaffold-subcommand` (head of [#699](https://github.com/stellar/stellar-rpc/pull/699)), not `feature/full-history`. This branch stacks on [#699](https://github.com/stellar/stellar-rpc/pull/699); I'll re-target the base after [#699](https://github.com/stellar/stellar-rpc/pull/699) merges.

Closes [#684](https://github.com/stellar/stellar-rpc/issues/684).

## Summary

- Port `pkg/geometry` from reference commit `19a9179` — Index-only API; drops the old `Range*` nomenclature per the current design doc.
- Add `backfill/config/` with the UPPER_SNAKE_CASE TOML schema, plus `ParseConfig` + `MarshalTOML` round-trip.
- `Validate` — required fields + path defaults under `DEFAULT_DATA_DIR`.
- `ApplyFlags` — widens `--start-ledger` / `--end-ledger` outward to chunk boundaries; resolves the `0 = GOMAXPROCS` sentinel on `--workers`; merges `--log-level` / `--log-format` overrides.
- `ValidateFlags` + `ValidateAgainstStore` (`CHUNKS_PER_TXHASH_INDEX` immutability) + `ValidateAgainstBSB` (availability probe).
- `Store` and `BSBAvailabilityProbe` interfaces with in-memory / no-op implementations. Real implementations replace these constructor calls as part of [#689](https://github.com/stellar/stellar-rpc/issues/689) and [#688](https://github.com/stellar/stellar-rpc/issues/688).
- Fill in the subcommand body scaffolded by [#699](https://github.com/stellar/stellar-rpc/pull/699): read TOML → run the pipeline → print summary. Adds `--log-level` / `--log-format` flags.

## Unit tests

- `pkg/geometry`
  - Chunk + index boundary math (`ChunkFirstLedger`, `ChunkLastLedger`, `IndexFirstChunk`, `IndexLastChunk`, etc.).
  - Ledger → chunk and chunk → index round-trips.
  - Index contiguity across 5 consecutive indexes.
- `config/config_test.go`
  - Full-schema TOML parse (every section + nested `[BACKFILL.BSB]`).
  - Default path + numeric resolution under `DEFAULT_DATA_DIR`.
  - `MarshalTOML` round-trip.
- `config/flags_test.go`
  - Chunk-boundary widening — 4 cases (both mid-chunk, both aligned, start=2 + end mid-chunk, start mid-chunk + end aligned).
  - `workers=0` → `GOMAXPROCS`; `max-retries` passes through literally (including 0).
  - Logging override merge.
  - `BuildGeometry` threads `CHUNKS_PER_TXHASH_INDEX`.
- `config/validate_test.go`
  - Required-field rejections (missing `DEFAULT_DATA_DIR`, missing `[BACKFILL.BSB]`, empty `BUCKET_PATH`).
  - `ValidateFlags` — start < 2, end ≤ start, workers < 0, max-retries < 0; workers=0 sentinel passes.
  - `ValidateAgainstStore` — absent / match / mismatch branches via mock `Store`; precondition error when `Validate()` was skipped.
  - `ValidateAgainstBSB` — available / insufficient / probe-error branches via mock probe.
- `backfill/cmd_test.go`
  - Flag registration (all 8 flags present).
  - Golden-path summary (valid config exits 0, summary contains resolved fields).
  - 4 failure paths surfaced through `cmd.Execute` (start < 2, end ≤ start, missing `DEFAULT_DATA_DIR`, missing `[BACKFILL.BSB]`).
  - Missing `--config` file.