### PR TITLE
ledger,rocksdb: hot-store FirstSeq/LastSeq range accessors

### DIFF
--- a/cmd/stellar-rpc/internal/fullhistory/pkg/rocksdb/rocksdb.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/rocksdb/rocksdb.go
@@ -292,6 +292,46 @@ func (s *Store) Iterate(cf string, prefix []byte) iter.Seq2[Entry, error] {
 	}
 }
 
+// FirstKey returns the smallest key in cf, or ok=false if the CF is empty.
+// Cheap: a single boundary seek (no scan).
+func (s *Store) FirstKey(cf string) ([]byte, bool, error) {
+	return s.edgeKey(cf, false)
+}
+
+// LastKey returns the largest key in cf, or ok=false if the CF is empty.
+// Cheap: a single boundary seek (no scan).
+func (s *Store) LastKey(cf string) ([]byte, bool, error) {
+	return s.edgeKey(cf, true)
+}
+
+//nolint:funcorder // helper grouped with FirstKey/LastKey for readability
+func (s *Store) edgeKey(cf string, last bool) ([]byte, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if err := s.checkOpen(); err != nil {
+		return nil, false, err
+	}
+	cfh, err := s.resolveCF(cf)
+	if err != nil {
+		return nil, false, err
+	}
+
+	it := s.db.NewIteratorCF(s.ro, cfh)
+	defer it.Close()
+	if last {
+		it.SeekToLast()
+	} else {
+		it.SeekToFirst()
+	}
+	if !it.Valid() {
+		// Empty CF (it.Err() is nil) or a mid-seek RocksDB error.
+		return nil, false, it.Err()
+	}
+	// Copy: the KeySlice is freed when the iterator closes.
+	return append([]byte(nil), it.KeySlice().Data()...), true, it.Err()
+}
+
 // IterateRange yields (key, value) for keys in [start, end] byte-lex
 // inclusive. nil or empty start means "from the first key in the CF";
 // nil or empty end means "walk to the end of the CF". Right tool for

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/rocksdb/rocksdb.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/rocksdb/rocksdb.go
@@ -171,7 +171,7 @@ func (s *Store) Get(cf string, key []byte) ([]byte, bool, error) {
 	}
 	// handle.Data() points into the pinned cache page; copy before
 	// Destroy invalidates it.
-	out := append([]byte(nil), handle.Data()...)
+	out := bytes.Clone(handle.Data())
 	return out, true, nil
 }
 
@@ -223,7 +223,7 @@ func (s *Store) BatchMultiGet(cf string, keys [][]byte) ([][]byte, error) {
 		}
 		// p.Data() points into the pinned cache page; copy before
 		// Destroy invalidates it.
-		results[i] = append([]byte(nil), p.Data()...)
+		results[i] = bytes.Clone(p.Data())
 	}
 	return results, nil
 }
@@ -273,7 +273,7 @@ func (s *Store) Iterate(cf string, prefix []byte) iter.Seq2[Entry, error] {
 		defer it.Close()
 
 		// Copy prefix: the caller may mutate its buffer while ranging.
-		pcopy := append([]byte(nil), prefix...)
+		pcopy := bytes.Clone(prefix)
 		it.Seek(pcopy)
 
 		for ; it.Valid(); it.Next() {
@@ -329,7 +329,7 @@ func (s *Store) edgeKey(cf string, last bool) ([]byte, bool, error) {
 		return nil, false, it.Err()
 	}
 	// Copy: the KeySlice is freed when the iterator closes.
-	return append([]byte(nil), it.KeySlice().Data()...), true, it.Err()
+	return bytes.Clone(it.KeySlice().Data()), true, it.Err()
 }
 
 // IterateRange yields (key, value) for keys in [start, end] byte-lex
@@ -362,12 +362,12 @@ func (s *Store) IterateRange(cf string, start, end []byte) iter.Seq2[Entry, erro
 		if len(start) == 0 {
 			it.SeekToFirst()
 		} else {
-			sk := append([]byte(nil), start...)
+			sk := bytes.Clone(start)
 			it.Seek(sk)
 		}
 
 		// Copy end: caller may mutate its buffer mid-iteration.
-		endCopy := append([]byte(nil), end...)
+		endCopy := bytes.Clone(end)
 		hasUpperBound := len(endCopy) > 0
 
 		for ; it.Valid(); it.Next() {

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/rocksdb/rocksdb.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/rocksdb/rocksdb.go
@@ -292,13 +292,19 @@ func (s *Store) Iterate(cf string, prefix []byte) iter.Seq2[Entry, error] {
 	}
 }
 
-// FirstKey returns the smallest key in cf, or ok=false if the CF is empty.
+// FirstKey returns the smallest key in cf. If cf has no keys this is not
+// an error: it returns (nil, false, nil), so callers detect emptiness via
+// ok. (cf == "" selects the default column family; an unregistered cf name
+// returns ErrCFNotFound.)
 // Cheap: a single boundary seek (no scan).
 func (s *Store) FirstKey(cf string) ([]byte, bool, error) {
 	return s.edgeKey(cf, false)
 }
 
-// LastKey returns the largest key in cf, or ok=false if the CF is empty.
+// LastKey returns the largest key in cf. If cf has no keys this is not an
+// error: it returns (nil, false, nil), so callers detect emptiness via ok.
+// (cf == "" selects the default column family; an unregistered cf name
+// returns ErrCFNotFound.)
 // Cheap: a single boundary seek (no scan).
 func (s *Store) LastKey(cf string) ([]byte, bool, error) {
 	return s.edgeKey(cf, true)

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/rocksdb/rocksdb_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/rocksdb/rocksdb_test.go
@@ -141,6 +141,60 @@ func TestStore_PutGet_DefaultCF(t *testing.T) {
 	assert.False(t, found3)
 }
 
+func TestStore_FirstLastKey(t *testing.T) {
+	s := openTestStore(t, nil)
+
+	// Empty default CF: ok=false, no error, at both ends.
+	_, ok, err := s.FirstKey("")
+	require.NoError(t, err)
+	require.False(t, ok)
+	_, ok, err = s.LastKey("")
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	// EncodeUint32 is big-endian, so byte-lex key order is numeric order:
+	// insert out of order and expect the min/max back.
+	for _, n := range []uint32{500, 1, 9999, 42} {
+		require.NoError(t, s.Put("", EncodeUint32(n), []byte{byte(n)}))
+	}
+	first, ok, err := s.FirstKey("")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint32(1), DecodeUint32(first))
+
+	last, ok, err := s.LastKey("")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint32(9999), DecodeUint32(last))
+
+	// Unknown CF surfaces ErrCFNotFound (distinct from ok=false on an
+	// empty-but-configured CF).
+	_, _, err = s.FirstKey("not-configured")
+	require.ErrorIs(t, err, ErrCFNotFound)
+	_, _, err = s.LastKey("not-configured")
+	require.ErrorIs(t, err, ErrCFNotFound)
+
+	// Non-default CF: FirstKey/LastKey resolve the requested CF
+	// independently of the default CF.
+	const altCF = "alt"
+	sAlt := openTestStore(t, []string{altCF})
+	for _, n := range []uint32{7, 3, 8} {
+		require.NoError(t, sAlt.Put(altCF, EncodeUint32(n), []byte{byte(n)}))
+	}
+	first, ok, err = sAlt.FirstKey(altCF)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint32(3), DecodeUint32(first))
+	last, ok, err = sAlt.LastKey(altCF)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint32(8), DecodeUint32(last))
+	// The default CF of the same store is untouched → ok=false.
+	_, ok, err = sAlt.FirstKey("")
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
 func TestStore_FlushSucceedsOnOpenStore(t *testing.T) {
 	s := openTestStore(t, nil)
 	require.NoError(t, s.Put(defaultCFName, []byte("k"), []byte("v")))
@@ -319,6 +373,8 @@ func TestStore_OpsAfterCloseFailWithErrStoreClosed(t *testing.T) {
 	}{
 		{"Put", func() error { return s.Put(defaultCFName, []byte("k"), []byte("v")) }},
 		{"Get", func() error { _, _, err := s.Get(defaultCFName, []byte("k")); return err }},
+		{"FirstKey", func() error { _, _, err := s.FirstKey(defaultCFName); return err }},
+		{"LastKey", func() error { _, _, err := s.LastKey(defaultCFName); return err }},
 		{"Delete", func() error { return s.Delete(defaultCFName, []byte("k")) }},
 		{"Iterate", func() error {
 			for _, err := range s.Iterate(defaultCFName, nil) {

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/ledger/hot_store.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/ledger/hot_store.go
@@ -153,6 +153,31 @@ func (h *HotStore) GetLedgerRaw(seq uint32) ([]byte, error) {
 	return out, nil
 }
 
+// FirstSeq returns the lowest ledger sequence in the store, or ok=false
+// if the store is empty. Cheap (a single RocksDB boundary seek): lets a
+// caller learn the store's ledger range without an external chunk hint.
+func (h *HotStore) FirstSeq() (uint32, bool, error) { return h.edgeSeq(false) }
+
+// LastSeq returns the highest ledger sequence in the store, or ok=false
+// if the store is empty.
+func (h *HotStore) LastSeq() (uint32, bool, error) { return h.edgeSeq(true) }
+
+//nolint:funcorder // helper grouped with FirstSeq/LastSeq for readability
+func (h *HotStore) edgeSeq(last bool) (uint32, bool, error) {
+	edge := h.store.FirstKey
+	if last {
+		edge = h.store.LastKey
+	}
+	k, ok, err := edge("")
+	if err != nil {
+		return 0, false, translateRocksErr(err)
+	}
+	if !ok {
+		return 0, false, nil
+	}
+	return rocksdb.DecodeUint32(k), true, nil
+}
+
 // IterateLedgers walks (seq, uncompressed bytes) pairs in
 // [start, end] inclusive, ascending. start > end yields no entries
 // and no error. Gaps in the keyspace are visible as missing

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/ledger/hot_store_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/ledger/hot_store_test.go
@@ -85,6 +85,34 @@ func TestHotStore_AddGetRoundTripVerbatim(t *testing.T) {
 	require.NoError(t, h.AddLedgers())
 }
 
+// TestHotStore_AddLedgersIdempotentRetry mirrors the events store's retry
+// contract: re-delivering the same (seq, bytes) — e.g. a restarted ingester
+// replaying the in-flight ledger — is a clean no-op. Unlike the
+// log-structured events store (which drops the duplicate), the ledger store
+// is a seq-keyed upsert, so the retry overwrites with identical bytes and
+// does not duplicate the key.
+func TestHotStore_AddLedgersIdempotentRetry(t *testing.T) {
+	h := openTestHotStore(t)
+	payload := []byte("ledger payload")
+
+	require.NoError(t, h.AddLedgers(Entry{Seq: 7, Bytes: payload}))
+	require.NoError(t, h.AddLedgers(Entry{Seq: 7, Bytes: payload})) // retry
+
+	got, err := h.GetLedgerRaw(7)
+	require.NoError(t, err)
+	assert.Equal(t, payload, got)
+
+	// Still a single entry — the retry overwrote rather than appended.
+	first, ok, err := h.FirstSeq()
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, uint32(7), first)
+	last, ok, err := h.LastSeq()
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, uint32(7), last)
+}
+
 func TestHotStore_FirstLastSeq(t *testing.T) {
 	h := openTestHotStore(t)
 

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/ledger/hot_store_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/ledger/hot_store_test.go
@@ -85,6 +85,34 @@ func TestHotStore_AddGetRoundTripVerbatim(t *testing.T) {
 	require.NoError(t, h.AddLedgers())
 }
 
+func TestHotStore_FirstLastSeq(t *testing.T) {
+	h := openTestHotStore(t)
+
+	// Empty store: ok=false, no error.
+	_, ok, err := h.FirstSeq()
+	require.NoError(t, err)
+	require.False(t, ok)
+	_, ok, err = h.LastSeq()
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	// Insert seqs out of order; FirstSeq/LastSeq report the min/max present.
+	require.NoError(t, h.AddLedgers(
+		Entry{Seq: 105, Bytes: []byte("c")},
+		Entry{Seq: 100, Bytes: []byte("a")},
+		Entry{Seq: 103, Bytes: []byte("b")},
+	))
+	first, ok, err := h.FirstSeq()
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, uint32(100), first)
+
+	last, ok, err := h.LastSeq()
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, uint32(105), last)
+}
+
 func TestHotStore_AddLedgersMultipleEntries(t *testing.T) {
 	h := openTestHotStore(t)
 


### PR DESCRIPTION
## Summary

Adds `HotStore.FirstSeq()` / `LastSeq()` to the hot ledger store so a caller can learn the store's covered ledger range without an external chunk hint — the cold reader (`ColdReader.FirstSeq`/`LastSeq`) already exposes the equivalents, so this restores symmetry.

They delegate to two new `rocksdb.Store` primitives:

- `Store.FirstKey(cf)` / `LastKey(cf)` — the smallest / largest key in a CF (or `ok=false` if the CF is empty), via a single `SeekToFirst`/`SeekToLast` boundary seek under the store's `RLock`. No scan.

`edgeKey` copies the boundary key out before the iterator closes (matching the existing `Get`/`Iterate` ownership pattern); `edgeSeq` decodes it with `DecodeUint32`.

Ported from `rpc-hack`, with the documentary named returns dropped and a `//nolint:funcorder` on the unexported helpers (kept adjacent to their callers) to satisfy this branch's lint.

A second commit modernizes the six C-buffer copy sites in `rocksdb.go` (`Get`, `BatchMultiGet`, `Iterate`, `IterateRange` ×2, and the new `FirstKey`/`LastKey`) from `append([]byte(nil), x...)` to `bytes.Clone` so the new accessors match their siblings — equivalent, since `bytes` is already imported and the nil-vs-empty difference for a zero-length source is unobservable here.

## Test plan

- `TestStore_FirstLastKey`: empty CF (`ok=false`); out-of-order inserts → min/max (big-endian key order == numeric); non-default CF resolution; unknown CF → `ErrCFNotFound`.
- `TestStore_OpsAfterCloseFailWithErrStoreClosed`: adds `FirstKey`/`LastKey` (post-close → `ErrStoreClosed`).
- `TestHotStore_FirstLastSeq`: empty store (`ok=false`); out-of-order `AddLedgers` → min/max.
- `go build` / `go vet` / `golangci-lint` clean on the `rocksdb` and `ledger` packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
