### PR TITLE
Update packfile design doc to match merged writer and reader implementations

### DIFF
--- a/design-docs/packfile-library.md
+++ b/design-docs/packfile-library.md
@@ -21,7 +21,9 @@ Non-goals:
 
 On disk, items are grouped into **records**. `ItemsPerRecord` controls how many items go into each record.
 
-Records can be stored in one of three formats: **Compressed** (zstd with built-in integrity, the default), **Uncompressed** (raw bytes with CRC32C integrity check), or **Raw** (raw bytes, no integrity check).
+Record bytes are transformed on the way to and from disk by a **caller-supplied codec** — a pair of `RecordEncoder` / `RecordDecoder` implementations the caller plugs into `WriterOptions` and `ReaderOptions`. With a nil codec, records are passthrough (written and read verbatim). The package ships no built-in codec; the `zstd` subpackage provides `*zstd.Compressor` and `*zstd.Decompressor` that satisfy the interfaces directly, and callers are free to provide their own (e.g. raw bytes with a trailing CRC32C).
+
+The trailer carries a caller-assigned `Format uint32` field. Readers dispatch on `Format` to pick the matching decoder (and any other decode-side choice such as the content-hash extract — see [Codec Contract](#codec-contract)). The library does not interpret `Format` values.
 
 The file ends with a compact **offset index** that maps each record to its byte position on disk. When a file is opened, the offset index is loaded into memory. After that, looking up any item is a single read to fetch the record containing it — no further index I/O. This is how packfile achieves the "one I/O on open, one I/O per lookup" goal.
 
@@ -44,9 +46,13 @@ Error handling omitted for clarity. All functions return errors.
 
 ```go
 w, _ := packfile.Create("output.pack", packfile.WriterOptions{
-    ItemsPerRecord: 128,  // items per record (default 128)
-    Concurrency:    4,    // parallel compression goroutines
-    ContentHash:    true, // compute SHA-256 content hash
+    ItemsPerRecord:   128,                              // items per record (default 128)
+    Format:           packfile.Format(1),               // caller-assigned codec identifier
+    NewRecordEncoder: func() packfile.RecordEncoder {   // per-worker encoder
+        return zstd.NewCompressor()
+    },
+    Concurrency:      4,                                // parallel encode/hash goroutines
+    ContentHash:      true,                             // compute SHA-256 content hash
 })
 defer w.Close() // removes file if Finish was not called
 
@@ -57,12 +63,18 @@ for _, item := range items {
 w.Finish(nil) // seal the file (nil = no app data)
 ```
 
-Items are appended in order. `Finish` seals the file and fsyncs. `Close` after `Finish` is a no-op; `Close` without `Finish` removes the incomplete file.
+Items are appended in order. `Finish` seals the file and fsyncs. `Close` after `Finish` is a no-op; `Close` without `Finish` removes the incomplete file. `NewRecordEncoder` is called once per worker; passing nil makes records passthrough (no encoding).
 
 ### Reading: Point Lookup
 
 ```go
-r := packfile.Open("output.pack")
+// Decompressor is concurrent-safe — instantiate once at app startup and
+// share across all Readers.
+decoder := zstd.NewDecompressor()
+
+r := packfile.Open("output.pack", packfile.ReaderOptions{
+    RecordDecoder: decoder,
+})
 defer r.Close()
 
 r.ReadItem(42, func(data []byte) error {
@@ -72,12 +84,12 @@ r.ReadItem(42, func(data []byte) error {
 })
 ```
 
-`Open` returns immediately — file I/O runs in a background goroutine. The first read call blocks until the file is ready. `ReadItem` fetches a single item by position and passes it to the callback.
+`Open` returns immediately — file I/O runs in a background goroutine. The first read call blocks until the file is ready. `ReadItem` fetches a single item by position and passes it to the callback. The caller owns the decoder; `Reader.Close` does not close it.
 
 ### Reading: Sequential Scan
 
 ```go
-r := packfile.Open("output.pack")
+r := packfile.Open("output.pack", packfile.ReaderOptions{RecordDecoder: decoder})
 defer r.Close()
 
 for data, err := range r.ReadRange(0, 1000) {
@@ -89,14 +101,17 @@ for data, err := range r.ReadRange(0, 1000) {
 }
 ```
 
-Safe to break early. No cleanup required.
+Safe to break early. The yielded slice is invalidated once the loop exits (break or natural completion), so copy anything you want to retain. Invalid `start`/`count` yields a single `(nil, ErrPositionOutOfRange)` pair and stops; `count == 0` is valid and yields nothing.
 
 ### Reading: Multiple Items
 
-`ReadItems` is like `ReadItem` but fetches many items at once using parallel I/O. You pass the positions of the items you want (sorted, no duplicates). The callback is called concurrently from multiple goroutines — `idx` tells you which element in your positions slice the data corresponds to:
+`ReadItems` is like `ReadItem` but fetches many items at once. With `Concurrency > 1`, batches are read in parallel and the callback runs concurrently from multiple goroutines. You pass the positions of the items you want (strictly sorted, no duplicates) — `idx` tells you which element in your positions slice the data corresponds to:
 
 ```go
-r := packfile.Open("output.pack", packfile.WithConcurrency(8))
+r := packfile.Open("output.pack", packfile.ReaderOptions{
+    RecordDecoder: decoder,
+    Concurrency:   8,
+})
 defer r.Close()
 
 // fetch items at positions 42, 1000, 500000, and 8700000
@@ -110,10 +125,12 @@ r.ReadItems(ctx, positions, func(idx int, data []byte) error {
 // results[0] = item at position 42, results[1] = item at position 1000, etc.
 ```
 
+Returns `ErrPositionOutOfRange` if any position is outside `[0, TotalItems)` or `ErrPositionsUnsorted` if positions are not strictly sorted.
+
 ### Content Hash Verification
 
 ```go
-r := packfile.Open("output.pack")
+r := packfile.Open("output.pack", packfile.ReaderOptions{RecordDecoder: decoder})
 defer r.Close()
 
 hash, ok, _ := r.ContentHash() // stored SHA-256, if present
@@ -122,8 +139,41 @@ if ok {
 }
 ```
 
+If the file was written with `ContentHashExtract`, the reader must pass the matching `ReaderOptions.ContentHashExtract` or `Verify` will mismatch — see [Codec Contract](#codec-contract).
+
 
 ## API Reference
+
+### Codec Contract
+
+```go
+// Format is a caller-assigned identifier stored in the trailer. The packfile
+// library does not interpret Format values; readers use them to dispatch to
+// the matching decoder. Any change to the on-disk encoding — what goes in a
+// record, what bytes are hashed, which codec is used — requires a new Format
+// value.
+type Format uint32
+
+// RecordEncoder transforms one record's payload before it is written. Encode
+// writes the encoded bytes into dst (growing if needed) and returns the
+// result. Pass nil for dst to get a fresh allocation. The returned slice is
+// owned by the caller. Encoders may be stateful; the writer constructs a
+// fresh one per worker via WriterOptions.NewRecordEncoder.
+type RecordEncoder interface {
+    Encode(dst, src []byte) ([]byte, error)
+    io.Closer
+}
+
+// RecordDecoder is the symmetric read-side transformation. A RecordDecoder
+// MUST be safe for concurrent use — the reader shares a single instance
+// across all in-flight reads. Decoder lifecycle is caller-owned;
+// Reader.Close does not close it.
+type RecordDecoder interface {
+    Decode(dst, src []byte) ([]byte, error)
+}
+```
+
+The `zstd` subpackage provides `*zstd.Compressor` (implements `RecordEncoder`) and `*zstd.Decompressor` (implements `RecordDecoder`, internally pools `ZSTD_DCtx` instances for concurrent use). Callers can supply their own codec implementations for any other transformation.
 
 ### Writer
 
@@ -135,23 +185,37 @@ type WriterOptions struct {
     // ItemsPerRecord is the number of items per record. 0 defaults to 128.
     ItemsPerRecord int
 
-    // Format controls record encoding. Default (zero value) is Compressed.
-    // Compressed: zstd with built-in integrity.
-    // Uncompressed: raw records with CRC32C integrity.
-    // Raw: raw records with no integrity wrapper.
-    Format RecordFormat
+    // Format is a caller-assigned identifier written to the trailer. Readers
+    // dispatch on it to pick the matching decoder + content-hash extract.
+    Format Format
 
-    // Concurrency sets the number of parallel compression goroutines.
-    // 0 or 1 means serial.
-    Concurrency int
+    // NewRecordEncoder, if non-nil, returns a per-worker RecordEncoder.
+    // Called once per worker goroutine; the writer invokes Encode once per
+    // record before write and Close on shutdown. Pass nil for passthrough
+    // records (no encoding).
+    NewRecordEncoder func() RecordEncoder
 
-    // ContentHash enables SHA-256 content hashing over the logical item stream.
+    // ContentHash enables SHA-256 content hashing over the logical item
+    // stream. The digest is stored in the trailer.
     ContentHash bool
+
+    // ContentHashExtract, if non-nil, transforms each item into the bytes
+    // fed to the content hasher. Use it when items as received aren't the
+    // canonical hash input (e.g. to decompress pre-compressed items so the
+    // hash is stable across encoder versions). Must be safe for concurrent
+    // invocation. Readers must pass a matching ReaderOptions.ContentHashExtract.
+    ContentHashExtract func(item []byte) ([]byte, error)
+
+    // Concurrency sets the parallel worker count when an encoder or content
+    // hash is enabled. 0 defaults to 1. With no encoder and no content hash,
+    // ignored — records are written directly. Values above runtime.NumCPU()
+    // tend to hurt throughput; pick a value ≤ NumCPU.
+    Concurrency int
 
     // BytesPerSync initiates background writeback of dirty pages every N bytes
     // written. On Linux this uses sync_file_range(SYNC_FILE_RANGE_WRITE) which
     // is non-blocking — it tells the kernel to start flushing without waiting.
-    // This spreads I/O across the write phase so the final fdatasync in Finish()
+    // This spreads I/O across the write phase so the final fsync in Finish()
     // has less data to flush. 0 disables (default).
     BytesPerSync int
 
@@ -161,15 +225,24 @@ type WriterOptions struct {
 }
 
 // Writer creates a new packfile. Items must be appended in order.
+//
+// A Writer must be used by a single goroutine; concurrent AppendItem,
+// Finish, or Close calls from multiple goroutines are not safe. Internally
+// the Writer spawns a background pipeline, but the caller-facing API is
+// single-threaded.
 type Writer struct{ /* unexported */ }
 
 // Create starts writing a new packfile at path. Fails if the file already
 // exists unless Overwrite is set.
 func Create(path string, opts WriterOptions) (*Writer, error)
 
-// AppendItem adds a single item. If multiple byte slices are passed,
-// they are concatenated into one item.
-// Flushes a record when ItemsPerRecord items accumulate.
+// AppendItem adds a single item. If multiple byte slices are passed, they
+// are concatenated into one item. An item may be zero bytes:
+// AppendItem([]byte{}) records an empty item, while AppendItem() (no
+// arguments) is a no-op. Parts are copied; the caller may reuse argument
+// slices after the call returns. Flushes a record when ItemsPerRecord
+// items accumulate. Returns ErrWriterClosed if the writer has been closed,
+// or an error if the concatenated item exceeds math.MaxUint32 bytes.
 func (w *Writer) AppendItem(parts ...[]byte) error
 
 // Finish flushes any partial record, writes index + optional app data + trailer,
@@ -186,19 +259,37 @@ func (w *Writer) Close() error
 ### Reader
 
 ```go
+// ReaderOptions configures Reader behavior.
+type ReaderOptions struct {
+    // RecordDecoder, if non-nil, decodes record payloads. Must be safe for
+    // concurrent use — the reader shares a single instance across in-flight
+    // reads. Caller-owned; not closed by Reader.Close. nil means passthrough,
+    // symmetric to the writer's nil NewRecordEncoder.
+    RecordDecoder RecordDecoder
+
+    // ContentHashExtract mirrors WriterOptions.ContentHashExtract. If the
+    // file was written with an extract, Verify must apply the same
+    // transformation or the recomputed digest will not match the stored one.
+    ContentHashExtract func(item []byte) ([]byte, error)
+
+    // Concurrency sets the max parallel goroutines for ReadItems. Zero
+    // normalizes to 1 (serial). Negative values are rejected (deferred error
+    // surfaced by the first read call). ReadItems still coalesces consecutive
+    // records into single ReadAt calls even when serial; concurrency only
+    // controls fan-out across I/O batches.
+    Concurrency int
+}
+
 // Reader provides random access to items in a packfile.
-// Safe for concurrent use by multiple goroutines.
+// Read methods are safe for concurrent use by multiple goroutines. Close is
+// NOT safe to call concurrently with any in-flight read.
 type Reader struct{ /* unexported */ }
 
-// Open returns a Reader immediately. File I/O runs in a background goroutine;
-// the first read call blocks until the file is ready. Open never fails;
-// errors are deferred to the first method that needs the result.
+// Open returns a Reader immediately. File I/O and option validation run in
+// a background goroutine; both kinds of failure are deferred to the first
+// method that needs the result. Open itself has no error return.
 // Close must always be called.
-func Open(path string, opts ...ReaderOption) *Reader
-
-// WithConcurrency sets the max parallel goroutines for ReadItems.
-// Values less than 1 are clamped to 1. Default 8.
-func WithConcurrency(n int) ReaderOption
+func Open(path string, opts ReaderOptions) *Reader
 
 // TotalItems returns the total number of logical items in the packfile.
 func (r *Reader) TotalItems() (int, error)
@@ -206,22 +297,38 @@ func (r *Reader) TotalItems() (int, error)
 // ReadItem reads a single item by position and passes it to fn.
 // The []byte passed to fn is borrowed and must not be retained after fn
 // returns — copy if needed. Returns ErrPositionOutOfRange if position is
-// out of [0, TotalItems).
+// out of [0, TotalItems). An error returned by fn is returned verbatim.
 func (r *Reader) ReadItem(position int, fn func([]byte) error) error
 
 // ReadRange returns an iterator over count contiguous items starting at start.
-// Each yielded []byte is valid only until the next iteration — copy if you
-// need to retain it. Safe to break early. Thread-safe.
+// Each yielded []byte is valid only until the next iteration AND only inside
+// the for-range body — once the loop exits (break or natural completion) the
+// last yielded slice is no longer safe to read; the underlying buffer goes
+// back to the pool. Copy if you need to retain anything past the loop.
+//
+// Concurrent ReadRange calls on the same Reader are safe; the returned
+// iterator itself is NOT safe for concurrent iteration. Yields a single
+// (nil, ErrPositionOutOfRange) and stops if start/count are invalid; count
+// == 0 is valid and yields nothing.
 func (r *Reader) ReadRange(start, count int) iter.Seq2[[]byte, error]
 
-// ReadItems reads items at the given positions with parallel I/O and calls
-// fn for each item. fn receives the index in the positions slice and a
-// borrowed data slice valid only for the duration of the call — copy if needed.
+// ReadItems reads items at the given positions and calls fn for each.
+// fn receives the index in the positions slice and a borrowed data slice
+// valid only for the duration of the call — copy if needed.
 //
-// fn is called concurrently from multiple goroutines, in arbitrary order.
+// With Concurrency > 1 and more than one I/O batch, fn is called
+// concurrently from multiple goroutines in arbitrary order; with a single
+// batch (or Concurrency == 1), calls are serial and in order. Context
+// cancellation is checked at batch boundaries, not between items inside a
+// batch, so fn may continue to be called for the remaining items of an
+// in-flight batch after the context is canceled. ReadItems is not atomic
+// on error: if fn returns an error or the context is canceled, fn may
+// have already run for some positions and not others.
 //
-// positions must be sorted ascending with no duplicates.
-// Panics if any position is out of range or positions are not sorted/unique.
+// positions must be strictly sorted (ascending, no duplicates); an empty
+// slice is valid and returns nil immediately. Returns ErrPositionOutOfRange
+// if any position is outside [0, TotalItems), ErrPositionsUnsorted if
+// positions are not strictly sorted, or fn's error verbatim if fn fails.
 func (r *Reader) ReadItems(ctx context.Context, positions []int, fn func(idx int, data []byte) error) error
 
 // ContentHash returns the SHA-256 content hash stored in the trailer, if present.
@@ -229,7 +336,8 @@ func (r *Reader) ContentHash() ([32]byte, bool, error)
 
 // Verify recomputes the SHA-256 content hash by streaming all items and
 // compares it to the hash stored in the trailer. Returns nil if no hash is
-// stored or if the hash matches.
+// stored or if the hash matches. Applies ReaderOptions.ContentHashExtract if
+// set — must be the same transform as on the writer side.
 func (r *Reader) Verify(ctx context.Context) error
 
 // AppData returns the app data section, or nil if appDataSize == 0.
@@ -238,8 +346,11 @@ func (r *Reader) AppData() ([]byte, error)
 // Trailer returns the parsed trailer fields (record count, total items, etc.).
 func (r *Reader) Trailer() (Trailer, error)
 
-// Close releases all resources. Safe to call multiple times.
-// Must always be called, even if no read methods were called.
+// Close releases the underlying file handle. The caller-supplied
+// RecordDecoder is not closed — its lifecycle is the caller's concern.
+// If the background open is still in flight, Close blocks until it
+// completes (so the file handle, if opened, is the one Close releases).
+// Safe to call multiple times. Must always be called.
 func (r *Reader) Close() error
 ```
 
@@ -253,7 +364,9 @@ var (
     ErrChecksum            = fmt.Errorf("%w: checksum mismatch", ErrCorrupt)
     ErrSize                = fmt.Errorf("%w: file size inconsistent with trailer", ErrCorrupt)
     ErrPositionOutOfRange  = errors.New("packfile: position out of range")
+    ErrPositionsUnsorted   = errors.New("packfile: positions not strictly sorted")
     ErrContentHashMismatch = errors.New("packfile: content hash mismatch")
+    ErrWriterClosed        = errors.New("packfile: writer is closed")
 )
 ```
 
@@ -267,8 +380,8 @@ Everything below is internal to the library. Callers don't need to know this —
 |---|---|
 | **Item** | One opaque byte blob — the unit the caller writes and reads |
 | **Record** | A group of 1 to `ItemsPerRecord` items, stored as one contiguous blob on disk |
-| **Payload** | The concatenated raw bytes of all items in a record, before compression |
-| **Item size index** | FOR-encoded byte lengths appended to each multi-item record, so the reader can find individual items within the decompressed payload |
+| **Payload** | The concatenated raw bytes of all items in a record, before the caller's encoder runs |
+| **Item size index** | FOR-encoded byte lengths appended to each multi-item record, so the reader can find individual items within the decoded payload |
 | **Offset index** | The file-level table at the end of the file mapping each record to its byte position on disk |
 | **FOR group** | A batch of integers (up to 128) encoded together using Frame of Reference compression |
 | **W** | Bit width needed to store the largest residual in a FOR group |
@@ -290,7 +403,7 @@ Reads throughout this section use `pread` — positioned read at a specific file
 ├──────────────────────────────────┤  (optional)
 │ app data                         │
 ├──────────────────────────────────┤
-│ trailer (64 bytes)               │
+│ trailer (76 bytes)               │
 └──────────────────────────────────┘  EOF
 ```
 
@@ -329,44 +442,42 @@ offset    = offsets[recordIdx]
 
 Each `ReadItem` is an array lookup + single disk read + decode.
 
-The FOR group size for the offset index is 128 — a library constant, independent of `ItemsPerRecord`. If it changes, the format version is bumped.
+The FOR group size for the offset index is 128 — a library constant, independent of `ItemsPerRecord` and of the caller-assigned `Format` value. The chosen value is recorded in the trailer's `indexForGroupSize` field; readers reject files whose recorded value doesn't match the library constant, so changing it would require bumping the on-disk `version` byte.
 
 ### Records
 
 Each record contains up to `ItemsPerRecord` items.
 
-**Multi-item records** (`ItemsPerRecord > 1`): Items are concatenated into a payload. An **item size index** is appended after the payload — a single FOR group encoding each item's byte length, followed by a CRC32C of the FOR data. The item size index is always uncompressed regardless of the record format, and is stripped from the raw record bytes before any format-specific processing.
+**Multi-item records** (`ItemsPerRecord > 1`): Items are concatenated into a payload. The payload is passed through the caller's `RecordEncoder` (or written verbatim in passthrough mode), then an **item size index** is appended — a single FOR group encoding each item's byte length followed by a CRC32C of the FOR data. The item size index is library-managed and always written verbatim regardless of the encoder; the reader strips and CRC-verifies it before invoking the decoder.
 
 ```
 Multi-item record on-disk layout:
 
-  Compressed:   [zstd(payload)][item_sizes]
-  Uncompressed: [payload][4B CRC_items][item_sizes]
-  Raw:          [payload][item_sizes]
+  [encoder.Encode(payload) | payload if passthrough][item_sizes]
 
-item_sizes = [FOR-encoded item lengths][4B CRC32C]
+  item_sizes = [FOR-encoded item lengths][4B CRC32C]
 ```
 
-The decoder strips and verifies the item size index from the tail of the record before decompression, enabling early corruption detection without paying decompression cost.
+Stripping the size index before decoding enables early corruption detection — a CRC failure on the size index surfaces before the (potentially expensive) decoder is invoked.
 
 **Single-item records** (`ItemsPerRecord=1`): The item size index is omitted entirely — the item is the entire payload.
 
 ```
 Single-item record layout (ItemsPerRecord=1):
-  Compressed:   [zstd(item)]
-  Uncompressed: [item][4B CRC_items]
-  Raw:          [item]
+  [encoder.Encode(item) | item if passthrough]
 ```
 
-**Compressed records** (default): The payload is zstd-compressed. Integrity is provided by zstd's built-in content checksum (xxHash64), verified automatically during decompression.
+**Encoder responsibility for payload integrity.** The library does not wrap encoded payloads with a CRC. Per-record payload integrity is whatever the encoder provides:
 
-**Uncompressed records** (`Format: Uncompressed`): The payload is stored as-is with a 4-byte CRC32C covering only the payload bytes.
+- `*zstd.Compressor` — zstd frames carry a built-in xxHash64 checksum, verified during decompression.
+- Passthrough (nil encoder) — no per-record integrity. Use only when items are already checksummed by the caller or the trailer-level content hash is sufficient.
+- Custom encoder — caller's choice (e.g. raw bytes with a trailing CRC32C).
 
-**Raw records** (`Format: Raw`): The payload is stored as-is with no integrity wrapper.
+The library-managed item-size-index CRC is independent of the payload codec.
 
 ### Worked Example
 
-Here's how records, item size indexes, and the offset index compose into a complete file. Compressed payload sizes are approximate (marked ≈); FOR encoding math is exact.
+Here's how records, item size indexes, and the offset index compose into a complete file. The example assumes a zstd encoder (`*zstd.Compressor`). Encoded payload sizes are approximate (marked ≈); FOR encoding math is exact. The same example with a passthrough encoder would skip the size reduction but keep the layout identical.
 
 5 items with sizes [120, 95, 200, 80, 150] bytes.
 
@@ -401,8 +512,8 @@ File layout:
   191     Record 1  (≈ 246 B)
   437     Record 2  (≈ 125 B)
   562     Offset index (12 B)
-  574     Trailer (64 B)
-  638     EOF
+  574     Trailer (76 B)
+  650     EOF
 ```
 
 **With `ItemsPerRecord=1`** (5 records, same items):
@@ -425,61 +536,77 @@ File layout:
   347     Record 3  (≈ 70 B)
   417     Record 4  (≈ 125 B)
   542     Offset index (14 B)
-  556     Trailer (64 B)
-  620     EOF
+  556     Trailer (76 B)
+  632     EOF
 ```
 
 Key difference: with `ItemsPerRecord=2`, each multi-item record carries an item size index so the reader can find individual items inside the decompressed payload. With `ItemsPerRecord=1`, that disappears entirely — each read fetches exactly one item, no slicing needed. The tradeoff is 5 index entries instead of 3.
 
 ### Content Hash
 
-When `ContentHash: true`, the writer computes a chunked SHA-256 over the logical item stream. Each record's items are hashed together into a digest, then all digests are hashed into the final hash:
+When `ContentHash: true`, the writer computes a chunked SHA-256 over the logical item stream. Each record's items are hashed together into a per-record digest, then all per-record digests are hashed into the final hash:
 
 ```
-// Example with ItemsPerRecord=128:
+// Example with ItemsPerRecord=128, no ContentHashExtract:
 record_0_digest = SHA-256([4B len][item_0][4B len][item_1]...[4B len][item_127])
 record_1_digest = SHA-256([4B len][item_128]...[4B len][item_255])
 ...
 finalHash = SHA-256(record_0_digest || record_1_digest || ...)
 ```
 
-The hash is independent of compression and format — same items in the same order with the same `ItemsPerRecord` always produce the same hash. Note that changing `ItemsPerRecord` changes the chunk boundaries and therefore the hash.
+The hash is independent of the record encoder — same items in the same order with the same `ItemsPerRecord` always produce the same hash regardless of which `RecordEncoder` is plugged in. Changing `ItemsPerRecord` changes the chunk boundaries and therefore the hash.
 
-### Trailer (64 bytes at EOF)
+**`ContentHashExtract`** lets the caller transform each item before it is fed to the hasher:
+
+```
+// With ContentHashExtract: each item is replaced by extract(item) in the hash input.
+hashed_item_i = ContentHashExtract(item_i)
+record_0_digest = SHA-256([4B len][hashed_item_0]...[4B len][hashed_item_127])
+```
+
+The extract is useful when items as received aren't the canonical hash input (e.g. items are pre-compressed and the hash should cover their decompressed form so it's stable across encoder versions). Verify requires a matching extract on the reader side; mismatched extracts produce `ErrContentHashMismatch` even on an intact file.
+
+### Trailer (76 bytes at EOF)
 
 ```
 Offset  Size  Type      Field
-0       4     uint32    magic (0x534C4348)
+0       4     uint32    magic (0x48434C53, "SLCH" in on-disk byte order)
 4       1     uint8     version (1)
 5       1     uint8     flags
-6       4     uint32    recordCount
-10      4     uint32    totalItems
-14      4     uint32    itemsPerRecord
-18      4     uint32    indexSize (offset index bytes + 4-byte CRC32C)
-22      4     uint32    appDataSize (0 if none)
-26      32    [32]byte  contentHash (zeroed if flagContentHash not set)
-58      2     uint16    indexForGroupSize (FOR group size for offset index)
-60      4     uint32    CRC32C of trailer[0:60]
+6       2     —         reserved
+8       4     uint32    format (caller-assigned)
+12      4     uint32    recordCount
+16      4     uint32    totalItems
+20      4     uint32    itemsPerRecord
+24      2     uint16    indexForGroupSize (FOR group size for offset index)
+26      2     —         reserved
+28      4     uint32    indexSize (offset index bytes + 4-byte CRC32C)
+32      4     uint32    appDataSize (0 if none)
+36      32    [32]byte  contentHash (zeroed if flagContentHash not set)
+68      4     —         reserved
+72      4     uint32    CRC32C of trailer[0:72]
 ```
 
 Flags (uint8):
-- Bit 0 (`flagNoCompression`): records are not zstd-compressed (Uncompressed format with CRC32C, or Raw when combined with Bit 2)
-- Bit 1 (`flagContentHash`): trailer contains a 32-byte SHA-256 content hash
-- Bit 2 (`flagNoCRC`): per-record CRC32C is omitted (only valid with flagNoCompression; this combination is the Raw format)
+- Bit 0 (`flagContentHash`): trailer contains a 32-byte SHA-256 content hash
 
-The `Checksum` at offset 60 covers `trailer[0:60]`. The reader validates flags against `knownFlags` and rejects files with unknown flag bits.
+All other bits are reserved. The reader validates flags against `knownFlags` and rejects files with unknown flag bits.
+
+The `Checksum` at offset 72 covers `trailer[0:72]`.
 
 ### Integrity
 
 **Index checksum:** CRC32C of the raw offset index bytes. Verified on open before decoding. After decoding, the reader also asserts that the running offset sum equals `indexBase` — an independent structural invariant that catches encode/decode logic bugs.
 
-**Trailer checksum:** CRC32C of `trailer[0:60]` protects all structural fields. App data has no packfile-level integrity check — callers are responsible for their own app data integrity.
+**Trailer checksum:** CRC32C of `trailer[0:72]` protects all structural fields. App data has no packfile-level integrity check — callers are responsible for their own app data integrity.
 
 **Trailer validation:** On open: flags against `knownFlags`, `itemsPerRecord > 0`, `ceil(totalItems / itemsPerRecord) == recordCount`.
 
-**Record checksums:** Compressed records use zstd's built-in content checksum (xxHash64), verified during decompression. Uncompressed records use a trailing CRC32C. Raw records have no per-record integrity — use only when items are already checksummed.
+**Item-size-index checksum:** Each multi-item record carries a CRC32C over its FOR-encoded item-size index, verified before the record's encoded payload is passed to the decoder. The CRC is library-managed and independent of the encoder.
 
-**Content hash verification:** `Verify(ctx)` recomputes the SHA-256 content hash by streaming all items and compares to the stored hash.
+**Per-record payload integrity:** Caller-supplied — see [Records](#records). The library does not wrap encoded payloads with a CRC.
+
+**Content hash verification:** `Verify(ctx)` recomputes the chunked SHA-256 by streaming all items (applying `ReaderOptions.ContentHashExtract` if set) and compares to the stored hash. Mismatched extract on read produces `ErrContentHashMismatch`.
 
 ### Edge Cases
 
@@ -499,7 +626,7 @@ The `Checksum` at offset 60 covers `trailer[0:60]`. The reader validates flags a
 
 **Non-blocking Open.** `Open` returns a `*Reader` immediately. A background goroutine performs all I/O: open, stat, speculative read, trailer parse, CRC verification, index decode, app data read. A `sync.OnceValue` drains the result on the first query call. Errors are deferred to query time — `Open` itself never fails. This enables overlapped initialization: the caller can open multiple files or perform other setup while the goroutine runs.
 
-**Speculative Read.** On open, one pread of the last `min(256KB, fileSize)` bytes. If the offset index fits within this range, the trailer, app data, and index are all loaded in a single I/O operation. Otherwise, a fallback read fetches the rest.
+**Speculative Read.** On open, one pread of the last `min(256 KiB, fileSize)` bytes. If the offset index fits within this range, the trailer, app data, and index are all loaded in a single I/O operation. Otherwise, a fallback read fetches the rest.
 
 **Index Decode OOM Guard.** Before decoding the offset index, validates that `recordCount` is plausible given `indexSize`. Each FOR group of up to 128 records requires at least 6 bytes. This prevents crafted trailers from causing huge allocations.
 
@@ -508,16 +635,18 @@ The `Checksum` at offset 60 covers `trailer[0:60]`. The reader validates flags a
 1. Record number = `42 / 128 = 0`, local position = `42 % 128 = 42`
 2. Look up record 0's byte offset from the in-memory offset table (array access)
 3. One `pread` fetches the entire record from disk
-4. Decode: strip and verify the item size index, decompress if needed
+4. Decode: for multi-item records, strip and CRC-verify the item size index; then run the caller's `RecordDecoder` on the payload (or alias verbatim in passthrough mode). Single-item records skip the size-index step.
 5. Extract item 42 from the decoded payload, pass to `fn`
 
-All of steps 2-5 are a single I/O operation. A pooled decoder is used and returned after the callback.
+All of steps 2-5 are a single I/O operation. A `*record` workspace is borrowed from a package-level pool and returned after the callback.
 
-**ReadRange.** Coalesces consecutive records that fit in a pooled 1MB buffer into single `ReadAt` calls. Oversized records (> 1MB) get one-off allocations.
+**ReadRange.** Coalesces consecutive records that fit in a pooled 1 MiB buffer into single `ReadAt` calls. Oversized records (> 1 MiB) get one-off allocations.
 
-**ReadItems.** Single-pass partition of sorted positions into I/O batches (consecutive records ≤ 1MB). Workers (up to `concurrency` goroutines) claim batches via an atomic counter, read with a single `ReadAt`, decode, and call `fn(idx, data)` directly. No channels, no reorder goroutine. On error or cancellation, an atomic flag stops remaining workers.
+**ReadItems.** Single-pass partition of sorted positions into I/O batches (consecutive records ≤ 1 MiB). With `Concurrency == 1`, batches are processed serially in the calling goroutine — no goroutine spawn, no errgroup overhead. With `Concurrency > 1`, an `errgroup.WithContext` drives up to `Concurrency` workers; each worker claims batches via an atomic counter, reads with a single `ReadAt`, decodes, and calls `fn(idx, data)`. The derived context propagates cancellation; the first non-nil error wins.
 
-**Decoder Pool.** `sync.Pool` of decoder instances, each owning a `ZSTD_DCtx` allocated via CGo. Decoders are stateless between calls.
+**Decoder Lifecycle.** `RecordDecoder` is a single concurrent-safe instance supplied by the caller via `ReaderOptions.RecordDecoder` and reused across every read on every Reader. `*zstd.Decompressor` pools `ZSTD_DCtx` instances internally with finalizers, so one decompressor per process amortizes context construction across all packfiles. `Reader.Close` does not touch the decoder.
+
+**Workspace Pool.** A package-level `sync.Pool` of `*record` workspaces (scratch buffers, sizes, offsets — no resources requiring explicit cleanup). Workspaces are reused across Readers; GC reclaims them when the pool drains naturally.
 
 **Concurrency.** Safe for concurrent use after `Open`. The offset table and metadata are immutable. All read methods use stateless `ReadAt` (pread) with pooled resources.
 
@@ -525,6 +654,6 @@ All of steps 2-5 are a single I/O operation. A pooled decoder is used and return
 
 **Create.** Opens the file directly at `path` with `O_EXCL` (fails if exists, unless `Overwrite` is set). `Finish` writes remaining items, the offset index, app data, trailer, then fsyncs. `Close` without `Finish` removes the incomplete file.
 
-**Parallel Pipeline.** When `Concurrency > 1`, the writer runs a streaming pipeline: `AppendItem` accumulates items → flush sends records to workers → N block workers compress/CRC/hash in parallel → writer goroutine reorders by block ID and writes sequentially.
+**Parallel Pipeline.** When either a `NewRecordEncoder` or `ContentHash` is set, the writer runs a streaming pipeline: `AppendItem` accumulates items → flush sends records to workers → `max(Concurrency, 1)` workers run the caller's encoder (one fresh `RecordEncoder` per worker via the factory) and compute the chunked SHA-256 digest in parallel → writer goroutine reorders by record ordinal and writes sequentially. With neither an encoder nor a content hash, records are written directly from the main goroutine and `Concurrency` is ignored.
 
 **BytesPerSync.** Optional background writeback via `sync_file_range(SYNC_FILE_RANGE_WRITE)` on Linux (no-op elsewhere). Spreads I/O so the final fsync has less to flush.

--- a/design-docs/packfile-library.md
+++ b/design-docs/packfile-library.md
@@ -285,9 +285,10 @@ type ReaderOptions struct {
 // NOT safe to call concurrently with any in-flight read.
 type Reader struct{ /* unexported */ }
 
-// Open returns a Reader immediately. File I/O and option validation run in
-// a background goroutine; both kinds of failure are deferred to the first
-// method that needs the result. Open itself has no error return.
+// Open returns a Reader immediately. Option validation runs synchronously;
+// file I/O runs in a background goroutine. Errors from either are deferred
+// to the first method that needs the result, since Open itself has no error
+// return.
 // Close must always be called.
 func Open(path string, opts ReaderOptions) *Reader
 


### PR DESCRIPTION
## Summary

The packfile design doc has been out of sync with the implementation. Most of the divergence came in with the writer (#702) and was never reflected in the doc; the reader (#712) added a few more deltas on top. This PR brings the doc end-to-end into alignment with the merged code.

**No code changes** — doc-only.

## Major changes

### From #702 (writer) — doc was never updated

- **Format model.** `WriterOptions.Format` is now a caller-assigned `Format uint32` identifier, not the old `RecordFormat` enum (`Compressed` / `Uncompressed` / `Raw`). The built-in formats are gone — codec is plug-in via `NewRecordEncoder`.
- **New WriterOptions fields.** `NewRecordEncoder func() RecordEncoder` (per-worker factory), `ContentHashExtract` for per-item transformation before hashing.
- **Trailer is 76 bytes (was 64).** New `format uint32` field at offset 8; only `flagContentHash` remains (`flagNoCompression` / `flagNoCRC` are gone). Magic constant corrected to `0x48434C53`. Worked-example file-size math updated.
- **Records.** Caller-encoded payload + library-managed item-size-index CRC. Per-record payload integrity is encoder-supplied (zstd's xxHash64, or caller's choice, or none with passthrough).
- **Writer single-goroutine constraint** documented (parallel to the Reader's concurrency disclosure).
- **AppendItem semantics**: no-args is a no-op, `[]byte{}` records an empty item, parts are copied, oversized items error.
- **Sync nit**: doc said `fdatasync`; the code calls `os.File.Sync()` which is `fsync`.
- **Concurrency sizing advice**: values above `runtime.NumCPU()` tend to hurt throughput.
- **ErrWriterClosed** added to the Errors section.

### From #712 (reader)

- **ReaderOptions is a struct** (was variadic `WithConcurrency`). Default `Concurrency` is 1 (serial), not 8.
- **RecordDecoder is a single concurrent-safe instance**, caller-owned, not closed by `Reader.Close`.
- **Error semantics.** `ReadItems` / `ReadRange` return errors instead of panicking. New `ErrPositionsUnsorted` sentinel.
- **ReadRange lifetimes.** Yielded slice is invalidated after the for-range loop exits (break or natural completion); iterator itself is not safe for concurrent iteration; `count == 0` is valid.
- **ReadItems cancellation / atomicity.** Context is checked at batch boundaries, not between items inside a batch; `ReadItems` is not atomic on error (fn may have run for some positions and not others). Empty positions slice is valid. fn's error is returned verbatim.
- **Close blocks** on the background open if it is still in flight.
- **Implementation notes.** `ReadItems` uses `errgroup.WithContext` (no more atomic-flag cancellation); single concurrent-safe decoder + package-level workspace pool replaces the old per-Reader decoder pool.

### New section

- **Codec Contract.** Documents `Format uint32`, the `RecordEncoder` / `RecordDecoder` interfaces, and the in-tree `zstd` codec (`*zstd.Compressor` / `*zstd.Decompressor`).

### Polish

- Disambiguated "format version" (the on-disk `version` byte vs the caller-assigned `Format` field) at the index-encoding section.
- Used KiB/MiB binary prefixes where referring to specific code constants (1 MiB pooled buffer, 256 KiB speculative read).
- Parallel-pipeline gate description corrected (triggered by encoder/hash, not by `Concurrency`).

## Verification

Doc was fact-checked end-to-end against the current implementation in `cmd/stellar-rpc/internal/packfile/` via five review passes: three parallel agents on API surface, on-disk format, and behavior/implementation; followed by deep audits dedicated to the writer side and the reader side. All trailer offsets, struct fields, method signatures, error names, default values, lifetime contracts, and implementation claims verified against code.

## Test plan

- [x] No code changes; no tests to run
- [x] Doc renders cleanly in GitHub preview
- [x] All anchors / cross-references resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)
