### PR TITLE
[DRAFT] ingest: full-history ingest core (pkg/ingest) — on throwaway stores-integration base

### DIFF
--- a/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/config.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/config.go
@@ -1,0 +1,34 @@
+package ingest
+
+import "errors"
+
+// Config selects which data types the ingest drivers write. At least one of
+// Ledgers/Txhash/Events must be enabled. Decode is always parsed and per-ledger
+// fan-out is always parallel; those are not configurable.
+//
+// Passphrase is the network passphrase used to derive event payloads from a
+// LedgerCloseMeta. It is required iff Events is enabled.
+type Config struct {
+	Ledgers bool
+	Txhash  bool
+	Events  bool
+
+	Passphrase string
+}
+
+// validate rejects a Config with no enabled data types, or one that enables
+// Events without supplying a network passphrase.
+func (c Config) validate() error {
+	if !c.Ledgers && !c.Txhash && !c.Events {
+		return errors.New("ingest: Config enables no data types (set at least one of Ledgers/Txhash/Events)")
+	}
+	if c.Events && c.Passphrase == "" {
+		return errors.New("ingest: Config.Passphrase is required when Events is enabled")
+	}
+	return nil
+}
+
+// needsLCM reports whether the driver must decode each ledger's raw bytes into
+// an xdr.LedgerCloseMeta. The ledgers ingesters consume raw bytes verbatim, so
+// the decode is only needed when events or txhash are enabled.
+func (c Config) needsLCM() bool { return c.Events || c.Txhash }

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/doc.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/doc.go
@@ -3,10 +3,16 @@
 // contract events into the hot and cold full-history stores.
 //
 // The package exposes a small surface: a Config selecting which data types to
-// ingest, a Source/SourceOpts pair plus OpenChunkStream for opening per-chunk
-// ledger streams, and two drivers — RunHot (continuous single-stream fan-out
-// into the hot stores) and RunCold (chunk-range, parallel chunk workers, each
-// finalizing its own cold artifact).
+// ingest, a ChunkSource abstraction (with built-in NewPackSource /
+// NewDataStoreSource / NewGCSSource / NewS3Source constructors) that yields a
+// per-chunk ledger stream from any backend, and two drivers — RunHot
+// (single-chunk fan-out into the hot stores) and RunCold (chunk-range, parallel
+// chunk workers, each finalizing its own cold artifact). Both drivers take a
+// ChunkSource and open one stream per chunk.
+//
+// ChunkSource is the extension point: GCS, S3, and Filesystem share one
+// datastore-backed code path and differ only by config, and a new backend just
+// implements the interface — there is no central switch to edit.
 //
 // The per-type ingesters (ledgers/txhash/events × hot/cold) are unexported;
 // consumers drive ingest through the two driver functions. Decode is always

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/doc.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/doc.go
@@ -1,0 +1,20 @@
+// Package ingest is the reusable full-history ingest core: it streams raw
+// ledgers from a source backend and writes ledgers, transaction hashes, and
+// contract events into the hot and cold full-history stores.
+//
+// The package exposes a small surface: a Config selecting which data types to
+// ingest, a Source/SourceOpts pair plus OpenChunkStream for opening per-chunk
+// ledger streams, and two drivers — RunHot (continuous single-stream fan-out
+// into the hot stores) and RunCold (chunk-range, parallel chunk workers, each
+// finalizing its own cold artifact).
+//
+// The per-type ingesters (ledgers/txhash/events × hot/cold) are unexported;
+// consumers drive ingest through the two driver functions. Decode is always
+// parsed: when events or txhash are enabled the driver unmarshals each ledger's
+// raw bytes into an xdr.LedgerCloseMeta once and shares it read-only across the
+// enabled ingesters. Per-ledger fan-out is always parallel via errgroup.
+//
+// This package is a production refactor of the bench-fullhistory ingest
+// harness, with all benchmarking-only code (collectors, samples, metrics,
+// CSV/percentile reporting, profiling, flag parsing) removed.
+package ingest

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/driver.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/driver.go
@@ -13,11 +13,6 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
 )
 
-// streamFactory opens an independent LedgerStream for one chunk. Each cold
-// chunk worker uses it to acquire its own stream (a BSB cursor cannot be
-// shared); it is also the injection seam for tests.
-type streamFactory func(chunkID chunk.ID) (ledgerbackend.LedgerStream, error)
-
 // buildLedger turns one ledger's raw bytes (borrowed from the stream) into a
 // Ledger. When needsLCM is set (events or txhash enabled), it decodes the raw
 // bytes into an xdr.LedgerCloseMeta once, shared read-only across the enabled
@@ -125,7 +120,7 @@ func drainStream[T ingester](ctx context.Context, stream ledgerbackend.LedgerStr
 	return nil
 }
 
-// RunHot streams a single chunk's ledgers from stream and fans each one out to
+// RunHot opens one stream for chunkID from source and fans each ledger out to
 // the enabled hot ingesters, writing into per-type subdirectories under hotDir
 // (hotDir/ledgers, hotDir/txhash, hotDir/events). Ingest errors abort the run
 // fast; the per-ledger errgroup gates the next stream pull so the borrowed raw
@@ -134,13 +129,18 @@ func drainStream[T ingester](ctx context.Context, stream ledgerbackend.LedgerStr
 func RunHot(
 	ctx context.Context,
 	logger *supportlog.Entry,
-	stream ledgerbackend.LedgerStream,
+	source ChunkSource,
 	chunkID chunk.ID,
 	hotDir string,
 	cfg Config,
 ) (err error) {
 	if verr := cfg.validate(); verr != nil {
 		return verr
+	}
+
+	stream, oerr := source.OpenStream(chunkID)
+	if oerr != nil {
+		return fmt.Errorf("open stream for chunk %d: %w", uint32(chunkID), oerr)
 	}
 
 	ings, berr := buildIngesters(cfg, func(subdir string) (ingester, error) {
@@ -164,30 +164,27 @@ func RunHot(
 
 // RunCold ingests numChunks consecutive chunks starting at startChunk into the
 // cold stores under coldDir, processing up to chunkWorkers chunks concurrently.
-// Each chunk worker opens its own stream via OpenChunkStream(src, opts, id).
+// Each chunk worker opens its own stream via source.OpenStream(chunkID), so the
+// chunks run with fully independent backend pipelines.
 func RunCold(
 	ctx context.Context,
 	logger *supportlog.Entry,
-	src Source,
-	opts SourceOpts,
+	source ChunkSource,
 	coldDir string,
 	startChunk chunk.ID,
 	numChunks, chunkWorkers int,
 	cfg Config,
 ) error {
-	factory := func(id chunk.ID) (ledgerbackend.LedgerStream, error) {
-		return OpenChunkStream(src, opts, id)
-	}
-	return runColdWithStreamFactory(ctx, logger, factory, coldDir, startChunk, numChunks, chunkWorkers, cfg)
+	return runColdWithSource(ctx, logger, source, coldDir, startChunk, numChunks, chunkWorkers, cfg)
 }
 
-// runColdWithStreamFactory is the testable core of RunCold: it orchestrates the
-// chunk range using factory to open each worker's stream. Tests inject a fake
-// stream factory here.
-func runColdWithStreamFactory(
+// runColdWithSource is the testable core of RunCold: it orchestrates the chunk
+// range, each worker opening its own stream from source. Tests inject a custom
+// ChunkSource (e.g. a ChunkSourceFunc) here.
+func runColdWithSource(
 	ctx context.Context,
 	logger *supportlog.Entry,
-	factory streamFactory,
+	source ChunkSource,
 	coldDir string,
 	startChunk chunk.ID,
 	numChunks, chunkWorkers int,
@@ -212,7 +209,7 @@ func runColdWithStreamFactory(
 	for i := range numChunks {
 		chunkID := startChunk + chunk.ID(uint32(i))
 		g.Go(func() error {
-			if rerr := runOneChunkCold(gctx, factory, coldDir, chunkID, cfg); rerr != nil {
+			if rerr := runOneChunkCold(gctx, source, coldDir, chunkID, cfg); rerr != nil {
 				return fmt.Errorf("chunk %d: %w", uint32(chunkID), rerr)
 			}
 			return nil
@@ -221,19 +218,19 @@ func runColdWithStreamFactory(
 	return g.Wait()
 }
 
-// runOneChunkCold processes a single chunk: opens its own stream via factory,
+// runOneChunkCold processes a single chunk: opens its own stream from source,
 // builds the enabled cold ingesters, runs the per-ledger fan-out, then calls
 // Finalize on each cold ingester (explicit, error-checked, not deferred).
 // Ingester Close is deferred and idempotent — on the failure path it removes
 // any partial cold artifact for writers whose Finalize never ran.
 func runOneChunkCold(
 	ctx context.Context,
-	factory streamFactory,
+	source ChunkSource,
 	coldDir string,
 	chunkID chunk.ID,
 	cfg Config,
 ) (err error) {
-	stream, oerr := factory(chunkID)
+	stream, oerr := source.OpenStream(chunkID)
 	if oerr != nil {
 		return oerr
 	}

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/driver.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/driver.go
@@ -1,0 +1,261 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
+)
+
+// streamFactory opens an independent LedgerStream for one chunk. Each cold
+// chunk worker uses it to acquire its own stream (a BSB cursor cannot be
+// shared); it is also the injection seam for tests.
+type streamFactory func(chunkID chunk.ID) (ledgerbackend.LedgerStream, error)
+
+// buildLedger turns one ledger's raw bytes (borrowed from the stream) into a
+// Ledger. When needsLCM is set (events or txhash enabled), it decodes the raw
+// bytes into an xdr.LedgerCloseMeta once, shared read-only across the enabled
+// ingesters. When only ledgers are enabled, the decode is skipped (the ledgers
+// ingesters write raw bytes verbatim).
+//
+// raw is BORROWED and valid only for the current iteration step; the resulting
+// Ledger must be fully consumed before the next stream yield, which the driver
+// guarantees by waiting on the per-ledger errgroup before pulling again.
+func buildLedger(seq uint32, raw []byte, needsLCM bool) (Ledger, error) {
+	if !needsLCM {
+		return Ledger{Seq: seq, Raw: raw}, nil
+	}
+	return newParsedLedger(seq, raw)
+}
+
+// closeAll closes every ingester, joining each Close error into err. Used in
+// the deferred cleanup of both drivers so a store-handle leak or partial-file
+// removal failure surfaces on the returned error.
+func closeAll[T ingester](ings []T, err error) error {
+	for _, ing := range ings {
+		if cerr := ing.Close(); cerr != nil {
+			err = errors.Join(err, fmt.Errorf("close: %w", cerr))
+		}
+	}
+	return err
+}
+
+// RunHot streams a single chunk's ledgers from stream and fans each one out to
+// the enabled hot ingesters, writing into per-type subdirectories under hotDir
+// (hotDir/ledgers, hotDir/txhash, hotDir/events). Ingest errors abort the run
+// fast; the per-ledger errgroup gates the next stream pull so the borrowed raw
+// slice is never read past its lifetime. Ingester Close is deferred and
+// idempotent.
+func RunHot(
+	ctx context.Context,
+	logger *supportlog.Entry,
+	stream ledgerbackend.LedgerStream,
+	chunkID chunk.ID,
+	hotDir string,
+	cfg Config,
+) (err error) {
+	if verr := cfg.validate(); verr != nil {
+		return verr
+	}
+
+	var ings []ingester
+	if cfg.Ledgers {
+		ing, ierr := newLedgersHot(filepath.Join(hotDir, "ledgers"), logger)
+		if ierr != nil {
+			return closeAll(ings, fmt.Errorf("open ledgers hot: %w", ierr))
+		}
+		ings = append(ings, ing)
+	}
+	if cfg.Txhash {
+		ing, ierr := newTxhashHot(filepath.Join(hotDir, "txhash"), logger)
+		if ierr != nil {
+			return closeAll(ings, fmt.Errorf("open txhash hot: %w", ierr))
+		}
+		ings = append(ings, ing)
+	}
+	if cfg.Events {
+		ing, ierr := newEventsHot(filepath.Join(hotDir, "events"), chunkID, logger, cfg.Passphrase)
+		if ierr != nil {
+			return closeAll(ings, fmt.Errorf("open events hot: %w", ierr))
+		}
+		ings = append(ings, ing)
+	}
+	defer func() { err = closeAll(ings, err) }()
+
+	first, last := chunkID.FirstLedger(), chunkID.LastLedger()
+	needsLCM := cfg.needsLCM()
+	seq := first
+	for raw, serr := range stream.RawLedgers(ctx, ledgerbackend.BoundedRange(first, last)) {
+		if cerr := ctx.Err(); cerr != nil {
+			return cerr
+		}
+		if serr != nil {
+			return fmt.Errorf("RawLedgers(%d): %w", seq, serr)
+		}
+		l, lerr := buildLedger(seq, raw, needsLCM)
+		if lerr != nil {
+			return lerr
+		}
+		if ferr := fanOut(ctx, ings, l); ferr != nil {
+			return ferr
+		}
+		seq++
+	}
+	return nil
+}
+
+// RunCold ingests numChunks consecutive chunks starting at startChunk into the
+// cold stores under coldDir, processing up to chunkWorkers chunks concurrently.
+// Each chunk worker opens its own stream via OpenChunkStream(src, opts, id).
+func RunCold(
+	ctx context.Context,
+	logger *supportlog.Entry,
+	src Source,
+	opts SourceOpts,
+	coldDir string,
+	startChunk chunk.ID,
+	numChunks, chunkWorkers int,
+	cfg Config,
+) error {
+	factory := func(id chunk.ID) (ledgerbackend.LedgerStream, error) {
+		return OpenChunkStream(src, opts, id)
+	}
+	return runColdWithStreamFactory(ctx, logger, factory, coldDir, startChunk, numChunks, chunkWorkers, cfg)
+}
+
+// runColdWithStreamFactory is the testable core of RunCold: it orchestrates the
+// chunk range using factory to open each worker's stream. Tests inject a fake
+// stream factory here.
+func runColdWithStreamFactory(
+	ctx context.Context,
+	logger *supportlog.Entry,
+	factory streamFactory,
+	coldDir string,
+	startChunk chunk.ID,
+	numChunks, chunkWorkers int,
+	cfg Config,
+) error {
+	if verr := cfg.validate(); verr != nil {
+		return verr
+	}
+	if numChunks < 1 {
+		return fmt.Errorf("ingest: numChunks must be >= 1, got %d", numChunks)
+	}
+	if chunkWorkers < 1 {
+		return fmt.Errorf("ingest: chunkWorkers must be >= 1, got %d", chunkWorkers)
+	}
+	if chunkWorkers > numChunks {
+		logger.Infof("chunkWorkers=%d > numChunks=%d; clamping to %d", chunkWorkers, numChunks, numChunks)
+		chunkWorkers = numChunks
+	}
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(chunkWorkers)
+	for i := range numChunks {
+		chunkID := startChunk + chunk.ID(uint32(i))
+		g.Go(func() error {
+			if rerr := runOneChunkCold(gctx, factory, coldDir, chunkID, cfg); rerr != nil {
+				return fmt.Errorf("chunk %d: %w", uint32(chunkID), rerr)
+			}
+			return nil
+		})
+	}
+	return g.Wait()
+}
+
+// runOneChunkCold processes a single chunk: opens its own stream via factory,
+// builds the enabled cold ingesters, runs the per-ledger fan-out, then calls
+// Finalize on each cold ingester (explicit, error-checked, not deferred).
+// Ingester Close is deferred and idempotent — on the failure path it removes
+// any partial cold artifact for writers whose Finalize never ran.
+func runOneChunkCold(
+	ctx context.Context,
+	factory streamFactory,
+	coldDir string,
+	chunkID chunk.ID,
+	cfg Config,
+) (err error) {
+	stream, oerr := factory(chunkID)
+	if oerr != nil {
+		return oerr
+	}
+
+	var ings []coldIngester
+	if cfg.Ledgers {
+		ing, ierr := newLedgersCold(filepath.Join(coldDir, "ledgers"), chunkID, LedgersColdOpts{})
+		if ierr != nil {
+			return closeAll(ings, fmt.Errorf("open ledgers cold: %w", ierr))
+		}
+		ings = append(ings, ing)
+	}
+	if cfg.Txhash {
+		ing, ierr := newTxhashCold(filepath.Join(coldDir, "txhash"), chunkID)
+		if ierr != nil {
+			return closeAll(ings, fmt.Errorf("open txhash cold: %w", ierr))
+		}
+		ings = append(ings, ing)
+	}
+	if cfg.Events {
+		ing, ierr := newEventsCold(filepath.Join(coldDir, "events"), chunkID, EventsColdOpts{}, cfg.Passphrase)
+		if ierr != nil {
+			return closeAll(ings, fmt.Errorf("open events cold: %w", ierr))
+		}
+		ings = append(ings, ing)
+	}
+	defer func() { err = closeAll(ings, err) }()
+
+	first, last := chunkID.FirstLedger(), chunkID.LastLedger()
+	needsLCM := cfg.needsLCM()
+	seq := first
+	for raw, serr := range stream.RawLedgers(ctx, ledgerbackend.BoundedRange(first, last)) {
+		if cerr := ctx.Err(); cerr != nil {
+			return cerr
+		}
+		if serr != nil {
+			return fmt.Errorf("RawLedgers(%d): %w", seq, serr)
+		}
+		l, lerr := buildLedger(seq, raw, needsLCM)
+		if lerr != nil {
+			return lerr
+		}
+		if ferr := fanOutCold(ctx, ings, l); ferr != nil {
+			return ferr
+		}
+		seq++
+	}
+
+	// Finalize each chunk's cold artifact. Explicit and error-checked — never
+	// deferred. A Finalize error means the chunk did not durably land.
+	for _, ing := range ings {
+		if ferr := ing.Finalize(ctx); ferr != nil {
+			return fmt.Errorf("finalize: %w", ferr)
+		}
+	}
+	return nil
+}
+
+// fanOut runs every hot ingester on l concurrently, waiting for all to finish
+// before returning so the borrowed raw is safe to release. The first Ingest
+// error cancels the siblings via the errgroup context.
+func fanOut(ctx context.Context, ings []ingester, l Ledger) error {
+	g, gctx := errgroup.WithContext(ctx)
+	for _, ing := range ings {
+		g.Go(func() error { return ing.Ingest(gctx, l) })
+	}
+	return g.Wait()
+}
+
+// fanOutCold is fanOut for the cold-ingester slice type.
+func fanOutCold(ctx context.Context, ings []coldIngester, l Ledger) error {
+	g, gctx := errgroup.WithContext(ctx)
+	for _, ing := range ings {
+		g.Go(func() error { return ing.Ingest(gctx, l) })
+	}
+	return g.Wait()
+}

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/driver.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/driver.go
@@ -31,7 +31,17 @@ func buildLedger(seq uint32, raw []byte, needsLCM bool) (Ledger, error) {
 	if !needsLCM {
 		return Ledger{Seq: seq, Raw: raw}, nil
 	}
-	return newParsedLedger(seq, raw)
+	l, err := newParsedLedger(seq, raw)
+	if err != nil {
+		return Ledger{}, err
+	}
+	// Guard against a misordered/mislabeled backend before it corrupts the
+	// event-ID offsets: the decoded ledger seq must match what the driver
+	// expects at this position in the range.
+	if got := l.LCM.LedgerSequence(); got != seq {
+		return Ledger{}, fmt.Errorf("ingest: ledger at expected seq %d decoded as seq %d", seq, got)
+	}
+	return l, nil
 }
 
 // closeAll closes every ingester, joining each Close error into err. Used in
@@ -106,6 +116,11 @@ func RunHot(
 			return ferr
 		}
 		seq++
+	}
+	// Guard against a stream that ended early (partial chunk, backend stopped
+	// without error): the range must have been fully consumed.
+	if seq != last+1 {
+		return fmt.Errorf("ingest: stream for chunk %d ended at %d, expected through %d", uint32(chunkID), seq-1, last)
 	}
 	return nil
 }
@@ -188,7 +203,7 @@ func runOneChunkCold(
 
 	var ings []coldIngester
 	if cfg.Ledgers {
-		ing, ierr := newLedgersCold(filepath.Join(coldDir, "ledgers"), chunkID, LedgersColdOpts{})
+		ing, ierr := newLedgersCold(filepath.Join(coldDir, "ledgers"), chunkID, ledgersColdOpts{})
 		if ierr != nil {
 			return closeAll(ings, fmt.Errorf("open ledgers cold: %w", ierr))
 		}
@@ -202,7 +217,7 @@ func runOneChunkCold(
 		ings = append(ings, ing)
 	}
 	if cfg.Events {
-		ing, ierr := newEventsCold(filepath.Join(coldDir, "events"), chunkID, EventsColdOpts{}, cfg.Passphrase)
+		ing, ierr := newEventsCold(filepath.Join(coldDir, "events"), chunkID, eventsColdOpts{}, cfg.Passphrase)
 		if ierr != nil {
 			return closeAll(ings, fmt.Errorf("open events cold: %w", ierr))
 		}
@@ -228,6 +243,12 @@ func runOneChunkCold(
 			return ferr
 		}
 		seq++
+	}
+	// Verify the range was fully consumed BEFORE Finalize, so a stream that
+	// ended early (partial chunk, backend stopped without error) never produces
+	// a finalized — and thus reader-trusted — but truncated cold artifact.
+	if seq != last+1 {
+		return fmt.Errorf("ingest: stream for chunk %d ended at %d, expected through %d", uint32(chunkID), seq-1, last)
 	}
 
 	// Finalize each chunk's cold artifact. Explicit and error-checked — never

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/driver.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/driver.go
@@ -56,50 +56,48 @@ func closeAll[T ingester](ings []T, err error) error {
 	return err
 }
 
-// RunHot streams a single chunk's ledgers from stream and fans each one out to
-// the enabled hot ingesters, writing into per-type subdirectories under hotDir
-// (hotDir/ledgers, hotDir/txhash, hotDir/events). Ingest errors abort the run
-// fast; the per-ledger errgroup gates the next stream pull so the borrowed raw
-// slice is never read past its lifetime. Ingester Close is deferred and
-// idempotent.
-func RunHot(
-	ctx context.Context,
-	logger *supportlog.Entry,
-	stream ledgerbackend.LedgerStream,
-	chunkID chunk.ID,
-	hotDir string,
-	cfg Config,
-) (err error) {
-	if verr := cfg.validate(); verr != nil {
-		return verr
-	}
+// ingestType is one of the three data types, carrying its config selector and
+// its per-tier on-disk subdirectory name. Centralizing these removes the
+// per-type copy-paste (the "ledgers"/"txhash"/"events" literals and the
+// enable-check branches) from both driver setup paths.
+type ingestType struct {
+	subdir    string
+	enabledIn func(Config) bool
+}
 
-	var ings []ingester
-	if cfg.Ledgers {
-		ing, ierr := newLedgersHot(filepath.Join(hotDir, "ledgers"), logger)
-		if ierr != nil {
-			return closeAll(ings, fmt.Errorf("open ledgers hot: %w", ierr))
-		}
-		ings = append(ings, ing)
-	}
-	if cfg.Txhash {
-		ing, ierr := newTxhashHot(filepath.Join(hotDir, "txhash"), logger)
-		if ierr != nil {
-			return closeAll(ings, fmt.Errorf("open txhash hot: %w", ierr))
-		}
-		ings = append(ings, ing)
-	}
-	if cfg.Events {
-		ing, ierr := newEventsHot(filepath.Join(hotDir, "events"), chunkID, logger, cfg.Passphrase)
-		if ierr != nil {
-			return closeAll(ings, fmt.Errorf("open events hot: %w", ierr))
-		}
-		ings = append(ings, ing)
-	}
-	defer func() { err = closeAll(ings, err) }()
+var ingestTypes = []ingestType{
+	{subdir: "ledgers", enabledIn: func(c Config) bool { return c.Ledgers }},
+	{subdir: "txhash", enabledIn: func(c Config) bool { return c.Txhash }},
+	{subdir: "events", enabledIn: func(c Config) bool { return c.Events }},
+}
 
+// buildIngesters constructs one ingester per data type enabled in cfg, in
+// canonical ledgers→txhash→events order. mk constructs a type's ingester given
+// its on-disk subdirectory; on any constructor error it closes the ingesters
+// built so far (joining errors) and returns. T is ingester for the hot driver
+// and coldIngester for the cold driver.
+func buildIngesters[T ingester](cfg Config, mk func(subdir string) (T, error)) ([]T, error) {
+	var ings []T
+	for _, t := range ingestTypes {
+		if !t.enabledIn(cfg) {
+			continue
+		}
+		ing, err := mk(t.subdir)
+		if err != nil {
+			return nil, closeAll(ings, fmt.Errorf("open %s ingester: %w", t.subdir, err))
+		}
+		ings = append(ings, ing)
+	}
+	return ings, nil
+}
+
+// drainStream pulls the chunk's raw ledgers from stream and fans each out to
+// ings, then verifies the full [first,last] range was consumed. The borrowed
+// raw is fully consumed inside fanOut (which waits for all ingesters) before
+// the next pull. The completeness check lives here so both drivers share one
+// error message: a stream that ends early is rejected before any cold Finalize.
+func drainStream[T ingester](ctx context.Context, stream ledgerbackend.LedgerStream, chunkID chunk.ID, ings []T, needsLCM bool) error {
 	first, last := chunkID.FirstLedger(), chunkID.LastLedger()
-	needsLCM := cfg.needsLCM()
 	seq := first
 	for raw, serr := range stream.RawLedgers(ctx, ledgerbackend.BoundedRange(first, last)) {
 		if cerr := ctx.Err(); cerr != nil {
@@ -118,11 +116,50 @@ func RunHot(
 		seq++
 	}
 	// Guard against a stream that ended early (partial chunk, backend stopped
-	// without error): the range must have been fully consumed.
+	// without error): the range must have been fully consumed. For the cold
+	// path this runs before Finalize, so a short stream never produces a
+	// finalized — and thus reader-trusted — but truncated artifact.
 	if seq != last+1 {
 		return fmt.Errorf("ingest: stream for chunk %d ended at %d, expected through %d", uint32(chunkID), seq-1, last)
 	}
 	return nil
+}
+
+// RunHot streams a single chunk's ledgers from stream and fans each one out to
+// the enabled hot ingesters, writing into per-type subdirectories under hotDir
+// (hotDir/ledgers, hotDir/txhash, hotDir/events). Ingest errors abort the run
+// fast; the per-ledger errgroup gates the next stream pull so the borrowed raw
+// slice is never read past its lifetime. Ingester Close is deferred and
+// idempotent.
+func RunHot(
+	ctx context.Context,
+	logger *supportlog.Entry,
+	stream ledgerbackend.LedgerStream,
+	chunkID chunk.ID,
+	hotDir string,
+	cfg Config,
+) (err error) {
+	if verr := cfg.validate(); verr != nil {
+		return verr
+	}
+
+	ings, berr := buildIngesters(cfg, func(subdir string) (ingester, error) {
+		dir := filepath.Join(hotDir, subdir)
+		switch subdir {
+		case "ledgers":
+			return newLedgersHot(dir, logger)
+		case "txhash":
+			return newTxhashHot(dir, logger)
+		default: // "events"
+			return newEventsHot(dir, chunkID, logger, cfg.Passphrase)
+		}
+	})
+	if berr != nil {
+		return berr
+	}
+	defer func() { err = closeAll(ings, err) }()
+
+	return drainStream(ctx, stream, chunkID, ings, cfg.needsLCM())
 }
 
 // RunCold ingests numChunks consecutive chunks starting at startChunk into the
@@ -201,58 +238,30 @@ func runOneChunkCold(
 		return oerr
 	}
 
-	var ings []coldIngester
-	if cfg.Ledgers {
-		ing, ierr := newLedgersCold(filepath.Join(coldDir, "ledgers"), chunkID, ledgersColdOpts{})
-		if ierr != nil {
-			return closeAll(ings, fmt.Errorf("open ledgers cold: %w", ierr))
+	ings, berr := buildIngesters(cfg, func(subdir string) (coldIngester, error) {
+		dir := filepath.Join(coldDir, subdir)
+		switch subdir {
+		case "ledgers":
+			return newLedgersCold(dir, chunkID, ledgersColdOpts{})
+		case "txhash":
+			return newTxhashCold(dir, chunkID)
+		default: // "events"
+			return newEventsCold(dir, chunkID, eventsColdOpts{}, cfg.Passphrase)
 		}
-		ings = append(ings, ing)
-	}
-	if cfg.Txhash {
-		ing, ierr := newTxhashCold(filepath.Join(coldDir, "txhash"), chunkID)
-		if ierr != nil {
-			return closeAll(ings, fmt.Errorf("open txhash cold: %w", ierr))
-		}
-		ings = append(ings, ing)
-	}
-	if cfg.Events {
-		ing, ierr := newEventsCold(filepath.Join(coldDir, "events"), chunkID, eventsColdOpts{}, cfg.Passphrase)
-		if ierr != nil {
-			return closeAll(ings, fmt.Errorf("open events cold: %w", ierr))
-		}
-		ings = append(ings, ing)
+	})
+	if berr != nil {
+		return berr
 	}
 	defer func() { err = closeAll(ings, err) }()
 
-	first, last := chunkID.FirstLedger(), chunkID.LastLedger()
-	needsLCM := cfg.needsLCM()
-	seq := first
-	for raw, serr := range stream.RawLedgers(ctx, ledgerbackend.BoundedRange(first, last)) {
-		if cerr := ctx.Err(); cerr != nil {
-			return cerr
-		}
-		if serr != nil {
-			return fmt.Errorf("RawLedgers(%d): %w", seq, serr)
-		}
-		l, lerr := buildLedger(seq, raw, needsLCM)
-		if lerr != nil {
-			return lerr
-		}
-		if ferr := fanOutCold(ctx, ings, l); ferr != nil {
-			return ferr
-		}
-		seq++
-	}
-	// Verify the range was fully consumed BEFORE Finalize, so a stream that
-	// ended early (partial chunk, backend stopped without error) never produces
-	// a finalized — and thus reader-trusted — but truncated cold artifact.
-	if seq != last+1 {
-		return fmt.Errorf("ingest: stream for chunk %d ended at %d, expected through %d", uint32(chunkID), seq-1, last)
+	if derr := drainStream(ctx, stream, chunkID, ings, cfg.needsLCM()); derr != nil {
+		return derr
 	}
 
 	// Finalize each chunk's cold artifact. Explicit and error-checked — never
-	// deferred. A Finalize error means the chunk did not durably land.
+	// deferred. A Finalize error means the chunk did not durably land. drainStream
+	// already verified the full range was consumed, so no truncated artifact is
+	// finalized.
 	for _, ing := range ings {
 		if ferr := ing.Finalize(ctx); ferr != nil {
 			return fmt.Errorf("finalize: %w", ferr)
@@ -261,19 +270,18 @@ func runOneChunkCold(
 	return nil
 }
 
-// fanOut runs every hot ingester on l concurrently, waiting for all to finish
+// fanOut runs every ingester on l concurrently, waiting for all to finish
 // before returning so the borrowed raw is safe to release. The first Ingest
-// error cancels the siblings via the errgroup context.
-func fanOut(ctx context.Context, ings []ingester, l Ledger) error {
-	g, gctx := errgroup.WithContext(ctx)
-	for _, ing := range ings {
-		g.Go(func() error { return ing.Ingest(gctx, l) })
+// error cancels the siblings via the errgroup context. It is generic over the
+// ingester type so both the hot ([]ingester) and cold ([]coldIngester) drivers
+// share one implementation.
+//
+// Single-ingester fast path: the common single-type config skips the errgroup
+// and goroutine spawn entirely and calls Ingest directly.
+func fanOut[T ingester](ctx context.Context, ings []T, l Ledger) error {
+	if len(ings) == 1 {
+		return ings[0].Ingest(ctx, l)
 	}
-	return g.Wait()
-}
-
-// fanOutCold is fanOut for the cold-ingester slice type.
-func fanOutCold(ctx context.Context, ings []coldIngester, l Ledger) error {
 	g, gctx := errgroup.WithContext(ctx)
 	for _, ing := range ings {
 		g.Go(func() error { return ing.Ingest(gctx, l) })

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/events.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/events.go
@@ -63,10 +63,10 @@ func (e *eventsHot) Close() error { return e.store.Close() }
 
 // ───────────────────────── Cold ingester ─────────────────────────
 
-// EventsColdOpts is per-packfile tuning for the events.pack writer.
-type EventsColdOpts struct {
-	Concurrency  int
-	BytesPerSync int
+// eventsColdOpts is per-packfile tuning for the events.pack writer.
+type eventsColdOpts struct {
+	concurrency  int
+	bytesPerSync int
 }
 
 // eventsCold models the backfill path: per-ledger LCM → payloads → term-index
@@ -83,11 +83,11 @@ type eventsCold struct {
 	bucketDir  string
 }
 
-func newEventsCold(outRoot string, chunkID chunk.ID, opts EventsColdOpts, passphrase string) (*eventsCold, error) {
+func newEventsCold(outRoot string, chunkID chunk.ID, opts eventsColdOpts, passphrase string) (*eventsCold, error) {
 	bucketDir := filepath.Join(outRoot, chunkID.BucketID())
 	w, err := eventstore.NewColdWriter(chunkID, bucketDir, eventstore.ColdWriterOptions{
-		Concurrency:  opts.Concurrency,
-		BytesPerSync: opts.BytesPerSync,
+		Concurrency:  opts.concurrency,
+		BytesPerSync: opts.bytesPerSync,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("eventstore.NewColdWriter: %w", err)

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/events.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/events.go
@@ -1,0 +1,167 @@
+package ingest
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/events"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore"
+)
+
+// extractEvents derives event payloads from a ledger's parsed LedgerCloseMeta
+// using the configured network passphrase. l.LCM must be non-nil.
+func extractEvents(passphrase string, l Ledger) ([]events.Payload, error) {
+	if l.LCM == nil {
+		return nil, fmt.Errorf("events ingester requires a parsed LCM but ledger %d has none", l.Seq)
+	}
+	return events.LCMToPayloads(passphrase, *l.LCM)
+}
+
+// ───────────────────────── Hot ingester ─────────────────────────
+
+// eventsHot decodes LCM → []events.Payload and writes them with
+// IngestLedgerEvents. Each call is one atomic RocksDB batch (sync=true) plus an
+// in-memory mirror update.
+//
+// IngestLedgerEvents is called on every ledger, including ones with zero
+// payloads — LedgerOffsets.Append requires a contiguous sequence and would
+// reject the next non-empty ledger if an empty one were skipped.
+type eventsHot struct {
+	store      *eventstore.HotStore
+	passphrase string
+}
+
+func newEventsHot(dir string, chunkID chunk.ID, logger *supportlog.Entry, passphrase string) (*eventsHot, error) {
+	if err := os.MkdirAll(filepath.Dir(dir), 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir parent of %s: %w", dir, err)
+	}
+	store, err := eventstore.OpenHotStore(dir, chunkID, logger)
+	if err != nil {
+		return nil, fmt.Errorf("eventstore.OpenHotStore %s: %w", dir, err)
+	}
+	return &eventsHot{store: store, passphrase: passphrase}, nil
+}
+
+func (e *eventsHot) Ingest(_ context.Context, l Ledger) error {
+	payloads, err := extractEvents(e.passphrase, l)
+	if err != nil {
+		return fmt.Errorf("extract seq %d: %w", l.Seq, err)
+	}
+	if err := e.store.IngestLedgerEvents(l.Seq, payloads); err != nil {
+		return fmt.Errorf("IngestLedgerEvents(seq=%d, n=%d): %w", l.Seq, len(payloads), err)
+	}
+	return nil
+}
+
+func (e *eventsHot) Close() error { return e.store.Close() }
+
+// ───────────────────────── Cold ingester ─────────────────────────
+
+// EventsColdOpts is per-packfile tuning for the events.pack writer.
+type EventsColdOpts struct {
+	Concurrency  int
+	BytesPerSync int
+}
+
+// eventsCold models the backfill path: per-ledger LCM → payloads → term-index
+// accumulate + cold append, then chunk-end Finish + WriteColdIndex. No HotStore
+// is involved — it maintains an in-memory events.Bitmaps mirror via NewBitmaps
+// + per-event TermsForBytes, and an events.LedgerOffsets to assign
+// chunk-relative event IDs.
+type eventsCold struct {
+	chunkID    chunk.ID
+	passphrase string
+	writer     *eventstore.ColdWriter
+	mirror     events.Bitmaps
+	offsets    *events.LedgerOffsets
+	bucketDir  string
+}
+
+func newEventsCold(outRoot string, chunkID chunk.ID, opts EventsColdOpts, passphrase string) (*eventsCold, error) {
+	bucketDir := filepath.Join(outRoot, chunkID.BucketID())
+	w, err := eventstore.NewColdWriter(chunkID, bucketDir, eventstore.ColdWriterOptions{
+		Concurrency:  opts.Concurrency,
+		BytesPerSync: opts.BytesPerSync,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("eventstore.NewColdWriter: %w", err)
+	}
+	return &eventsCold{
+		chunkID:    chunkID,
+		passphrase: passphrase,
+		writer:     w,
+		mirror:     events.NewBitmaps(),
+		offsets:    events.NewLedgerOffsets(chunkID.FirstLedger()),
+		bucketDir:  bucketDir,
+	}, nil
+}
+
+func (e *eventsCold) Ingest(_ context.Context, l Ledger) error {
+	payloads, err := extractEvents(e.passphrase, l)
+	if err != nil {
+		return fmt.Errorf("extract seq %d: %w", l.Seq, err)
+	}
+
+	startID := e.offsets.TotalEvents()
+	if uint64(startID)+uint64(len(payloads)) > math.MaxUint32 {
+		return fmt.Errorf("chunk %s would overflow uint32 event-id space at ledger %d", e.chunkID, l.Seq)
+	}
+
+	// Empty-payload ledger: still advance offsets to preserve the
+	// LedgerOffsets monotonicity invariant.
+	if len(payloads) == 0 {
+		if oerr := e.offsets.Append(l.Seq, 0); oerr != nil {
+			return fmt.Errorf("offsets append seq %d: %w", l.Seq, oerr)
+		}
+		return nil
+	}
+
+	// Term-index stage: derive keys from each payload's raw ContractEvent XDR
+	// and AddTo the in-memory mirror under the chunk-relative event ID.
+	for i := range payloads {
+		keys, terr := events.TermsForBytes(payloads[i].ContractEventBytes)
+		if terr != nil {
+			return fmt.Errorf("TermsForBytes seq %d eventIdx %d: %w", l.Seq, i, terr)
+		}
+		eventID := startID + uint32(i)
+		for _, k := range keys {
+			e.mirror.AddTo(k, eventID)
+		}
+	}
+
+	// Cold-append stage: write each payload to events.pack.
+	for i := range payloads {
+		if aerr := e.writer.Append(payloads[i]); aerr != nil {
+			return fmt.Errorf("cold Append seq %d eventIdx %d: %w", l.Seq, i, aerr)
+		}
+	}
+
+	// offsets.Append LAST — it is the commit point for the ledger. If any
+	// earlier stage failed, offsets isn't advanced and the chunk state stays
+	// recoverable.
+	if oerr := e.offsets.Append(l.Seq, uint32(len(payloads))); oerr != nil {
+		return fmt.Errorf("offsets append seq %d: %w", l.Seq, oerr)
+	}
+	return nil
+}
+
+// Finalize writes the events.pack trailer (Finish) + materializes the cold
+// index (WriteColdIndex). An error from either step means the chunk did not
+// durably land.
+func (e *eventsCold) Finalize(ctx context.Context) error {
+	if err := e.writer.Finish(e.offsets); err != nil {
+		return fmt.Errorf("events ColdWriter.Finish: %w", err)
+	}
+	if err := eventstore.WriteColdIndex(ctx, e.chunkID, e.mirror, e.bucketDir); err != nil {
+		return fmt.Errorf("WriteColdIndex: %w", err)
+	}
+	return nil
+}
+
+func (e *eventsCold) Close() error { return e.writer.Close() }

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ingest_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ingest_test.go
@@ -2,6 +2,7 @@ package ingest
 
 import (
 	"context"
+	"encoding/binary"
 	"iter"
 	"os"
 	"path/filepath"
@@ -11,54 +12,198 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stellar/go-stellar-sdk/network"
 	supportlog "github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/go-stellar-sdk/xdr"
 
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/ledger"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash"
 )
 
 // testPassphrase is a network passphrase literal used only by the tests; the
 // package never hardcodes one.
 const testPassphrase = "Public Global Stellar Network ; September 2015"
 
-// fakeStream is an in-memory ledgerbackend.LedgerStream. It yields a synthetic
-// LedgerCloseMeta for every seq in [r.From(), r.From()+count) — i.e. count
-// ledgers from the start of the requested range. When count covers the whole
+// ───────────────────────── fake streams ─────────────────────────
+
+// fakeStream is an in-memory ledgerbackend.LedgerStream. It yields LCM bytes
+// for count ledgers from r.From() via gen. When count covers the whole
 // requested range the driver's chunk-completeness check passes; a smaller count
 // models a backend that ends early (used by the short-stream negative test).
 //
-// LCMs are generated lazily so a full 10k-ledger chunk costs no up-front map.
+// gen is called per seq so LCMs are generated lazily — a full 10k-ledger chunk
+// costs no up-front allocation. The default gen yields a cheap zero-tx LCM.
 type fakeStream struct {
 	t     *testing.T
 	count uint32
+	gen   func(t *testing.T, seq uint32) []byte
 }
 
 var _ ledgerbackend.LedgerStream = (*fakeStream)(nil)
 
 func (f *fakeStream) RawLedgers(_ context.Context, r ledgerbackend.Range, _ ...ledgerbackend.StreamOption) iter.Seq2[[]byte, error] {
+	gen := f.gen
+	if gen == nil {
+		gen = marshalLCM
+	}
 	return func(yield func([]byte, error) bool) {
 		for i := uint32(0); i < f.count; i++ {
 			seq := r.From() + i
-			if !yield(marshalLCM(f.t, seq), nil) {
+			if !yield(gen(f.t, seq), nil) {
 				return
 			}
 		}
 	}
 }
 
-// fullStream yields exactly the requested chunk's full [First,Last] range.
-func fullStream(t *testing.T, chunkID chunk.ID) *fakeStream {
+// fullStream yields exactly the requested chunk's full [First,Last] range using
+// the given per-seq LCM generator (nil → cheap zero-tx LCMs).
+func fullStream(t *testing.T, chunkID chunk.ID, gen func(*testing.T, uint32) []byte) *fakeStream {
 	t.Helper()
-	return &fakeStream{t: t, count: chunkID.LastLedger() - chunkID.FirstLedger() + 1}
+	return &fakeStream{
+		t:     t,
+		count: chunkID.LastLedger() - chunkID.FirstLedger() + 1,
+		gen:   gen,
+	}
 }
 
+// sourceOf wraps a single stream as a ChunkSource (every chunk gets it). For
+// the cold driver this is safe in tests because each test uses one chunk.
+func sourceOf(s ledgerbackend.LedgerStream) ChunkSource {
+	return ChunkSourceFunc(func(chunk.ID) (ledgerbackend.LedgerStream, error) { return s, nil })
+}
+
+// ───────────────────────── LCM fixtures ─────────────────────────
+
 // marshalLCM builds a minimal valid zero-transaction LedgerCloseMeta (V2) for
-// the given ledger seq and returns its wire bytes. The shape mirrors the
-// known-good fixture in internal/events/ingest_test.go; zero transactions is
+// the given ledger seq and returns its wire bytes. Zero transactions is
 // acceptable to events.LCMToPayloads (its tx reader opens it and finds none).
 func marshalLCM(t *testing.T, seq uint32) []byte {
 	t.Helper()
+	raw, err := buildLCM(t, seq, nil).MarshalBinary()
+	require.NoError(t, err)
+	return raw
+}
+
+// eventTopic is the symbol topic embedded by event-bearing fixtures; the same
+// term key derives from it, so tests can look the event up in the index.
+const eventTopic = "ingest_test"
+
+// marshalLCMWithEvent builds a V2 LCM carrying one transaction with one
+// operation-level contract event (topic=eventTopic). It returns the wire bytes,
+// the transaction hash (for txhash lookups), and the event's term key (for
+// event index lookups).
+func marshalLCMWithEvent(t *testing.T, seq uint32) (raw []byte, txHash [32]byte, term events.TermKey) {
+	t.Helper()
+	ev := buildContractEvent(eventTopic)
+	meta := xdr.TransactionMeta{
+		V:  4,
+		V4: &xdr.TransactionMetaV4{Operations: []xdr.OperationMetaV2{{Events: []xdr.ContractEvent{ev}}}},
+	}
+	lcm, hash := buildLCMWithTx(t, seq, meta)
+	rawBytes, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+
+	evBytes, err := ev.MarshalBinary()
+	require.NoError(t, err)
+	keys, err := events.TermsForBytes(evBytes)
+	require.NoError(t, err)
+	require.NotEmpty(t, keys)
+	return rawBytes, hash, keys[0]
+}
+
+// buildContractEvent returns a contract ContractEvent with a single symbol
+// topic, mirroring the events-package test fixture.
+func buildContractEvent(topic string) xdr.ContractEvent {
+	var contractID xdr.ContractId
+	contractID[0] = 0xab
+	contractID[1] = 0xcd
+	sym := xdr.ScSymbol(topic)
+	return xdr.ContractEvent{
+		ContractId: &contractID,
+		Type:       xdr.ContractEventTypeContract,
+		Body: xdr.ContractEventBody{
+			V: 0,
+			V0: &xdr.ContractEventV0{
+				Topics: []xdr.ScVal{{Type: xdr.ScValTypeScvSymbol, Sym: &sym}},
+				Data:   xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &sym},
+			},
+		},
+	}
+}
+
+func successResult() xdr.TransactionResult {
+	opResults := []xdr.OperationResult{}
+	return xdr.TransactionResult{
+		FeeCharged: 100,
+		Result: xdr.TransactionResultResult{
+			Code:    xdr.TransactionResultCodeTxSuccess,
+			Results: &opResults,
+		},
+	}
+}
+
+// buildLCM builds a V2 LedgerCloseMeta from the given per-tx metas. With no
+// metas it is a zero-transaction ledger.
+func buildLCM(t *testing.T, seq uint32, txMetas []xdr.TransactionMeta) xdr.LedgerCloseMeta {
+	t.Helper()
+	lcm, _ := buildLCMReturningHashes(t, seq, txMetas)
+	return lcm
+}
+
+// buildLCMWithTx builds a single-transaction V2 LCM and returns the tx hash.
+func buildLCMWithTx(t *testing.T, seq uint32, meta xdr.TransactionMeta) (xdr.LedgerCloseMeta, [32]byte) {
+	t.Helper()
+	lcm, hashes := buildLCMReturningHashes(t, seq, []xdr.TransactionMeta{meta})
+	require.Len(t, hashes, 1)
+	return lcm, hashes[0]
+}
+
+// buildLCMReturningHashes assembles a V2 LedgerCloseMeta with one envelope per
+// tx meta and returns the per-tx transaction hashes in order.
+func buildLCMReturningHashes(t *testing.T, seq uint32, txMetas []xdr.TransactionMeta) (xdr.LedgerCloseMeta, [][32]byte) {
+	t.Helper()
+	phases := make([]xdr.TransactionPhase, 0, len(txMetas))
+	txProcessing := make([]xdr.TransactionResultMetaV1, 0, len(txMetas))
+	hashes := make([][32]byte, 0, len(txMetas))
+
+	for _, meta := range txMetas {
+		envelope := xdr.TransactionEnvelope{
+			Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+			V1: &xdr.TransactionV1Envelope{
+				Tx: xdr.Transaction{
+					SourceAccount: xdr.MustMuxedAddress(keypair.MustRandom().Address()),
+					Ext: xdr.TransactionExt{
+						V:           1,
+						SorobanData: &xdr.SorobanTransactionData{},
+					},
+				},
+			},
+		}
+		hash, err := network.HashTransactionInEnvelope(envelope, testPassphrase)
+		require.NoError(t, err)
+		hashes = append(hashes, hash)
+
+		txProcessing = append(txProcessing, xdr.TransactionResultMetaV1{
+			TxApplyProcessing: meta,
+			Result: xdr.TransactionResultPair{
+				TransactionHash: hash,
+				Result:          successResult(),
+			},
+		})
+		comp := []xdr.TxSetComponent{{
+			Type: xdr.TxSetComponentTypeTxsetCompTxsMaybeDiscountedFee,
+			TxsMaybeDiscountedFee: &xdr.TxSetComponentTxsMaybeDiscountedFee{
+				Txs: []xdr.TransactionEnvelope{envelope},
+			},
+		}}
+		phases = append(phases, xdr.TransactionPhase{V: 0, V0Components: &comp})
+	}
+
 	lcm := xdr.LedgerCloseMeta{
 		V: 2,
 		V2: &xdr.LedgerCloseMetaV2{
@@ -70,14 +215,12 @@ func marshalLCM(t *testing.T, seq uint32) []byte {
 			},
 			TxSet: xdr.GeneralizedTransactionSet{
 				V:       1,
-				V1TxSet: &xdr.TransactionSetV1{Phases: nil},
+				V1TxSet: &xdr.TransactionSetV1{Phases: phases},
 			},
-			TxProcessing: nil,
+			TxProcessing: txProcessing,
 		},
 	}
-	raw, err := lcm.MarshalBinary()
-	require.NoError(t, err)
-	return raw
+	return lcm, hashes
 }
 
 func testLogger() *supportlog.Entry {
@@ -86,50 +229,144 @@ func testLogger() *supportlog.Entry {
 	return l
 }
 
-// TestRunHot_AllTypes_ShortStream exercises the ledgers+txhash+events hot
-// ingesters together (the parsed-decode + passphrase path) over a short stream.
-// Because the stream ends before the chunk's full range, RunHot must return the
-// chunk-completeness error — but only after fanning out to all three ingesters
-// for the ledgers it did process, so this also covers the events/txhash hot
-// write path and the parsed-LCM seq assertion.
-func TestRunHot_AllTypes_ShortStream(t *testing.T) {
+// ───────────────────────── hot driver tests ─────────────────────────
+
+// TestRunHot_AllTypes_Readback runs RunHot with all three types enabled over
+// event/tx-bearing ledgers and reopens each hot store to assert the ingested
+// data reads back: ledger bytes, the tx hashes, and the event term.
+//
+// The hot stores fsync once per ledger, so driving the full 10k-ledger chunk
+// would be far too slow for a unit test. Instead this uses a short stream of two
+// event/tx-bearing ledgers: RunHot writes both through all three hot ingesters
+// and then returns the chunk-completeness error (the stream ends early). The
+// readback below proves every hot store retained the ingested data — the
+// completeness error is expected and asserted.
+func TestRunHot_AllTypes_Readback(t *testing.T) {
 	chunkID := chunk.ID(0)
 	first := chunkID.FirstLedger()
-	stream := &fakeStream{t: t, count: 4}
+
+	// Two event/tx-bearing sentinel ledgers; capture each tx hash + the shared
+	// event term for the lookups.
+	evSeqA, evSeqB := first, first+1
+	rawA, hashA, termA := marshalLCMWithEvent(t, evSeqA)
+	rawB, hashB, _ := marshalLCMWithEvent(t, evSeqB)
+	gen := func(tt *testing.T, seq uint32) []byte {
+		switch seq {
+		case evSeqA:
+			return rawA
+		case evSeqB:
+			return rawB
+		default:
+			return marshalLCM(tt, seq)
+		}
+	}
+	stream := &fakeStream{t: t, count: 2, gen: gen}
 
 	hotDir := t.TempDir()
 	logger := testLogger()
 	cfg := Config{Ledgers: true, Txhash: true, Events: true, Passphrase: testPassphrase}
 
-	err := RunHot(context.Background(), logger, stream, chunkID, hotDir, cfg)
+	// Short stream → completeness error after both ledgers are fully ingested.
+	err := RunHot(context.Background(), logger, sourceOf(stream), chunkID, hotDir, cfg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "ended at")
 
-	// The 4 processed ledgers landed in the ledgers hot store before the
-	// completeness check fired.
-	store, oerr := ledger.OpenHotStore(filepath.Join(hotDir, "ledgers"), logger)
-	require.NoError(t, oerr)
-	defer func() { require.NoError(t, store.Close()) }()
-	for i := uint32(0); i < 4; i++ {
-		raw, gerr := store.GetLedgerRaw(first + i)
-		require.NoError(t, gerr)
-		require.NotEmpty(t, raw)
-	}
+	// Ledger hot: both sentinel ledgers read back verbatim.
+	ls, err := ledger.OpenHotStore(filepath.Join(hotDir, "ledgers"), logger)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, ls.Close()) }()
+	gotRawA, err := ls.GetLedgerRaw(evSeqA)
+	require.NoError(t, err)
+	require.Equal(t, rawA, gotRawA)
+
+	// Txhash hot: both sentinel tx hashes map back to their ledger seqs.
+	ts, err := txhash.OpenHotStore(filepath.Join(hotDir, "txhash"), logger)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, ts.Close()) }()
+	gotA, err := ts.Lookup(hashA)
+	require.NoError(t, err)
+	require.Equal(t, evSeqA, gotA)
+	gotB, err := ts.Lookup(hashB)
+	require.NoError(t, err)
+	require.Equal(t, evSeqB, gotB)
+
+	// Events hot: the shared term key resolves to a bitmap covering both events.
+	es, err := eventstore.OpenHotStore(filepath.Join(hotDir, "events"), chunkID, logger)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, es.Close()) }()
+	bm, err := es.Lookup(context.Background(), termA)
+	require.NoError(t, err)
+	require.NotNil(t, bm)
+	require.Equal(t, uint64(2), bm.GetCardinality(), "both sentinel events share the term")
 }
+
+// TestPackSource_RoundTrip exercises the production PackSource + packStream
+// path end-to-end against a REAL cold ledger packfile (not the fake stream):
+//
+//  1. write a full chunk's cold packfile via ledger.NewColdWriter,
+//  2. RunCold- from-nowhere is not the point here — instead drive the packStream
+//     through a driver by re-ingesting the pack into the COLD ledger store via
+//     RunCold(NewPackSource(...)), which streams the whole chunk (cold writers
+//     batch, so the full range is fast), and assert the re-ingested cold store
+//     reads the same bytes back.
+//
+// (RunHot over a full chunk would fsync per ledger and be far too slow; the
+// hot driver's source plumbing is identical and is covered by the fake-stream
+// hot tests. This test's job is to prove the real PackSource feeds a driver.)
+func TestPackSource_RoundTrip(t *testing.T) {
+	chunkID := chunk.ID(0)
+	first, last := chunkID.FirstLedger(), chunkID.LastLedger()
+
+	// Write a full chunk's cold packfile so the completeness check passes.
+	srcDir := t.TempDir()
+	packFile := packPath(srcDir, chunkID)
+	require.NoError(t, os.MkdirAll(filepath.Dir(packFile), 0o755))
+	cw, err := ledger.NewColdWriter(packFile, first, ledger.ColdWriterOptions{})
+	require.NoError(t, err)
+	for seq := first; seq <= last; seq++ {
+		require.NoError(t, cw.AppendLedger(seq, marshalLCM(t, seq)))
+	}
+	require.NoError(t, cw.Commit())
+	require.NoError(t, cw.Close())
+
+	// Re-ingest the pack into a fresh cold store via the production PackSource.
+	src := NewPackSource(srcDir)
+	dstDir := t.TempDir()
+	logger := testLogger()
+	require.NoError(t, RunCold(
+		context.Background(), logger, src, dstDir, chunkID, 1, 1, Config{Ledgers: true},
+	))
+
+	// The re-ingested cold store reads back the same boundary bytes.
+	cr, err := ledger.OpenColdReader(packPath(filepath.Join(dstDir, "ledgers"), chunkID))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, cr.Close()) }()
+	rawFirst, err := cr.GetLedgerRaw(first)
+	require.NoError(t, err)
+	require.Equal(t, marshalLCM(t, first), rawFirst)
+	rawLast, err := cr.GetLedgerRaw(last)
+	require.NoError(t, err)
+	require.Equal(t, marshalLCM(t, last), rawLast)
+
+	// OpenStream errors clearly for a chunk with no packfile.
+	_, missErr := src.OpenStream(chunkID + 1)
+	require.Error(t, missErr)
+	require.Contains(t, missErr.Error(), "cold pack missing")
+}
+
+// ───────────────────────── cold driver tests ─────────────────────────
 
 func TestRunCold_RoundTrip(t *testing.T) {
 	chunkID := chunk.ID(0)
 	first, last := chunkID.FirstLedger(), chunkID.LastLedger()
-	stream := fullStream(t, chunkID)
+	stream := fullStream(t, chunkID, nil)
 
 	coldDir := t.TempDir()
 	logger := testLogger()
 	cfg := Config{Ledgers: true}
 
-	factory := func(_ chunk.ID) (ledgerbackend.LedgerStream, error) { return stream, nil }
-
-	require.NoError(t, runColdWithStreamFactory(
-		context.Background(), logger, factory, coldDir, chunkID, 1, 1, cfg,
+	require.NoError(t, runColdWithSource(
+		context.Background(), logger, sourceOf(stream), coldDir, chunkID, 1, 1, cfg,
 	))
 
 	// Reopen the chunk's cold ledger packfile and read back the boundary ledgers.
@@ -158,10 +395,9 @@ func TestRunCold_ShortStream_NoArtifact(t *testing.T) {
 
 	// Yield only 3 ledgers of a 10k-ledger chunk.
 	short := &fakeStream{t: t, count: 3}
-	factory := func(_ chunk.ID) (ledgerbackend.LedgerStream, error) { return short, nil }
 
-	err := runColdWithStreamFactory(
-		context.Background(), logger, factory, coldDir, chunkID, 1, 1, cfg,
+	err := runColdWithSource(
+		context.Background(), logger, sourceOf(short), coldDir, chunkID, 1, 1, cfg,
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "ended at")
@@ -171,4 +407,118 @@ func TestRunCold_ShortStream_NoArtifact(t *testing.T) {
 	path := packPath(filepath.Join(coldDir, "ledgers"), chunkID)
 	_, statErr := os.Stat(path)
 	require.True(t, os.IsNotExist(statErr), "expected no cold artifact at %s, stat err: %v", path, statErr)
+}
+
+// customSource is a tiny in-test ChunkSource over in-memory LCMs, demonstrating
+// that adding a backend requires only implementing the interface — no central
+// switch edit.
+type customSource struct {
+	t   *testing.T
+	gen func(*testing.T, uint32) []byte
+}
+
+func (c customSource) OpenStream(chunkID chunk.ID) (ledgerbackend.LedgerStream, error) {
+	return fullStream(c.t, chunkID, c.gen), nil
+}
+
+// TestRunCold_CustomSource_Extensibility runs the cold driver against a
+// caller-defined ChunkSource implementation and asserts success + readback,
+// proving a new backend plugs in via the interface alone.
+func TestRunCold_CustomSource_Extensibility(t *testing.T) {
+	chunkID := chunk.ID(0)
+	first := chunkID.FirstLedger()
+	coldDir := t.TempDir()
+	logger := testLogger()
+	cfg := Config{Ledgers: true}
+
+	src := customSource{t: t}
+	require.NoError(t, RunCold(
+		context.Background(), logger, src, coldDir, chunkID, 1, 1, cfg,
+	))
+
+	cr, err := ledger.OpenColdReader(packPath(filepath.Join(coldDir, "ledgers"), chunkID))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, cr.Close()) }()
+	raw, err := cr.GetLedgerRaw(first)
+	require.NoError(t, err)
+	require.Equal(t, marshalLCM(t, first), raw)
+}
+
+// TestRunCold_TxhashCold_Bin runs the cold txhash path over a chunk whose
+// sentinel ledgers carry one tx each, then reads the produced .bin file's
+// header and asserts the entry count matches the number of txs ingested.
+func TestRunCold_TxhashCold_Bin(t *testing.T) {
+	chunkID := chunk.ID(0)
+	first := chunkID.FirstLedger()
+	coldDir := t.TempDir()
+	logger := testLogger()
+	cfg := Config{Txhash: true}
+
+	// Two sentinel ledgers carry one tx each; the rest are zero-tx.
+	txSeqs := map[uint32]bool{first: true, first + 1: true}
+	gen := func(tt *testing.T, seq uint32) []byte {
+		if txSeqs[seq] {
+			raw, _, _ := marshalLCMWithEvent(tt, seq)
+			return raw
+		}
+		return marshalLCM(tt, seq)
+	}
+
+	require.NoError(t, RunCold(
+		context.Background(), logger, customSource{t: t, gen: gen}, coldDir, chunkID, 1, 1, cfg,
+	))
+
+	// The cold txhash .bin lives at coldDir/txhash/<chunk>.bin. Read the 8-byte
+	// LE header and assert it equals the number of txs (2).
+	binPath := filepath.Join(coldDir, "txhash", chunkID.String()+".bin")
+	data, err := os.ReadFile(binPath)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(data), 8)
+	count := binary.LittleEndian.Uint64(data[:8])
+	require.Equal(t, uint64(len(txSeqs)), count)
+	// File size = 8-byte header + entrySize per entry.
+	require.Equal(t, 8+int(count)*entrySize, len(data))
+}
+
+// TestRunCold_EventsCold_Readback runs the cold events path over a chunk whose
+// sentinel ledgers carry one contract event each, finalizes the cold artifact,
+// then reopens the eventstore cold reader and asserts the event term resolves.
+func TestRunCold_EventsCold_Readback(t *testing.T) {
+	chunkID := chunk.ID(0)
+	first := chunkID.FirstLedger()
+	coldDir := t.TempDir()
+	logger := testLogger()
+	cfg := Config{Events: true, Passphrase: testPassphrase}
+
+	// Two sentinel ledgers carry one event each (sharing eventTopic's term).
+	evSeqs := map[uint32]bool{first: true, first + 1: true}
+	var term events.TermKey
+	gen := func(tt *testing.T, seq uint32) []byte {
+		if evSeqs[seq] {
+			raw, _, tk := marshalLCMWithEvent(tt, seq)
+			term = tk
+			return raw
+		}
+		return marshalLCM(tt, seq)
+	}
+
+	require.NoError(t, RunCold(
+		context.Background(), logger, customSource{t: t, gen: gen}, coldDir, chunkID, 1, 1, cfg,
+	))
+
+	// Reopen the events cold reader over coldDir/events/<bucket> and look up the
+	// term — it must resolve to a non-empty bitmap (≥2 events).
+	bucketDir := filepath.Join(coldDir, "events", chunkID.BucketID())
+	cr, err := eventstore.OpenColdReader(chunkID, bucketDir, eventstore.ColdReaderOptions{})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, cr.Close()) }()
+
+	cnt, err := cr.EventCount()
+	require.NoError(t, err)
+	require.Equal(t, uint32(len(evSeqs)), cnt)
+
+	bm, err := cr.Lookup(context.Background(), term)
+	require.NoError(t, err)
+	require.NotNil(t, bm)
+	require.Equal(t, uint64(len(evSeqs)), bm.GetCardinality())
 }

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ingest_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ingest_test.go
@@ -1,0 +1,146 @@
+package ingest
+
+import (
+	"context"
+	"iter"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/ledger"
+)
+
+// testPassphrase is a network passphrase literal used only by the tests; the
+// package never hardcodes one.
+const testPassphrase = "Public Global Stellar Network ; September 2015"
+
+// fakeStream is an in-memory ledgerbackend.LedgerStream. RawLedgers yields the
+// seeded raw bytes for each seq in [r.From(), r.From()+len(seqs)) in order,
+// stopping at the first seq it has no bytes for (so a chunk's full
+// [First,Last] range need not be seeded — tests seed only a small prefix).
+type fakeStream struct {
+	raws map[uint32][]byte
+}
+
+var _ ledgerbackend.LedgerStream = (*fakeStream)(nil)
+
+func (f *fakeStream) RawLedgers(_ context.Context, r ledgerbackend.Range, _ ...ledgerbackend.StreamOption) iter.Seq2[[]byte, error] {
+	return func(yield func([]byte, error) bool) {
+		for seq := r.From(); ; seq++ {
+			raw, ok := f.raws[seq]
+			if !ok {
+				return
+			}
+			if !yield(raw, nil) {
+				return
+			}
+		}
+	}
+}
+
+// marshalLCM builds a minimal valid zero-transaction LedgerCloseMeta (V2) for
+// the given ledger seq and returns its wire bytes. The shape mirrors the
+// known-good fixture in internal/events/ingest_test.go; zero transactions is
+// acceptable to events.LCMToPayloads (its tx reader opens it and finds none).
+func marshalLCM(t *testing.T, seq uint32) []byte {
+	t.Helper()
+	lcm := xdr.LedgerCloseMeta{
+		V: 2,
+		V2: &xdr.LedgerCloseMetaV2{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+				Header: xdr.LedgerHeader{
+					ScpValue:  xdr.StellarValue{CloseTime: xdr.TimePoint(0)},
+					LedgerSeq: xdr.Uint32(seq),
+				},
+			},
+			TxSet: xdr.GeneralizedTransactionSet{
+				V:       1,
+				V1TxSet: &xdr.TransactionSetV1{Phases: nil},
+			},
+			TxProcessing: nil,
+		},
+	}
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	return raw
+}
+
+func testLogger() *supportlog.Entry {
+	l := supportlog.New()
+	l.SetLevel(logrus.ErrorLevel)
+	return l
+}
+
+// seedChunkPrefix seeds n contiguous ledgers starting at chunkID.FirstLedger().
+func seedChunkPrefix(t *testing.T, chunkID chunk.ID, n int) *fakeStream {
+	t.Helper()
+	raws := make(map[uint32][]byte, n)
+	first := chunkID.FirstLedger()
+	for i := range n {
+		seq := first + uint32(i)
+		raws[seq] = marshalLCM(t, seq)
+	}
+	return &fakeStream{raws: raws}
+}
+
+func TestRunHot_RoundTrip(t *testing.T) {
+	const n = 5
+	chunkID := chunk.ID(0)
+	first := chunkID.FirstLedger()
+	stream := seedChunkPrefix(t, chunkID, n)
+
+	hotDir := t.TempDir()
+	logger := testLogger()
+	cfg := Config{Ledgers: true, Txhash: true, Events: true, Passphrase: testPassphrase}
+
+	require.NoError(t, RunHot(context.Background(), logger, stream, chunkID, hotDir, cfg))
+
+	// Reopen the ledgers hot store and assert each seeded ledger reads back.
+	store, err := ledger.OpenHotStore(filepath.Join(hotDir, "ledgers"), logger)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	for i := range n {
+		seq := first + uint32(i)
+		raw, gerr := store.GetLedgerRaw(seq)
+		require.NoError(t, gerr)
+		require.NotEmpty(t, raw, "ledger %d read back empty", seq)
+	}
+}
+
+func TestRunCold_RoundTrip(t *testing.T) {
+	const n = 5
+	chunkID := chunk.ID(0)
+	first := chunkID.FirstLedger()
+	stream := seedChunkPrefix(t, chunkID, n)
+
+	coldDir := t.TempDir()
+	logger := testLogger()
+	cfg := Config{Ledgers: true}
+
+	factory := func(_ chunk.ID) (ledgerbackend.LedgerStream, error) { return stream, nil }
+
+	require.NoError(t, runColdWithStreamFactory(
+		context.Background(), logger, factory, coldDir, chunkID, 1, 1, cfg,
+	))
+
+	// Reopen the chunk's cold ledger packfile and read back the first ledger.
+	path := packPath(filepath.Join(coldDir, "ledgers"), uint32(chunkID))
+	cr, err := ledger.OpenColdReader(path)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, cr.Close()) }()
+
+	raw, err := cr.GetLedgerRaw(first)
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+
+	// The round-tripped bytes match what we seeded.
+	require.Equal(t, stream.raws[first], raw)
+}

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ingest_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ingest_test.go
@@ -3,6 +3,7 @@ package ingest
 import (
 	"context"
 	"iter"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -21,28 +22,35 @@ import (
 // package never hardcodes one.
 const testPassphrase = "Public Global Stellar Network ; September 2015"
 
-// fakeStream is an in-memory ledgerbackend.LedgerStream. RawLedgers yields the
-// seeded raw bytes for each seq in [r.From(), r.From()+len(seqs)) in order,
-// stopping at the first seq it has no bytes for (so a chunk's full
-// [First,Last] range need not be seeded — tests seed only a small prefix).
+// fakeStream is an in-memory ledgerbackend.LedgerStream. It yields a synthetic
+// LedgerCloseMeta for every seq in [r.From(), r.From()+count) — i.e. count
+// ledgers from the start of the requested range. When count covers the whole
+// requested range the driver's chunk-completeness check passes; a smaller count
+// models a backend that ends early (used by the short-stream negative test).
+//
+// LCMs are generated lazily so a full 10k-ledger chunk costs no up-front map.
 type fakeStream struct {
-	raws map[uint32][]byte
+	t     *testing.T
+	count uint32
 }
 
 var _ ledgerbackend.LedgerStream = (*fakeStream)(nil)
 
 func (f *fakeStream) RawLedgers(_ context.Context, r ledgerbackend.Range, _ ...ledgerbackend.StreamOption) iter.Seq2[[]byte, error] {
 	return func(yield func([]byte, error) bool) {
-		for seq := r.From(); ; seq++ {
-			raw, ok := f.raws[seq]
-			if !ok {
-				return
-			}
-			if !yield(raw, nil) {
+		for i := uint32(0); i < f.count; i++ {
+			seq := r.From() + i
+			if !yield(marshalLCM(f.t, seq), nil) {
 				return
 			}
 		}
 	}
+}
+
+// fullStream yields exactly the requested chunk's full [First,Last] range.
+func fullStream(t *testing.T, chunkID chunk.ID) *fakeStream {
+	t.Helper()
+	return &fakeStream{t: t, count: chunkID.LastLedger() - chunkID.FirstLedger() + 1}
 }
 
 // marshalLCM builds a minimal valid zero-transaction LedgerCloseMeta (V2) for
@@ -78,48 +86,41 @@ func testLogger() *supportlog.Entry {
 	return l
 }
 
-// seedChunkPrefix seeds n contiguous ledgers starting at chunkID.FirstLedger().
-func seedChunkPrefix(t *testing.T, chunkID chunk.ID, n int) *fakeStream {
-	t.Helper()
-	raws := make(map[uint32][]byte, n)
-	first := chunkID.FirstLedger()
-	for i := range n {
-		seq := first + uint32(i)
-		raws[seq] = marshalLCM(t, seq)
-	}
-	return &fakeStream{raws: raws}
-}
-
-func TestRunHot_RoundTrip(t *testing.T) {
-	const n = 5
+// TestRunHot_AllTypes_ShortStream exercises the ledgers+txhash+events hot
+// ingesters together (the parsed-decode + passphrase path) over a short stream.
+// Because the stream ends before the chunk's full range, RunHot must return the
+// chunk-completeness error — but only after fanning out to all three ingesters
+// for the ledgers it did process, so this also covers the events/txhash hot
+// write path and the parsed-LCM seq assertion.
+func TestRunHot_AllTypes_ShortStream(t *testing.T) {
 	chunkID := chunk.ID(0)
 	first := chunkID.FirstLedger()
-	stream := seedChunkPrefix(t, chunkID, n)
+	stream := &fakeStream{t: t, count: 4}
 
 	hotDir := t.TempDir()
 	logger := testLogger()
 	cfg := Config{Ledgers: true, Txhash: true, Events: true, Passphrase: testPassphrase}
 
-	require.NoError(t, RunHot(context.Background(), logger, stream, chunkID, hotDir, cfg))
+	err := RunHot(context.Background(), logger, stream, chunkID, hotDir, cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ended at")
 
-	// Reopen the ledgers hot store and assert each seeded ledger reads back.
-	store, err := ledger.OpenHotStore(filepath.Join(hotDir, "ledgers"), logger)
-	require.NoError(t, err)
+	// The 4 processed ledgers landed in the ledgers hot store before the
+	// completeness check fired.
+	store, oerr := ledger.OpenHotStore(filepath.Join(hotDir, "ledgers"), logger)
+	require.NoError(t, oerr)
 	defer func() { require.NoError(t, store.Close()) }()
-
-	for i := range n {
-		seq := first + uint32(i)
-		raw, gerr := store.GetLedgerRaw(seq)
+	for i := uint32(0); i < 4; i++ {
+		raw, gerr := store.GetLedgerRaw(first + i)
 		require.NoError(t, gerr)
-		require.NotEmpty(t, raw, "ledger %d read back empty", seq)
+		require.NotEmpty(t, raw)
 	}
 }
 
 func TestRunCold_RoundTrip(t *testing.T) {
-	const n = 5
 	chunkID := chunk.ID(0)
-	first := chunkID.FirstLedger()
-	stream := seedChunkPrefix(t, chunkID, n)
+	first, last := chunkID.FirstLedger(), chunkID.LastLedger()
+	stream := fullStream(t, chunkID)
 
 	coldDir := t.TempDir()
 	logger := testLogger()
@@ -131,16 +132,43 @@ func TestRunCold_RoundTrip(t *testing.T) {
 		context.Background(), logger, factory, coldDir, chunkID, 1, 1, cfg,
 	))
 
-	// Reopen the chunk's cold ledger packfile and read back the first ledger.
+	// Reopen the chunk's cold ledger packfile and read back the boundary ledgers.
 	path := packPath(filepath.Join(coldDir, "ledgers"), uint32(chunkID))
 	cr, err := ledger.OpenColdReader(path)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, cr.Close()) }()
 
-	raw, err := cr.GetLedgerRaw(first)
+	rawFirst, err := cr.GetLedgerRaw(first)
 	require.NoError(t, err)
-	require.NotEmpty(t, raw)
+	require.Equal(t, marshalLCM(t, first), rawFirst)
 
-	// The round-tripped bytes match what we seeded.
-	require.Equal(t, stream.raws[first], raw)
+	rawLast, err := cr.GetLedgerRaw(last)
+	require.NoError(t, err)
+	require.Equal(t, marshalLCM(t, last), rawLast)
+}
+
+// TestRunCold_ShortStream_NoArtifact verifies that a stream which ends before
+// the chunk's full range makes RunCold return an error AND never produces a
+// finalized cold artifact (the completeness check runs before Finalize).
+func TestRunCold_ShortStream_NoArtifact(t *testing.T) {
+	chunkID := chunk.ID(0)
+	coldDir := t.TempDir()
+	logger := testLogger()
+	cfg := Config{Ledgers: true}
+
+	// Yield only 3 ledgers of a 10k-ledger chunk.
+	short := &fakeStream{t: t, count: 3}
+	factory := func(_ chunk.ID) (ledgerbackend.LedgerStream, error) { return short, nil }
+
+	err := runColdWithStreamFactory(
+		context.Background(), logger, factory, coldDir, chunkID, 1, 1, cfg,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ended at")
+
+	// No finalized cold packfile must exist for the chunk: Close removed the
+	// partial file because Finalize never ran.
+	path := packPath(filepath.Join(coldDir, "ledgers"), uint32(chunkID))
+	_, statErr := os.Stat(path)
+	require.True(t, os.IsNotExist(statErr), "expected no cold artifact at %s, stat err: %v", path, statErr)
 }

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ingest_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ingest_test.go
@@ -133,7 +133,7 @@ func TestRunCold_RoundTrip(t *testing.T) {
 	))
 
 	// Reopen the chunk's cold ledger packfile and read back the boundary ledgers.
-	path := packPath(filepath.Join(coldDir, "ledgers"), uint32(chunkID))
+	path := packPath(filepath.Join(coldDir, "ledgers"), chunkID)
 	cr, err := ledger.OpenColdReader(path)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, cr.Close()) }()
@@ -168,7 +168,7 @@ func TestRunCold_ShortStream_NoArtifact(t *testing.T) {
 
 	// No finalized cold packfile must exist for the chunk: Close removed the
 	// partial file because Finalize never ran.
-	path := packPath(filepath.Join(coldDir, "ledgers"), uint32(chunkID))
+	path := packPath(filepath.Join(coldDir, "ledgers"), chunkID)
 	_, statErr := os.Stat(path)
 	require.True(t, os.IsNotExist(statErr), "expected no cold artifact at %s, stat err: %v", path, statErr)
 }

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ingester.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ingester.go
@@ -1,0 +1,44 @@
+package ingest
+
+import (
+	"context"
+	"io"
+)
+
+// ingester ingests one data type into one storage tier. Hot ingesters
+// implement only this interface; cold ingesters implement coldIngester (below).
+// The hot driver holds a []ingester, the cold driver a []coldIngester — there
+// is no mixed-type slice and no type assertion in the per-ledger loop.
+//
+// Concurrency:
+//   - Ingest on a single ingester instance is invoked serially across ledgers
+//     (each ingester's own state is never accessed by two goroutines).
+//   - Distinct ingester instances are invoked concurrently within the same
+//     ledger (the driver fans out per-ledger via errgroup). Each instance
+//     reads its own state plus the read-only Ledger value.
+//
+// Lifecycle:
+//   - Constructors open the underlying store/writer. For cold tiers that opens
+//     the per-chunk writer.
+//   - Ingest is called once per ledger in the chunk range.
+//   - Close is ALWAYS deferred. It is idempotent and drops the store handle.
+//     For cold ingesters, when Finalize never ran (the failure path), the
+//     underlying packfile writer's Close removes any partial file.
+type ingester interface {
+	Ingest(ctx context.Context, l Ledger) error
+	io.Closer
+}
+
+// coldIngester adds the cold-tier commit step: Commit (ledger) / Finish +
+// WriteColdIndex (events) / sort + write .bin (txhash).
+//
+// Finalize is called explicitly by the driver on the success path with an error
+// check; it is never deferred. An error from Finalize means the chunk's cold
+// artifact did not durably land and must be re-ingested.
+//
+// Hot ingesters intentionally do NOT implement coldIngester — the distinction
+// is enforced at compile time by the per-driver slice type.
+type coldIngester interface {
+	ingester
+	Finalize(ctx context.Context) error
+}

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ledger.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ledger.go
@@ -1,0 +1,35 @@
+package ingest
+
+import (
+	"fmt"
+
+	"github.com/stellar/go-stellar-sdk/xdr"
+)
+
+// Ledger is the per-iteration value the driver hands to every ingester.
+//
+// Raw is always set: it is the wire-format LedgerCloseMeta bytes borrowed from
+// the source stream, valid only for the current iteration step. The ledgers
+// ingesters consume Raw verbatim.
+//
+// LCM is non-nil iff the decode was needed (events or txhash enabled). It is
+// shared read-only across ingesters for a single ledger and may be read
+// concurrently from multiple goroutines during parallel fan-out. Do not mutate
+// it. It is passed by pointer for nil-discrimination only.
+type Ledger struct {
+	Seq uint32
+	Raw []byte
+	LCM *xdr.LedgerCloseMeta
+}
+
+// newParsedLedger builds a Ledger by unmarshaling raw into an
+// xdr.LedgerCloseMeta. The resulting LCM is shared across all ingesters for
+// this ledger. raw is retained on the Ledger (borrowed) for the ledgers
+// ingesters, which write it verbatim rather than re-marshaling the parsed LCM.
+func newParsedLedger(seq uint32, raw []byte) (Ledger, error) {
+	var lcm xdr.LedgerCloseMeta
+	if err := lcm.UnmarshalBinary(raw); err != nil {
+		return Ledger{}, fmt.Errorf("ingest: UnmarshalBinary seq %d: %w", seq, err)
+	}
+	return Ledger{Seq: seq, Raw: raw, LCM: &lcm}, nil
+}

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ledgers.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ledgers.go
@@ -60,7 +60,7 @@ type ledgersCold struct {
 }
 
 func newLedgersCold(outRoot string, chunkID chunk.ID, opts ledgersColdOpts) (*ledgersCold, error) {
-	path := packPath(outRoot, uint32(chunkID))
+	path := packPath(outRoot, chunkID)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return nil, fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
 	}

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ledgers.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ledgers.go
@@ -43,11 +43,11 @@ func (h *ledgersHot) Close() error { return h.store.Close() }
 
 // ───────────────────────── Cold ingester ─────────────────────────
 
-// LedgersColdOpts is the per-packfile tuning passed to the underlying writer.
+// ledgersColdOpts is the per-packfile tuning passed to the underlying writer.
 // The zero value picks library defaults (serial, no writeback).
-type LedgersColdOpts struct {
-	Concurrency  int
-	BytesPerSync int
+type ledgersColdOpts struct {
+	concurrency  int
+	bytesPerSync int
 }
 
 // ledgersCold writes raw ledger bytes into a per-chunk ledger.ColdWriter (one
@@ -59,14 +59,14 @@ type ledgersCold struct {
 	appended bool
 }
 
-func newLedgersCold(outRoot string, chunkID chunk.ID, opts LedgersColdOpts) (*ledgersCold, error) {
+func newLedgersCold(outRoot string, chunkID chunk.ID, opts ledgersColdOpts) (*ledgersCold, error) {
 	path := packPath(outRoot, uint32(chunkID))
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return nil, fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
 	}
 	w, err := ledger.NewColdWriter(path, chunkID.FirstLedger(), ledger.ColdWriterOptions{
-		Concurrency:  opts.Concurrency,
-		BytesPerSync: opts.BytesPerSync,
+		Concurrency:  opts.concurrency,
+		BytesPerSync: opts.bytesPerSync,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("ledger.NewColdWriter %s: %w", path, err)

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ledgers.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ledgers.go
@@ -1,0 +1,98 @@
+package ingest
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/ledger"
+)
+
+// ───────────────────────── Hot ingester ─────────────────────────
+
+// ledgersHot writes raw ledger bytes verbatim into a ledger.HotStore.
+// AddLedgers fsyncs once per call, so each ledger is durable before Ingest
+// returns.
+type ledgersHot struct {
+	store *ledger.HotStore
+}
+
+func newLedgersHot(dir string, logger *supportlog.Entry) (*ledgersHot, error) {
+	if err := os.MkdirAll(filepath.Dir(dir), 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir parent of %s: %w", dir, err)
+	}
+	store, err := ledger.OpenHotStore(dir, logger)
+	if err != nil {
+		return nil, fmt.Errorf("ledger.OpenHotStore %s: %w", dir, err)
+	}
+	return &ledgersHot{store: store}, nil
+}
+
+func (h *ledgersHot) Ingest(_ context.Context, l Ledger) error {
+	if err := h.store.AddLedgers(ledger.Entry{Seq: l.Seq, Bytes: l.Raw}); err != nil {
+		return fmt.Errorf("AddLedgers(seq=%d): %w", l.Seq, err)
+	}
+	return nil
+}
+
+func (h *ledgersHot) Close() error { return h.store.Close() }
+
+// ───────────────────────── Cold ingester ─────────────────────────
+
+// LedgersColdOpts is the per-packfile tuning passed to the underlying writer.
+// The zero value picks library defaults (serial, no writeback).
+type LedgersColdOpts struct {
+	Concurrency  int
+	BytesPerSync int
+}
+
+// ledgersCold writes raw ledger bytes into a per-chunk ledger.ColdWriter (one
+// packfile per chunk). Finalize calls Commit, which finalizes the trailer and
+// fsyncs. Close cleans up the partial file when Finalize never ran (idempotent
+// — no-op after Commit).
+type ledgersCold struct {
+	writer   *ledger.ColdWriter
+	appended bool
+}
+
+func newLedgersCold(outRoot string, chunkID chunk.ID, opts LedgersColdOpts) (*ledgersCold, error) {
+	path := packPath(outRoot, uint32(chunkID))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
+	}
+	w, err := ledger.NewColdWriter(path, chunkID.FirstLedger(), ledger.ColdWriterOptions{
+		Concurrency:  opts.Concurrency,
+		BytesPerSync: opts.BytesPerSync,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ledger.NewColdWriter %s: %w", path, err)
+	}
+	return &ledgersCold{writer: w}, nil
+}
+
+func (c *ledgersCold) Ingest(_ context.Context, l Ledger) error {
+	if err := c.writer.AppendLedger(l.Seq, l.Raw); err != nil {
+		return fmt.Errorf("AppendLedger(seq=%d): %w", l.Seq, err)
+	}
+	c.appended = true
+	return nil
+}
+
+func (c *ledgersCold) Finalize(_ context.Context) error {
+	// ColdWriter.Commit errors on a zero-append pack. If the per-ledger loop
+	// bailed out before any AppendLedger succeeded, skip Commit so the failure
+	// surface is clean (Close in deferred cleanup removes the partial pack).
+	if !c.appended {
+		return nil
+	}
+	if err := c.writer.Commit(); err != nil {
+		return fmt.Errorf("ledger ColdWriter.Commit: %w", err)
+	}
+	return nil
+}
+
+func (c *ledgersCold) Close() error { return c.writer.Close() }

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/source.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/source.go
@@ -47,14 +47,10 @@ type SourceOpts struct {
 }
 
 // packPath returns the on-disk path of a chunk's cold packfile under coldDir,
-// grouped into per-bucket subdirectories (bucket_id = chunk_id /
-// chunk.ChunksPerBucket).
-func packPath(coldDir string, c uint32) string {
-	return filepath.Join(
-		coldDir,
-		fmt.Sprintf("%05d", c/uint32(chunk.ChunksPerBucket)),
-		fmt.Sprintf("%08d.pack", c),
-	)
+// grouped into per-bucket subdirectories via the chunk.ID helpers
+// (BucketID() = %05d bucket dir, String() = %08d chunk id).
+func packPath(coldDir string, c chunk.ID) string {
+	return filepath.Join(coldDir, c.BucketID(), c.String()+".pack")
 }
 
 // packStream is a ledgerbackend.LedgerStream backed by a single cold packfile.
@@ -75,7 +71,7 @@ var _ ledgerbackend.LedgerStream = (*packStream)(nil)
 // ingester copies the bytes it retains.
 func (p *packStream) RawLedgers(_ context.Context, r ledgerbackend.Range, _ ...ledgerbackend.StreamOption) iter.Seq2[[]byte, error] {
 	return func(yield func([]byte, error) bool) {
-		path := packPath(p.coldDir, uint32(p.chunkID))
+		path := packPath(p.coldDir, p.chunkID)
 		cr, err := ledger.OpenColdReader(path)
 		if err != nil {
 			yield(nil, fmt.Errorf("OpenColdReader %s: %w", path, err))
@@ -116,7 +112,7 @@ func OpenChunkStream(source Source, opts SourceOpts, chunkID chunk.ID) (ledgerba
 		if opts.ColdDir == "" {
 			return nil, errors.New("ingest: SourceOpts.ColdDir is required for SourcePack")
 		}
-		path := packPath(opts.ColdDir, uint32(chunkID))
+		path := packPath(opts.ColdDir, chunkID)
 		if _, err := os.Stat(path); err != nil {
 			return nil, fmt.Errorf("cold pack missing: %s: %w", path, err)
 		}

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/source.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/source.go
@@ -1,15 +1,27 @@
 package ingest
 
-// Ledger sources for the ingest drivers. Both RunHot and RunCold treat their
-// input as a ledgerbackend.LedgerStream, so a local cold packfile (packStream,
-// this file) and a GCS-backed buffered-storage stream
-// (ledgerbackend.NewBufferedStorageStream) plug into the same per-chunk
-// RawLedgers iteration. Each stream owns its own setup + teardown, so there is
-// no separate prepare/close to manage.
+// Ledger sources for the ingest drivers.
+//
+// The drivers consume one ledgerbackend.LedgerStream per chunk via the
+// ChunkSource abstraction. A ChunkSource yields a FRESH, independent stream for
+// each chunk (cold chunk workers run concurrently and a backend cursor cannot
+// be shared), and every stream yields each ledger's wire-format
+// xdr.LedgerCloseMeta bytes for the requested range.
+//
+// Built-in sources:
+//   - NewPackSource     — local cold packfiles (one .pack per chunk).
+//   - NewDataStoreSource — any SDK datastore (GCS / S3 / Filesystem / future),
+//     replayed through a buffered-storage stream. GCS and S3 share this single
+//     code path and differ only by datastore.DataStoreConfig; NewGCSSource and
+//     NewS3Source are thin wrappers over it.
+//
+// Extensibility: adding a new cloud backend the SDK datastore already supports
+// is a one-line wrapper over NewDataStoreSource. A completely different backend
+// (custom RPC, a test double, …) just implements ChunkSource directly — the
+// pipeline needs nothing else, and there is no central switch to edit.
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"iter"
 	"os"
@@ -23,27 +35,22 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/ledger"
 )
 
-// Source selects the ledger backend kind.
-type Source string
+// ChunkSource opens an independent LedgerStream for one chunk. Each call returns
+// a FRESH stream (cold workers run chunks concurrently; a backend cursor can't
+// be shared). Contract: the returned stream yields each ledger's wire-format
+// xdr.LedgerCloseMeta bytes for the requested range. Implement this to add a new
+// backend — the pipeline needs nothing else.
+type ChunkSource interface {
+	OpenStream(chunkID chunk.ID) (ledgerbackend.LedgerStream, error)
+}
 
-const (
-	// SourcePack replays a local cold packfile per chunk.
-	SourcePack Source = "pack"
-	// SourceBSB streams from a GCS buffered-storage backend.
-	SourceBSB Source = "bsb"
-)
+// ChunkSourceFunc adapts a plain function to ChunkSource. It is the test seam
+// and the escape hatch for callers that already hold a per-chunk stream factory.
+type ChunkSourceFunc func(chunk.ID) (ledgerbackend.LedgerStream, error)
 
-// SourceOpts carries pack/BSB tuning. ColdDir is required for SourcePack;
-// BucketPath is required for SourceBSB. The remaining fields tune the BSB
-// prefetch pipeline and are ignored for SourcePack.
-type SourceOpts struct {
-	ColdDir    string // required for SourcePack
-	BucketPath string // required for SourceBSB
-
-	BufferSize uint // BSB prefetch buffer depth
-	NumWorkers uint // BSB download workers
-	RetryLimit uint // BSB retry attempts on transient backend failure
-	RetryWait  time.Duration
+// OpenStream implements ChunkSource.
+func (f ChunkSourceFunc) OpenStream(id chunk.ID) (ledgerbackend.LedgerStream, error) {
+	return f(id)
 }
 
 // packPath returns the on-disk path of a chunk's cold packfile under coldDir,
@@ -51,6 +58,30 @@ type SourceOpts struct {
 // (BucketID() = %05d bucket dir, String() = %08d chunk id).
 func packPath(coldDir string, c chunk.ID) string {
 	return filepath.Join(coldDir, c.BucketID(), c.String()+".pack")
+}
+
+// packSource opens packStreams over local cold packfiles under coldDir.
+type packSource struct {
+	coldDir string
+}
+
+// NewPackSource returns a ChunkSource backed by local cold packfiles: one
+// .pack per chunk under coldDir, addressed via packPath. OpenStream verifies
+// the chunk's packfile exists (returning a clear error otherwise) before
+// handing back a stream for it.
+func NewPackSource(coldDir string) ChunkSource {
+	return &packSource{coldDir: coldDir}
+}
+
+func (s *packSource) OpenStream(chunkID chunk.ID) (ledgerbackend.LedgerStream, error) {
+	if s.coldDir == "" {
+		return nil, fmt.Errorf("ingest: PackSource requires a non-empty coldDir")
+	}
+	path := packPath(s.coldDir, chunkID)
+	if _, err := os.Stat(path); err != nil {
+		return nil, fmt.Errorf("cold pack missing: %s: %w", path, err)
+	}
+	return &packStream{coldDir: s.coldDir, chunkID: chunkID}, nil
 }
 
 // packStream is a ledgerbackend.LedgerStream backed by a single cold packfile.
@@ -100,39 +131,70 @@ func (p *packStream) RawLedgers(_ context.Context, r ledgerbackend.Range, _ ...l
 	}
 }
 
-// OpenChunkStream returns the LedgerStream for one chunk. Both sources are
-// self-contained — the stream owns its setup and teardown — so there is no
-// cleanup handle: a pack stream opens/closes a ColdReader per iteration, and a
-// buffered-storage stream opens/closes its datastore + backend per iteration.
-// Each call yields an INDEPENDENT stream, so concurrent chunk workers run fully
-// in parallel (independent ColdReaders / GCS prefetch pipelines).
-func OpenChunkStream(source Source, opts SourceOpts, chunkID chunk.ID) (ledgerbackend.LedgerStream, error) {
-	switch source {
-	case SourcePack:
-		if opts.ColdDir == "" {
-			return nil, errors.New("ingest: SourceOpts.ColdDir is required for SourcePack")
-		}
-		path := packPath(opts.ColdDir, chunkID)
-		if _, err := os.Stat(path); err != nil {
-			return nil, fmt.Errorf("cold pack missing: %s: %w", path, err)
-		}
-		return &packStream{coldDir: opts.ColdDir, chunkID: chunkID}, nil
-	case SourceBSB:
-		if opts.BucketPath == "" {
-			return nil, errors.New("ingest: SourceOpts.BucketPath is required for SourceBSB")
-		}
-		dsConfig := datastore.DataStoreConfig{
-			Type:   "GCS",
-			Params: map[string]string{"destination_bucket_path": opts.BucketPath},
-		}
-		cfg := ledgerbackend.BufferedStorageBackendConfig{
-			BufferSize: uint32(opts.BufferSize),
-			NumWorkers: uint32(opts.NumWorkers),
-			RetryLimit: uint32(opts.RetryLimit),
-			RetryWait:  opts.RetryWait,
-		}
-		return ledgerbackend.NewBufferedStorageStream(cfg, dsConfig, nil), nil
-	default:
-		return nil, fmt.Errorf("ingest: unknown source %q (expected %q or %q)", source, SourcePack, SourceBSB)
+// BSBOptions tunes the buffered-storage prefetch pipeline shared by every
+// datastore-backed source (GCS / S3 / Filesystem). The zero value is usable;
+// callers tune BufferSize/NumWorkers for throughput and RetryLimit/RetryWait
+// for transient-failure resilience.
+type BSBOptions struct {
+	BufferSize uint // prefetch buffer depth
+	NumWorkers uint // download workers
+	RetryLimit uint // retry attempts on transient backend failure
+	RetryWait  time.Duration
+}
+
+// dataStoreSource opens an independent buffered-storage stream per chunk over a
+// configured SDK datastore. One code path serves GCS, S3, and Filesystem — they
+// differ only in cfg.
+type dataStoreSource struct {
+	cfg  datastore.DataStoreConfig
+	opts BSBOptions
+}
+
+// NewDataStoreSource returns a ChunkSource over any SDK datastore (the SDK's
+// datastore.NewDataStore switches on cfg.Type: "GCS", "S3", "Filesystem").
+// Each OpenStream returns an independent buffered-storage stream that owns its
+// own datastore + backend lifecycle, so concurrent chunk workers run fully in
+// parallel. This is the single shared path for all cloud/object-store backends;
+// GCS and S3 are thin wrappers (NewGCSSource / NewS3Source), and any future
+// datastore type plugs in with no change here.
+func NewDataStoreSource(cfg datastore.DataStoreConfig, opts BSBOptions) ChunkSource {
+	return &dataStoreSource{cfg: cfg, opts: opts}
+}
+
+func (s *dataStoreSource) OpenStream(_ chunk.ID) (ledgerbackend.LedgerStream, error) {
+	bsbCfg := ledgerbackend.BufferedStorageBackendConfig{
+		BufferSize: uint32(s.opts.BufferSize),
+		NumWorkers: uint32(s.opts.NumWorkers),
+		RetryLimit: uint32(s.opts.RetryLimit),
+		RetryWait:  s.opts.RetryWait,
 	}
+	return ledgerbackend.NewBufferedStorageStream(bsbCfg, s.cfg, nil), nil
+}
+
+// NewGCSSource returns a ChunkSource streaming from a GCS bucket path. It is a
+// thin wrapper over NewDataStoreSource with Type:"GCS".
+func NewGCSSource(bucketPath string, opts BSBOptions) ChunkSource {
+	return NewDataStoreSource(datastore.DataStoreConfig{
+		Type:   "GCS",
+		Params: map[string]string{"destination_bucket_path": bucketPath},
+	}, opts)
+}
+
+// NewS3Source returns a ChunkSource streaming from an S3 bucket path. It is a
+// thin wrapper over NewDataStoreSource with Type:"S3". The SDK's S3 datastore
+// requires both the bucket path and an AWS region (read from the "region"
+// param), so region is taken explicitly here; an optional endpointURL ("" to
+// omit) supports S3-compatible stores.
+func NewS3Source(bucketPath, region, endpointURL string, opts BSBOptions) ChunkSource {
+	params := map[string]string{
+		"destination_bucket_path": bucketPath,
+		"region":                  region,
+	}
+	if endpointURL != "" {
+		params["endpoint_url"] = endpointURL
+	}
+	return NewDataStoreSource(datastore.DataStoreConfig{
+		Type:   "S3",
+		Params: params,
+	}, opts)
 }

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/source.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/source.go
@@ -1,0 +1,142 @@
+package ingest
+
+// Ledger sources for the ingest drivers. Both RunHot and RunCold treat their
+// input as a ledgerbackend.LedgerStream, so a local cold packfile (packStream,
+// this file) and a GCS-backed buffered-storage stream
+// (ledgerbackend.NewBufferedStorageStream) plug into the same per-chunk
+// RawLedgers iteration. Each stream owns its own setup + teardown, so there is
+// no separate prepare/close to manage.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
+	"github.com/stellar/go-stellar-sdk/support/datastore"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/ledger"
+)
+
+// Source selects the ledger backend kind.
+type Source string
+
+const (
+	// SourcePack replays a local cold packfile per chunk.
+	SourcePack Source = "pack"
+	// SourceBSB streams from a GCS buffered-storage backend.
+	SourceBSB Source = "bsb"
+)
+
+// SourceOpts carries pack/BSB tuning. ColdDir is required for SourcePack;
+// BucketPath is required for SourceBSB. The remaining fields tune the BSB
+// prefetch pipeline and are ignored for SourcePack.
+type SourceOpts struct {
+	ColdDir    string // required for SourcePack
+	BucketPath string // required for SourceBSB
+
+	BufferSize uint // BSB prefetch buffer depth
+	NumWorkers uint // BSB download workers
+	RetryLimit uint // BSB retry attempts on transient backend failure
+	RetryWait  time.Duration
+}
+
+// packPath returns the on-disk path of a chunk's cold packfile under coldDir,
+// grouped into per-bucket subdirectories (bucket_id = chunk_id /
+// chunk.ChunksPerBucket).
+func packPath(coldDir string, c uint32) string {
+	return filepath.Join(
+		coldDir,
+		fmt.Sprintf("%05d", c/uint32(chunk.ChunksPerBucket)),
+		fmt.Sprintf("%08d.pack", c),
+	)
+}
+
+// packStream is a ledgerbackend.LedgerStream backed by a single cold packfile.
+// Like NewBufferedStorageStream it owns its lifecycle: each RawLedgers call
+// opens the chunk's ColdReader, yields each ledger's bytes, and closes the
+// reader when iteration ends.
+type packStream struct {
+	coldDir string
+	chunkID chunk.ID
+}
+
+var _ ledgerbackend.LedgerStream = (*packStream)(nil)
+
+// RawLedgers streams the chunk's raw ledger bytes over r by opening a
+// ColdReader and delegating to IterateLedgers, which yields packfile borrows
+// directly. Each yielded slice is valid only until the next iteration step; the
+// ingest driver consumes each ledger fully before the next yield, and every
+// ingester copies the bytes it retains.
+func (p *packStream) RawLedgers(_ context.Context, r ledgerbackend.Range, _ ...ledgerbackend.StreamOption) iter.Seq2[[]byte, error] {
+	return func(yield func([]byte, error) bool) {
+		path := packPath(p.coldDir, uint32(p.chunkID))
+		cr, err := ledger.OpenColdReader(path)
+		if err != nil {
+			yield(nil, fmt.Errorf("OpenColdReader %s: %w", path, err))
+			return
+		}
+		defer func() { _ = cr.Close() }()
+
+		to := r.To()
+		if !r.Bounded() {
+			last, lerr := cr.LastSeq()
+			if lerr != nil {
+				yield(nil, lerr)
+				return
+			}
+			to = last
+		}
+		for entry, ierr := range cr.IterateLedgers(r.From(), to) {
+			if ierr != nil {
+				yield(nil, ierr)
+				return
+			}
+			if !yield(entry.Bytes, nil) {
+				return
+			}
+		}
+	}
+}
+
+// OpenChunkStream returns the LedgerStream for one chunk. Both sources are
+// self-contained — the stream owns its setup and teardown — so there is no
+// cleanup handle: a pack stream opens/closes a ColdReader per iteration, and a
+// buffered-storage stream opens/closes its datastore + backend per iteration.
+// Each call yields an INDEPENDENT stream, so concurrent chunk workers run fully
+// in parallel (independent ColdReaders / GCS prefetch pipelines).
+func OpenChunkStream(source Source, opts SourceOpts, chunkID chunk.ID) (ledgerbackend.LedgerStream, error) {
+	switch source {
+	case SourcePack:
+		if opts.ColdDir == "" {
+			return nil, errors.New("ingest: SourceOpts.ColdDir is required for SourcePack")
+		}
+		path := packPath(opts.ColdDir, uint32(chunkID))
+		if _, err := os.Stat(path); err != nil {
+			return nil, fmt.Errorf("cold pack missing: %s: %w", path, err)
+		}
+		return &packStream{coldDir: opts.ColdDir, chunkID: chunkID}, nil
+	case SourceBSB:
+		if opts.BucketPath == "" {
+			return nil, errors.New("ingest: SourceOpts.BucketPath is required for SourceBSB")
+		}
+		dsConfig := datastore.DataStoreConfig{
+			Type:   "GCS",
+			Params: map[string]string{"destination_bucket_path": opts.BucketPath},
+		}
+		cfg := ledgerbackend.BufferedStorageBackendConfig{
+			BufferSize: uint32(opts.BufferSize),
+			NumWorkers: uint32(opts.NumWorkers),
+			RetryLimit: uint32(opts.RetryLimit),
+			RetryWait:  opts.RetryWait,
+		}
+		return ledgerbackend.NewBufferedStorageStream(cfg, dsConfig, nil), nil
+	default:
+		return nil, fmt.Errorf("ingest: unknown source %q (expected %q or %q)", source, SourcePack, SourceBSB)
+	}
+}

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/txhash.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/txhash.go
@@ -36,7 +36,7 @@ func extractTxHashes(l Ledger) ([]txhash.Entry, error) {
 	out := make([]txhash.Entry, 0, n)
 	for i := range n {
 		h := lcm.TransactionHash(i)
-		out = append(out, txhash.Entry{Hash: [32]byte(h), LedgerSeq: l.Seq})
+		out = append(out, txhash.Entry{Hash: h, LedgerSeq: l.Seq})
 	}
 	return out, nil
 }

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/txhash.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/txhash.go
@@ -109,14 +109,20 @@ func newTxhashCold(outRoot string, chunkID chunk.ID) (*txhashCold, error) {
 }
 
 func (t *txhashCold) Ingest(_ context.Context, l Ledger) error {
-	entries, err := extractTxHashes(l)
-	if err != nil {
-		return fmt.Errorf("extract seq %d: %w", l.Seq, err)
+	if l.LCM == nil {
+		return fmt.Errorf("txhash ingester requires a parsed LCM but ledger %d has none", l.Seq)
 	}
-	for _, e := range entries {
+	lcm := *l.LCM
+	// Single pass: read each precomputed tx hash off the LCM, truncate to
+	// keySize, and append directly into the accumulator — no intermediate
+	// []txhash.Entry. Output is identical to the hot path's full-hash extract
+	// truncated at Finalize.
+	n := lcm.CountTransactions()
+	for i := range n {
+		h := lcm.TransactionHash(i)
 		var ke txhashEntry
-		copy(ke.key[:], e.Hash[:keySize])
-		ke.seq = e.LedgerSeq
+		copy(ke.key[:], h[:keySize])
+		ke.seq = l.Seq
 		t.entries = append(t.entries, ke)
 	}
 	return nil
@@ -133,7 +139,7 @@ func (t *txhashCold) Finalize(_ context.Context) error {
 	sort.Slice(t.entries, func(i, j int) bool {
 		return bytes.Compare(t.entries[i].key[:], t.entries[j].key[:]) < 0
 	})
-	path := filepath.Join(t.outRoot, fmt.Sprintf("%08d.bin", uint32(t.chunkID)))
+	path := filepath.Join(t.outRoot, t.chunkID.String()+".bin")
 	return writeTxhashBin(path, t.entries)
 }
 

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/txhash.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/ingest/txhash.go
@@ -1,0 +1,178 @@
+package ingest
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash"
+)
+
+const (
+	// keySize is the truncated tx-hash key width stored in the cold .bin file.
+	keySize = 16
+	// entrySize is the per-entry width in the cold .bin file: keySize bytes of
+	// truncated hash + a uint32 LE ledger seq.
+	entrySize = keySize + 4
+)
+
+// extractTxHashes reads precomputed transaction hashes off the parsed
+// LedgerCloseMeta. Cheap — TransactionHash(i) returns a stored value, no
+// walking or hashing required. l.LCM must be non-nil.
+func extractTxHashes(l Ledger) ([]txhash.Entry, error) {
+	if l.LCM == nil {
+		return nil, fmt.Errorf("txhash ingester requires a parsed LCM but ledger %d has none", l.Seq)
+	}
+	lcm := *l.LCM
+	n := lcm.CountTransactions()
+	out := make([]txhash.Entry, 0, n)
+	for i := range n {
+		h := lcm.TransactionHash(i)
+		out = append(out, txhash.Entry{Hash: [32]byte(h), LedgerSeq: l.Seq})
+	}
+	return out, nil
+}
+
+// ───────────────────────── Hot ingester ─────────────────────────
+
+// txhashHot extracts (txhash, seq) tuples from each ledger and writes them in
+// one AddEntries call. AddEntries fsyncs once per ledger.
+type txhashHot struct {
+	store *txhash.HotStore
+}
+
+func newTxhashHot(dir string, logger *supportlog.Entry) (*txhashHot, error) {
+	if err := os.MkdirAll(filepath.Dir(dir), 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir parent of %s: %w", dir, err)
+	}
+	store, err := txhash.OpenHotStore(dir, logger)
+	if err != nil {
+		return nil, fmt.Errorf("txhash.OpenHotStore %s: %w", dir, err)
+	}
+	return &txhashHot{store: store}, nil
+}
+
+func (t *txhashHot) Ingest(_ context.Context, l Ledger) error {
+	entries, err := extractTxHashes(l)
+	if err != nil {
+		return fmt.Errorf("extract seq %d: %w", l.Seq, err)
+	}
+	if len(entries) > 0 {
+		if err := t.store.AddEntries(entries); err != nil {
+			return fmt.Errorf("AddEntries(seq=%d, n=%d): %w", l.Seq, len(entries), err)
+		}
+	}
+	return nil
+}
+
+func (t *txhashHot) Close() error { return t.store.Close() }
+
+// ───────────────────────── Cold ingester ─────────────────────────
+
+// txhashEntry is the in-memory tuple buffered by the cold ingester. Stored at
+// full keySize key width; the cold .bin reader compares by full key.
+type txhashEntry struct {
+	key [keySize]byte
+	seq uint32
+}
+
+// txhashCold accumulates (txhash[:keySize], seq) tuples per ledger; at Finalize
+// time it lex-sorts by the truncated key and writes a per-chunk sorted .bin
+// file under <out-root>/<chunkID:08d>.bin. A separate index-build step (not in
+// this package) turns these .bin files into the queryable cold MPHF index.
+type txhashCold struct {
+	outRoot string
+	chunkID chunk.ID
+	entries []txhashEntry
+}
+
+func newTxhashCold(outRoot string, chunkID chunk.ID) (*txhashCold, error) {
+	if err := os.MkdirAll(outRoot, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir %s: %w", outRoot, err)
+	}
+	// Initial cap sized for a typical pubnet chunk (~3M tx total). A few
+	// growths is fine; we don't want a large allocation for chunks that turn
+	// out empty.
+	return &txhashCold{
+		outRoot: outRoot,
+		chunkID: chunkID,
+		entries: make([]txhashEntry, 0, 1<<16),
+	}, nil
+}
+
+func (t *txhashCold) Ingest(_ context.Context, l Ledger) error {
+	entries, err := extractTxHashes(l)
+	if err != nil {
+		return fmt.Errorf("extract seq %d: %w", l.Seq, err)
+	}
+	for _, e := range entries {
+		var ke txhashEntry
+		copy(ke.key[:], e.Hash[:keySize])
+		ke.seq = e.LedgerSeq
+		t.entries = append(t.entries, ke)
+	}
+	return nil
+}
+
+// Finalize sorts the in-memory accumulator and writes the per-chunk .bin file.
+//
+// File layout (consumed by the separate index-build step):
+//
+//	header  uint64 LE  entry count
+//	entry   16 bytes    txhash[:keySize]
+//	        uint32 LE   absolute ledger seq
+func (t *txhashCold) Finalize(_ context.Context) error {
+	sort.Slice(t.entries, func(i, j int) bool {
+		return bytes.Compare(t.entries[i].key[:], t.entries[j].key[:]) < 0
+	})
+	path := filepath.Join(t.outRoot, fmt.Sprintf("%08d.bin", uint32(t.chunkID)))
+	return writeTxhashBin(path, t.entries)
+}
+
+// Close is a no-op for cold txhash: no open file handle (the .bin is written in
+// Finalize).
+func (t *txhashCold) Close() error { return nil }
+
+// writeTxhashBin writes the .bin file via os.Create + bufio.
+//
+// The Close error is explicitly checked: on many filesystems ENOSPC/EIO only
+// surface at fd close, and a silently truncated .bin would produce a wrong
+// index without any signal.
+func writeTxhashBin(path string, entries []txhashEntry) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", path, err)
+	}
+	bw := bufio.NewWriterSize(f, 1<<20)
+	var header [8]byte
+	binary.LittleEndian.PutUint64(header[:], uint64(len(entries)))
+	if _, werr := bw.Write(header[:]); werr != nil {
+		_ = f.Close()
+		return fmt.Errorf("write header: %w", werr)
+	}
+	var entryBuf [entrySize]byte
+	for _, e := range entries {
+		copy(entryBuf[:keySize], e.key[:])
+		binary.LittleEndian.PutUint32(entryBuf[keySize:], e.seq)
+		if _, werr := bw.Write(entryBuf[:]); werr != nil {
+			_ = f.Close()
+			return fmt.Errorf("write entry: %w", werr)
+		}
+	}
+	if ferr := bw.Flush(); ferr != nil {
+		_ = f.Close()
+		return fmt.Errorf("flush: %w", ferr)
+	}
+	if cerr := f.Close(); cerr != nil {
+		return fmt.Errorf("close %s: %w", path, cerr)
+	}
+	return nil
+}

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash/cold_format.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash/cold_format.go
@@ -1,0 +1,174 @@
+package txhash
+
+// cold_format.go defines the on-disk format for the cold txhash index
+// and the streamhash MPHF wrapper shared by the cold reader.
+//
+// The cold index is a single global file covering the entire cold
+// ledger store: one streamhash MPHF over every (txhash, ledgerSeq)
+// pair. Unlike the eventstore (which needs a separate index.pack for
+// variable-length roaring bitmaps), the txhash payload is a fixed
+// ledger-seq offset that fits natively in streamhash's per-key payload
+// slot. One file is enough.
+//
+// Build is two-phase (lives in cmd/.../scripts/bench-fullhistory):
+//
+//	phase 1   ingest-raw-txhash    one .bin file per cold chunk, sorted
+//	phase 2   build-txhash-index   merge .bin files into one .idx via
+//	                               streamhash.NewSortedBuilder
+//
+// On-disk layout (streamhash-managed):
+//
+//   - Sorted-mode build: caller pre-sorts keys ascending by
+//     big-endian uint64 prefix; the build is one-pass and avoids the
+//     temp-partition writes of unsorted mode.
+//   - WithPayload(ColdPayloadSize) — per-key payload is a 3-byte
+//     ledger-seq offset from MinLedger. 3 bytes covers any range up
+//     to 2^24 ≈ 16.7M ledgers, comfortably above mainnet history.
+//   - WithFingerprint(ColdFingerprintSize) — 1-byte fingerprint
+//     streamhash verifies internally on Query. Residual FPR ≈ 1/256
+//     for unseen keys; downstream txhash-in-LCM verification rejects
+//     false positives at the cost of one wasted ledger fetch.
+//   - WithMetadata(EncodeLedgerRange(...)) — 8-byte [MinLedger,
+//     MaxLedger] anchor embedded in the index. MinLedger lets the
+//     reader recover absolute seqs without external metadata; MaxLedger
+//     lets callers learn the index's coverage without probing it.
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/stellar/streamhash"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores"
+)
+
+// ColdIndexName is the conventional filename for the cold txhash
+// index. Producers and consumers compose the full path as
+// {coldRoot}/{ColdIndexName}.
+const ColdIndexName = "txhash.idx"
+
+// ColdPayloadSize — bytes of per-key payload in the MPHF. Each
+// payload stores ledgerSeq - MinLedger, so a 3-byte slot caps the
+// supported ledger span at 2^24 ≈ 16.7 M ledgers from MinLedger.
+// Build-time and read-time both enforce that ceiling; widening the
+// payload requires bumping this constant and rebuilding the index.
+const ColdPayloadSize = 3
+
+// ColdFingerprintSize — bytes of per-key fingerprint streamhash
+// verifies on Query.
+const ColdFingerprintSize = 1
+
+// coldMetadataSize — size of the WithUserMetadata blob: 8 bytes (two
+// 4-byte LE values) containing the [MinLedger, MaxLedger] coverage anchor.
+const coldMetadataSize = 8
+
+// ErrInvalidMetadata is returned when an opened cold index's
+// UserMetadata is not exactly coldMetadataSize bytes — the cold index
+// was either built by something other than ColdBuildOptions or is
+// corrupt.
+var ErrInvalidMetadata = errors.New("txhash: cold index user metadata malformed")
+
+// EncodeLedgerRange packs [minLedger, maxLedger] as the 8-byte blob
+// (two 4-byte LE values) stored in the streamhash UserMetadata slot.
+// minLedger anchors the per-key payload (seq - minLedger); maxLedger
+// lets callers learn the index's ledger coverage without probing.
+func EncodeLedgerRange(minLedger, maxLedger uint32) []byte {
+	buf := make([]byte, coldMetadataSize)
+	binary.LittleEndian.PutUint32(buf[:4], minLedger)
+	binary.LittleEndian.PutUint32(buf[4:], maxLedger)
+	return buf
+}
+
+// ParseLedgerRange recovers [minLedger, maxLedger] from a streamhash
+// UserMetadata blob.
+func ParseLedgerRange(metadata []byte) (minLedger, maxLedger uint32, err error) {
+	if len(metadata) != coldMetadataSize {
+		return 0, 0, fmt.Errorf("%w: got %d bytes, want %d", ErrInvalidMetadata, len(metadata), coldMetadataSize)
+	}
+	minLedger = binary.LittleEndian.Uint32(metadata[:4])
+	maxLedger = binary.LittleEndian.Uint32(metadata[4:])
+	// Reject an inverted range: a consumer deriving a chunk range from this
+	// would underflow (maxChunk - minChunk + 1 as uint32) into a huge value.
+	if maxLedger < minLedger {
+		return 0, 0, fmt.Errorf("%w: maxLedger %d < minLedger %d", ErrInvalidMetadata, maxLedger, minLedger)
+	}
+	return minLedger, maxLedger, nil
+}
+
+// ColdBuildOptions returns the streamhash.BuildOption set used to
+// build a cold txhash index. The options pin payload size,
+// fingerprint size, and the [minLedger, maxLedger] coverage anchor
+// embedded as user metadata. Callers append other options
+// (WithWorkers, WithAlgorithm) as needed.
+func ColdBuildOptions(minLedger, maxLedger uint32) []streamhash.BuildOption {
+	return []streamhash.BuildOption{
+		streamhash.WithPayload(ColdPayloadSize),
+		streamhash.WithFingerprint(ColdFingerprintSize),
+		streamhash.WithMetadata(EncodeLedgerRange(minLedger, maxLedger)),
+	}
+}
+
+// coldMPHF wraps a streamhash PayloadIndex for the txhash cold
+// lookup path. It stores the [minLedger, maxLedger] coverage recovered
+// from the index's UserMetadata so Lookup can return absolute seqs and
+// callers can learn the index's range.
+type coldMPHF struct {
+	idx       *streamhash.PayloadIndex
+	minLedger uint32
+	maxLedger uint32
+}
+
+// openColdMPHF mmaps the cold-index streamhash file at path,
+// validates its UserMetadata, and returns a query-ready wrapper.
+func openColdMPHF(path string) (*coldMPHF, error) {
+	idx, err := streamhash.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("txhash: open cold index %s: %w", path, err)
+	}
+	minLedger, maxLedger, err := ParseLedgerRange(idx.UserMetadata())
+	if err != nil {
+		_ = idx.Close()
+		return nil, fmt.Errorf("txhash: open cold index %s: %w", path, err)
+	}
+	pidx, err := idx.WithPayload()
+	if err != nil {
+		_ = idx.Close()
+		return nil, fmt.Errorf("txhash: cold index %s payload view: %w", path, err)
+	}
+	return &coldMPHF{idx: pidx, minLedger: minLedger, maxLedger: maxLedger}, nil
+}
+
+// coveredRange returns the [minLedger, maxLedger] the index was built
+// over (inclusive), recovered from its UserMetadata.
+func (m *coldMPHF) coveredRange() (minLedger, maxLedger uint32) {
+	return m.minLedger, m.maxLedger
+}
+
+// lookup returns the absolute ledgerSeq stored under hash, or
+// stores.ErrNotFound when streamhash's fingerprint check proves the
+// hash was not in the build set. Concurrent calls are safe —
+// streamhash.PayloadIndex supports concurrent reads.
+func (m *coldMPHF) lookup(hash [32]byte) (uint32, error) {
+	_, payload, err := m.idx.QueryPayload(hash[:])
+	if err != nil {
+		if errors.Is(err, streamhash.ErrNotFound) {
+			return 0, stores.ErrNotFound
+		}
+		return 0, fmt.Errorf("txhash: cold MPHF query: %w", err)
+	}
+	if payload > 0xFFFFFF {
+		// Payload is ColdPayloadSize (3) bytes; streamhash zero-extends
+		// to uint64. A value above 2^24 means the on-disk representation
+		// is wider than configured — corruption.
+		return 0, fmt.Errorf("%w: txhash: ledger offset %d exceeds 24 bits", stores.ErrCorrupt, payload)
+	}
+	return m.minLedger + uint32(payload), nil
+}
+
+func (m *coldMPHF) close() error {
+	if err := m.idx.Close(); err != nil {
+		return fmt.Errorf("txhash: close cold MPHF: %w", err)
+	}
+	return nil
+}

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash/cold_format_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash/cold_format_test.go
@@ -1,0 +1,199 @@
+package txhash
+
+import (
+	"bytes"
+	"context"
+	"math/rand/v2"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stellar/streamhash"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores"
+)
+
+// randHash returns a 32-byte hash drawn from r. Test data uses true
+// random hashes (matching streamhash's own test patterns) — structured
+// hashes can produce correlated 16-byte prefixes that defeat the
+// fingerprint check and confuse this test.
+func randHash(r *rand.Rand) [32]byte {
+	var h [32]byte
+	for i := range h {
+		h[i] = byte(r.UintN(256))
+	}
+	return h
+}
+
+// testRNG returns a deterministic rand source. Tests using this RNG
+// are reproducible even though the hashes look random.
+func testRNG(seed uint64) *rand.Rand {
+	return rand.New(rand.NewPCG(seed, seed*7919+1))
+}
+
+// fixtureEntry pairs a generated hash with its assigned ledgerSeq.
+type fixtureEntry struct {
+	hash [32]byte
+	seq  uint32
+}
+
+// fixtureMinLedger is the MinLedger anchor used by buildColdFixture.
+// Picked >0 so the offset math is exercised (a bug returning the raw
+// payload as the absolute seq would surface as a 100-off mismatch).
+const fixtureMinLedger uint32 = 100
+
+// fixtureMaxLedger is the MaxLedger coverage bound stored alongside
+// fixtureMinLedger; picked well above every fixture entry seq.
+const fixtureMaxLedger uint32 = 9999
+
+// buildColdFixture builds a populated cold index at a tempdir path by
+// driving streamhash.NewSortedBuilder directly with ColdBuildOptions,
+// then returns (path, entries). Keys are pre-sorted (streamhash's
+// sorted-mode requirement); seqs are assigned distinct from the slot
+// index so a bug swapping the two surfaces as a value mismatch.
+func buildColdFixture(t *testing.T, n int) (string, []fixtureEntry) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), ColdIndexName)
+
+	// Generate n unique hashes.
+	r := testRNG(uint64(n) | 0xfeed)
+	entries := make([]fixtureEntry, 0, n)
+	seen := make(map[[32]byte]struct{}, n)
+	for len(entries) < n {
+		h := randHash(r)
+		if _, dup := seen[h]; dup {
+			continue
+		}
+		seen[h] = struct{}{}
+		entries = append(entries, fixtureEntry{
+			hash: h,
+			seq:  fixtureMinLedger + uint32(len(entries)*7),
+		})
+	}
+
+	// streamhash sorted mode requires keys ascending by the
+	// big-endian 16-byte prefix; sorting full hashes lex-byte is
+	// equivalent for our purposes.
+	sort.Slice(entries, func(i, j int) bool {
+		return bytes.Compare(entries[i].hash[:16], entries[j].hash[:16]) < 0
+	})
+
+	opts := ColdBuildOptions(fixtureMinLedger, fixtureMaxLedger)
+	sb, err := streamhash.NewSortedBuilder(context.Background(), path, uint64(n), opts...)
+	require.NoError(t, err)
+	for _, e := range entries {
+		payload := uint64(e.seq - fixtureMinLedger)
+		require.NoError(t, sb.AddKey(e.hash[:], payload))
+	}
+	require.NoError(t, sb.Finish())
+	return path, entries
+}
+
+func TestEncodeParseLedgerRange_RoundTrip(t *testing.T) {
+	cases := []struct{ min, max uint32 }{
+		{0, 0}, {1, 2}, {100, 12345}, {0, 0xFFFFFFFF}, {0xFFFFFFFF, 0xFFFFFFFF},
+	}
+	for _, c := range cases {
+		gotMin, gotMax, err := ParseLedgerRange(EncodeLedgerRange(c.min, c.max))
+		require.NoError(t, err)
+		assert.Equal(t, c.min, gotMin)
+		assert.Equal(t, c.max, gotMax)
+	}
+}
+
+func TestParseLedgerRange_WrongSizeErrors(t *testing.T) {
+	for _, sz := range []int{0, 1, 3, 4, 5, 7, 9, 16} {
+		_, _, err := ParseLedgerRange(make([]byte, sz))
+		assert.ErrorIs(t, err, ErrInvalidMetadata, "size %d should error", sz)
+	}
+}
+
+func TestParseLedgerRange_RejectsInvertedRange(t *testing.T) {
+	// maxLedger < minLedger is malformed; reject it so a consumer doesn't
+	// derive a nonsensical (underflowing) chunk range from the metadata.
+	_, _, err := ParseLedgerRange(EncodeLedgerRange(100, 50))
+	assert.ErrorIs(t, err, ErrInvalidMetadata)
+}
+
+func TestColdBuildOptions_RoundTrip(t *testing.T) {
+	// Build a tiny index with ColdBuildOptions and verify the reader
+	// recovers (a) the MinLedger anchor and (b) the absolute seq for
+	// every entry. This is the format contract end-to-end.
+	path, entries := buildColdFixture(t, 16)
+
+	m, err := openColdMPHF(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = m.close() })
+
+	assert.Equal(t, fixtureMinLedger, m.minLedger, "MinLedger must survive UserMetadata round-trip")
+	assert.Equal(t, fixtureMaxLedger, m.maxLedger, "MaxLedger must survive UserMetadata round-trip")
+
+	for _, e := range entries {
+		got, err := m.lookup(e.hash)
+		require.NoError(t, err)
+		assert.Equal(t, e.seq, got, "absolute ledgerSeq for hash %x must round-trip", e.hash[:8])
+	}
+}
+
+func TestColdLookup_UnseenKeyReturnsNotFound(t *testing.T) {
+	// With a 1-byte fingerprint, the residual false-positive rate for
+	// unseen keys is ~1/256. Across 1000 probes the expected FP count
+	// is ~4 (std dev ≈ 2). Requiring at least 95% rejection gives
+	// generous headroom and still catches a regression where the
+	// fingerprint isn't checked at all.
+	const n = 64
+	path, entries := buildColdFixture(t, n)
+
+	m, err := openColdMPHF(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = m.close() })
+
+	seen := make(map[[32]byte]struct{}, n)
+	for _, e := range entries {
+		seen[e.hash] = struct{}{}
+	}
+
+	r := testRNG(0xdeadbeef)
+	const probes = 1000
+	notFound := 0
+	tried := 0
+	for tried < probes {
+		unseen := randHash(r)
+		if _, dup := seen[unseen]; dup {
+			continue
+		}
+		tried++
+		_, err := m.lookup(unseen)
+		if err != nil {
+			require.ErrorIs(t, err, stores.ErrNotFound)
+			notFound++
+		}
+	}
+	assert.GreaterOrEqual(t, notFound, tried*95/100,
+		"WithFingerprint(1) should reject >=95%% of unseen keys; got %d/%d", notFound, tried)
+}
+
+func TestColdMPHF_OpenNonExistentErrors(t *testing.T) {
+	_, err := openColdMPHF(filepath.Join(t.TempDir(), "does-not-exist.idx"))
+	assert.Error(t, err)
+}
+
+func TestColdMPHF_OpenBadMetadataErrors(t *testing.T) {
+	// Build an index with no UserMetadata; openColdMPHF should
+	// reject it because ParseLedgerRange requires exactly 8 bytes.
+	path := filepath.Join(t.TempDir(), ColdIndexName)
+	sb, err := streamhash.NewSortedBuilder(context.Background(), path, 1,
+		streamhash.WithPayload(ColdPayloadSize),
+		streamhash.WithFingerprint(ColdFingerprintSize),
+		// no WithMetadata
+	)
+	require.NoError(t, err)
+	var k [16]byte
+	require.NoError(t, sb.AddKey(k[:], 0))
+	require.NoError(t, sb.Finish())
+
+	_, err = openColdMPHF(path)
+	assert.ErrorIs(t, err, ErrInvalidMetadata)
+}

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash/cold_reader.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash/cold_reader.go
@@ -1,0 +1,55 @@
+package txhash
+
+import (
+	"sync/atomic"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores"
+)
+
+// ColdReader serves point lookups against the cold txhash index.
+//
+// Concurrency: Lookup is safe to call concurrently with other Lookups.
+// Lookup is NOT safe to call concurrently with Close — the caller must
+// drain in-flight lookups before invoking Close. The post-Close atomic
+// guard catches calls that begin after Close returns, but a Lookup
+// already past its entry check when Close starts tearing down the mmap
+// is undefined.
+type ColdReader struct {
+	mphf   *coldMPHF
+	closed atomic.Bool
+}
+
+// OpenColdReader opens the cold txhash index at path. Returns the
+// path-wrapped error from openColdMPHF on failure.
+func OpenColdReader(path string) (*ColdReader, error) {
+	m, err := openColdMPHF(path)
+	if err != nil {
+		return nil, err
+	}
+	return &ColdReader{mphf: m}, nil
+}
+
+// Lookup returns the ledgerSeq the transaction was committed in, or
+// stores.ErrNotFound if hash was not in the cold-index build set.
+// Returns stores.ErrStoreClosed after Close.
+func (r *ColdReader) Lookup(hash [32]byte) (uint32, error) {
+	if r.closed.Load() {
+		return 0, stores.ErrStoreClosed
+	}
+	return r.mphf.lookup(hash)
+}
+
+// CoveredRange returns the inclusive [minLedger, maxLedger] the index
+// was built over, recovered from its metadata. Lets callers learn the
+// index's ledger coverage without probing it.
+func (r *ColdReader) CoveredRange() (minLedger, maxLedger uint32) {
+	return r.mphf.coveredRange()
+}
+
+// Close releases the mmap. Idempotent.
+func (r *ColdReader) Close() error {
+	if r.closed.Swap(true) {
+		return nil
+	}
+	return r.mphf.close()
+}

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash/cold_reader_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash/cold_reader_test.go
@@ -1,0 +1,54 @@
+package txhash
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores"
+)
+
+func TestOpenColdReader_NonExistentErrors(t *testing.T) {
+	_, err := OpenColdReader(filepath.Join(t.TempDir(), "missing.idx"))
+	assert.Error(t, err)
+}
+
+func TestColdReader_LookupHitAndMiss(t *testing.T) {
+	path, entries := buildColdFixture(t, 64)
+
+	r, err := OpenColdReader(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	for _, e := range entries {
+		got, err := r.Lookup(e.hash)
+		require.NoError(t, err)
+		assert.Equal(t, e.seq, got)
+	}
+
+	// An unseen key returns ErrNotFound.
+	unseenRng := testRNG(0xbeef_face)
+	_, err = r.Lookup(randHash(unseenRng))
+	assert.ErrorIs(t, err, stores.ErrNotFound)
+}
+
+func TestColdReader_CloseIsIdempotent(t *testing.T) {
+	path, _ := buildColdFixture(t, 4)
+	r, err := OpenColdReader(path)
+	require.NoError(t, err)
+
+	require.NoError(t, r.Close())
+	require.NoError(t, r.Close())
+}
+
+func TestColdReader_LookupAfterCloseReturnsClosed(t *testing.T) {
+	path, entries := buildColdFixture(t, 4)
+	r, err := OpenColdReader(path)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+
+	_, err = r.Lookup(entries[0].hash)
+	assert.ErrorIs(t, err, stores.ErrStoreClosed)
+}

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash/hot_store.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash/hot_store.go
@@ -33,11 +33,17 @@ type Entry struct {
 // HotStore — RocksDB-backed hot transaction-hash store. 16 CFs named
 // cf-0..cf-f; each hash routes to cf-{txhash[0]>>4}; ledgerSeq
 // encoded big-endian. Routing, CF names, and encoding are internal.
+//
+// Concurrency: RocksDB is concurrent-safe for in-flight read/write
+// operations. Close, however, must not be called concurrently with
+// any in-flight Get / AddEntries / iteration — drain reads/writes
+// first. Close is idempotent (delegates to rocksdb.Store.Close
+// which guards with atomic.Bool + CompareAndSwap).
 type HotStore struct {
 	store *rocksdb.Store
 }
 
-func NewHotStore(path string, logger *supportlog.Entry) (*HotStore, error) {
+func OpenHotStore(path string, logger *supportlog.Entry) (*HotStore, error) {
 	if path == "" {
 		return nil, rocksdb.ErrInvalidConfig
 	}
@@ -127,6 +133,9 @@ func tuning() rocksdb.Tuning {
 	}
 }
 
+// Close releases the underlying RocksDB store. Idempotent —
+// delegates to rocksdb.Store.Close. Must not be called concurrently
+// with in-flight reads/writes on this HotStore.
 func (h *HotStore) Close() error { return h.store.Close() }
 
 // AddEntries writes a batch of (txhash → ledgerSeq) atomically
@@ -152,9 +161,9 @@ func (h *HotStore) AddEntries(entries []Entry) error {
 	}
 }
 
-// Get returns the ledger sequence the hash was committed in, or
+// Lookup returns the ledger sequence the hash was committed in, or
 // (0, stores.ErrNotFound) on miss. Only the routed CF is queried.
-func (h *HotStore) Get(hash [32]byte) (uint32, error) {
+func (h *HotStore) Lookup(hash [32]byte) (uint32, error) {
 	v, found, err := h.store.Get(cfNameForTxHash(hash), hash[:])
 	if err != nil {
 		return 0, err

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash/hot_store_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash/hot_store_test.go
@@ -38,30 +38,30 @@ func txhashFor(nibble, tag byte) [32]byte {
 
 func openTestHotStore(t *testing.T) *HotStore {
 	t.Helper()
-	s, err := NewHotStore(t.TempDir(), silentLogger())
+	s, err := OpenHotStore(t.TempDir(), silentLogger())
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = s.Close() })
 	return s
 }
 
-func TestNewHotStore_ValidatesInputs(t *testing.T) {
-	_, err := NewHotStore("", silentLogger())
+func TestOpenHotStore_ValidatesInputs(t *testing.T) {
+	_, err := OpenHotStore("", silentLogger())
 	require.ErrorIs(t, err, rocksdb.ErrInvalidConfig)
 
-	_, err = NewHotStore(t.TempDir(), nil)
+	_, err = OpenHotStore(t.TempDir(), nil)
 	require.ErrorIs(t, err, rocksdb.ErrInvalidConfig)
 }
 
-func TestNewHotStore_CreatesMissingDirectory(t *testing.T) {
+func TestOpenHotStore_CreatesMissingDirectory(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "subdir-never-created")
-	s, err := NewHotStore(path, silentLogger())
+	s, err := OpenHotStore(path, silentLogger())
 	require.NoError(t, err)
 	require.NotNil(t, s)
 	t.Cleanup(func() { _ = s.Close() })
 }
 
 func TestHotStore_CloseIsIdempotent(t *testing.T) {
-	s, err := NewHotStore(t.TempDir(), silentLogger())
+	s, err := OpenHotStore(t.TempDir(), silentLogger())
 	require.NoError(t, err)
 
 	require.NoError(t, s.Close())
@@ -74,18 +74,18 @@ func TestHotStore_AddGetRoundTrip(t *testing.T) {
 	h := txhashFor(0xa, 1)
 
 	// Missing hash.
-	_, err := s.Get(h)
+	_, err := s.Lookup(h)
 	require.ErrorIs(t, err, stores.ErrNotFound)
 
 	// Single-entry AddEntries.
 	require.NoError(t, s.AddEntries([]Entry{{Hash: h, LedgerSeq: 12345}}))
-	got, err := s.Get(h)
+	got, err := s.Lookup(h)
 	require.NoError(t, err)
 	assert.Equal(t, uint32(12345), got)
 
 	// Overwrite via a second AddEntries.
 	require.NoError(t, s.AddEntries([]Entry{{Hash: h, LedgerSeq: 67890}}))
-	got, err = s.Get(h)
+	got, err = s.Lookup(h)
 	require.NoError(t, err)
 	assert.Equal(t, uint32(67890), got)
 
@@ -107,7 +107,7 @@ func TestHotStore_NibbleRoutingAcrossAllCFs(t *testing.T) {
 	require.NoError(t, s.AddEntries(entries))
 
 	for n := range numCFs {
-		got, err := s.Get(entries[n].Hash)
+		got, err := s.Lookup(entries[n].Hash)
 		require.NoError(t, err, "nibble %x", n)
 		assert.Equal(t, uint32(n)*100, got, "nibble %x", n)
 	}
@@ -126,7 +126,7 @@ func TestHotStore_AddEntriesMultipleSpansCFs(t *testing.T) {
 	require.NoError(t, s.AddEntries(entries))
 
 	for _, e := range entries {
-		got, err := s.Get(e.Hash)
+		got, err := s.Lookup(e.Hash)
 		require.NoError(t, err)
 		assert.Equal(t, e.LedgerSeq, got)
 	}
@@ -138,20 +138,20 @@ func TestHotStore_AddEntriesMultipleSpansCFs(t *testing.T) {
 	}
 	require.NoError(t, s.AddEntries(updated))
 	for _, e := range updated {
-		got, err := s.Get(e.Hash)
+		got, err := s.Lookup(e.Hash)
 		require.NoError(t, err)
 		assert.Equal(t, e.LedgerSeq, got)
 	}
 }
 
 func TestHotStore_PostCloseOps(t *testing.T) {
-	s, err := NewHotStore(t.TempDir(), silentLogger())
+	s, err := OpenHotStore(t.TempDir(), silentLogger())
 	require.NoError(t, err)
 	require.NoError(t, s.Close())
 
 	h := txhashFor(0x5, 1)
 	require.ErrorIs(t, s.AddEntries([]Entry{{Hash: h, LedgerSeq: 1}}), rocksdb.ErrStoreClosed)
-	_, err = s.Get(h)
+	_, err = s.Lookup(h)
 	require.ErrorIs(t, err, rocksdb.ErrStoreClosed)
 
 	require.ErrorIs(t, s.AddEntries(nil), rocksdb.ErrStoreClosed)
@@ -161,7 +161,7 @@ func TestHotStore_PostCloseOps(t *testing.T) {
 func TestHotStore_GracefulCloseAndReopenRoundTrips(t *testing.T) {
 	path := t.TempDir()
 
-	first, err := NewHotStore(path, silentLogger())
+	first, err := OpenHotStore(path, silentLogger())
 	require.NoError(t, err)
 	for n := range numCFs {
 		require.NoError(t, first.AddEntries([]Entry{
@@ -170,12 +170,12 @@ func TestHotStore_GracefulCloseAndReopenRoundTrips(t *testing.T) {
 	}
 	require.NoError(t, first.Close())
 
-	second, err := NewHotStore(path, silentLogger())
+	second, err := OpenHotStore(path, silentLogger())
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = second.Close() })
 
 	for n := range numCFs {
-		got, err := second.Get(txhashFor(byte(n), 1))
+		got, err := second.Lookup(txhashFor(byte(n), 1))
 		require.NoError(t, err)
 		assert.Equal(t, uint32(n)+1, got)
 	}
@@ -203,7 +203,7 @@ func TestHotStore_ConcurrentOpsAndCloseRaceFree(t *testing.T) {
 		})
 		wg.Go(func() {
 			for i := byte(0); !stop.Load(); i++ {
-				_, _ = s.Get(txhashFor(i%numCFs, 1))
+				_, _ = s.Lookup(txhashFor(i%numCFs, 1))
 			}
 		})
 	}

--- a/docs/superpowers/plans/2026-06-05-fullhistory-ingest-core.md
+++ b/docs/superpowers/plans/2026-06-05-fullhistory-ingest-core.md
@@ -1,0 +1,807 @@
+# Full-history Ingest Core Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the full-history ingest pipeline from the `rpc-hack` bench harness into a reusable production package `cmd/stellar-rpc/internal/fullhistory/pkg/ingest`, dropping all benchmarking code and keeping a single path (zero-copy XDR views + parallel fan-out).
+
+**Architecture:** One self-contained package with two driver functions (`RunHot` continuous-bounded; `RunCold` chunk-range with per-chunk `Finalize`), fed by a `ledgerbackend.LedgerStream` source (local cold packfile replay or GCS BufferedStorageBackend). Three data-type ingesters (ledgers, events, txhash) each with a hot and a cold implementation, satisfying `Ingester` / `ColdIngester` interfaces. The package sits atop the already-extracted `stores/{ledger,eventstore,txhash}`.
+
+**Tech Stack:** Go, `github.com/stellar/go-stellar-sdk/ingest/ledgerbackend`, `golang.org/x/sync/errgroup`, RocksDB-backed hot stores + packfile-backed cold stores, `tamirms/streamhash` (txhash cold index).
+
+**Source of truth:** the bench harness on branch `rpc-hack` at `cmd/stellar-rpc/scripts/bench-fullhistory/`. Throughout, retrieve a source body with:
+`git show rpc-hack:cmd/stellar-rpc/scripts/bench-fullhistory/<file>`
+
+**Branch topology:**
+```
+origin/feature/full-history
+  ├─ origin/events-eventstore-core   (#756, OPEN)         ← fh-ingest-core is based here
+  └─ txhash-cold-store               (Phase 0, NEW)       ← merged into fh-ingest-core in Phase 1
+fh-ingest-core  (already created off events-eventstore-core; holds the design spec)
+```
+
+---
+
+## Phase 0 — `txhash-cold-store` prerequisite slice
+
+A standalone #755-style byte-identical extraction of the cold txhash store onto `feature/full-history`. It has **no external importer** on `feature/full-history`, and the new files import only `streamhash` + `pkg/stores` sentinels (both present), so the checkout compiles as-is.
+
+### Task 0.1: Extract cold txhash store onto its own branch
+
+**Files (all copied verbatim from `rpc-hack`):**
+- Create: `cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash/cold_format.go`
+- Create: `cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash/cold_format_test.go`
+- Create: `cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash/cold_reader.go`
+- Create: `cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash/cold_reader_test.go`
+- Modify: `cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash/hot_store.go` (rename `NewHotStore`→`OpenHotStore`, `Get`→`Lookup`, + concurrency docs)
+- Modify: `cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash/hot_store_test.go` (uses `Lookup`/`OpenHotStore`)
+
+- [ ] **Step 1: Create the branch off `feature/full-history`**
+
+```bash
+cd /Users/simonchow/stellar-rpc
+git fetch origin feature/full-history
+git checkout -b txhash-cold-store origin/feature/full-history
+```
+
+- [ ] **Step 2: Pull the txhash store paths verbatim from `rpc-hack`**
+
+```bash
+git checkout rpc-hack -- cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash/
+git status --short
+```
+Expected: the 4 new files + 2 modified files staged.
+
+- [ ] **Step 3: Verify the tree matches `rpc-hack` byte-for-byte (the #755 invariant)**
+
+```bash
+git diff --quiet rpc-hack -- cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash/ && echo "IDENTICAL" || echo "DIVERGED"
+```
+Expected: `IDENTICAL`
+
+- [ ] **Step 4: Build the package**
+
+```bash
+go build ./cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash/
+```
+Expected: no output (success). If it fails on a missing symbol, the failing reference is the scope boundary — stop and report; do not pull unrelated files.
+
+- [ ] **Step 5: Test the package**
+
+```bash
+go test ./cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash/
+```
+Expected: `ok  ...stores/txhash`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash/
+git commit -m "txhash: add cold store (packfile + streamhash point lookup); rename hot Get->Lookup, NewHotStore->OpenHotStore"
+```
+
+- [ ] **Step 7: Push and (optionally) open the PR**
+
+```bash
+git push -u origin txhash-cold-store
+gh pr create --repo stellar/stellar-rpc --base feature/full-history --head txhash-cold-store \
+  --title "txhash: add cold store + hot Lookup/OpenHotStore rename" \
+  --body "Part of the series extracting reviewable components from rpc-hack. Byte-identical to the corresponding paths on rpc-hack. Cold txhash store (cold_format/cold_reader) + the hot-store API rename (Get->Lookup, NewHotStore->OpenHotStore). Prerequisite for the ingest-core slice."
+```
+
+---
+
+## Phase 1 — Base setup on `fh-ingest-core`
+
+### Task 1.1: Merge the txhash prereq into `fh-ingest-core` and confirm all store deps compile
+
+**Files:** none created; merge only.
+
+- [ ] **Step 1: Switch to `fh-ingest-core` and merge the prereq**
+
+```bash
+git checkout fh-ingest-core
+git merge --no-ff txhash-cold-store -m "merge txhash-cold-store prereq into fh-ingest-core"
+```
+Expected: clean merge (the txhash paths don't overlap with the #756 events/eventstore paths).
+
+- [ ] **Step 2: Verify all three store dependencies build on this base**
+
+```bash
+go build ./cmd/stellar-rpc/internal/fullhistory/pkg/stores/ledger/ \
+         ./cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/ \
+         ./cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash/ \
+         ./cmd/stellar-rpc/internal/events/
+```
+Expected: no output (all succeed). This confirms the ingest package has every symbol it imports.
+
+- [ ] **Step 3: Create the package directory + doc file**
+
+Create `cmd/stellar-rpc/internal/fullhistory/pkg/ingest/doc.go`:
+```go
+// Package ingest streams ledgers from a backend (local cold packfile replay
+// or GCS BufferedStorageBackend) and writes ledgers, transactions, and events
+// into the hot and cold full-history stores. RunHot drives a single bounded
+// stream into the hot stores; RunCold orchestrates a chunk range into the cold
+// stores, finalizing each chunk's artifact. Decode is always zero-copy XDR
+// views; per-ledger fan-out across enabled data types is always parallel.
+package ingest
+```
+
+- [ ] **Step 4: Commit the skeleton**
+
+```bash
+git add cmd/stellar-rpc/internal/fullhistory/pkg/ingest/doc.go
+git commit -m "ingest: add package skeleton"
+```
+
+---
+
+## Phase 2 — Port the ingest core (no metrics; views + parallel only)
+
+Each port task: create the file from the named `rpc-hack` source with the listed deltas, then `go build` the package. The package will not fully build until the interfaces + value type exist (Tasks 2.1–2.2), so build-verification starts at Task 2.3.
+
+### Task 2.1: `ledger.go` — the per-ledger value (view path only)
+
+**Files:**
+- Create: `cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ledger.go`
+- Source: `git show rpc-hack:.../bench-fullhistory/ledger.go`
+
+- [ ] **Step 1: Create `ledger.go`**
+
+Port the `Ledger` struct and `newViewLedger` **only**. Drop `newParsedLedger` and the `LCM` field's parsed-mode role — the view path never sets `LCM`.
+
+```go
+package ingest
+
+// Ledger is the per-iteration value handed to every ingester. The view
+// path sets Raw (borrowed wire-format LedgerCloseMeta bytes, valid only
+// until the next stream yield); ingesters copy what they retain.
+type Ledger struct {
+	Seq uint32
+	Raw []byte
+}
+
+// newViewLedger builds a Ledger for the zero-copy XDR-view extraction path.
+func newViewLedger(seq uint32, raw []byte) Ledger {
+	return Ledger{Seq: seq, Raw: raw}
+}
+```
+
+> Note: the bench's `Ledger` carried an `LCM *xdr.LedgerCloseMeta` for parsed mode. Confirm none of the view-path ingesters (Tasks 2.4–2.6) read `l.LCM`; they decode from `l.Raw` via XDR views. If a ported ingester references `l.LCM`, that line belongs to the dropped parsed branch — remove it.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ledger.go
+git commit -m "ingest: add Ledger value (view path)"
+```
+
+### Task 2.2: `ingester.go` — the interfaces
+
+**Files:**
+- Create: `cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ingester.go`
+- Source: `git show rpc-hack:.../bench-fullhistory/ingester.go`
+
+- [ ] **Step 1: Create `ingester.go` verbatim from source**
+
+The source `ingester.go` has no metrics coupling — port it as-is (only the package clause stays `package ingest`). Final content:
+
+```go
+package ingest
+
+import (
+	"context"
+	"io"
+)
+
+// Ingester ingests one data type into one storage tier. Hot ingesters
+// implement only this interface; cold ingesters implement ColdIngester.
+// The driver holds one typed slice per tier — hot uses []Ingester, cold
+// uses []ColdIngester — so there is no type assertion in the per-ledger loop.
+//
+// Concurrency: Ingest on a single instance is invoked serially across
+// ledgers; distinct instances may be invoked concurrently within the same
+// ledger (parallel fan-out). Each instance owns its state and reads the
+// read-only Ledger value.
+//
+// Lifecycle: constructors open the underlying store/writer; Ingest is called
+// once per ledger; Close is ALWAYS deferred, idempotent, and (for cold tiers
+// whose Finalize never ran) removes any partial file.
+type Ingester interface {
+	Ingest(ctx context.Context, l Ledger) error
+	io.Closer
+}
+
+// ColdIngester adds the cold-tier commit step. Finalize is called explicitly
+// by the driver on the success path with an error check; never deferred. A
+// Finalize error means the chunk's cold artifact did not durably land and must
+// be re-ingested. Hot ingesters intentionally do NOT implement ColdIngester —
+// enforced at compile time by the per-driver slice type.
+type ColdIngester interface {
+	Ingester
+	Finalize(ctx context.Context) error
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ingester.go
+git commit -m "ingest: add Ingester / ColdIngester interfaces"
+```
+
+### Task 2.3: `source.go` — ledger stream sources + exported factory
+
+**Files:**
+- Create: `cmd/stellar-rpc/internal/fullhistory/pkg/ingest/source.go`
+- Source: `git show rpc-hack:.../bench-fullhistory/sources.go`
+
+- [ ] **Step 1: Create `source.go`**
+
+Port `packStream` (with its `RawLedgers` method) verbatim. Replace the bench's `const (sourcePack = "pack"; sourceBSB = "bsb")` and the unexported `openChunkStream(source, coldDir, bucketPath string, opts BSBOpts, chunkID)` with the **exported** API from the spec. Keep `BSBOpts` but expose it as part of `SourceOpts`.
+
+New exported surface (replaces the bench's flag-string plumbing):
+```go
+type Source string
+
+const (
+	SourcePack Source = "pack"
+	SourceBSB  Source = "bsb"
+)
+
+// SourceOpts carries the pack/BSB tuning previously passed as separate args.
+type SourceOpts struct {
+	ColdDir    string        // required for SourcePack
+	BucketPath string        // required for SourceBSB
+	BufferSize uint          // BSB prefetch depth
+	NumWorkers uint          // BSB download workers
+	RetryLimit uint
+	RetryWait  time.Duration
+}
+
+// OpenChunkStream returns an INDEPENDENT LedgerStream for one chunk. Concurrent
+// chunk workers must each call this (BSB's sequential cursor cannot be shared).
+func OpenChunkStream(source Source, opts SourceOpts, chunkID chunk.ID) (ledgerbackend.LedgerStream, error) {
+	switch source {
+	case SourcePack:
+		if opts.ColdDir == "" {
+			return nil, errors.New("SourceOpts.ColdDir is required for SourcePack")
+		}
+		path := packPath(opts.ColdDir, uint32(chunkID))
+		if _, err := os.Stat(path); err != nil {
+			return nil, fmt.Errorf("cold pack missing: %s: %w", path, err)
+		}
+		return &packStream{coldDir: opts.ColdDir, chunkID: chunkID}, nil
+	case SourceBSB:
+		if opts.BucketPath == "" {
+			return nil, errors.New("SourceOpts.BucketPath is required for SourceBSB")
+		}
+		dsConfig := datastore.DataStoreConfig{
+			Type:   "GCS",
+			Params: map[string]string{"destination_bucket_path": opts.BucketPath},
+		}
+		cfg := ledgerbackend.BufferedStorageBackendConfig{
+			BufferSize: uint32(opts.BufferSize),
+			NumWorkers: uint32(opts.NumWorkers),
+			RetryLimit: uint32(opts.RetryLimit),
+			RetryWait:  opts.RetryWait,
+		}
+		return ledgerbackend.NewBufferedStorageStream(cfg, dsConfig, nil), nil
+	default:
+		return nil, fmt.Errorf("unknown source %q; expected %q|%q", source, SourcePack, SourceBSB)
+	}
+}
+```
+
+> `packPath` is a small helper in the bench harness (`packPath(coldDir string, chunkID uint32) string`). Port it into `source.go` too — retrieve it with `git show rpc-hack:.../bench-fullhistory/ | grep -rn "func packPath"`; it is defined in `bench_cold_ledgers.go`. Keep the `var _ ledgerbackend.LedgerStream = (*packStream)(nil)` assertion.
+
+- [ ] **Step 2: Build the package**
+
+```bash
+go build ./cmd/stellar-rpc/internal/fullhistory/pkg/ingest/
+```
+Expected: failure only on the not-yet-created ingesters/drivers referenced elsewhere — but `source.go`, `ledger.go`, `ingester.go` themselves must have no unresolved symbols. If the error mentions `packStream`, `OpenChunkStream`, `SourceOpts`, or `packPath`, fix here; errors about `RunHot`/`ledgersHot` are expected (later tasks).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/stellar-rpc/internal/fullhistory/pkg/ingest/source.go
+git commit -m "ingest: add LedgerStream sources (pack replay + BSB) and OpenChunkStream"
+```
+
+### Task 2.4: `ledgers.go` — ledger ingesters (drop collector)
+
+**Files:**
+- Create: `cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ledgers.go`
+- Source: `git show rpc-hack:.../bench-fullhistory/ingest_ledgers.go`
+
+- [ ] **Step 1: Create `ledgers.go`**
+
+Port **only** the ingester types `LedgersHot` and `LedgersCold`, the `LedgersColdOpts` struct, and their methods. **Drop** everything above the first ingester (the `ledgerSample`, `LedgerCollector`, and all its methods — they are benchmarking-only). Apply these signature deltas (rename to unexported types, drop the collector arg, drop the sample appends):
+
+```go
+// before (bench): func NewLedgersHot(c *LedgerCollector, dir string, logger *supportlog.Entry) (*LedgersHot, error)
+// after:          func newLedgersHot(dir string, logger *supportlog.Entry) (*ledgersHot, error)
+
+// before: func NewLedgersCold(c *LedgerCollector, outRoot string, chunkID chunk.ID, opts LedgersColdOpts) (*LedgersCold, error)
+// after:  func newLedgersCold(outRoot string, chunkID chunk.ID, opts LedgersColdOpts) (*ledgersCold, error)
+```
+
+In each `Ingest` method, remove the `t0 := time.Now()` and the `h.collector.samples = append(...)` / `c.collector.samples = append(...)` lines; keep the actual store write. Remove the `collector *LedgerCollector` struct field. In `LedgersCold.Finalize`, remove the `if len(c.collector.samples) == 0 { ... }` empty-chunk guard that depended on samples — replace with the equivalent state already tracked by the writer (check the body: if the only use of samples was metrics, drop the branch; if it guarded an empty-commit, gate on the writer's own "anything written" state instead). `LedgersColdOpts{Concurrency, BytesPerSync int}` is kept verbatim.
+
+Resulting exported-to-package symbols: `ledgersHot`, `ledgersCold`, `LedgersColdOpts`, `newLedgersHot`, `newLedgersCold`.
+
+- [ ] **Step 2: Build**
+
+```bash
+go build ./cmd/stellar-rpc/internal/fullhistory/pkg/ingest/
+```
+Expected: no errors about `ledgers.go` symbols (driver errors still expected). Confirm no `time`/collector imports remain unused.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ledgers.go
+git commit -m "ingest: add ledger hot/cold ingesters (no metrics)"
+```
+
+### Task 2.5: `events.go` — events ingesters (view path only, drop collector)
+
+**Files:**
+- Create: `cmd/stellar-rpc/internal/fullhistory/pkg/ingest/events.go`
+- Source: `git show rpc-hack:.../bench-fullhistory/ingest_events.go`
+
+- [ ] **Step 1: Create `events.go`**
+
+Drop the `eventSample` / `EventsCollector` block (benchmarking-only). Port `EventsHot` and `EventsCold` (+ `EventsColdOpts{Concurrency, BytesPerSync int}`) with deltas:
+
+```go
+// before: func NewEventsHot(c *EventsCollector, dir string, chunkID chunk.ID, logger *supportlog.Entry, xdrViews bool) (*EventsHot, error)
+// after:  func newEventsHot(dir string, chunkID chunk.ID, logger *supportlog.Entry) (*eventsHot, error)
+
+// before: func NewEventsCold(c *EventsCollector, outRoot string, chunkID chunk.ID, opts EventsColdOpts, xdrViews bool) (*EventsCold, error)
+// after:  func newEventsCold(outRoot string, chunkID chunk.ID, opts EventsColdOpts) (*eventsCold, error)
+```
+
+Remove the `xdrViews bool` param **and** the parsed-mode branch inside each `Ingest` (the code path taken when `xdrViews == false` / `l.LCM != nil`); keep only the zero-copy view extraction from `l.Raw`. Remove the `collector *EventsCollector` field and every `e.collector.samples = append(...)` site. Watch the `EventsCold.Ingest` body: per the source comment near line 256, `offsets.Append` must still be called even though the sample append is removed — keep the `offsets.Append`, drop only the sample line.
+
+Resulting symbols: `eventsHot`, `eventsCold`, `EventsColdOpts`, `newEventsHot`, `newEventsCold`.
+
+- [ ] **Step 2: Build**
+
+```bash
+go build ./cmd/stellar-rpc/internal/fullhistory/pkg/ingest/
+```
+Expected: no `events.go` symbol errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/stellar-rpc/internal/fullhistory/pkg/ingest/events.go
+git commit -m "ingest: add events hot/cold ingesters (view path, no metrics)"
+```
+
+### Task 2.6: `txhash.go` — txhash ingesters (view path only, drop collector)
+
+**Files:**
+- Create: `cmd/stellar-rpc/internal/fullhistory/pkg/ingest/txhash.go`
+- Source: `git show rpc-hack:.../bench-fullhistory/ingest_txhash.go`
+
+- [ ] **Step 1: Create `txhash.go`**
+
+Drop the `txhashSample` / `TxhashCollector` block. Port `TxhashHot` and `TxhashCold` with deltas:
+
+```go
+// before: func NewTxhashHot(c *TxhashCollector, dir string, logger *supportlog.Entry, xdrViews bool) (*TxhashHot, error)
+// after:  func newTxhashHot(dir string, logger *supportlog.Entry) (*txhashHot, error)
+
+// before: func NewTxhashCold(c *TxhashCollector, outRoot string, chunkID chunk.ID, xdrViews bool) (*TxhashCold, error)
+// after:  func newTxhashCold(outRoot string, chunkID chunk.ID) (*txhashCold, error)
+```
+
+Remove the `xdrViews bool` param and the parsed branch; keep the view extraction. Remove the `collector` field and sample appends. `TxhashCold.Close` returns `nil` in the source (entries buffer in memory, flushed in `Finalize`) — keep that. The hot ingester must use the renamed store API from Phase 0: ensure it calls `txhash.OpenHotStore` (not `NewHotStore`); if the bench source still says `NewHotStore`, rename it.
+
+Resulting symbols: `txhashHot`, `txhashCold`, `newTxhashHot`, `newTxhashCold`.
+
+- [ ] **Step 2: Build**
+
+```bash
+go build ./cmd/stellar-rpc/internal/fullhistory/pkg/ingest/
+```
+Expected: no `txhash.go` symbol errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/stellar-rpc/internal/fullhistory/pkg/ingest/txhash.go
+git commit -m "ingest: add txhash hot/cold ingesters (view path, no metrics)"
+```
+
+### Task 2.7: `driver.go` — `RunHot`
+
+**Files:**
+- Create: `cmd/stellar-rpc/internal/fullhistory/pkg/ingest/driver.go`
+- Source: `git show rpc-hack:.../bench-fullhistory/bench_hot_ingest.go` (the `runHot` loop, lines ~200–270)
+
+- [ ] **Step 1: Create `driver.go` with `RunHot` and the shared `buildLedger` helper**
+
+Port the **loop body** of the bench's `runHot`, discarding: flag parsing (`buildHotDeps`), the `hotDeps` struct, `driverMetrics`, cpu/mem profiling, `reportHot`, and all `dm.*` timing appends. Keep: the per-type ingester construction (now via `newLedgersHot`/`newEventsHot`/`newTxhashHot`), the `errgroup` parallel fan-out, the borrowed-`raw` contract (`g.Wait()` gates the next yield), the deferred idempotent `Close` chain with `errors.Join`. Decode is always views, so `buildLedger` becomes `newViewLedger(seq, raw)` directly.
+
+Exported signature:
+```go
+func RunHot(ctx context.Context, logger *supportlog.Entry,
+	stream ledgerbackend.LedgerStream, chunkID chunk.ID, hotDir string, cfg Config) (err error)
+```
+
+Add `Config` here (or in a tiny `config.go`):
+```go
+// Config selects which data types to ingest; at least one must be true.
+// Decode is always XDR views; per-ledger fan-out is always parallel.
+type Config struct {
+	Ledgers, Txhash, Events bool
+}
+
+func (c Config) any() bool { return c.Ledgers || c.Txhash || c.Events }
+```
+
+`RunHot` skeleton (fill the ingester construction from the enabled `cfg` flags, mirroring the bench's per-type switch but without collectors):
+```go
+func RunHot(ctx context.Context, logger *supportlog.Entry,
+	stream ledgerbackend.LedgerStream, chunkID chunk.ID, hotDir string, cfg Config) (err error) {
+	if !cfg.any() {
+		return errors.New("ingest: Config selects no data types")
+	}
+	var ings []Ingester
+	if cfg.Ledgers {
+		ing, ierr := newLedgersHot(filepath.Join(hotDir, "ledgers"), logger)
+		if ierr != nil { return fmt.Errorf("open ledgers hot: %w", ierr) }
+		ings = append(ings, ing)
+	}
+	if cfg.Txhash {
+		ing, ierr := newTxhashHot(filepath.Join(hotDir, "txhash"), logger)
+		if ierr != nil { closeAll(ings); return fmt.Errorf("open txhash hot: %w", ierr) }
+		ings = append(ings, ing)
+	}
+	if cfg.Events {
+		ing, ierr := newEventsHot(filepath.Join(hotDir, "events"), chunkID, logger)
+		if ierr != nil { closeAll(ings); return fmt.Errorf("open events hot: %w", ierr) }
+		ings = append(ings, ing)
+	}
+	for _, ing := range ings {
+		ing := ing
+		defer func() {
+			if cerr := ing.Close(); cerr != nil {
+				err = errors.Join(err, fmt.Errorf("close: %w", cerr))
+			}
+		}()
+	}
+
+	first, last := chunkID.FirstLedger(), chunkID.LastLedger()
+	seq := first
+	for raw, serr := range stream.RawLedgers(ctx, ledgerbackend.BoundedRange(first, last)) {
+		if cerr := ctx.Err(); cerr != nil { return cerr }
+		if serr != nil { return fmt.Errorf("RawLedgers(%d): %w", seq, serr) }
+		l := newViewLedger(seq, raw)
+		g, gctx := errgroup.WithContext(ctx)
+		for _, ing := range ings {
+			ing := ing
+			g.Go(func() error { return ing.Ingest(gctx, l) })
+		}
+		if werr := g.Wait(); werr != nil { return werr }
+		seq++
+	}
+	return nil
+}
+
+// closeAll closes already-opened ingesters on a constructor failure path.
+func closeAll(ings []Ingester) { for _, ing := range ings { _ = ing.Close() } }
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+go build ./cmd/stellar-rpc/internal/fullhistory/pkg/ingest/
+```
+Expected: only `RunCold` references missing now (added next task). If `RunCold` isn't referenced yet, this should fully build.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/stellar-rpc/internal/fullhistory/pkg/ingest/driver.go
+git commit -m "ingest: add RunHot driver + Config"
+```
+
+### Task 2.8: `RunCold` + `runOneChunkCold`
+
+**Files:**
+- Modify: `cmd/stellar-rpc/internal/fullhistory/pkg/ingest/driver.go`
+- Source: `git show rpc-hack:.../bench-fullhistory/bench_cold_ingest.go` (`runCold` lines ~216–250, `runOneChunkCold` ~258–365)
+
+- [ ] **Step 1: Add `RunCold` and `runOneChunkCold`**
+
+Port the cold orchestration, discarding the `coldDeps` struct, `chunkResult` metrics fields, collector merges, and `reportCold`. Keep: the `errgroup` with `g.SetLimit(chunkWorkers)` over `[startChunk, startChunk+numChunks)`, the per-chunk `OpenChunkStream` (each worker its own backend), the per-type cold ingester construction (`newLedgersCold`/`newEventsCold`/`newTxhashCold`), the per-ledger fan-out, and the explicit `Finalize` loop on the success path (error-checked, not deferred) plus the deferred idempotent `Close`.
+
+Exported signature:
+```go
+func RunCold(ctx context.Context, logger *supportlog.Entry,
+	src Source, opts SourceOpts, coldDir string,
+	startChunk chunk.ID, numChunks, chunkWorkers int, cfg Config) error
+```
+
+`RunCold` validates (`numChunks >= 1`, `chunkWorkers >= 1`, clamp `chunkWorkers` to `numChunks`, `cfg.any()`), then:
+```go
+g, gctx := errgroup.WithContext(ctx)
+g.SetLimit(chunkWorkers)
+for i := 0; i < numChunks; i++ {
+	chunkID := startChunk + chunk.ID(uint32(i))
+	g.Go(func() error {
+		if rerr := runOneChunkCold(gctx, logger, src, opts, coldDir, chunkID, cfg); rerr != nil {
+			return fmt.Errorf("chunk %d: %w", uint32(chunkID), rerr)
+		}
+		return nil
+	})
+}
+return g.Wait()
+```
+
+`runOneChunkCold(ctx, logger, src, opts, coldDir, chunkID, cfg) error`:
+1. `stream, err := OpenChunkStream(src, opts, chunkID)` (each worker its own).
+2. Build enabled `[]ColdIngester` via `newLedgersCold(filepath.Join(coldDir,"ledgers"), chunkID, LedgersColdOpts{...})`, `newEventsCold(...)`, `newTxhashCold(...)`. For `Concurrency`/`BytesPerSync`, thread them through `Config` or default to `0` (the writer treats `0` as "serial/default" per the ledger `ColdWriterOptions` contract). **Decision for this slice:** default both to `0` (no new knobs); a later subcommand slice can expose them.
+3. Defer idempotent `Close` on each (with `errors.Join`).
+4. Iterate `stream.RawLedgers(ctx, BoundedRange(chunkID.FirstLedger(), chunkID.LastLedger()))`, building `newViewLedger` and fanning out via `errgroup` exactly like `RunHot`.
+5. On success, loop the cold ingesters calling `Finalize(ctx)`, returning the first error.
+
+- [ ] **Step 2: Build + vet**
+
+```bash
+go build ./cmd/stellar-rpc/internal/fullhistory/pkg/ingest/
+go vet ./cmd/stellar-rpc/internal/fullhistory/pkg/ingest/
+```
+Expected: both clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/stellar-rpc/internal/fullhistory/pkg/ingest/driver.go
+git commit -m "ingest: add RunCold chunk-range driver with per-chunk Finalize"
+```
+
+---
+
+## Phase 3 — Tests
+
+### Task 3.1: Fake `LedgerStream` test helper + synthetic ledgers
+
+**Files:**
+- Create: `cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ingest_test.go`
+
+The eventstore/txhash/ledger packages already have synthetic-LCM helpers on `rpc-hack`. Find a reusable one:
+`git show rpc-hack:.../bench-fullhistory/ | grep -rln "func.*LedgerCloseMeta" cmd/stellar-rpc/internal/fullhistory/` — reuse the store packages' test fixtures if exported, else build minimal valid `LedgerCloseMeta` bytes here.
+
+- [ ] **Step 1: Write the fake stream**
+
+```go
+package ingest
+
+import (
+	"context"
+	"iter"
+
+	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
+)
+
+// fakeStream replays a fixed set of raw LedgerCloseMeta byte slices, keyed by
+// sequence, as a ledgerbackend.LedgerStream — the driver's only input seam.
+type fakeStream struct {
+	raws map[uint32][]byte // seq -> wire-format LCM bytes
+}
+
+var _ ledgerbackend.LedgerStream = (*fakeStream)(nil)
+
+func (f *fakeStream) RawLedgers(_ context.Context, r ledgerbackend.Range) iter.Seq2[[]byte, error] {
+	return func(yield func([]byte, error) bool) {
+		for seq := r.From(); seq <= r.To(); seq++ {
+			if !yield(f.raws[seq], nil) {
+				return
+			}
+		}
+	}
+}
+```
+
+> The synthetic `raws` must be real marshaled `LedgerCloseMeta` bytes (the ingesters decode via XDR views). Add a helper `marshalLCM(t, seq) []byte` that builds a minimal `xdr.LedgerCloseMeta` (V1) with the given ledger seq and zero transactions, then `MarshalBinary`. Retrieve a known-good fixture shape from `git show rpc-hack:cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/hot_store_test.go` and adapt.
+
+- [ ] **Step 2: Commit the helper**
+
+```bash
+git add cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ingest_test.go
+git commit -m "ingest: add fake LedgerStream + synthetic LCM test helpers"
+```
+
+### Task 3.2: `RunHot` round-trip test
+
+**Files:**
+- Modify: `cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ingest_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestRunHot_RoundTrip(t *testing.T) {
+	const first, last = uint32(1), uint32(8) // chunk 0's range; adjust to chunk.ID(...).FirstLedger()
+	chunkID := chunk.ID(0) // pick a chunk whose [First,Last] covers the synthetic seqs
+	raws := map[uint32][]byte{}
+	for seq := chunkID.FirstLedger(); seq <= chunkID.LastLedger(); seq++ {
+		raws[seq] = marshalLCM(t, seq)
+	}
+	stream := &fakeStream{raws: raws}
+	hotDir := t.TempDir()
+	logger := supportlog.New()
+
+	err := RunHot(context.Background(), logger, stream, chunkID, hotDir, Config{Ledgers: true, Txhash: true, Events: true})
+	require.NoError(t, err)
+
+	// Reopen the ledger hot store and assert each seq reads back.
+	ls, err := ledger.OpenHotStore(filepath.Join(hotDir, "ledgers"), logger)
+	require.NoError(t, err)
+	defer ls.Close()
+	for seq := chunkID.FirstLedger(); seq <= chunkID.LastLedger(); seq++ {
+		got, gerr := ls.GetLedgerRaw(seq)
+		require.NoError(t, gerr, "ledger %d", seq)
+		require.NotEmpty(t, got)
+	}
+}
+```
+
+> Adjust the reader calls to the actual hot-store reader API on this branch (`ledger.OpenHotStore` / `GetLedgerRaw` per #755). If the events/txhash hot readers are convenient, assert one read from each too; otherwise the ledger read + `RunHot` returning nil is the minimum guard.
+
+- [ ] **Step 2: Run, expect FAIL (compile or assertion)**
+
+```bash
+go test ./cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ -run TestRunHot_RoundTrip -v
+```
+Expected: FAIL until `marshalLCM` and reader calls are correct.
+
+- [ ] **Step 3: Fix `marshalLCM` / reader calls until green**
+
+Iterate on the synthetic LCM shape until the ingesters accept it and reads return data.
+
+- [ ] **Step 4: Run, expect PASS**
+
+```bash
+go test ./cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ -run TestRunHot_RoundTrip -v
+```
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ingest_test.go
+git commit -m "ingest: add RunHot round-trip test"
+```
+
+### Task 3.3: `RunCold` round-trip test (chunk → finalized artifact → reopen)
+
+**Files:**
+- Modify: `cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ingest_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+`RunCold` opens its own stream via `OpenChunkStream`, so the fake stream can't be injected directly. Drive cold through `SourcePack` against a temp cold dir seeded by a ledger `ColdWriter` (the cleanest in-package fixture), OR add an unexported seam `runColdWithStreamFactory(... factory func(chunk.ID)(LedgerStream,error) ...)` that `RunCold` delegates to, and inject `fakeStream` in the test. **Decision:** add the factory seam — it keeps the test hermetic (no packfile fixture needed).
+
+```go
+func TestRunCold_RoundTrip(t *testing.T) {
+	chunkID := chunk.ID(0)
+	raws := map[uint32][]byte{}
+	for seq := chunkID.FirstLedger(); seq <= chunkID.LastLedger(); seq++ {
+		raws[seq] = marshalLCM(t, seq)
+	}
+	factory := func(chunk.ID) (ledgerbackend.LedgerStream, error) { return &fakeStream{raws: raws}, nil }
+	coldDir := t.TempDir()
+	logger := supportlog.New()
+
+	err := runColdWithStreamFactory(context.Background(), logger, factory, coldDir,
+		chunkID, 1 /*numChunks*/, 1 /*chunkWorkers*/, Config{Ledgers: true})
+	require.NoError(t, err)
+
+	// Reopen the finalized cold ledger artifact for this chunk.
+	cr, err := ledger.OpenColdReader(filepath.Join(coldDir, "ledgers", coldPackName(chunkID)))
+	require.NoError(t, err)
+	defer cr.Close()
+	got, gerr := cr.GetLedgerRaw(chunkID.FirstLedger())
+	require.NoError(t, gerr)
+	require.NotEmpty(t, got)
+}
+```
+
+> Refactor Task 2.8 so `RunCold` calls `runColdWithStreamFactory` with the production factory `func(id chunk.ID)(ledgerbackend.LedgerStream,error){ return OpenChunkStream(src, opts, id) }`. `coldPackName`/`packPath` give the chunk's artifact path — reuse the helper from `source.go`.
+
+- [ ] **Step 2: Run, expect FAIL**
+
+```bash
+go test ./cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ -run TestRunCold_RoundTrip -v
+```
+Expected: FAIL until the factory seam + path helper are wired.
+
+- [ ] **Step 3: Wire the factory seam in `driver.go`; iterate to green**
+
+- [ ] **Step 4: Run, expect PASS**
+
+```bash
+go test ./cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ -run TestRunCold_RoundTrip -v
+```
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/stellar-rpc/internal/fullhistory/pkg/ingest/
+git commit -m "ingest: add RunCold round-trip test + stream-factory seam"
+```
+
+---
+
+## Phase 4 — Verify & finalize
+
+### Task 4.1: Full build/vet/test, lint, push, open PR
+
+- [ ] **Step 1: Build, vet, and test the package + its deps**
+
+```bash
+go build ./cmd/stellar-rpc/internal/fullhistory/... ./cmd/stellar-rpc/internal/events/
+go vet ./cmd/stellar-rpc/internal/fullhistory/pkg/ingest/
+go test ./cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ -v
+```
+Expected: all green.
+
+- [ ] **Step 2: Run the repo linter on the new package**
+
+```bash
+golangci-lint run ./cmd/stellar-rpc/internal/fullhistory/pkg/ingest/... 2>/dev/null || echo "(golangci-lint not installed — skip; CI will run it)"
+```
+Expected: no findings (or skipped).
+
+- [ ] **Step 3: Confirm no benchmarking artifacts leaked into the package**
+
+```bash
+grep -rnE "Collector|Sample|driverMetrics|WriteCSV|pprof|flag\.|bench" cmd/stellar-rpc/internal/fullhistory/pkg/ingest/ && echo "LEAK — remove" || echo "CLEAN"
+```
+Expected: `CLEAN`
+
+- [ ] **Step 4: Push and open the PR (base = #756 branch; retargets to feature/full-history as parents merge)**
+
+```bash
+git push -u origin fh-ingest-core
+gh pr create --repo stellar/stellar-rpc --base events-eventstore-core --head fh-ingest-core \
+  --title "ingest: productionized full-history ingest core (pkg/ingest)" \
+  --body "$(cat <<'EOF'
+Part of the series extracting reviewable components from rpc-hack into feature/full-history.
+
+Lifts the ingest pipeline out of the scripts/bench-fullhistory harness into a reusable production package internal/fullhistory/pkg/ingest, dropping all benchmarking code (collectors, samples, driver metrics, CSV/percentile reporting, profiling, flag parsing, and the parsed/serial comparison modes). Single path: zero-copy XDR views + parallel fan-out.
+
+- RunHot: bounded single-stream fan-out into the hot stores.
+- RunCold: chunk-range orchestration into the cold stores, per-chunk Finalize.
+- Sources: local cold-packfile replay + GCS BufferedStorageBackend, via OpenChunkStream.
+
+Stacked on #756 (events-eventstore-core) and includes the txhash-cold-store prereq (merged). GitHub will retarget to feature/full-history once parents merge.
+
+Design: docs/superpowers/specs/2026-06-05-fullhistory-ingest-core-design.md
+
+## Test plan
+- [x] go build ./cmd/stellar-rpc/internal/fullhistory/...
+- [x] go test ./cmd/stellar-rpc/internal/fullhistory/pkg/ingest/
+- [x] RunHot + RunCold round-trip tests (synthetic LCM -> reopen store -> read back)
+EOF
+)"
+```
+
+- [ ] **Step 5: Final task-list cleanup**
+
+Mark the plan complete; note any follow-up slices (ingest subcommand / live frontfill orchestration; eventstore query engine) as separate future work.
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** Phase 0 = txhash prereq (spec §Topology); Phase 1 = base/merge; Phase 2.1–2.8 = package layout & API (spec §Architecture, §Public API, §Data flow); error/lifecycle (spec §Error handling) is preserved in the ported `Close`/`Finalize`/`errgroup` logic; Phase 3 = tests (spec §Testing); Phase 4 = faithfulness via build+test (spec §Testing). All spec sections map to tasks.
+- **Known port judgment calls flagged inline:** the `LedgersCold.Finalize` empty-chunk guard (2.4), the `EventsCold` `offsets.Append` retention (2.5), the `txhash` `OpenHotStore` rename (2.6), and the cold `Concurrency/BytesPerSync` default-to-0 decision (2.8). These require reading the source body — they are the only spots where a blind copy would be wrong.
+- **Type consistency:** unexported ingester types `ledgersHot/ledgersCold/eventsHot/eventsCold/txhashHot/txhashCold`; constructors `new*`; exported `Config`, `Source`, `SourceOpts`, `OpenChunkStream`, `RunHot`, `RunCold`; opts structs `LedgersColdOpts`, `EventsColdOpts` kept verbatim. Consistent across tasks.

--- a/docs/superpowers/specs/2026-06-05-fullhistory-ingest-core-design.md
+++ b/docs/superpowers/specs/2026-06-05-fullhistory-ingest-core-design.md
@@ -1,0 +1,266 @@
+# Full-history ingest core (`pkg/ingest`) — design
+
+**Date:** 2026-06-05
+**Branch:** `fh-stores-integration` (was `fh-ingest-core`)
+**Status:** Approved design; in implementation
+
+---
+
+## AMENDMENT (2026-06-05) — two pivots found during execution
+
+Execution surfaced facts that override decisions below. Read this first.
+
+**1. Decode path is PARSED, not XDR-views.** Open PR #756 (commit `2739b51c`)
+*deleted* `internal/events/ingest_view.go` / `LCMToPayloadsFromRaw` — the
+zero-copy view extractor the "views only" decision relied on. The surviving
+events API is parsed-only: `events.LCMToPayloads(passphrase string, lcm
+xdr.LedgerCloseMeta) ([]events.Payload, error)`. So:
+- `Ledger` carries `{Seq, Raw, LCM *xdr.LedgerCloseMeta}`; the driver decodes
+  `raw → LCM` once per ledger when events or txhash are enabled, shared
+  read-only (the bench's `newParsedLedger` / `needsLCM` path — the path the
+  original plan said to drop; now it's the *only* path, views dropped instead).
+- The events ingester takes a **network passphrase** (new required input on
+  `Config`/driver) for `LCMToPayloads`.
+- Events hot: `eventstore.OpenHotStore(dir, chunkID, logger)` +
+  `IngestLedgerEvents(seq, payloads)`. Events cold: `eventstore.NewColdWriter`
+  + per-payload `Append` + offsets + `Finish(offsets)` + `WriteColdIndex`.
+
+**2. Base is `fh-stores-integration`, not `#756`.** The three store deps lived
+on un-integrated branches (feature/full-history = ledger-cold + OLD events;
+#756 = new events + NO ledger-cold; txhash-cold = rpc-hack only). Built a
+throwaway integration branch `fh-stores-integration` = feature/full-history +
+merge #756 + txhash-cold (streamhash import migrated `tamirms/streamhash` →
+`github.com/stellar/streamhash`). All store deps + events test green on it.
+Upstream redoes the integration when #756 merges to feature/full-history.
+
+**3. txhash cold scope.** The cold txhash *write* path is bench logic: the cold
+ingester accumulates entries and writes a sorted per-chunk `.bin`; a SEPARATE
+streamhash-MPHF build turns `.bin` files into the queryable cold index that
+`txhash/cold_reader.go` reads. This slice's `txhashCold.Finalize` produces the
+`.bin` (faithful to the bench); the MPHF index-build step is a follow-up, so
+the cold-txhash round-trip is not asserted end-to-end here (ledger + events
+cold round-trips are).
+
+Everything below is unchanged EXCEPT: wherever it says "views + parallel only" /
+`newViewLedger` / drop-LCM, substitute the parsed path above.
+
+---
+
+## Context
+
+`rpc-hack` is the kitchen-sink branch for full-history work, built on top of
+`feature/full-history` (+~16.6k LOC). Reviewable slices are being peeled off it
+one at a time onto `feature/full-history`, each as its own PR. Merged/open
+slices so far:
+
+| Slice | PR | Status | Paths |
+|-------|-----|--------|-------|
+| Ledger cold store reader/writer + hot store | #739, #755 | merged | `stores/ledger/` |
+| packfile writer buffer pool | #754 | merged | `internal/packfile/` |
+| Events index + eventstore core (no query engine) | #756 | open | `internal/events/`, `stores/eventstore/` (minus `query.go`) |
+
+This spec covers the next slice: the **productionized ingest core** — the code
+that streams ledgers and writes ledgers, transactions, and events into both the
+hot and cold stores. On `rpc-hack` this logic lives as `package main` in
+`cmd/stellar-rpc/scripts/bench-fullhistory/`, fused to benchmark scaffolding.
+This slice lifts the production-relevant core into a real package and discards
+the benchmarking code.
+
+## Goal
+
+A reusable ingest-core package usable for both **frontfill** (live network tip)
+and **backfill** (historical ranges), feeding both **hot** and **cold** stores.
+
+Out of scope for this slice (deferred to later slices):
+- A `stellar-rpc` ingest subcommand / fill orchestration (range selection,
+  resume, live-tip handoff).
+- The eventstore query engine (`query.go` + postfilter) — separate slice on #756.
+
+## Decisions (from brainstorming)
+
+1. **Deliverable:** reusable ingest-core package only. No subcommand yet.
+2. **Sequencing:** stack on #756; extract the cold-txhash store as a
+   prerequisite slice first (see Topology). The txhash-cold-store extraction is
+   **in scope for this effort** — done as its own branch/PR, but as the first
+   implementation step here, not handed off separately.
+3. **Measurement:** none. All benchmarking-only code (collectors, samples,
+   driver metrics, CSV/percentile reporting, cpu/mem profiling, `flag` parsing)
+   is refactored away, not ported. (This supersedes an earlier "observer hook"
+   decision — with the bench harness out of scope, no metrics plumbing is
+   needed in the core.)
+4. **Modes:** single path only — zero-copy XDR views + parallel fan-out. The
+   `parsed` decode mode and the `serial` fan-out mode are dropped.
+5. **Structure:** one self-contained package, two drivers (hot + cold),
+   ingesters unexported. (Approach A.)
+
+## Architecture & package layout
+
+New package `cmd/stellar-rpc/internal/fullhistory/pkg/ingest/`, at the top of
+the store dependency stack:
+
+```
+internal/fullhistory/pkg/ingest/
+  ledger.go      Ledger value {Seq, Raw, LCM} + newViewLedger constructor
+  ingester.go    Ingester (Ingest+Close) and ColdIngester (adds Finalize) interfaces
+  source.go      LedgerStream sources: packStream (cold-packfile replay) + BSB (GCS); OpenChunkStream factory
+  driver.go      RunHot (continuous single-stream fan-out) + RunCold (chunk-range, parallel chunk workers, Finalize)
+  ledgers.go     ledgersHot / ledgersCold ingesters  -> stores/ledger
+  events.go      eventsHot / eventsCold ingesters    -> stores/eventstore (zero-copy view path)
+  txhash.go      txhashHot / txhashCold ingesters    -> stores/txhash
+```
+
+**Dependency direction (no cycles):**
+`ingest` → `stores/{ledger,eventstore,txhash}` → `chunk`, `packfile`, `rocksdb`;
+plus `internal/events` (index types) and `go-stellar-sdk/ingest/ledgerbackend`
+(the `LedgerStream` interface). Nothing depends back on `ingest`.
+
+**Consumers:** a future backfill/frontfill subcommand (later slice) imports this
+package. The existing `scripts/bench-fullhistory` harness is **not** rewired in
+this slice — its parsed/serial comparisons cannot route through the single-path
+package, so it is left as-is (or pruned) and is explicitly out of scope.
+
+## Public API
+
+Small surface: a config, the source factory, and two driver functions.
+Ingester implementations are unexported (consumers drive via the tier driver).
+
+```go
+// Config selects which data types to ingest. Decode=views, fan-out=parallel are fixed.
+type Config struct {
+    Ledgers, Txhash, Events bool   // at least one required
+}
+
+// Source selects the backend kind (pack replay or GCS BSB).
+type Source string
+const (
+    SourcePack Source = "pack"
+    SourceBSB  Source = "bsb"
+)
+
+// SourceOpts carries pack/BSB tuning (cold dir or bucket path + BSB buffer/workers/retry).
+type SourceOpts struct {
+    ColdDir    string        // required for SourcePack
+    BucketPath string        // required for SourceBSB
+    BufferSize uint          // BSB prefetch depth
+    NumWorkers uint          // BSB download workers
+    RetryLimit uint
+    RetryWait  time.Duration
+}
+
+// OpenChunkStream returns an independent LedgerStream for one chunk
+// (concurrent chunk workers each get their own — BSB's cursor can't be shared).
+func OpenChunkStream(source Source, opts SourceOpts, chunkID chunk.ID) (ledgerbackend.LedgerStream, error)
+
+// RunHot: continuous fan-out over a single stream into the hot stores.
+func RunHot(ctx context.Context, logger *supportlog.Entry,
+    stream ledgerbackend.LedgerStream, chunkID chunk.ID, hotDir string, cfg Config) error
+
+// RunCold: orchestrates a chunk range, chunkWorkers chunks concurrently,
+// each worker opening its own backend; Finalize lands each chunk's cold artifact.
+func RunCold(ctx context.Context, logger *supportlog.Entry,
+    src Source, opts SourceOpts, coldDir string,
+    startChunk chunk.ID, numChunks, chunkWorkers int, cfg Config) error
+```
+
+Internally unchanged from `rpc-hack` minus metrics: the `Ingester` /
+`ColdIngester` interfaces, the typed `[]Ingester` / `[]ColdIngester` slices
+(preserving the compile-time hot/cold split), and per-ledger `errgroup` fan-out.
+The bench's `buildHotDeps`/`hotDeps` struct existed only to inject collectors
+into a testable loop; with metrics gone, the natural seam is the
+`ledgerbackend.LedgerStream` interface itself (a fake stream feeds the driver),
+so the drivers become plain exported functions.
+
+## Data flow
+
+**Hot (continuous / frontfill-shaped).** `RunHot` pulls
+`stream.RawLedgers(BoundedRange(first,last))`; for each raw ledger it builds a
+`Ledger` via the zero-copy view path (`newViewLedger` — `Raw` set, `LCM` nil),
+then fans out to the enabled hot ingesters concurrently via `errgroup`. The
+borrowed `raw` slice is valid only until the next yield, so `g.Wait()` gates the
+next pull and each ingester copies what it retains. Hot ingesters have no
+finalize — writes land as they go.
+
+**Cold (chunk-batched / backfill-shaped).** `RunCold` spawns up to
+`chunkWorkers` goroutines (`errgroup` + `SetLimit`) over
+`[startChunk, startChunk+numChunks)`. Each worker (`runOneChunkCold`) opens its
+**own** backend (a pack reader or an independent BSB session — BSB's sequential
+cursor can't be shared), opens per-type cold ingesters, iterates the chunk's
+ledgers fanning out per-ledger, then on the success path calls `Finalize` on
+each `ColdIngester` to durably land that chunk's cold artifact (ledger `Commit`,
+events `WriteColdIndex`, txhash sort + write `.bin`).
+
+**Same seam, both fill directions.** Backfill = a bounded range over historical
+chunks (BSB from GCS, or local pack replay). Frontfill = the same driver fed an
+advancing range at the network tip. Fill *orchestration* (range selection,
+resume, live-tip handoff) is a later slice; this package is the reusable engine.
+`RunHot` as ported here is bounded/single-chunk (`BoundedRange`); continuous
+live-tip ingest belongs to the deferred orchestration slice — confirmed in
+scope of *that* later slice, not this one.
+
+## Error handling & lifecycle
+
+- **Fail-fast on ingest:** any `Ingest` error aborts the loop and propagates; in
+  parallel fan-out the `errgroup` context cancels siblings.
+- **Close always deferred, idempotent:** for cold ingesters, if `Finalize` never
+  ran (failure path), the packfile writer's `Close` removes the partial file —
+  a failed chunk leaves no half-written cold artifact. `Close` errors are joined
+  via `errors.Join`.
+- **Finalize explicit, never deferred, error-checked:** a `Finalize` error means
+  the chunk's cold artifact did not durably land and must be re-ingested.
+- **Context cancellation** (SIGINT/SIGTERM) honored at each loop step and
+  between chunks.
+- **Store-boundary sentinels** (`stores.ErrCorrupt` / `ErrOutOfRange` / …)
+  propagate as-is; the ingest package adds no new error taxonomy.
+
+## Testing
+
+- **Driver tests** drive `RunHot` / `RunCold` against a **fake `LedgerStream`**
+  (in-memory ledgers) into a `t.TempDir()` store root, asserting all enabled
+  types are written and the cold path produces a finalized, re-readable
+  artifact. The `LedgerStream` interface is the seam — no metrics injection.
+- **Round-trip test:** ingest a small synthetic chunk → reopen each store's
+  reader → assert ledgers / events / tx-hashes read back. The real regression
+  guard.
+- **Faithfulness:** this slice *refactors* (drops metrics), so equivalence to
+  `rpc-hack` is asserted by the round-trip tests + `go build` / `go vet` on the
+  new package — not by a byte-identical `git diff` (unlike #755).
+- Existing store-level tests already cover the write primitives; ingest tests
+  cover orchestration.
+
+## Git topology & branch plan
+
+The ingest core depends on both #756 (events) and a cold-txhash store that has
+not been extracted yet. The stack:
+
+```
+origin/feature/full-history
+  ├─ origin/events-eventstore-core        (#756, OPEN)
+  └─ txhash-cold-store                    (NEW prereq slice; byte-identical extraction like #755)
+
+fh-ingest-core   ← branch off events-eventstore-core, then merge in txhash-cold-store
+                   (so it compiles against BOTH); PR base = events-eventstore-core,
+                   GitHub retargets to feature/full-history as parents merge.
+```
+
+Two branches result from this work:
+
+1. **`txhash-cold-store`** — off `feature/full-history`; byte-identical port of
+   `stores/txhash/{cold_format,cold_format_test,cold_reader,cold_reader_test}.go`
+   plus the `hot_store.go` deltas from `rpc-hack` (its own small PR, mirrors
+   #755). Prerequisite; its own spec/PR.
+2. **`fh-ingest-core`** — off `events-eventstore-core`, with `txhash-cold-store`
+   merged in; contains the new `pkg/ingest/` package. **This spec.**
+
+## Source-of-truth references on `rpc-hack`
+
+Files to port (minus metrics) from
+`cmd/stellar-rpc/scripts/bench-fullhistory/`:
+
+- `ledger.go` → `ingest/ledger.go` (drop `parsed`-mode `newParsedLedger`)
+- `ingester.go` → `ingest/ingester.go` (interfaces verbatim)
+- `sources.go` → `ingest/source.go` (pack + BSB; export factory)
+- `bench_hot_ingest.go` → `ingest/driver.go` `RunHot` (drop flags, collectors, profiling, reporting; keep the loop)
+- `bench_cold_ingest.go` → `ingest/driver.go` `RunCold` (drop flags, collectors, profiling, reporting; keep chunk-worker orchestration + `runOneChunkCold`)
+- `ingest_ledgers.go` → `ingest/ledgers.go` (drop collector arg + sample recording)
+- `ingest_events.go` → `ingest/events.go` (drop collector arg; keep view path only)
+- `ingest_txhash.go` → `ingest/txhash.go` (drop collector arg; keep view path only)

--- a/docs/superpowers/specs/2026-06-05-fullhistory-ingest-core-design.md
+++ b/docs/superpowers/specs/2026-06-05-fullhistory-ingest-core-design.md
@@ -170,6 +170,42 @@ into a testable loop; with metrics gone, the natural seam is the
 `ledgerbackend.LedgerStream` interface itself (a fake stream feeds the driver),
 so the drivers become plain exported functions.
 
+### Source abstraction (revised — supersedes the `Source` enum above)
+
+The `Source` string enum + combined `SourceOpts` struct + `OpenChunkStream`
+switch were replaced by an extensible **`ChunkSource`** interface so that adding
+a backend never requires editing a central switch:
+
+```go
+// ChunkSource opens a FRESH, independent LedgerStream per chunk; the stream
+// yields each ledger's wire-format xdr.LedgerCloseMeta bytes for the range.
+type ChunkSource interface {
+    OpenStream(chunkID chunk.ID) (ledgerbackend.LedgerStream, error)
+}
+// ChunkSourceFunc adapts a func to ChunkSource (test seam / raw-stream escape hatch).
+type ChunkSourceFunc func(chunk.ID) (ledgerbackend.LedgerStream, error)
+
+func NewPackSource(coldDir string) ChunkSource                                   // local cold packfiles
+type BSBOptions struct { BufferSize, NumWorkers, RetryLimit uint; RetryWait time.Duration }
+func NewDataStoreSource(cfg datastore.DataStoreConfig, opts BSBOptions) ChunkSource // any SDK datastore
+func NewGCSSource(bucketPath string, opts BSBOptions) ChunkSource                // thin wrapper, Type:"GCS"
+func NewS3Source(bucketPath, region, endpointURL string, opts BSBOptions) ChunkSource // Type:"S3"
+
+// Both drivers now take a ChunkSource and open one stream per chunk:
+func RunHot(ctx, logger, source ChunkSource, chunkID chunk.ID, hotDir string, cfg Config) error
+func RunCold(ctx, logger, source ChunkSource, coldDir string,
+    startChunk chunk.ID, numChunks, chunkWorkers int, cfg Config) error
+```
+
+GCS, S3, and Filesystem unify on the single datastore-backed buffered-storage
+path (the SDK's `datastore.NewDataStore` switches on `cfg.Type`); they differ
+only by config, so `NewGCSSource`/`NewS3Source` are one-line wrappers over
+`NewDataStoreSource`. The S3 datastore additionally requires an AWS `region`
+param (and accepts an optional `endpoint_url` for S3-compatible stores), so
+`NewS3Source` takes them explicitly. A completely different backend (custom RPC,
+a test double) implements `ChunkSource` directly. Internally `runColdWithSource`
+is the test seam (a `ChunkSourceFunc` or custom impl injects a fake stream).
+
 ## Data flow
 
 **Hot (continuous / frontfill-shaped).** `RunHot` pulls


### PR DESCRIPTION
> **Draft / not for direct merge.** This branch sits on a *speculative integration base* — it merges open PR #756 (`events-eventstore-core`) and a ported txhash cold store on top of `feature/full-history` purely so the new ingest package has all its store dependencies on one branch to compile and test against. The real ingest-core PR will replay the `pkg/ingest` commits onto a clean `feature/full-history` once #756 and the txhash cold store land upstream. The diff below will include #756's commits until that happens.

## What this delivers

A reusable, productionized full-history **ingest core** at `cmd/stellar-rpc/internal/fullhistory/pkg/ingest`, extracted and refactored out of the `rpc-hack` bench harness (`scripts/bench-fullhistory/`), with **all benchmarking-only code dropped** (collectors, per-stage samples, driver metrics, CSV/percentile reporting, cpu/mem profiling, flag parsing, and the parsed-vs-views toggle).

It streams ledgers and writes **ledgers + transactions + events** into both the **hot** and **cold** stores — the engine for both frontfill and backfill.

### Package (10 files)
- `Config{Ledgers,Txhash,Events bool; Passphrase string}` (+ validation)
- `Ledger{Seq,Raw,LCM}` — parsed decode path (`raw → xdr.LedgerCloseMeta`, decoded once per ledger, shared read-only)
- `Ingester` / `ColdIngester` interfaces (compile-time hot/cold split)
- `OpenChunkStream` — `ledgerbackend.LedgerStream` sources: local cold-packfile replay + GCS BufferedStorageBackend
- 6 ingesters: `{ledgers,events,txhash} × {hot,cold}`
- `RunHot` (bounded single-stream, parallel fan-out) and `RunCold` (chunk-range, `chunkWorkers`-concurrent, each worker its own stream, per-chunk `Finalize`)

### Design pivots (vs the original spec)
- **Parsed path, not XDR-views** — #756 deleted the view extractor (`ingest_view.go`), so events ingest via `events.LCMToPayloads(passphrase, lcm)`. Network passphrase is a `Config` input.
- **txhash cold** writes a sorted per-chunk `.bin`; the streamhash MPHF index build is a follow-up (so cold-txhash readback isn't asserted here).
- Added a **chunk-completeness guard**: a short stream errors instead of finalizing a truncated cold artifact.

Design + plan: `docs/superpowers/specs/2026-06-05-fullhistory-ingest-core-design.md`, `docs/superpowers/plans/2026-06-05-fullhistory-ingest-core.md`.

## Test plan
- [x] `go build ./cmd/stellar-rpc/internal/fullhistory/... ./cmd/stellar-rpc/internal/events/`
- [x] `go test ./cmd/stellar-rpc/internal/fullhistory/pkg/ingest/` — RunHot all-types + short-stream, RunCold ledger round-trip + short-stream-no-artifact
- [x] `go test ./cmd/stellar-rpc/internal/fullhistory/pkg/stores/... ./cmd/stellar-rpc/internal/events/` (integration base green)
- [x] spec-compliance + code-quality review