### PR TITLE
views: zero-copy XDR view extractors — events, tx-hashes, tx-details, tx-pages (#764)

### DIFF
--- a/cmd/stellar-rpc/internal/fullhistory/views/coverage_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/coverage_test.go
@@ -351,25 +351,44 @@ func TestExtractTransactions_MissingEnvelopeHash(t *testing.T) {
 	assert.Contains(t, derr.Error(), "missing from TxSet")
 }
 
-// TestExtractTxDetails_UnsupportedMetaVersion feeds a TransactionMeta{V:0}
-// through the read path and asserts the "unsupported TransactionMeta V=" error
-// (not a panic). The matched tx triggers collectTxParts -> extractEventRawsFromMeta.
-func TestExtractTxDetails_UnsupportedMetaVersion(t *testing.T) {
-	lcm := buildLCM(t, 8601, 1_700_042_001, []xdr.TransactionMeta{
-		{V: 0, Operations: &[]xdr.OperationMeta{}},
-	})
+// TestExtractTxDetails_LegacyMetaV0 feeds a legacy TransactionMeta{V:0}
+// (pre-Soroban, Operations only) through the read path and asserts it is
+// materialized successfully with empty event fields rather than erroring. The
+// SDK reference path (db.ParseTransaction) rejects V0 meta, so this can't be a
+// differential case — full-history backfills from genesis and must tolerate
+// V0, so the view path is deliberately more permissive. The matched tx
+// triggers collectTxParts -> extractEventRawsFromMeta's V0 arm.
+func TestExtractTxDetails_LegacyMetaV0(t *testing.T) {
+	v0Meta := xdr.TransactionMeta{V: 0, Operations: &[]xdr.OperationMeta{}}
+	wantMeta, err := v0Meta.MarshalBinary()
+	require.NoError(t, err)
+
+	lcm := buildLCM(t, 8601, 1_700_042_001, []xdr.TransactionMeta{v0Meta})
 	raw, err := lcm.MarshalBinary()
 	require.NoError(t, err)
 	view := xdr.LedgerCloseMetaView(raw)
-
 	hash := [32]byte(lcm.TransactionHash(0))
-	_, _, derr := views.ExtractTxDetailsByHash(view, hash, testPassphrase)
-	require.Error(t, derr)
-	assert.Contains(t, derr.Error(), "unsupported TransactionMeta V=0")
 
-	_, terr := views.ExtractTransactions(view, 0, 0, testPassphrase)
-	require.Error(t, terr)
-	assert.Contains(t, terr.Error(), "unsupported TransactionMeta V=0")
+	assertV0Tx := func(tx views.Transaction) {
+		assert.Equal(t, hash, tx.Hash, "Hash")
+		assert.Equal(t, int32(1), tx.ApplicationOrder)
+		assert.True(t, tx.Successful)
+		assert.Equal(t, wantMeta, tx.Meta, "Meta wire bytes")
+		assert.NotEmpty(t, tx.Envelope, "Envelope")
+		assert.Empty(t, tx.Events, "no diagnostic events")
+		assert.Empty(t, tx.TransactionEvents, "no transaction events")
+		assert.Empty(t, tx.ContractEvents, "no contract events")
+	}
+
+	got, found, derr := views.ExtractTxDetailsByHash(view, hash, testPassphrase)
+	require.NoError(t, derr)
+	require.True(t, found)
+	assertV0Tx(got)
+
+	page, terr := views.ExtractTransactions(view, 0, 0, testPassphrase)
+	require.NoError(t, terr)
+	require.Len(t, page, 1)
+	assertV0Tx(page[0])
 }
 
 // TestExtractTransactions_NegativeStartIdx asserts startIdx<0 is an error

--- a/cmd/stellar-rpc/internal/fullhistory/views/coverage_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/coverage_test.go
@@ -17,7 +17,7 @@ import (
 // buildParallelTxsLCM builds an LCM V2 whose GeneralizedTransactionSet uses a
 // V=1 TransactionPhase (ParallelTxsComponent) with multiple ExecutionStages,
 // multiple clusters, and a cluster holding >1 tx — exercising
-// enumerateParallelTxs (the previously-0%-coverage parallel walk). The
+// enumerateParallelTxs. The
 // clusters' envelope order is deliberately NOT the apply order: apply order is
 // txs[0..n) (TxProcessing), but the clusters list them in a shuffled layout,
 // so hash-pairing is exercised here too. layout is a slice of stages; each

--- a/cmd/stellar-rpc/internal/fullhistory/views/coverage_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/coverage_test.go
@@ -1,0 +1,386 @@
+package views_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stellar/go-stellar-sdk/network"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/views"
+)
+
+// buildParallelTxsLCM builds an LCM V2 whose GeneralizedTransactionSet uses a
+// V=1 TransactionPhase (ParallelTxsComponent) with multiple ExecutionStages,
+// multiple clusters, and a cluster holding >1 tx — exercising
+// enumerateParallelTxs (the previously-0%-coverage parallel walk). The
+// clusters' envelope order is deliberately NOT the apply order: apply order is
+// txs[0..n) (TxProcessing), but the clusters list them in a shuffled layout,
+// so hash-pairing is exercised here too. layout is a slice of stages; each
+// stage is a slice of clusters; each cluster is a slice of indices into txs.
+func buildParallelTxsLCM(t testing.TB, ledgerSeq uint32, closeTimestamp int64, txs []txWithHash, layout [][][]int) xdr.LedgerCloseMeta {
+	t.Helper()
+
+	processing := make([]xdr.TransactionResultMetaV1, 0, len(txs))
+	for _, tx := range txs {
+		processing = append(processing, xdr.TransactionResultMetaV1{
+			TxApplyProcessing: tx.meta,
+			Result: xdr.TransactionResultPair{
+				TransactionHash: tx.hash,
+				Result:          transactionResult(true),
+			},
+		})
+	}
+
+	stages := make([]xdr.ParallelTxExecutionStage, 0, len(layout))
+	for _, stage := range layout {
+		clusters := make(xdr.ParallelTxExecutionStage, 0, len(stage))
+		for _, cluster := range stage {
+			cl := make(xdr.DependentTxCluster, 0, len(cluster))
+			for _, idx := range cluster {
+				cl = append(cl, txs[idx].env)
+			}
+			clusters = append(clusters, cl)
+		}
+		stages = append(stages, clusters)
+	}
+
+	phases := []xdr.TransactionPhase{{
+		V: 1,
+		ParallelTxsComponent: &xdr.ParallelTxsComponent{
+			ExecutionStages: stages,
+		},
+	}}
+
+	return xdr.LedgerCloseMeta{
+		V: 2,
+		V2: &xdr.LedgerCloseMetaV2{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+				Header: xdr.LedgerHeader{
+					ScpValue:  xdr.StellarValue{CloseTime: xdr.TimePoint(closeTimestamp)},
+					LedgerSeq: xdr.Uint32(ledgerSeq),
+				},
+			},
+			TxSet:        xdr.GeneralizedTransactionSet{V: 1, V1TxSet: &xdr.TransactionSetV1{Phases: phases}},
+			TxProcessing: processing,
+		},
+	}
+}
+
+// TestExtractTransactions_ParallelTxsPhase exercises the V=1 ParallelTxs phase
+// (multiple stages, multiple clusters, a multi-tx cluster) with paging windows
+// that cross a cluster boundary, asserting wire-parity with the reference.
+func TestExtractTransactions_ParallelTxsPhase(t *testing.T) {
+	txs := buildOrderedTxs(t, 6)
+	// Stage0: cluster{tx5,tx4}, cluster{tx3}. Stage1: cluster{tx2,tx1,tx0}.
+	// (Layout intentionally not apply order; pairing is by hash.)
+	layout := [][][]int{
+		{{5, 4}, {3}},
+		{{2, 1, 0}},
+	}
+	lcm := buildParallelTxsLCM(t, 8201, 1_700_040_001, txs, layout)
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	view := xdr.LedgerCloseMetaView(raw)
+	refs := referenceTxs(t, raw)
+	require.Len(t, refs, 6)
+
+	check := func(start, limit int) {
+		got, gerr := views.ExtractTransactions(view, start, limit, testPassphrase)
+		require.NoError(t, gerr)
+		want := len(refs) - start
+		if limit > 0 && limit < want {
+			want = limit
+		}
+		require.Len(t, got, want, "page start=%d limit=%d", start, limit)
+		for k := range got {
+			assertMatchesReference(t, refs[start+k], got[k])
+		}
+	}
+	check(0, 0) // full
+	check(0, 2) // first cluster only
+	check(1, 3) // page crossing the stage0 cluster{5,4}/cluster{3} boundary
+	check(3, 0) // start in second stage
+	check(2, 3) // crosses stage0->stage1 boundary
+
+	// And ExtractTxDetailsByHash for each tx.
+	for k := range refs {
+		hb, derr := hex.DecodeString(refs[k].TransactionHash)
+		require.NoError(t, derr)
+		var h [32]byte
+		copy(h[:], hb)
+		d, found, derr2 := views.ExtractTxDetailsByHash(view, h, testPassphrase)
+		require.NoError(t, derr2)
+		require.True(t, found)
+		assertMatchesReference(t, refs[k], d)
+	}
+}
+
+// buildV0ComponentsMultiLCM builds an LCM V2 GeneralizedTransactionSet V=0
+// phase with multiple components, one holding 2-3 envelopes, exercising paging
+// windows that begin/end mid-component. components is a slice of components,
+// each a slice of indices into txs.
+func buildV0ComponentsMultiLCM(t testing.TB, ledgerSeq uint32, closeTimestamp int64, txs []txWithHash, components [][]int) xdr.LedgerCloseMeta {
+	t.Helper()
+
+	processing := make([]xdr.TransactionResultMetaV1, 0, len(txs))
+	for _, tx := range txs {
+		processing = append(processing, xdr.TransactionResultMetaV1{
+			TxApplyProcessing: tx.meta,
+			Result: xdr.TransactionResultPair{
+				TransactionHash: tx.hash,
+				Result:          transactionResult(true),
+			},
+		})
+	}
+
+	comps := make([]xdr.TxSetComponent, 0, len(components))
+	for _, comp := range components {
+		envs := make([]xdr.TransactionEnvelope, 0, len(comp))
+		for _, idx := range comp {
+			envs = append(envs, txs[idx].env)
+		}
+		comps = append(comps, xdr.TxSetComponent{
+			Type: xdr.TxSetComponentTypeTxsetCompTxsMaybeDiscountedFee,
+			TxsMaybeDiscountedFee: &xdr.TxSetComponentTxsMaybeDiscountedFee{
+				Txs: envs,
+			},
+		})
+	}
+	phases := []xdr.TransactionPhase{{V: 0, V0Components: &comps}}
+
+	return xdr.LedgerCloseMeta{
+		V: 2,
+		V2: &xdr.LedgerCloseMetaV2{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+				Header: xdr.LedgerHeader{
+					ScpValue:  xdr.StellarValue{CloseTime: xdr.TimePoint(closeTimestamp)},
+					LedgerSeq: xdr.Uint32(ledgerSeq),
+				},
+			},
+			TxSet:        xdr.GeneralizedTransactionSet{V: 1, V1TxSet: &xdr.TransactionSetV1{Phases: phases}},
+			TxProcessing: processing,
+		},
+	}
+}
+
+// TestExtractTransactions_V0ComponentsMultiEnvelope exercises a V0Components
+// phase with a multi-envelope component and paging windows that begin/end
+// mid-component.
+func TestExtractTransactions_V0ComponentsMultiEnvelope(t *testing.T) {
+	txs := buildOrderedTxs(t, 5)
+	// component{tx4,tx3,tx2} (3 envelopes), component{tx1,tx0}.
+	components := [][]int{{4, 3, 2}, {1, 0}}
+	lcm := buildV0ComponentsMultiLCM(t, 8301, 1_700_041_001, txs, components)
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	view := xdr.LedgerCloseMetaView(raw)
+	refs := referenceTxs(t, raw)
+	require.Len(t, refs, 5)
+
+	check := func(start, limit int) {
+		got, gerr := views.ExtractTransactions(view, start, limit, testPassphrase)
+		require.NoError(t, gerr)
+		want := len(refs) - start
+		if limit > 0 && limit < want {
+			want = limit
+		}
+		require.Len(t, got, want)
+		for k := range got {
+			assertMatchesReference(t, refs[start+k], got[k])
+		}
+	}
+	check(0, 0) // full
+	check(1, 0) // begin mid-first-component
+	check(0, 2) // end mid-first-component
+	check(2, 2) // window inside+crossing first component end
+}
+
+// TestExtractTransactions_FeeBumpInnerSuccess asserts Successful is read from
+// the result code for both a FAILED tx (txFAILED) and a fee-bump tx whose
+// outer code is txFEE_BUMP_INNER_SUCCESS, matching the SDK reference per tx.
+func TestExtractTransactions_FeeBumpInnerSuccess(t *testing.T) {
+	// Plain failed tx.
+	failedEnv := xdr.TransactionEnvelope{
+		Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+		V1: &xdr.TransactionV1Envelope{
+			Tx: xdr.Transaction{SourceAccount: xdr.MustMuxedAddress(keypair.MustRandom().Address())},
+		},
+	}
+	failedHash, err := network.HashTransactionInEnvelope(failedEnv, testPassphrase)
+	require.NoError(t, err)
+
+	// Fee-bump tx with inner success.
+	inner := xdr.TransactionV1Envelope{
+		Tx: xdr.Transaction{SourceAccount: xdr.MustMuxedAddress(keypair.MustRandom().Address())},
+	}
+	feeBumpEnv := xdr.TransactionEnvelope{
+		Type: xdr.EnvelopeTypeEnvelopeTypeTxFeeBump,
+		FeeBump: &xdr.FeeBumpTransactionEnvelope{
+			Tx: xdr.FeeBumpTransaction{
+				FeeSource: xdr.MustMuxedAddress(keypair.MustRandom().Address()),
+				Fee:       2000,
+				InnerTx: xdr.FeeBumpTransactionInnerTx{
+					Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+					V1:   &inner,
+				},
+			},
+		},
+	}
+	feeBumpHash, err := network.HashTransactionInEnvelope(feeBumpEnv, testPassphrase)
+	require.NoError(t, err)
+
+	var innerHash xdr.Hash
+	innerHash[0] = 0x42
+	failedOps := []xdr.OperationResult{}
+	feeBumpResult := xdr.TransactionResult{
+		FeeCharged: 2000,
+		Result: xdr.TransactionResultResult{
+			Code: xdr.TransactionResultCodeTxFeeBumpInnerSuccess,
+			InnerResultPair: &xdr.InnerTransactionResultPair{
+				TransactionHash: innerHash,
+				Result: xdr.InnerTransactionResult{
+					FeeCharged: 100,
+					Result: xdr.InnerTransactionResultResult{
+						Code:    xdr.TransactionResultCodeTxSuccess,
+						Results: &[]xdr.OperationResult{},
+					},
+				},
+			},
+		},
+	}
+	failedResult := xdr.TransactionResult{
+		FeeCharged: 100,
+		Result:     xdr.TransactionResultResult{Code: xdr.TransactionResultCodeTxFailed, Results: &failedOps},
+	}
+
+	// Apply order: [failed, feeBump].
+	processing := []xdr.TransactionResultMetaV1{
+		{
+			TxApplyProcessing: xdr.TransactionMeta{V: 1, V1: &xdr.TransactionMetaV1{}},
+			Result:            xdr.TransactionResultPair{TransactionHash: failedHash, Result: failedResult},
+		},
+		{
+			TxApplyProcessing: xdr.TransactionMeta{V: 1, V1: &xdr.TransactionMetaV1{}},
+			Result:            xdr.TransactionResultPair{TransactionHash: feeBumpHash, Result: feeBumpResult},
+		},
+	}
+	// TxSet order reversed to also exercise hash pairing.
+	comp := []xdr.TxSetComponent{{
+		Type: xdr.TxSetComponentTypeTxsetCompTxsMaybeDiscountedFee,
+		TxsMaybeDiscountedFee: &xdr.TxSetComponentTxsMaybeDiscountedFee{
+			Txs: []xdr.TransactionEnvelope{feeBumpEnv, failedEnv},
+		},
+	}}
+	lcm := xdr.LedgerCloseMeta{
+		V: 2,
+		V2: &xdr.LedgerCloseMetaV2{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{Header: xdr.LedgerHeader{LedgerSeq: 8401}},
+			TxSet:        xdr.GeneralizedTransactionSet{V: 1, V1TxSet: &xdr.TransactionSetV1{Phases: []xdr.TransactionPhase{{V: 0, V0Components: &comp}}}},
+			TxProcessing: processing,
+		},
+	}
+
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	view := xdr.LedgerCloseMetaView(raw)
+	refs := referenceTxs(t, raw)
+	require.Len(t, refs, 2)
+
+	got, gerr := views.ExtractTransactions(view, 0, 0, testPassphrase)
+	require.NoError(t, gerr)
+	require.Len(t, got, 2)
+
+	// The failed tx is unsuccessful; the fee-bump (inner success) is
+	// successful. Both must match the SDK reference per tx.
+	for k := range got {
+		assert.Equal(t, refs[k].Successful, got[k].Successful, "Successful mismatch tx %d", k)
+		assert.Equal(t, refs[k].FeeBump, got[k].FeeBump, "FeeBump mismatch tx %d", k)
+	}
+	assert.False(t, got[0].Successful, "failed tx should be unsuccessful")
+	assert.True(t, got[1].Successful, "fee-bump inner-success should be successful")
+	assert.True(t, got[1].FeeBump, "second tx should be a fee bump")
+}
+
+// TestExtractTransactions_MissingEnvelopeHash forces the inconsistent-LCM
+// error: TxProcessing references a hash that has no envelope in the TxSet.
+// Both extractors must return an error, not panic.
+func TestExtractTransactions_MissingEnvelopeHash(t *testing.T) {
+	txs := buildOrderedTxs(t, 2)
+	// TxProcessing lists both txs, but the TxSet only contains tx0's envelope,
+	// so tx1's hash is unresolvable.
+	processing := make([]xdr.TransactionResultMetaV1, 0, 2)
+	for _, tx := range txs {
+		processing = append(processing, xdr.TransactionResultMetaV1{
+			TxApplyProcessing: tx.meta,
+			Result: xdr.TransactionResultPair{
+				TransactionHash: tx.hash,
+				Result:          transactionResult(true),
+			},
+		})
+	}
+	comp := []xdr.TxSetComponent{{
+		Type: xdr.TxSetComponentTypeTxsetCompTxsMaybeDiscountedFee,
+		TxsMaybeDiscountedFee: &xdr.TxSetComponentTxsMaybeDiscountedFee{
+			Txs: []xdr.TransactionEnvelope{txs[0].env}, // tx1 envelope missing
+		},
+	}}
+	lcm := xdr.LedgerCloseMeta{
+		V: 2,
+		V2: &xdr.LedgerCloseMetaV2{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{Header: xdr.LedgerHeader{LedgerSeq: 8501}},
+			TxSet:        xdr.GeneralizedTransactionSet{V: 1, V1TxSet: &xdr.TransactionSetV1{Phases: []xdr.TransactionPhase{{V: 0, V0Components: &comp}}}},
+			TxProcessing: processing,
+		},
+	}
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	view := xdr.LedgerCloseMetaView(raw)
+
+	_, gerr := views.ExtractTransactions(view, 0, 0, testPassphrase)
+	require.Error(t, gerr)
+	assert.Contains(t, gerr.Error(), "missing from TxSet")
+
+	// ExtractTxDetailsByHash for the unresolvable tx1 must also error.
+	_, _, derr := views.ExtractTxDetailsByHash(view, [32]byte(txs[1].hash), testPassphrase)
+	require.Error(t, derr)
+	assert.Contains(t, derr.Error(), "missing from TxSet")
+}
+
+// TestExtractTxDetails_UnsupportedMetaVersion feeds a TransactionMeta{V:0}
+// through the read path and asserts the "unsupported TransactionMeta V=" error
+// (not a panic). The matched tx triggers collectTxParts -> extractEventRawsFromMeta.
+func TestExtractTxDetails_UnsupportedMetaVersion(t *testing.T) {
+	lcm := buildLCM(t, 8601, 1_700_042_001, []xdr.TransactionMeta{
+		{V: 0, Operations: &[]xdr.OperationMeta{}},
+	})
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	view := xdr.LedgerCloseMetaView(raw)
+
+	hash := [32]byte(lcm.TransactionHash(0))
+	_, _, derr := views.ExtractTxDetailsByHash(view, hash, testPassphrase)
+	require.Error(t, derr)
+	assert.Contains(t, derr.Error(), "unsupported TransactionMeta V=0")
+
+	_, terr := views.ExtractTransactions(view, 0, 0, testPassphrase)
+	require.Error(t, terr)
+	assert.Contains(t, terr.Error(), "unsupported TransactionMeta V=0")
+}
+
+// TestExtractTransactions_NegativeStartIdx asserts startIdx<0 is an error
+// rather than being silently clamped to 0.
+func TestExtractTransactions_NegativeStartIdx(t *testing.T) {
+	lcm := buildLCM(t, 8701, 1_700_043_001, []xdr.TransactionMeta{
+		{V: 1, V1: &xdr.TransactionMetaV1{}},
+	})
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	_, gerr := views.ExtractTransactions(xdr.LedgerCloseMetaView(raw), -1, 0, testPassphrase)
+	require.Error(t, gerr)
+	assert.Contains(t, gerr.Error(), "startIdx")
+}

--- a/cmd/stellar-rpc/internal/fullhistory/views/diffextra_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/diffextra_test.go
@@ -1,0 +1,352 @@
+package views_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stellar/go-stellar-sdk/network"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/views"
+)
+
+// Issue #764 requires the differential fixture set to cover, beyond the
+// V0/V1/V2 + V3/V4-meta + empty cases already present, dedicated fixtures
+// for SPONSORSHIP, LARGE-TX, and PROTOCOL-TRANSITION. The three tests below
+// build those fixtures the same way as the existing differential cases and
+// run them through the SAME reference assertion (referenceTxs +
+// assertMatchesReference, i.e. the SDK ingest.LedgerTransactionReader +
+// db.ParseTransaction full decode) plus ExtractTxHashes. The guarantee under
+// test is: zero-copy view extraction == full decode on the SAME bytes, even
+// for sponsorship-shaped envelopes/metas, near-op-limit envelopes/metas, and
+// ledgers sitting on a protocol-version boundary.
+
+// buildSponsorshipEnvelopeAndHash builds a CLASSIC tx envelope whose
+// operations are a sponsorship sandwich:
+//
+//	BeginSponsoringFutureReserves(sponsoredId)
+//	CreateAccount(sponsoredId)         // the sponsored, reserve-creating op
+//	EndSponsoringFutureReserves
+//
+// It is a classic (non-Soroban) envelope, so it carries no contract events.
+func buildSponsorshipEnvelopeAndHash(t testing.TB) (xdr.TransactionEnvelope, xdr.Hash, xdr.AccountId) {
+	t.Helper()
+
+	source := xdr.MustMuxedAddress(keypair.MustRandom().Address())
+	sponsored := xdr.MustAddress(keypair.MustRandom().Address())
+
+	beginOp := xdr.Operation{
+		Body: xdr.OperationBody{
+			Type: xdr.OperationTypeBeginSponsoringFutureReserves,
+			BeginSponsoringFutureReservesOp: &xdr.BeginSponsoringFutureReservesOp{
+				SponsoredId: sponsored,
+			},
+		},
+	}
+	createOp := xdr.Operation{
+		Body: xdr.OperationBody{
+			Type: xdr.OperationTypeCreateAccount,
+			CreateAccountOp: &xdr.CreateAccountOp{
+				Destination:     sponsored,
+				StartingBalance: 10_000_000,
+			},
+		},
+	}
+	endOp := xdr.Operation{
+		Body: xdr.OperationBody{
+			Type: xdr.OperationTypeEndSponsoringFutureReserves,
+		},
+	}
+
+	envelope := xdr.TransactionEnvelope{
+		Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+		V1: &xdr.TransactionV1Envelope{
+			Tx: xdr.Transaction{
+				SourceAccount: source,
+				Fee:           300,
+				Operations:    []xdr.Operation{beginOp, createOp, endOp},
+			},
+		},
+	}
+	hash, err := network.HashTransactionInEnvelope(envelope, testPassphrase)
+	require.NoError(t, err)
+	return envelope, hash, sponsored
+}
+
+// sponsorshipMeta builds a TransactionMetaV2 whose op-1 (the CreateAccount)
+// LedgerEntryChanges materialize the sponsored account: a Created account
+// entry carrying a LedgerEntryExtensionV1 with SponsoringId set to the
+// sponsoring source. This mirrors the on-chain shape of a sponsored
+// reserve creation (sponsoring/sponsored fields populated).
+func sponsorshipMeta(sponsor xdr.AccountId, sponsored xdr.AccountId) xdr.TransactionMeta {
+	sponsoringID := sponsor // SponsorshipDescriptor = *AccountId
+	created := xdr.LedgerEntryChange{
+		Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
+		Created: &xdr.LedgerEntry{
+			LastModifiedLedgerSeq: 1,
+			Data: xdr.LedgerEntryData{
+				Type: xdr.LedgerEntryTypeAccount,
+				Account: &xdr.AccountEntry{
+					AccountId: sponsored,
+					Balance:   10_000_000,
+					SeqNum:    0,
+				},
+			},
+			Ext: xdr.LedgerEntryExt{
+				V: 1,
+				V1: &xdr.LedgerEntryExtensionV1{
+					SponsoringId: &sponsoringID,
+				},
+			},
+		},
+	}
+	return xdr.TransactionMeta{
+		V: 2,
+		V2: &xdr.TransactionMetaV2{
+			Operations: []xdr.OperationMeta{
+				{Changes: xdr.LedgerEntryChanges{}},        // begin op: no changes
+				{Changes: xdr.LedgerEntryChanges{created}}, // create op: sponsored entry
+				{Changes: xdr.LedgerEntryChanges{}},        // end op: no changes
+			},
+		},
+	}
+}
+
+// TestExtractTransactions_Sponsorship is the SPONSORSHIP differential
+// fixture (#764). A classic tx with a Begin/CreateAccount/End sponsorship
+// sandwich and a V2 meta whose LedgerEntryChanges carry the sponsoring/
+// sponsored fields is run through the tx-details, tx-pages, and tx-hashes
+// extractors and asserted wire-identical to the full-decode reference.
+func TestExtractTransactions_Sponsorship(t *testing.T) {
+	env, hash, sponsored := buildSponsorshipEnvelopeAndHash(t)
+	sponsor := env.SourceAccount().ToAccountId()
+	meta := sponsorshipMeta(sponsor, sponsored)
+
+	lcm := buildLCMV2SingleTx(t, 9301, 1_700_060_001, env, hash, meta)
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	view := xdr.LedgerCloseMetaView(raw)
+	refs := referenceTxs(t, raw)
+	require.Len(t, refs, 1)
+	require.False(t, refs[0].FeeBump)
+	// Classic tx → reference emits no contract events.
+	require.Empty(t, refs[0].ContractEvents, "sponsorship tx is classic; no contract events")
+
+	// tx-pages path.
+	got, gerr := views.ExtractTransactions(view, 0, 0, testPassphrase)
+	require.NoError(t, gerr)
+	require.Len(t, got, 1)
+	assertMatchesReference(t, refs[0], got[0])
+
+	// tx-details (by-hash) path.
+	gotOne, found, derr := views.ExtractTxDetailsByHash(view, [32]byte(hash), testPassphrase)
+	require.NoError(t, derr)
+	require.True(t, found)
+	assertMatchesReference(t, refs[0], gotOne)
+
+	// tx-hashes path.
+	hashes, herr := views.ExtractTxHashes(view)
+	require.NoError(t, herr)
+	require.Len(t, hashes, 1)
+	assert.Equal(t, [32]byte(hash), hashes[0].Hash, "ExtractTxHashes hash")
+	assert.Equal(t, uint32(9301), hashes[0].LedgerSeq, "ExtractTxHashes ledgerSeq")
+}
+
+// buildLargeTxEnvelopeAndHash builds a CLASSIC tx envelope with opCount
+// CreateAccount operations (near the per-tx op limit of 100), producing a
+// large envelope. Returns the destinations so a matching large meta can be
+// built.
+func buildLargeTxEnvelopeAndHash(t testing.TB, opCount int) (xdr.TransactionEnvelope, xdr.Hash, []xdr.AccountId) {
+	t.Helper()
+	source := xdr.MustMuxedAddress(keypair.MustRandom().Address())
+	ops := make([]xdr.Operation, 0, opCount)
+	dests := make([]xdr.AccountId, 0, opCount)
+	for i := 0; i < opCount; i++ {
+		dest := xdr.MustAddress(keypair.MustRandom().Address())
+		dests = append(dests, dest)
+		ops = append(ops, xdr.Operation{
+			Body: xdr.OperationBody{
+				Type: xdr.OperationTypeCreateAccount,
+				CreateAccountOp: &xdr.CreateAccountOp{
+					Destination:     dest,
+					StartingBalance: xdr.Int64(10_000_000 + i),
+				},
+			},
+		})
+	}
+	envelope := xdr.TransactionEnvelope{
+		Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+		V1: &xdr.TransactionV1Envelope{
+			Tx: xdr.Transaction{
+				SourceAccount: source,
+				Fee:           xdr.Uint32(100 * opCount),
+				Operations:    ops,
+			},
+		},
+	}
+	hash, err := network.HashTransactionInEnvelope(envelope, testPassphrase)
+	require.NoError(t, err)
+	return envelope, hash, dests
+}
+
+// largeTxMeta builds a TransactionMetaV2 with one OperationMeta per op, each
+// creating its account entry, so the marshaled meta is large too.
+func largeTxMeta(dests []xdr.AccountId) xdr.TransactionMeta {
+	ops := make([]xdr.OperationMeta, 0, len(dests))
+	for i, dest := range dests {
+		ops = append(ops, xdr.OperationMeta{
+			Changes: xdr.LedgerEntryChanges{{
+				Type: xdr.LedgerEntryChangeTypeLedgerEntryCreated,
+				Created: &xdr.LedgerEntry{
+					LastModifiedLedgerSeq: 1,
+					Data: xdr.LedgerEntryData{
+						Type: xdr.LedgerEntryTypeAccount,
+						Account: &xdr.AccountEntry{
+							AccountId: dest,
+							Balance:   xdr.Int64(10_000_000 + i),
+						},
+					},
+				},
+			}},
+		})
+	}
+	return xdr.TransactionMeta{
+		V:  2,
+		V2: &xdr.TransactionMetaV2{Operations: ops},
+	}
+}
+
+// TestExtractTransactions_LargeTx is the LARGE-TX differential fixture
+// (#764). A tx with many ops (near the per-tx op limit) yields a large
+// envelope + large meta; running it through the same differential exercises
+// the raw-byte copy at size and confirms no truncation/mismatch.
+func TestExtractTransactions_LargeTx(t *testing.T) {
+	const opCount = 90 // near the 100-op per-tx limit
+	env, hash, dests := buildLargeTxEnvelopeAndHash(t, opCount)
+	meta := largeTxMeta(dests)
+
+	lcm := buildLCMV2SingleTx(t, 9302, 1_700_061_001, env, hash, meta)
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	view := xdr.LedgerCloseMetaView(raw)
+	refs := referenceTxs(t, raw)
+	require.Len(t, refs, 1)
+
+	// Sanity: envelope and meta are genuinely large (exercises size).
+	require.Greater(t, len(refs[0].Envelope), 2000, "large-tx envelope should be sizable")
+	require.Greater(t, len(refs[0].Meta), 2000, "large-tx meta should be sizable")
+
+	// tx-pages path.
+	got, gerr := views.ExtractTransactions(view, 0, 0, testPassphrase)
+	require.NoError(t, gerr)
+	require.Len(t, got, 1)
+	assertMatchesReference(t, refs[0], got[0])
+
+	// tx-details (by-hash) path.
+	gotOne, found, derr := views.ExtractTxDetailsByHash(view, [32]byte(hash), testPassphrase)
+	require.NoError(t, derr)
+	require.True(t, found)
+	assertMatchesReference(t, refs[0], gotOne)
+
+	// tx-hashes path.
+	hashes, herr := views.ExtractTxHashes(view)
+	require.NoError(t, herr)
+	require.Len(t, hashes, 1)
+	assert.Equal(t, [32]byte(hash), hashes[0].Hash, "ExtractTxHashes hash")
+}
+
+// buildLCMV2WithUpgrade is buildLCMV2SingleTx with a protocol-version bump
+// stamped on the header: the header LedgerVersion is set to newVersion and
+// the ScpValue.Upgrades carries a marshaled LedgerUpgradeVersion step, so
+// the ledger sits on a protocol boundary.
+func buildLCMV2WithUpgrade(t testing.TB, ledgerSeq uint32, closeTimestamp int64, newVersion uint32, env xdr.TransactionEnvelope, hash xdr.Hash, meta xdr.TransactionMeta) xdr.LedgerCloseMeta {
+	t.Helper()
+
+	nv := xdr.Uint32(newVersion)
+	upgrade := xdr.LedgerUpgrade{
+		Type:             xdr.LedgerUpgradeTypeLedgerUpgradeVersion,
+		NewLedgerVersion: &nv,
+	}
+	upgradeBytes, err := upgrade.MarshalBinary()
+	require.NoError(t, err)
+
+	comp := []xdr.TxSetComponent{{
+		Type: xdr.TxSetComponentTypeTxsetCompTxsMaybeDiscountedFee,
+		TxsMaybeDiscountedFee: &xdr.TxSetComponentTxsMaybeDiscountedFee{
+			Txs: []xdr.TransactionEnvelope{env},
+		},
+	}}
+	return xdr.LedgerCloseMeta{
+		V: 2,
+		V2: &xdr.LedgerCloseMetaV2{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+				Header: xdr.LedgerHeader{
+					LedgerVersion: nv,
+					ScpValue: xdr.StellarValue{
+						CloseTime: xdr.TimePoint(closeTimestamp),
+						Upgrades:  []xdr.UpgradeType{upgradeBytes},
+					},
+					LedgerSeq: xdr.Uint32(ledgerSeq),
+				},
+			},
+			TxSet: xdr.GeneralizedTransactionSet{V: 1, V1TxSet: &xdr.TransactionSetV1{Phases: []xdr.TransactionPhase{{V: 0, V0Components: &comp}}}},
+			TxProcessing: []xdr.TransactionResultMetaV1{{
+				TxApplyProcessing: meta,
+				Result:            xdr.TransactionResultPair{TransactionHash: hash, Result: transactionResult(true)},
+			}},
+		},
+	}
+}
+
+// TestExtractTransactions_ProtocolTransition is the PROTOCOL-TRANSITION
+// differential fixture (#764). The LCM header carries a protocol-version
+// bump (LedgerVersion set + a LedgerUpgradeVersion in ScpValue.Upgrades) and
+// includes one tx so the extractors have something to materialize.
+//
+// NOTE: the view extractors are agnostic to header upgrades — they read only
+// the header seq/close-time plus the TxSet/TxProcessing, and the meta version
+// (not the header) drives meta handling. So a true protocol transition adds
+// no decode path beyond the existing V0–V4 version coverage; this case is
+// the explicit "a ledger on a protocol boundary still extracts correctly"
+// guarantee rather than a new code path. We still assert byte-for-byte parity
+// against the full-decode reference on the upgrade-bearing bytes.
+func TestExtractTransactions_ProtocolTransition(t *testing.T) {
+	const newProtocol = 23
+	env, hash := buildTxEnvelopeAndHash(t)
+	meta := txMetaWithV3SorobanEvents([]xdr.ContractEvent{buildContractEvent("transition")})
+
+	lcm := buildLCMV2WithUpgrade(t, 9303, 1_700_062_001, newProtocol, env, hash, meta)
+	require.Equal(t, xdr.Uint32(newProtocol), lcm.V2.LedgerHeader.Header.LedgerVersion)
+	require.Len(t, lcm.V2.LedgerHeader.Header.ScpValue.Upgrades, 1, "fixture must carry an upgrade step")
+
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	view := xdr.LedgerCloseMetaView(raw)
+	refs := referenceTxs(t, raw)
+	require.Len(t, refs, 1)
+
+	// tx-pages path.
+	got, gerr := views.ExtractTransactions(view, 0, 0, testPassphrase)
+	require.NoError(t, gerr)
+	require.Len(t, got, 1)
+	assertMatchesReference(t, refs[0], got[0])
+
+	// tx-details (by-hash) path.
+	gotOne, found, derr := views.ExtractTxDetailsByHash(view, [32]byte(hash), testPassphrase)
+	require.NoError(t, derr)
+	require.True(t, found)
+	assertMatchesReference(t, refs[0], gotOne)
+
+	// tx-hashes path.
+	hashes, herr := views.ExtractTxHashes(view)
+	require.NoError(t, herr)
+	require.Len(t, hashes, 1)
+	assert.Equal(t, [32]byte(hash), hashes[0].Hash, "ExtractTxHashes hash")
+	assert.Equal(t, uint32(9303), hashes[0].LedgerSeq, "ExtractTxHashes ledgerSeq")
+
+	// Confirm the close-time still extracts correctly across the boundary.
+	assert.Equal(t, int64(1_700_062_001), got[0].LedgerCloseTime, "close time on protocol boundary")
+}

--- a/cmd/stellar-rpc/internal/fullhistory/views/dispatch.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/dispatch.go
@@ -1,0 +1,165 @@
+package views
+
+import (
+	"fmt"
+	"iter"
+
+	"github.com/stellar/go-stellar-sdk/xdr"
+)
+
+// txResultMetaView is the view-side interface satisfied by both
+// TransactionResultMetaView (V0/V1 LCM TxProcessing element) and
+// TransactionResultMetaV1View (V2 LCM TxProcessing element).
+type txResultMetaView interface {
+	Result() (xdr.TransactionResultPairView, error)
+	MustResult() xdr.TransactionResultPairView
+	TxApplyProcessing() (xdr.TransactionMetaView, error)
+}
+
+// widen adapts a concrete per-version TxProcessing sequence (an
+// iter.Seq2[E, error] for a generated element view type E) into a sequence
+// of the txResultMetaView interface, letting V0/V1/V2 share one iteration
+// body.
+func widen[E txResultMetaView](seq iter.Seq2[E, error]) iter.Seq2[txResultMetaView, error] {
+	return func(yield func(txResultMetaView, error) bool) {
+		for elem, err := range seq {
+			if !yield(elem, err) {
+				return
+			}
+		}
+	}
+}
+
+// lcmDispatch holds the version-specific handles the extractors need from
+// one LedgerCloseMetaView: the version discriminant, the ledger header view,
+// the TxProcessing sequence (apply order), and an enumerator that drives a
+// per-envelope yield over the version-specific TxSet. The TxSet is opened
+// lazily inside the enumerator — the events and tx-hash extractors never
+// touch it. The TxSet is in agreed-set / hash-sorted order, which differs
+// from TxProcessing apply order, so envelopes are paired to transactions BY
+// HASH, never by array position. V0 uses a plain TransactionSet; V1/V2 use
+// a GeneralizedTransactionSet.
+type lcmDispatch struct {
+	disc          int32
+	header        xdr.LedgerHeaderHistoryEntryView
+	tp            iter.Seq2[txResultMetaView, error]
+	enumerateEnvs func(th *txHasher, yield envYield) (stopped bool, err error)
+}
+
+// dispatchLCM opens lcm, reads its discriminator, and returns the
+// version-specific handles. This is the ONE place the V0/V1/V2 LCM dispatch
+// lives; every extractor starts here and callers branch on the returned
+// disc for version-sensitive behavior (e.g. V0 events are unsupported).
+func dispatchLCM(lcm xdr.LedgerCloseMetaView) (lcmDispatch, error) {
+	dv, err := lcm.V()
+	if err != nil {
+		return lcmDispatch{}, fmt.Errorf("views: LCM.V: %w", err)
+	}
+	disc, err := dv.Value()
+	if err != nil {
+		return lcmDispatch{}, fmt.Errorf("views: LCM.V value: %w", err)
+	}
+
+	d := lcmDispatch{disc: disc}
+	switch disc {
+	case 0:
+		v0, err := lcm.V0()
+		if err != nil {
+			return lcmDispatch{}, fmt.Errorf("views: LCM V0: %w", err)
+		}
+		if d.header, err = v0.LedgerHeader(); err != nil {
+			return lcmDispatch{}, fmt.Errorf("views: V0 LedgerHeader: %w", err)
+		}
+		raw, err := v0.TxProcessing()
+		if err != nil {
+			return lcmDispatch{}, fmt.Errorf("views: V0 TxProcessing: %w", err)
+		}
+		d.tp = widen(raw.Iter())
+		d.enumerateEnvs = func(th *txHasher, yield envYield) (bool, error) {
+			txSet, err := v0.TxSet()
+			if err != nil {
+				return false, fmt.Errorf("views: V0 TxSet: %w", err)
+			}
+			return enumerateEnvelopesFromV0TxSet(txSet, th, yield)
+		}
+	case 1:
+		v1, err := lcm.V1()
+		if err != nil {
+			return lcmDispatch{}, fmt.Errorf("views: LCM V1: %w", err)
+		}
+		if d.header, err = v1.LedgerHeader(); err != nil {
+			return lcmDispatch{}, fmt.Errorf("views: V1 LedgerHeader: %w", err)
+		}
+		raw, err := v1.TxProcessing()
+		if err != nil {
+			return lcmDispatch{}, fmt.Errorf("views: V1 TxProcessing: %w", err)
+		}
+		d.tp = widen(raw.Iter())
+		d.enumerateEnvs = func(th *txHasher, yield envYield) (bool, error) {
+			txSet, err := v1.TxSet()
+			if err != nil {
+				return false, fmt.Errorf("views: V1 TxSet: %w", err)
+			}
+			return enumerateEnvelopesFromGeneralized(txSet, th, yield)
+		}
+	case 2:
+		v2, err := lcm.V2()
+		if err != nil {
+			return lcmDispatch{}, fmt.Errorf("views: LCM V2: %w", err)
+		}
+		if d.header, err = v2.LedgerHeader(); err != nil {
+			return lcmDispatch{}, fmt.Errorf("views: V2 LedgerHeader: %w", err)
+		}
+		raw, err := v2.TxProcessing()
+		if err != nil {
+			return lcmDispatch{}, fmt.Errorf("views: V2 TxProcessing: %w", err)
+		}
+		d.tp = widen(raw.Iter())
+		d.enumerateEnvs = func(th *txHasher, yield envYield) (bool, error) {
+			txSet, err := v2.TxSet()
+			if err != nil {
+				return false, fmt.Errorf("views: V2 TxSet: %w", err)
+			}
+			return enumerateEnvelopesFromGeneralized(txSet, th, yield)
+		}
+	default:
+		return lcmDispatch{}, fmt.Errorf("views: unknown LCM V=%d", disc)
+	}
+	return d, nil
+}
+
+// readLedgerHeader extracts (LedgerSequence, LedgerCloseTime) from a
+// LedgerHeaderHistoryEntryView via the same path xdr.LedgerCloseMeta's
+// LedgerSequence/LedgerCloseTime helpers use, but staying view-side. The
+// Must accessors panic with *xdr.ViewError on malformed input; xdr.Try
+// recovers the first failure as the returned error.
+func readLedgerHeader(header xdr.LedgerHeaderHistoryEntryView) (uint32, int64, error) {
+	type seqClose struct {
+		seq uint32
+		ct  uint64
+	}
+	r, err := xdr.Try(func() seqClose {
+		inner := header.MustHeader()
+		return seqClose{
+			seq: inner.MustLedgerSeq().MustValue(),
+			ct:  inner.MustScpValue().MustCloseTime().MustValue(),
+		}
+	})
+	if err != nil {
+		return 0, 0, fmt.Errorf("views: ledger header: %w", err)
+	}
+	return r.seq, int64(r.ct), nil //nolint:gosec // TimePoint is uint64
+}
+
+// readTxHash extracts the 32-byte TransactionHash from a TxProcessing
+// entry view (TransactionResultPair.TransactionHash). HashView is a fixed
+// opaque[32], so the value is always exactly 32 bytes on success.
+func readTxHash(tx txResultMetaView) (xdr.Hash, error) {
+	hb, err := xdr.Try(func() []byte {
+		return tx.MustResult().MustTransactionHash().MustValue()
+	})
+	if err != nil {
+		return xdr.Hash{}, fmt.Errorf("views: tx hash: %w", err)
+	}
+	return xdr.Hash(hb), nil
+}

--- a/cmd/stellar-rpc/internal/fullhistory/views/doc.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/doc.go
@@ -1,0 +1,37 @@
+// Package views holds zero-copy XDR-view extractors that turn a raw
+// LedgerCloseMeta (wire bytes, wrapped as xdr.LedgerCloseMetaView) into
+// the per-type shapes the full-history ingestion pipeline writes —
+// without ever calling lcm.UnmarshalBinary or any per-element
+// MarshalBinary. Each extractor walks the SDK's generated view
+// accessors (xdr.LedgerCloseMetaView and friends), which slice directly
+// into the input buffer, and copies out only the small scalars it
+// needs.
+//
+// These extractors build rpc-side shapes (events.Payload,
+// txhash.Entry, the package-local Transaction), so they live here in
+// the rpc tree rather than in the SDK. The SDK already provides the
+// zero-copy view navigation types (xdr.LedgerCloseMetaView is a []byte
+// alias); this package composes them into product-specific extraction.
+// Nothing in this package belongs in the SDK. The read-path extractors
+// deliberately return a package-local Transaction rather than
+// internal/db.Transaction so views stays a clean leaf (no inversion of
+// the db → views layering).
+//
+// Four extractors are provided:
+//
+//   - ExtractEvents — ingestion: one events.Payload per emitted
+//     contract event (V1/V2 LCM only).
+//   - ExtractTxHashes — ingestion: every tx hash in apply order
+//     (V0/V1/V2 LCM).
+//   - ExtractTxDetailsByHash — read path (getTransaction): the
+//     materialized Transaction for one hash (V0/V1/V2 LCM).
+//   - ExtractTransactions — read path (paginated getTransactions): a
+//     page of Transactions in apply order from a start index
+//     (V0/V1/V2 LCM).
+//
+// Buffer-lifetime contract: extractors that return slices aliasing the
+// view buffer document it on the function (e.g. ExtractEvents's
+// ContractEventBytes; the raw Envelope/Result/Meta/event fields of
+// Transaction). ExtractTxHashes copies its hashes, so its result is
+// independent of the view buffer.
+package views

--- a/cmd/stellar-rpc/internal/fullhistory/views/doc.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/doc.go
@@ -34,4 +34,16 @@
 // ContractEventBytes; the raw Envelope/Result/Meta/event fields of
 // Transaction). ExtractTxHashes copies its hashes, so its result is
 // independent of the view buffer.
+//
+// Trusted-input invariant (TransactionMeta V3): stellar-core only attaches
+// SorobanMeta to Soroban transactions, so "SorobanMeta present ⟺ soroban
+// tx" holds for any LCM core emits. ExtractEvents relies on this invariant
+// directly — it has no envelope in hand and emits V3 SorobanMeta.Events
+// whenever SorobanMeta is present. The read-path extractors pair each tx
+// with its envelope anyway (for the Envelope field), so they additionally
+// gate V3 contract events on the envelope's soroban-ness
+// (gateV3ContractEvents), matching the struct path's IsSorobanTx check in
+// GetTransactionEvents. On an LCM that violates the invariant the events
+// index and the transaction read path would disagree about the same
+// transaction; such input is outside this package's contract.
 package views

--- a/cmd/stellar-rpc/internal/fullhistory/views/envelopes.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/envelopes.go
@@ -22,9 +22,9 @@ type envPart struct {
 }
 
 // envPartFromView decodes the envelope view into an envPart: the RETURNED raw
-// bytes stay the zero-copy .Raw() slice; the binary decode is transient and
-// used only to compute the transaction hash (the map key the TxProcessing
-// entries reference). Mirrors ingest.LedgerTransactionReader.storeTransactions,
+// bytes stay the zero-copy .Raw() slice; the binary decode feeds the
+// transaction hash (the map key the TxProcessing entries reference), the
+// envelope type, and the soroban flag. Mirrors ingest.LedgerTransactionReader.storeTransactions,
 // which hashes every TxSet envelope (via network.HashTransactionInEnvelope,
 // which handles the fee-bump case) because the TxSet is in agreed-set /
 // hash-sorted order, NOT TxProcessing apply order.
@@ -33,10 +33,13 @@ func envPartFromView(env xdr.TransactionEnvelopeView, passphrase string) (envPar
 	if err != nil {
 		return envPart{}, fmt.Errorf("views: envelope.Raw: %w", err)
 	}
-	// Transient decode purely to compute the hash; the returned raw slice is
-	// the original zero-copy .Raw() view buffer, not this decoded value. The
-	// type and soroban flag are read off this decode too (we have it in hand),
-	// rather than via a separate view traversal.
+	// Decode once and read everything we need off it: the transaction hash
+	// (network.HashTransactionInEnvelope needs a decoded envelope — it builds
+	// the tx-hash preimage, not a hash of the raw bytes), the envelope type,
+	// and the soroban flag (which must inspect Tx.Ext). The decode is required
+	// regardless for isSoroban, so hashing piggybacks on it rather than being
+	// extra work. The RETURNED raw slice stays the zero-copy .Raw() view
+	// buffer, not this decoded value.
 	var decoded xdr.TransactionEnvelope
 	if uerr := decoded.UnmarshalBinary(raw); uerr != nil {
 		return envPart{}, fmt.Errorf("views: envelope decode for hashing: %w", uerr)

--- a/cmd/stellar-rpc/internal/fullhistory/views/envelopes.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/envelopes.go
@@ -33,16 +33,10 @@ func envPartFromView(env xdr.TransactionEnvelopeView, passphrase string) (envPar
 	if err != nil {
 		return envPart{}, fmt.Errorf("views: envelope.Raw: %w", err)
 	}
-	tv, err := env.Type()
-	if err != nil {
-		return envPart{}, fmt.Errorf("views: envelope.Type: %w", err)
-	}
-	t, err := tv.Value()
-	if err != nil {
-		return envPart{}, fmt.Errorf("views: envelope.Type value: %w", err)
-	}
 	// Transient decode purely to compute the hash; the returned raw slice is
-	// the original zero-copy .Raw() view buffer, not this decoded value.
+	// the original zero-copy .Raw() view buffer, not this decoded value. The
+	// type and soroban flag are read off this decode too (we have it in hand),
+	// rather than via a separate view traversal.
 	var decoded xdr.TransactionEnvelope
 	if uerr := decoded.UnmarshalBinary(raw); uerr != nil {
 		return envPart{}, fmt.Errorf("views: envelope decode for hashing: %w", uerr)
@@ -51,7 +45,7 @@ func envPartFromView(env xdr.TransactionEnvelopeView, passphrase string) (envPar
 	if err != nil {
 		return envPart{}, fmt.Errorf("views: hash envelope: %w", err)
 	}
-	return envPart{raw: raw, typ: t, hash: hash, isSoroban: envelopeIsSoroban(decoded)}, nil
+	return envPart{raw: raw, typ: decoded.Type, hash: hash, isSoroban: envelopeIsSoroban(decoded)}, nil
 }
 
 // envelopeIsSoroban mirrors ingest.LedgerTransaction.IsSorobanTx /

--- a/cmd/stellar-rpc/internal/fullhistory/views/envelopes.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/envelopes.go
@@ -1,7 +1,12 @@
 package views
 
 import (
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
 	"fmt"
+	"hash"
+	"strings"
 
 	"github.com/stellar/go-stellar-sdk/network"
 	"github.com/stellar/go-stellar-sdk/xdr"
@@ -9,11 +14,11 @@ import (
 
 // envPart is one envelope (raw bytes + type) gathered while enumerating a
 // TxSet. raw aliases the view buffer (zero-copy). hash is the transaction
-// hash computed from the envelope under the network passphrase — the key the
-// TxProcessing entries reference. isSoroban mirrors
-// ingest.LedgerTransaction.IsSorobanTx (computed from the SAME transient decode
-// used for hashing), used by the read path to gate V3 contract events the way
-// the struct path does.
+// hash computed from the envelope wire bytes under the network passphrase —
+// the key the TxProcessing entries reference. isSoroban mirrors
+// ingest.LedgerTransaction.IsSorobanTx (read from the inner Tx.Ext view
+// discriminant), used by the read path to gate V3 contract events the way
+// the struct path does (see the trusted-input invariant in doc.go).
 type envPart struct {
 	raw       []byte
 	typ       xdr.EnvelopeType
@@ -21,69 +26,118 @@ type envPart struct {
 	isSoroban bool
 }
 
-// envPartFromView decodes the envelope view into an envPart: the RETURNED raw
-// bytes stay the zero-copy .Raw() slice; the binary decode feeds the
-// transaction hash (the map key the TxProcessing entries reference), the
-// envelope type, and the soroban flag. Mirrors ingest.LedgerTransactionReader.storeTransactions,
-// which hashes every TxSet envelope (via network.HashTransactionInEnvelope,
-// which handles the fee-bump case) because the TxSet is in agreed-set /
-// hash-sorted order, NOT TxProcessing apply order.
-func envPartFromView(env xdr.TransactionEnvelopeView, passphrase string) (envPart, error) {
-	raw, err := env.Raw()
-	if err != nil {
-		return envPart{}, fmt.Errorf("views: envelope.Raw: %w", err)
-	}
-	// Decode once and read everything we need off it: the transaction hash
-	// (network.HashTransactionInEnvelope needs a decoded envelope — it builds
-	// the tx-hash preimage, not a hash of the raw bytes), the envelope type,
-	// and the soroban flag (which must inspect Tx.Ext). The decode is required
-	// regardless for isSoroban, so hashing piggybacks on it rather than being
-	// extra work. The RETURNED raw slice stays the zero-copy .Raw() view
-	// buffer, not this decoded value.
-	var decoded xdr.TransactionEnvelope
-	if uerr := decoded.UnmarshalBinary(raw); uerr != nil {
-		return envPart{}, fmt.Errorf("views: envelope decode for hashing: %w", uerr)
-	}
-	hash, err := network.HashTransactionInEnvelope(decoded, passphrase)
-	if err != nil {
-		return envPart{}, fmt.Errorf("views: hash envelope: %w", err)
-	}
-	return envPart{raw: raw, typ: decoded.Type, hash: hash, isSoroban: envelopeIsSoroban(decoded)}, nil
+// txHasher computes transaction hashes straight from envelope view bytes.
+// The tx-hash preimage is
+//
+//	SHA256(networkID ‖ envelope-type tag (4 bytes) ‖ Transaction XDR)
+//
+// — exactly what network.HashTransactionInEnvelope produces — and every
+// piece is available as a wire-byte slice off the view, so no envelope
+// decode is needed. The network ID is computed once per extraction and the
+// SHA-256 state is reused, so hashing allocates nothing per envelope.
+type txHasher struct {
+	networkID [32]byte
+	h         hash.Hash
 }
 
-// envelopeIsSoroban mirrors ingest.LedgerTransaction.IsSorobanTx /
-// GetSorobanData: a tx is Soroban iff its (inner, for fee-bump) tx envelope
-// carries SorobanTransactionData in its Ext. Only the v1 Tx and fee-bump inner
-// v1 Tx shapes can carry Soroban data; every other envelope type is classic.
-//
-// NB: the Tx -> V1.Tx.Ext.GetSorobanData (and fee-bump -> inner) access path
-// here mirrors the SDK's ingest.LedgerTransaction.IsSorobanTx/GetSorobanData;
-// if the SDK ever relocates where soroban-data lives, this is a known drift
-// point to update in lockstep.
-func envelopeIsSoroban(env xdr.TransactionEnvelope) bool {
-	switch env.Type {
-	case xdr.EnvelopeTypeEnvelopeTypeTx:
-		_, ok := env.V1.Tx.Ext.GetSorobanData()
-		return ok
-	case xdr.EnvelopeTypeEnvelopeTypeTxFeeBump:
-		_, ok := env.FeeBump.Tx.InnerTx.V1.Tx.Ext.GetSorobanData()
-		return ok
-	default:
-		return false
+// newTxHasher derives the network ID from passphrase. The empty-passphrase
+// guard matches network.hashTx's, surfaced once per extraction instead of
+// once per envelope.
+func newTxHasher(passphrase string) (*txHasher, error) {
+	if strings.TrimSpace(passphrase) == "" {
+		return nil, errors.New("views: empty network passphrase")
 	}
+	return &txHasher{networkID: network.ID(passphrase), h: sha256.New()}, nil
+}
+
+// sum computes SHA256(networkID ‖ tag ‖ parts...).
+func (th *txHasher) sum(tag xdr.EnvelopeType, parts ...[]byte) [32]byte {
+	th.h.Reset()
+	th.h.Write(th.networkID[:])
+	var tagBuf [4]byte
+	binary.BigEndian.PutUint32(tagBuf[:], uint32(tag)) //nolint:gosec // enum tag is small and non-negative
+	th.h.Write(tagBuf[:])
+	for _, p := range parts {
+		th.h.Write(p)
+	}
+	var out [32]byte
+	th.h.Sum(out[:0])
+	return out
+}
+
+// ed25519KeyTypePrefix is the 4-byte XDR discriminant
+// CryptoKeyTypeKeyTypeEd25519 (0) that converting a TransactionV0 to a
+// Transaction prepends to the source account key on the wire.
+var ed25519KeyTypePrefix = [4]byte{0, 0, 0, 0}
+
+// envPartFromView reads one envelope view into an envPart without decoding
+// the envelope: the type comes from the union discriminant view, the
+// transaction hash is computed by th straight from the inner transaction's
+// wire bytes, and the soroban flag is read from the inner Tx.Ext view. The
+// returned raw slice stays the zero-copy .Raw() view buffer.
+//
+// A TX_V0 envelope hashes as its V1 conversion (network.HashTransactionV0):
+// on the wire that conversion is exactly the 4-byte ed25519 key-type prefix
+// followed by the unchanged TransactionV0 bytes — the V0 optional-TimeBounds
+// and V1 Preconditions encodings are identical (absent ⇒ 0 ⇒ PRECOND_NONE,
+// present ⇒ 1 + TimeBounds ⇒ PRECOND_TIME), as are all fields after them
+// (both Ext arms are void).
+func envPartFromView(env xdr.TransactionEnvelopeView, th *txHasher) (envPart, error) {
+	typ, err := xdr.Try(func() xdr.EnvelopeType { return env.MustType().MustValue() })
+	if err != nil {
+		return envPart{}, fmt.Errorf("views: envelope type: %w", err)
+	}
+	switch typ {
+	case xdr.EnvelopeTypeEnvelopeTypeTx,
+		xdr.EnvelopeTypeEnvelopeTypeTxV0,
+		xdr.EnvelopeTypeEnvelopeTypeTxFeeBump:
+	default:
+		return envPart{}, fmt.Errorf("views: invalid transaction envelope type %v", typ)
+	}
+	p := envPart{typ: typ}
+	err = xdr.TryVoid(func() {
+		p.raw = env.MustRaw()
+		switch typ {
+		case xdr.EnvelopeTypeEnvelopeTypeTx:
+			tx := env.MustV1().MustTx()
+			p.hash = th.sum(typ, tx.MustRaw())
+			p.isSoroban = txExtIsSoroban(tx)
+		case xdr.EnvelopeTypeEnvelopeTypeTxV0:
+			p.hash = th.sum(xdr.EnvelopeTypeEnvelopeTypeTx,
+				ed25519KeyTypePrefix[:], env.MustV0().MustTx().MustRaw())
+		case xdr.EnvelopeTypeEnvelopeTypeTxFeeBump:
+			fbTx := env.MustFeeBump().MustTx()
+			p.hash = th.sum(typ, fbTx.MustRaw())
+			// IsSorobanTx inspects the fee-bump INNER transaction.
+			p.isSoroban = txExtIsSoroban(fbTx.MustInnerTx().MustV1().MustTx())
+		}
+	})
+	if err != nil {
+		return envPart{}, fmt.Errorf("views: envelope (%v): %w", typ, err)
+	}
+	return p, nil
+}
+
+// txExtIsSoroban reads Tx.Ext's union discriminant (1 ⟺
+// SorobanTransactionData present), mirroring
+// ingest.LedgerTransaction.IsSorobanTx / GetSorobanData. Must-style: panics
+// with *xdr.ViewError on malformed input, recovered by the caller's TryVoid.
+func txExtIsSoroban(tx xdr.TransactionView) bool {
+	return tx.MustExt().MustV().MustValue() == 1
 }
 
 // envYield is the per-envelope sink the TxSet enumerators drive. It is
 // called once per envelope (in agreed-set order, NOT TxProcessing apply
 // order); returning stop==true ends enumeration early (used by the
-// by-hash lookup once it finds its target), returning an error aborts it.
+// by-hash lookups once every wanted hash is resolved), returning an error
+// aborts it.
 type envYield func(envPart) (stop bool, err error)
 
 // enumerateEnvelopesFromV0TxSet walks a V0 TransactionSet, invoking yield for
 // every envelope. The TxSet is in agreed-set order (NOT TxProcessing apply
 // order); callers pair envelopes to transactions by hash, so enumeration order
 // is irrelevant here. Returns stopped==true if yield asked to stop early.
-func enumerateEnvelopesFromV0TxSet(txSet xdr.TransactionSetView, passphrase string, yield envYield) (stopped bool, err error) {
+func enumerateEnvelopesFromV0TxSet(txSet xdr.TransactionSetView, th *txHasher, yield envYield) (stopped bool, err error) {
 	txs, err := txSet.Txs()
 	if err != nil {
 		return false, fmt.Errorf("views: V0 TxSet.Txs: %w", err)
@@ -93,7 +147,7 @@ func enumerateEnvelopesFromV0TxSet(txSet xdr.TransactionSetView, passphrase stri
 		if eerr != nil {
 			return false, fmt.Errorf("views: V0 envelope at %d: %w", i, eerr)
 		}
-		p, perr := envPartFromView(env, passphrase)
+		p, perr := envPartFromView(env, th)
 		if perr != nil {
 			return false, perr
 		}
@@ -114,7 +168,7 @@ func enumerateEnvelopesFromV0TxSet(txSet xdr.TransactionSetView, passphrase stri
 // Like the V0 walker, the order is the agreed-set order (NOT TxProcessing apply
 // order); pairing is by hash so order does not matter. Returns stopped==true if
 // yield asked to stop early.
-func enumerateEnvelopesFromGeneralized(txSet xdr.GeneralizedTransactionSetView, passphrase string, yield envYield) (stopped bool, err error) {
+func enumerateEnvelopesFromGeneralized(txSet xdr.GeneralizedTransactionSetView, th *txHasher, yield envYield) (stopped bool, err error) {
 	v1Set, err := txSet.V1TxSet()
 	if err != nil {
 		return false, fmt.Errorf("views: V1TxSet: %w", err)
@@ -141,7 +195,7 @@ func enumerateEnvelopesFromGeneralized(txSet xdr.GeneralizedTransactionSetView, 
 			if err != nil {
 				return false, fmt.Errorf("views: V0Components: %w", err)
 			}
-			stop, err := enumerateV0Components(comps, passphrase, yield)
+			stop, err := enumerateV0Components(comps, th, yield)
 			if err != nil {
 				return false, err
 			}
@@ -153,7 +207,7 @@ func enumerateEnvelopesFromGeneralized(txSet xdr.GeneralizedTransactionSetView, 
 			if err != nil {
 				return false, fmt.Errorf("views: ParallelTxsComponent: %w", err)
 			}
-			stop, err := enumerateParallelTxs(ptx, passphrase, yield)
+			stop, err := enumerateParallelTxs(ptx, th, yield)
 			if err != nil {
 				return false, err
 			}
@@ -170,7 +224,7 @@ func enumerateEnvelopesFromGeneralized(txSet xdr.GeneralizedTransactionSetView, 
 // enumerateV0Components invokes yield for every envelope in V0-style phase
 // components (one component per fee group). Returns stopped==true if yield
 // asked to stop early.
-func enumerateV0Components(comps xdr.TransactionPhaseV0ComponentsView, passphrase string, yield envYield) (stopped bool, err error) {
+func enumerateV0Components(comps xdr.TransactionPhaseV0ComponentsView, th *txHasher, yield envYield) (stopped bool, err error) {
 	for comp, cerr := range comps.Iter() {
 		if cerr != nil {
 			return false, fmt.Errorf("views: component iter: %w", cerr)
@@ -187,7 +241,7 @@ func enumerateV0Components(comps xdr.TransactionPhaseV0ComponentsView, passphras
 			if eerr != nil {
 				return false, fmt.Errorf("views: component envelope iter: %w", eerr)
 			}
-			p, perr := envPartFromView(env, passphrase)
+			p, perr := envPartFromView(env, th)
 			if perr != nil {
 				return false, perr
 			}
@@ -206,7 +260,7 @@ func enumerateV0Components(comps xdr.TransactionPhaseV0ComponentsView, passphras
 // enumerateParallelTxs invokes yield for every envelope in V1-style parallel-txs
 // (stages -> clusters -> txs). Returns stopped==true if yield asked to stop
 // early.
-func enumerateParallelTxs(ptx xdr.ParallelTxsComponentView, passphrase string, yield envYield) (stopped bool, err error) {
+func enumerateParallelTxs(ptx xdr.ParallelTxsComponentView, th *txHasher, yield envYield) (stopped bool, err error) {
 	stages, err := ptx.ExecutionStages()
 	if err != nil {
 		return false, fmt.Errorf("views: ExecutionStages: %w", err)
@@ -223,7 +277,7 @@ func enumerateParallelTxs(ptx xdr.ParallelTxsComponentView, passphrase string, y
 				if eerr != nil {
 					return false, fmt.Errorf("views: cluster envelope iter: %w", eerr)
 				}
-				p, perr := envPartFromView(env, passphrase)
+				p, perr := envPartFromView(env, th)
 				if perr != nil {
 					return false, perr
 				}

--- a/cmd/stellar-rpc/internal/fullhistory/views/envelopes.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/envelopes.go
@@ -1,0 +1,244 @@
+package views
+
+import (
+	"fmt"
+
+	"github.com/stellar/go-stellar-sdk/network"
+	"github.com/stellar/go-stellar-sdk/xdr"
+)
+
+// envPart is one envelope (raw bytes + type) gathered while enumerating a
+// TxSet. raw aliases the view buffer (zero-copy). hash is the transaction
+// hash computed from the envelope under the network passphrase — the key the
+// TxProcessing entries reference. isSoroban mirrors
+// ingest.LedgerTransaction.IsSorobanTx (computed from the SAME transient decode
+// used for hashing), used by the read path to gate V3 contract events the way
+// the struct path does.
+type envPart struct {
+	raw       []byte
+	typ       xdr.EnvelopeType
+	hash      [32]byte
+	isSoroban bool
+}
+
+// envPartFromView decodes the envelope view into an envPart: the RETURNED raw
+// bytes stay the zero-copy .Raw() slice; the binary decode is transient and
+// used only to compute the transaction hash (the map key the TxProcessing
+// entries reference). Mirrors ingest.LedgerTransactionReader.storeTransactions,
+// which hashes every TxSet envelope (via network.HashTransactionInEnvelope,
+// which handles the fee-bump case) because the TxSet is in agreed-set /
+// hash-sorted order, NOT TxProcessing apply order.
+func envPartFromView(env xdr.TransactionEnvelopeView, passphrase string) (envPart, error) {
+	raw, err := env.Raw()
+	if err != nil {
+		return envPart{}, fmt.Errorf("views: envelope.Raw: %w", err)
+	}
+	tv, err := env.Type()
+	if err != nil {
+		return envPart{}, fmt.Errorf("views: envelope.Type: %w", err)
+	}
+	t, err := tv.Value()
+	if err != nil {
+		return envPart{}, fmt.Errorf("views: envelope.Type value: %w", err)
+	}
+	// Transient decode purely to compute the hash; the returned raw slice is
+	// the original zero-copy .Raw() view buffer, not this decoded value.
+	var decoded xdr.TransactionEnvelope
+	if uerr := decoded.UnmarshalBinary(raw); uerr != nil {
+		return envPart{}, fmt.Errorf("views: envelope decode for hashing: %w", uerr)
+	}
+	hash, err := network.HashTransactionInEnvelope(decoded, passphrase)
+	if err != nil {
+		return envPart{}, fmt.Errorf("views: hash envelope: %w", err)
+	}
+	return envPart{raw: raw, typ: t, hash: hash, isSoroban: envelopeIsSoroban(decoded)}, nil
+}
+
+// envelopeIsSoroban mirrors ingest.LedgerTransaction.IsSorobanTx /
+// GetSorobanData: a tx is Soroban iff its (inner, for fee-bump) tx envelope
+// carries SorobanTransactionData in its Ext. Only the v1 Tx and fee-bump inner
+// v1 Tx shapes can carry Soroban data; every other envelope type is classic.
+//
+// NB: the Tx -> V1.Tx.Ext.GetSorobanData (and fee-bump -> inner) access path
+// here mirrors the SDK's ingest.LedgerTransaction.IsSorobanTx/GetSorobanData;
+// if the SDK ever relocates where soroban-data lives, this is a known drift
+// point to update in lockstep.
+func envelopeIsSoroban(env xdr.TransactionEnvelope) bool {
+	switch env.Type {
+	case xdr.EnvelopeTypeEnvelopeTypeTx:
+		_, ok := env.V1.Tx.Ext.GetSorobanData()
+		return ok
+	case xdr.EnvelopeTypeEnvelopeTypeTxFeeBump:
+		_, ok := env.FeeBump.Tx.InnerTx.V1.Tx.Ext.GetSorobanData()
+		return ok
+	default:
+		return false
+	}
+}
+
+// envYield is the per-envelope sink the TxSet enumerators drive. It is
+// called once per envelope (in agreed-set order, NOT TxProcessing apply
+// order); returning stop==true ends enumeration early (used by the
+// by-hash lookup once it finds its target), returning an error aborts it.
+type envYield func(envPart) (stop bool, err error)
+
+// enumerateEnvelopesFromV0TxSet walks a V0 TransactionSet, invoking yield for
+// every envelope. The TxSet is in agreed-set order (NOT TxProcessing apply
+// order); callers pair envelopes to transactions by hash, so enumeration order
+// is irrelevant here. Returns stopped==true if yield asked to stop early.
+func enumerateEnvelopesFromV0TxSet(txSet xdr.TransactionSetView, passphrase string, yield envYield) (stopped bool, err error) {
+	txs, err := txSet.Txs()
+	if err != nil {
+		return false, fmt.Errorf("views: V0 TxSet.Txs: %w", err)
+	}
+	i := 0
+	for env, eerr := range txs.Iter() {
+		if eerr != nil {
+			return false, fmt.Errorf("views: V0 envelope at %d: %w", i, eerr)
+		}
+		p, perr := envPartFromView(env, passphrase)
+		if perr != nil {
+			return false, perr
+		}
+		stop, yerr := yield(p)
+		if yerr != nil {
+			return false, yerr
+		}
+		if stop {
+			return true, nil
+		}
+		i++
+	}
+	return false, nil
+}
+
+// enumerateEnvelopesFromGeneralized walks a V1/V2 GeneralizedTransactionSet
+// (phases -> components/clusters -> txs), invoking yield for every envelope.
+// Like the V0 walker, the order is the agreed-set order (NOT TxProcessing apply
+// order); pairing is by hash so order does not matter. Returns stopped==true if
+// yield asked to stop early.
+func enumerateEnvelopesFromGeneralized(txSet xdr.GeneralizedTransactionSetView, passphrase string, yield envYield) (stopped bool, err error) {
+	v1Set, err := txSet.V1TxSet()
+	if err != nil {
+		return false, fmt.Errorf("views: V1TxSet: %w", err)
+	}
+	phases, err := v1Set.Phases()
+	if err != nil {
+		return false, fmt.Errorf("views: Phases: %w", err)
+	}
+	for phase, perr := range phases.Iter() {
+		if perr != nil {
+			return false, fmt.Errorf("views: phase iter: %w", perr)
+		}
+		pv, err := phase.V()
+		if err != nil {
+			return false, fmt.Errorf("views: phase.V: %w", err)
+		}
+		pDisc, err := pv.Value()
+		if err != nil {
+			return false, fmt.Errorf("views: phase.V value: %w", err)
+		}
+		switch pDisc {
+		case 0:
+			comps, err := phase.V0Components()
+			if err != nil {
+				return false, fmt.Errorf("views: V0Components: %w", err)
+			}
+			stop, err := enumerateV0Components(comps, passphrase, yield)
+			if err != nil {
+				return false, err
+			}
+			if stop {
+				return true, nil
+			}
+		case 1:
+			ptx, err := phase.ParallelTxsComponent()
+			if err != nil {
+				return false, fmt.Errorf("views: ParallelTxsComponent: %w", err)
+			}
+			stop, err := enumerateParallelTxs(ptx, passphrase, yield)
+			if err != nil {
+				return false, err
+			}
+			if stop {
+				return true, nil
+			}
+		default:
+			return false, fmt.Errorf("views: unknown TransactionPhase V=%d", pDisc)
+		}
+	}
+	return false, nil
+}
+
+// enumerateV0Components invokes yield for every envelope in V0-style phase
+// components (one component per fee group). Returns stopped==true if yield
+// asked to stop early.
+func enumerateV0Components(comps xdr.TransactionPhaseV0ComponentsView, passphrase string, yield envYield) (stopped bool, err error) {
+	for comp, cerr := range comps.Iter() {
+		if cerr != nil {
+			return false, fmt.Errorf("views: component iter: %w", cerr)
+		}
+		tdf, err := comp.TxsMaybeDiscountedFee()
+		if err != nil {
+			return false, fmt.Errorf("views: TxsMaybeDiscountedFee: %w", err)
+		}
+		txs, err := tdf.Txs()
+		if err != nil {
+			return false, fmt.Errorf("views: component Txs: %w", err)
+		}
+		for env, eerr := range txs.Iter() {
+			if eerr != nil {
+				return false, fmt.Errorf("views: component envelope iter: %w", eerr)
+			}
+			p, perr := envPartFromView(env, passphrase)
+			if perr != nil {
+				return false, perr
+			}
+			stop, yerr := yield(p)
+			if yerr != nil {
+				return false, yerr
+			}
+			if stop {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// enumerateParallelTxs invokes yield for every envelope in V1-style parallel-txs
+// (stages -> clusters -> txs). Returns stopped==true if yield asked to stop
+// early.
+func enumerateParallelTxs(ptx xdr.ParallelTxsComponentView, passphrase string, yield envYield) (stopped bool, err error) {
+	stages, err := ptx.ExecutionStages()
+	if err != nil {
+		return false, fmt.Errorf("views: ExecutionStages: %w", err)
+	}
+	for stage, serr := range stages.Iter() {
+		if serr != nil {
+			return false, fmt.Errorf("views: stage iter: %w", serr)
+		}
+		for cluster, cerr := range stage.Iter() {
+			if cerr != nil {
+				return false, fmt.Errorf("views: cluster iter: %w", cerr)
+			}
+			for env, eerr := range cluster.Iter() {
+				if eerr != nil {
+					return false, fmt.Errorf("views: cluster envelope iter: %w", eerr)
+				}
+				p, perr := envPartFromView(env, passphrase)
+				if perr != nil {
+					return false, perr
+				}
+				stop, yerr := yield(p)
+				if yerr != nil {
+					return false, yerr
+				}
+				if stop {
+					return true, nil
+				}
+			}
+		}
+	}
+	return false, nil
+}

--- a/cmd/stellar-rpc/internal/fullhistory/views/events.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/events.go
@@ -41,7 +41,9 @@ var ErrV0Unsupported = errors.New("views: LCM V0 carries no contract events (cal
 // Supported shapes:
 //
 //   - LCM V1, V2 (apply order = TxProcessing array order)
-//   - TransactionMeta V1, V2 (no events, skipped)
+//   - TransactionMeta V0, V1, V2 (no events, skipped; V0 is legacy
+//     pre-Soroban meta that the SDK reference path rejects but full-history
+//     backfill must tolerate)
 //   - TransactionMeta V3 (SorobanMeta.Events as op-0 events; no
 //     top-level TransactionEvents in V3)
 //   - TransactionMeta V4 (top-level Events + Operations[i].Events)
@@ -209,30 +211,43 @@ func (it txProcIter[E]) iter() func(yield func(txResultMetaView, error) bool) {
 // readLedgerHeader extracts (LedgerSequence, LedgerCloseTime) from a
 // LedgerHeaderHistoryEntryView via the same path xdr.LedgerCloseMeta's
 // LedgerSequence/LedgerCloseTime helpers use, but staying view-side.
+// viewChain threads a single error through a sequence of zero-copy view
+// accessors. Once any step fails, later steps short-circuit and the first
+// (labeled) error is retained — collapsing the repeated
+// `v, err := f(); if err != nil { return wrap(err) }` ladder that view
+// navigation otherwise requires into a declarative sequence plus one terminal
+// check. This is the package-local stand-in for the fluent `.HeaderW().…W()`
+// chaining wished for in review; a true fluent API would need SDK-generated
+// wrapper types.
+type viewChain struct{ err error }
+
+// step runs one view accessor f under chain c: if a prior step already failed
+// it returns the zero value without calling f; otherwise it returns f's value,
+// recording (and labeling, under the "views:" prefix) the first error in c. f
+// is typically a method value such as `header.Header` or `seqView.Value`.
+func step[T any](c *viewChain, label string, f func() (T, error)) T {
+	var zero T
+	if c.err != nil {
+		return zero
+	}
+	v, err := f()
+	if err != nil {
+		c.err = fmt.Errorf("views: %s: %w", label, err)
+		return zero
+	}
+	return v
+}
+
 func readLedgerHeader(header xdr.LedgerHeaderHistoryEntryView) (uint32, int64, error) {
-	inner, err := header.Header()
-	if err != nil {
-		return 0, 0, fmt.Errorf("views: Header.Header: %w", err)
-	}
-	seqView, err := inner.LedgerSeq()
-	if err != nil {
-		return 0, 0, fmt.Errorf("views: LedgerSeq: %w", err)
-	}
-	seqVal, err := seqView.Value()
-	if err != nil {
-		return 0, 0, fmt.Errorf("views: LedgerSeq value: %w", err)
-	}
-	scp, err := inner.ScpValue()
-	if err != nil {
-		return 0, 0, fmt.Errorf("views: ScpValue: %w", err)
-	}
-	ctView, err := scp.CloseTime()
-	if err != nil {
-		return 0, 0, fmt.Errorf("views: CloseTime: %w", err)
-	}
-	ctVal, err := ctView.Value()
-	if err != nil {
-		return 0, 0, fmt.Errorf("views: CloseTime value: %w", err)
+	var c viewChain
+	inner := step(&c, "Header.Header", header.Header)
+	seqView := step(&c, "LedgerSeq", inner.LedgerSeq)
+	seqVal := step(&c, "LedgerSeq value", seqView.Value)
+	scp := step(&c, "ScpValue", inner.ScpValue)
+	ctView := step(&c, "CloseTime", scp.CloseTime)
+	ctVal := step(&c, "CloseTime value", ctView.Value)
+	if c.err != nil {
+		return 0, 0, c.err
 	}
 	return seqVal, int64(ctVal), nil //nolint:gosec // TimePoint is uint64
 }
@@ -240,22 +255,17 @@ func readLedgerHeader(header xdr.LedgerHeaderHistoryEntryView) (uint32, int64, e
 // readTxHash extracts the 32-byte TransactionHash from a TxProcessing
 // entry view (TransactionResultPair.TransactionHash).
 func readTxHash(tx txResultMetaView) (xdr.Hash, error) {
-	var h xdr.Hash
-	rp, err := tx.Result()
-	if err != nil {
-		return h, fmt.Errorf("views: Result: %w", err)
-	}
-	hv, err := rp.TransactionHash()
-	if err != nil {
-		return h, fmt.Errorf("views: TransactionHash: %w", err)
-	}
-	hb, err := hv.Value()
-	if err != nil {
-		return h, fmt.Errorf("views: TransactionHash value: %w", err)
+	var c viewChain
+	rp := step(&c, "Result", tx.Result)
+	hv := step(&c, "TransactionHash", rp.TransactionHash)
+	hb := step(&c, "TransactionHash value", hv.Value)
+	if c.err != nil {
+		return xdr.Hash{}, c.err
 	}
 	if len(hb) != 32 {
-		return h, fmt.Errorf("views: tx hash length %d != 32", len(hb))
+		return xdr.Hash{}, fmt.Errorf("views: tx hash length %d != 32", len(hb))
 	}
+	var h xdr.Hash
 	copy(h[:], hb)
 	return h, nil
 }
@@ -279,7 +289,13 @@ func payloadsFromTxView(tx txResultMetaView, state *txWalkState, dst []events.Pa
 	}
 
 	switch v {
-	case 1, 2:
+	case 0, 1, 2:
+		// V0 (legacy pre-Soroban, Operations only), V1, V2 carry no contract
+		// events. NB: the struct reference path (LCMToPayloads via the SDK's
+		// GetTransactionEvents) actually ERRORS on meta V0 ("unsupported
+		// TransactionMeta version: 0") — full-history backfills from genesis and
+		// must tolerate legacy V0 meta, so this path is deliberately more
+		// permissive than the reference and treats V0 as event-free.
 		return dst, nil
 	case 3:
 		return payloadsFromV3SorobanMeta(metaView, state, dst)

--- a/cmd/stellar-rpc/internal/fullhistory/views/events.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/events.go
@@ -1,0 +1,460 @@
+package views
+
+import (
+	"errors"
+	"fmt"
+	"iter"
+
+	"github.com/stellar/go-stellar-sdk/toid"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/events"
+)
+
+// ErrV0Unsupported is returned by ExtractEvents on an LCM with
+// discriminator V0. V0 (pre-Soroban) ledgers carry no contract events at
+// all, so the events extractor has nothing to produce; it signals callers
+// to skip / fall back (events.LCMToPayloads) rather than emit an empty
+// result that could be confused with a genuinely event-free V1+ ledger.
+// (This sentinel is NOT about apply order: the package treats TxProcessing
+// order as apply order for every version, and ExtractTransactions derives
+// V0 ApplicationOrder directly from the TxProcessing index.)
+var ErrV0Unsupported = errors.New("views: LCM V0 carries no contract events (caller should skip / fall back)")
+
+// ExtractEvents walks a zero-copy LedgerCloseMetaView and returns one
+// events.Payload per emitted contract event, in the same chronological
+// order as the parsed path (events.LCMToPayloads). ContractEventBytes
+// aliases the view buffer (zero-copy); callers must copy what they
+// retain. Returns ErrV0Unsupported for V0 LCMs.
+//
+// The produced Payloads carry only ContractEventBytes (the raw event
+// XDR) and the scalar metadata fields — term keys are NOT precomputed
+// here; downstream derives them via events.TermsForBytes on the bytes
+// (this matches the current events.Payload API on this branch and the
+// hot store's IngestLedgerEvents, which already calls TermsForBytes).
+//
+// Ordering matches LCMToPayloads exactly: per-tx in apply order; within
+// each tx, top-level TransactionEvents first (V4 only, dispatched on
+// Stage with ledger-wide before/after counters), then per-operation
+// events in (op, event) order.
+//
+// Supported shapes:
+//
+//   - LCM V1, V2 (apply order = TxProcessing array order)
+//   - TransactionMeta V1, V2 (no events, skipped)
+//   - TransactionMeta V3 (SorobanMeta.Events as op-0 events; no
+//     top-level TransactionEvents in V3)
+//   - TransactionMeta V4 (top-level Events + Operations[i].Events)
+func ExtractEvents(lcm xdr.LedgerCloseMetaView) ([]events.Payload, error) {
+	disc, headerView, tp, err := openHeaderAndTxProc(lcm)
+	if err != nil {
+		return nil, err
+	}
+	if disc == 0 {
+		return nil, ErrV0Unsupported
+	}
+
+	ledgerSeq, ledgerClosedAt, err := readLedgerHeader(headerView)
+	if err != nil {
+		return nil, err
+	}
+
+	// Ledger-wide event-index counters for V4 top-level TransactionEvents.
+	// These span the WHOLE ledger (NOT reset per-tx) — matches the
+	// struct path's beforeIndex/afterIndex in LCMToPayloads. The
+	// per-tx AfterTx counter (txAfterIndex) lives inside the loop body.
+	state := txWalkState{
+		ledgerSeq:      ledgerSeq,
+		ledgerClosedAt: ledgerClosedAt,
+	}
+
+	var payloads []events.Payload
+	applyIdx := uint32(0)
+	for tx, iterErr := range tp.iter() {
+		if iterErr != nil {
+			return nil, fmt.Errorf("views: TxProcessing iter: %w", iterErr)
+		}
+		applyIdx++ // 1-based, matching ingest reader's tx.Index
+
+		txHash, err := readTxHash(tx)
+		if err != nil {
+			return nil, err
+		}
+		state.txHash = txHash
+		state.applyIdx = applyIdx
+
+		payloads, err = payloadsFromTxView(tx, &state, payloads)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return payloads, nil
+}
+
+// txWalkState bundles the per-ledger and per-tx state threaded through
+// payloadsFromTxView. The before/after counters span the whole ledger;
+// txHash and applyIdx are reset each iteration of the TxProcessing
+// loop in ExtractEvents.
+type txWalkState struct {
+	ledgerSeq      uint32
+	ledgerClosedAt int64
+	txHash         xdr.Hash
+	applyIdx       uint32 // 1-based, matches ingest reader's tx.Index
+	beforeIndex    uint32 // ledger-wide BeforeAllTxs event counter
+	afterIndex     uint32 // ledger-wide AfterAllTxs event counter
+}
+
+// txProcessingIterable abstracts over the SDK TxProcessing array view
+// types (V0/V1/V2 LCM use distinct generated views) so the dispatch
+// switches above can share the iteration body. All yield a
+// txResultMetaView with the methods we need.
+type txProcessingIterable interface {
+	iter() func(yield func(txResultMetaView, error) bool)
+}
+
+// openHeaderAndTxProc opens an LCM view, reads its version discriminant,
+// and returns the ledger header view + the version-appropriate
+// TxProcessing iterable (apply order). This is the one place the
+// V0/V1/V2 "open header + TxProcessing" dispatch lives; callers branch on
+// the returned disc for version-sensitive behavior (e.g. V0 events are
+// unsupported). The version-specific TxSet open lives elsewhere (the
+// TxSet view types differ and cannot share this path).
+func openHeaderAndTxProc(lcm xdr.LedgerCloseMetaView) (
+	disc int32, header xdr.LedgerHeaderHistoryEntryView, tp txProcessingIterable, err error,
+) {
+	dv, err := lcm.V()
+	if err != nil {
+		return 0, header, nil, fmt.Errorf("views: LCM.V: %w", err)
+	}
+	disc, err = dv.Value()
+	if err != nil {
+		return 0, header, nil, fmt.Errorf("views: LCM.V value: %w", err)
+	}
+
+	switch disc {
+	case 0:
+		v0, err := lcm.V0()
+		if err != nil {
+			return disc, header, nil, fmt.Errorf("views: LCM V0: %w", err)
+		}
+		header, err = v0.LedgerHeader()
+		if err != nil {
+			return disc, header, nil, fmt.Errorf("views: V0 LedgerHeader: %w", err)
+		}
+		raw, err := v0.TxProcessing()
+		if err != nil {
+			return disc, header, nil, fmt.Errorf("views: V0 TxProcessing: %w", err)
+		}
+		return disc, header, txProcIter[xdr.TransactionResultMetaView]{raw.Iter()}, nil
+	case 1:
+		v1, err := lcm.V1()
+		if err != nil {
+			return disc, header, nil, fmt.Errorf("views: LCM V1: %w", err)
+		}
+		header, err = v1.LedgerHeader()
+		if err != nil {
+			return disc, header, nil, fmt.Errorf("views: V1 LedgerHeader: %w", err)
+		}
+		raw, err := v1.TxProcessing()
+		if err != nil {
+			return disc, header, nil, fmt.Errorf("views: V1 TxProcessing: %w", err)
+		}
+		return disc, header, txProcIter[xdr.TransactionResultMetaView]{raw.Iter()}, nil
+	case 2:
+		v2, err := lcm.V2()
+		if err != nil {
+			return disc, header, nil, fmt.Errorf("views: LCM V2: %w", err)
+		}
+		header, err = v2.LedgerHeader()
+		if err != nil {
+			return disc, header, nil, fmt.Errorf("views: V2 LedgerHeader: %w", err)
+		}
+		raw, err := v2.TxProcessing()
+		if err != nil {
+			return disc, header, nil, fmt.Errorf("views: V2 TxProcessing: %w", err)
+		}
+		return disc, header, txProcIter[xdr.TransactionResultMetaV1View]{raw.Iter()}, nil
+	default:
+		return disc, header, nil, fmt.Errorf("views: unknown LCM V=%d", disc)
+	}
+}
+
+// txResultMetaView is the view-side interface satisfied by both
+// TransactionResultMetaView (V0/V1 LCM TxProcessing element) and
+// TransactionResultMetaV1View (V2 LCM TxProcessing element).
+type txResultMetaView interface {
+	Result() (xdr.TransactionResultPairView, error)
+	TxApplyProcessing() (xdr.TransactionMetaView, error)
+}
+
+// txProcIter is a generic adapter over the per-version TxProcessing
+// Iter() (an iter.Seq2[E, error] for a concrete element view E that
+// satisfies txResultMetaView). It re-yields each element widened to the
+// txResultMetaView interface, letting V0/V1/V2 share one iteration body.
+type txProcIter[E txResultMetaView] struct {
+	seq iter.Seq2[E, error]
+}
+
+func (it txProcIter[E]) iter() func(yield func(txResultMetaView, error) bool) {
+	return func(yield func(txResultMetaView, error) bool) {
+		for elem, err := range it.seq {
+			if !yield(elem, err) {
+				return
+			}
+		}
+	}
+}
+
+// readLedgerHeader extracts (LedgerSequence, LedgerCloseTime) from a
+// LedgerHeaderHistoryEntryView via the same path xdr.LedgerCloseMeta's
+// LedgerSequence/LedgerCloseTime helpers use, but staying view-side.
+func readLedgerHeader(header xdr.LedgerHeaderHistoryEntryView) (uint32, int64, error) {
+	inner, err := header.Header()
+	if err != nil {
+		return 0, 0, fmt.Errorf("views: Header.Header: %w", err)
+	}
+	seqView, err := inner.LedgerSeq()
+	if err != nil {
+		return 0, 0, fmt.Errorf("views: LedgerSeq: %w", err)
+	}
+	seqVal, err := seqView.Value()
+	if err != nil {
+		return 0, 0, fmt.Errorf("views: LedgerSeq value: %w", err)
+	}
+	scp, err := inner.ScpValue()
+	if err != nil {
+		return 0, 0, fmt.Errorf("views: ScpValue: %w", err)
+	}
+	ctView, err := scp.CloseTime()
+	if err != nil {
+		return 0, 0, fmt.Errorf("views: CloseTime: %w", err)
+	}
+	ctVal, err := ctView.Value()
+	if err != nil {
+		return 0, 0, fmt.Errorf("views: CloseTime value: %w", err)
+	}
+	return seqVal, int64(ctVal), nil //nolint:gosec // TimePoint is uint64
+}
+
+// readTxHash extracts the 32-byte TransactionHash from a TxProcessing
+// entry view (TransactionResultPair.TransactionHash).
+func readTxHash(tx txResultMetaView) (xdr.Hash, error) {
+	var h xdr.Hash
+	rp, err := tx.Result()
+	if err != nil {
+		return h, fmt.Errorf("views: Result: %w", err)
+	}
+	hv, err := rp.TransactionHash()
+	if err != nil {
+		return h, fmt.Errorf("views: TransactionHash: %w", err)
+	}
+	hb, err := hv.Value()
+	if err != nil {
+		return h, fmt.Errorf("views: TransactionHash value: %w", err)
+	}
+	if len(hb) != 32 {
+		return h, fmt.Errorf("views: tx hash length %d != 32", len(hb))
+	}
+	copy(h[:], hb)
+	return h, nil
+}
+
+// payloadsFromTxView dispatches on TransactionMeta version and emits
+// the events for one tx. state holds per-ledger and per-tx counters;
+// V4 top-level events update state.beforeIndex / afterIndex in place
+// so subsequent txs continue from where this one left off.
+func payloadsFromTxView(tx txResultMetaView, state *txWalkState, dst []events.Payload) ([]events.Payload, error) {
+	metaView, err := tx.TxApplyProcessing()
+	if err != nil {
+		return nil, fmt.Errorf("views: TxApplyProcessing: %w", err)
+	}
+	vView, err := metaView.V()
+	if err != nil {
+		return nil, fmt.Errorf("views: meta.V: %w", err)
+	}
+	v, err := vView.Value()
+	if err != nil {
+		return nil, fmt.Errorf("views: meta.V value: %w", err)
+	}
+
+	switch v {
+	case 1, 2:
+		return dst, nil
+	case 3:
+		return payloadsFromV3SorobanMeta(metaView, state, dst)
+	case 4:
+		return payloadsFromV4Meta(metaView, state, dst)
+	default:
+		return nil, fmt.Errorf("views: unsupported TransactionMeta V=%d", v)
+	}
+}
+
+// payloadsFromV3SorobanMeta extracts V3 events. Per
+// ingest.LedgerTransaction.GetTransactionEvents case 3, only soroban
+// txs emit events; the SorobanMeta optional is the carrier. The struct
+// path emits SorobanMeta.Events as op-0 events with EventIdx running
+// 0..N-1. V3 has no top-level TransactionEvents, so the ledger-wide
+// before/after counters in state are not touched.
+//
+// Note: this view path emits SorobanMeta.Events whenever SorobanMeta is
+// present and relies on the core invariant "SorobanMeta present ⟺
+// soroban transaction" — it does NOT re-check the envelope via
+// IsSorobanTx the way the struct path does. This is why the differential
+// test's V3 fixtures, which always pair a present SorobanMeta with a
+// soroban envelope, agree on both paths.
+func payloadsFromV3SorobanMeta(metaView xdr.TransactionMetaView, state *txWalkState, dst []events.Payload) ([]events.Payload, error) {
+	v3, err := metaView.V3()
+	if err != nil {
+		return nil, fmt.Errorf("views: meta V3: %w", err)
+	}
+	smOpt, err := v3.SorobanMeta()
+	if err != nil {
+		return nil, fmt.Errorf("views: SorobanMeta opt: %w", err)
+	}
+	sm, present, err := smOpt.Unwrap()
+	if err != nil {
+		return nil, fmt.Errorf("views: SorobanMeta unwrap: %w", err)
+	}
+	if !present {
+		return dst, nil
+	}
+
+	eventsView, err := sm.Events()
+	if err != nil {
+		return nil, fmt.Errorf("views: SorobanMeta.Events: %w", err)
+	}
+
+	payloads := dst
+	eventIdx := uint32(0)
+	for evView, evErr := range eventsView.Iter() {
+		if evErr != nil {
+			return nil, fmt.Errorf("views: V3 event iter: %w", evErr)
+		}
+		evRaw, err := evView.Raw()
+		if err != nil {
+			return nil, fmt.Errorf("views: V3 ContractEvent.Raw: %w", err)
+		}
+		payloads = append(payloads, events.Payload{
+			TxHash:             state.txHash,
+			LedgerSequence:     state.ledgerSeq,
+			TxIdx:              state.applyIdx,
+			OpIdx:              0,
+			LedgerClosedAt:     state.ledgerClosedAt,
+			EventIdx:           eventIdx,
+			ContractEventBytes: evRaw,
+		})
+		eventIdx++
+	}
+	return payloads, nil
+}
+
+// payloadsFromV4Meta extracts V4 events:
+//
+//  1. Top-level TransactionEvents first, dispatched on Stage:
+//     BeforeAllTxs -> uses ledger-wide state.beforeIndex
+//     AfterAllTxs  -> uses ledger-wide state.afterIndex
+//     AfterTx      -> uses per-tx counter (reset here)
+//  2. Then per-operation contract events in (op, event) order.
+//
+// Order matches LCMToPayloads / db.InsertEvents and the (TxIdx, OpIdx,
+// EventIdx) sentinels match the struct path's encoding.
+//
+//nolint:cyclop,funlen // linear V4 pipeline: top-level Events (dispatched on Stage) -> per-op events
+func payloadsFromV4Meta(metaView xdr.TransactionMetaView, state *txWalkState, dst []events.Payload) ([]events.Payload, error) {
+	v4, err := metaView.V4()
+	if err != nil {
+		return nil, fmt.Errorf("views: meta V4: %w", err)
+	}
+
+	payloads := dst
+
+	// Top-level TransactionEvents.
+	txEventsView, err := v4.Events()
+	if err != nil {
+		return nil, fmt.Errorf("views: V4 Events: %w", err)
+	}
+	txAfterIndex := uint32(0)
+	for tevView, tevErr := range txEventsView.Iter() {
+		if tevErr != nil {
+			return nil, fmt.Errorf("views: V4 tx event iter: %w", tevErr)
+		}
+		stageView, err := tevView.Stage()
+		if err != nil {
+			return nil, fmt.Errorf("views: V4 tx event Stage: %w", err)
+		}
+		stage, err := stageView.Value()
+		if err != nil {
+			return nil, fmt.Errorf("views: V4 tx event Stage value: %w", err)
+		}
+		evView, err := tevView.Event()
+		if err != nil {
+			return nil, fmt.Errorf("views: V4 tx event Event: %w", err)
+		}
+		evRaw, err := evView.Raw()
+		if err != nil {
+			return nil, fmt.Errorf("views: V4 tx ContractEvent.Raw: %w", err)
+		}
+		var txIdx, opIdx, eventIdx uint32
+		switch stage {
+		case xdr.TransactionEventStageTransactionEventStageBeforeAllTxs:
+			txIdx, opIdx, eventIdx = 0, 0, state.beforeIndex
+			state.beforeIndex++
+		case xdr.TransactionEventStageTransactionEventStageAfterAllTxs:
+			txIdx, opIdx, eventIdx = uint32(toid.TransactionMask), 0, state.afterIndex
+			state.afterIndex++
+		case xdr.TransactionEventStageTransactionEventStageAfterTx:
+			txIdx, opIdx, eventIdx = state.applyIdx, uint32(toid.OperationMask), txAfterIndex
+			txAfterIndex++
+		default:
+			return nil, fmt.Errorf("views: unhandled tx event stage %v", stage)
+		}
+		payloads = append(payloads, events.Payload{
+			TxHash:             state.txHash,
+			LedgerSequence:     state.ledgerSeq,
+			TxIdx:              txIdx,
+			OpIdx:              opIdx,
+			LedgerClosedAt:     state.ledgerClosedAt,
+			EventIdx:           eventIdx,
+			ContractEventBytes: evRaw,
+		})
+	}
+
+	// Per-operation contract events.
+	opsView, err := v4.Operations()
+	if err != nil {
+		return nil, fmt.Errorf("views: V4 Operations: %w", err)
+	}
+	opIdx := uint32(0)
+	for opView, opErr := range opsView.Iter() {
+		if opErr != nil {
+			return nil, fmt.Errorf("views: V4 op iter: %w", opErr)
+		}
+		opEventsView, err := opView.Events()
+		if err != nil {
+			return nil, fmt.Errorf("views: V4 op.Events: %w", err)
+		}
+		eventIdx := uint32(0)
+		for evView, evErr := range opEventsView.Iter() {
+			if evErr != nil {
+				return nil, fmt.Errorf("views: V4 op event iter: %w", evErr)
+			}
+			evRaw, err := evView.Raw()
+			if err != nil {
+				return nil, fmt.Errorf("views: V4 op ContractEvent.Raw: %w", err)
+			}
+			payloads = append(payloads, events.Payload{
+				TxHash:             state.txHash,
+				LedgerSequence:     state.ledgerSeq,
+				TxIdx:              state.applyIdx,
+				OpIdx:              opIdx,
+				LedgerClosedAt:     state.ledgerClosedAt,
+				EventIdx:           eventIdx,
+				ContractEventBytes: evRaw,
+			})
+			eventIdx++
+		}
+		opIdx++
+	}
+	return payloads, nil
+}

--- a/cmd/stellar-rpc/internal/fullhistory/views/events.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/events.go
@@ -3,7 +3,6 @@ package views
 import (
 	"errors"
 	"fmt"
-	"iter"
 
 	"github.com/stellar/go-stellar-sdk/toid"
 	"github.com/stellar/go-stellar-sdk/xdr"
@@ -38,6 +37,10 @@ var ErrV0Unsupported = errors.New("views: LCM V0 carries no contract events (cal
 // Stage with ledger-wide before/after counters), then per-operation
 // events in (op, event) order.
 //
+// V3 events are emitted whenever SorobanMeta is present, relying on the
+// package's trusted-input invariant (see doc.go) rather than the paired
+// envelope.
+//
 // Supported shapes:
 //
 //   - LCM V1, V2 (apply order = TxProcessing array order)
@@ -48,15 +51,15 @@ var ErrV0Unsupported = errors.New("views: LCM V0 carries no contract events (cal
 //     top-level TransactionEvents in V3)
 //   - TransactionMeta V4 (top-level Events + Operations[i].Events)
 func ExtractEvents(lcm xdr.LedgerCloseMetaView) ([]events.Payload, error) {
-	disc, headerView, tp, err := openHeaderAndTxProc(lcm)
+	d, err := dispatchLCM(lcm)
 	if err != nil {
 		return nil, err
 	}
-	if disc == 0 {
+	if d.disc == 0 {
 		return nil, ErrV0Unsupported
 	}
 
-	ledgerSeq, ledgerClosedAt, err := readLedgerHeader(headerView)
+	ledgerSeq, ledgerClosedAt, err := readLedgerHeader(d.header)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +75,7 @@ func ExtractEvents(lcm xdr.LedgerCloseMetaView) ([]events.Payload, error) {
 
 	var payloads []events.Payload
 	applyIdx := uint32(0)
-	for tx, iterErr := range tp.iter() {
+	for tx, iterErr := range d.tp {
 		if iterErr != nil {
 			return nil, fmt.Errorf("views: TxProcessing iter: %w", iterErr)
 		}
@@ -105,169 +108,6 @@ type txWalkState struct {
 	applyIdx       uint32 // 1-based, matches ingest reader's tx.Index
 	beforeIndex    uint32 // ledger-wide BeforeAllTxs event counter
 	afterIndex     uint32 // ledger-wide AfterAllTxs event counter
-}
-
-// txProcessingIterable abstracts over the SDK TxProcessing array view
-// types (V0/V1/V2 LCM use distinct generated views) so the dispatch
-// switches above can share the iteration body. All yield a
-// txResultMetaView with the methods we need.
-type txProcessingIterable interface {
-	iter() func(yield func(txResultMetaView, error) bool)
-}
-
-// openHeaderAndTxProc opens an LCM view, reads its version discriminant,
-// and returns the ledger header view + the version-appropriate
-// TxProcessing iterable (apply order). This is the one place the
-// V0/V1/V2 "open header + TxProcessing" dispatch lives; callers branch on
-// the returned disc for version-sensitive behavior (e.g. V0 events are
-// unsupported). The version-specific TxSet open lives elsewhere (the
-// TxSet view types differ and cannot share this path).
-func openHeaderAndTxProc(lcm xdr.LedgerCloseMetaView) (
-	disc int32, header xdr.LedgerHeaderHistoryEntryView, tp txProcessingIterable, err error,
-) {
-	dv, err := lcm.V()
-	if err != nil {
-		return 0, header, nil, fmt.Errorf("views: LCM.V: %w", err)
-	}
-	disc, err = dv.Value()
-	if err != nil {
-		return 0, header, nil, fmt.Errorf("views: LCM.V value: %w", err)
-	}
-
-	switch disc {
-	case 0:
-		v0, err := lcm.V0()
-		if err != nil {
-			return disc, header, nil, fmt.Errorf("views: LCM V0: %w", err)
-		}
-		header, err = v0.LedgerHeader()
-		if err != nil {
-			return disc, header, nil, fmt.Errorf("views: V0 LedgerHeader: %w", err)
-		}
-		raw, err := v0.TxProcessing()
-		if err != nil {
-			return disc, header, nil, fmt.Errorf("views: V0 TxProcessing: %w", err)
-		}
-		return disc, header, txProcIter[xdr.TransactionResultMetaView]{raw.Iter()}, nil
-	case 1:
-		v1, err := lcm.V1()
-		if err != nil {
-			return disc, header, nil, fmt.Errorf("views: LCM V1: %w", err)
-		}
-		header, err = v1.LedgerHeader()
-		if err != nil {
-			return disc, header, nil, fmt.Errorf("views: V1 LedgerHeader: %w", err)
-		}
-		raw, err := v1.TxProcessing()
-		if err != nil {
-			return disc, header, nil, fmt.Errorf("views: V1 TxProcessing: %w", err)
-		}
-		return disc, header, txProcIter[xdr.TransactionResultMetaView]{raw.Iter()}, nil
-	case 2:
-		v2, err := lcm.V2()
-		if err != nil {
-			return disc, header, nil, fmt.Errorf("views: LCM V2: %w", err)
-		}
-		header, err = v2.LedgerHeader()
-		if err != nil {
-			return disc, header, nil, fmt.Errorf("views: V2 LedgerHeader: %w", err)
-		}
-		raw, err := v2.TxProcessing()
-		if err != nil {
-			return disc, header, nil, fmt.Errorf("views: V2 TxProcessing: %w", err)
-		}
-		return disc, header, txProcIter[xdr.TransactionResultMetaV1View]{raw.Iter()}, nil
-	default:
-		return disc, header, nil, fmt.Errorf("views: unknown LCM V=%d", disc)
-	}
-}
-
-// txResultMetaView is the view-side interface satisfied by both
-// TransactionResultMetaView (V0/V1 LCM TxProcessing element) and
-// TransactionResultMetaV1View (V2 LCM TxProcessing element).
-type txResultMetaView interface {
-	Result() (xdr.TransactionResultPairView, error)
-	TxApplyProcessing() (xdr.TransactionMetaView, error)
-}
-
-// txProcIter is a generic adapter over the per-version TxProcessing
-// Iter() (an iter.Seq2[E, error] for a concrete element view E that
-// satisfies txResultMetaView). It re-yields each element widened to the
-// txResultMetaView interface, letting V0/V1/V2 share one iteration body.
-type txProcIter[E txResultMetaView] struct {
-	seq iter.Seq2[E, error]
-}
-
-func (it txProcIter[E]) iter() func(yield func(txResultMetaView, error) bool) {
-	return func(yield func(txResultMetaView, error) bool) {
-		for elem, err := range it.seq {
-			if !yield(elem, err) {
-				return
-			}
-		}
-	}
-}
-
-// readLedgerHeader extracts (LedgerSequence, LedgerCloseTime) from a
-// LedgerHeaderHistoryEntryView via the same path xdr.LedgerCloseMeta's
-// LedgerSequence/LedgerCloseTime helpers use, but staying view-side.
-// viewChain threads a single error through a sequence of zero-copy view
-// accessors. Once any step fails, later steps short-circuit and the first
-// (labeled) error is retained — collapsing the repeated
-// `v, err := f(); if err != nil { return wrap(err) }` ladder that view
-// navigation otherwise requires into a declarative sequence plus one terminal
-// check. This is the package-local stand-in for the fluent `.HeaderW().…W()`
-// chaining wished for in review; a true fluent API would need SDK-generated
-// wrapper types.
-type viewChain struct{ err error }
-
-// step runs one view accessor f under chain c: if a prior step already failed
-// it returns the zero value without calling f; otherwise it returns f's value,
-// recording (and labeling, under the "views:" prefix) the first error in c. f
-// is typically a method value such as `header.Header` or `seqView.Value`.
-func step[T any](c *viewChain, label string, f func() (T, error)) T {
-	var zero T
-	if c.err != nil {
-		return zero
-	}
-	v, err := f()
-	if err != nil {
-		c.err = fmt.Errorf("views: %s: %w", label, err)
-		return zero
-	}
-	return v
-}
-
-func readLedgerHeader(header xdr.LedgerHeaderHistoryEntryView) (uint32, int64, error) {
-	var c viewChain
-	inner := step(&c, "Header.Header", header.Header)
-	seqView := step(&c, "LedgerSeq", inner.LedgerSeq)
-	seqVal := step(&c, "LedgerSeq value", seqView.Value)
-	scp := step(&c, "ScpValue", inner.ScpValue)
-	ctView := step(&c, "CloseTime", scp.CloseTime)
-	ctVal := step(&c, "CloseTime value", ctView.Value)
-	if c.err != nil {
-		return 0, 0, c.err
-	}
-	return seqVal, int64(ctVal), nil //nolint:gosec // TimePoint is uint64
-}
-
-// readTxHash extracts the 32-byte TransactionHash from a TxProcessing
-// entry view (TransactionResultPair.TransactionHash).
-func readTxHash(tx txResultMetaView) (xdr.Hash, error) {
-	var c viewChain
-	rp := step(&c, "Result", tx.Result)
-	hv := step(&c, "TransactionHash", rp.TransactionHash)
-	hb := step(&c, "TransactionHash value", hv.Value)
-	if c.err != nil {
-		return xdr.Hash{}, c.err
-	}
-	if len(hb) != 32 {
-		return xdr.Hash{}, fmt.Errorf("views: tx hash length %d != 32", len(hb))
-	}
-	var h xdr.Hash
-	copy(h[:], hb)
-	return h, nil
 }
 
 // payloadsFromTxView dispatches on TransactionMeta version and emits
@@ -313,12 +153,10 @@ func payloadsFromTxView(tx txResultMetaView, state *txWalkState, dst []events.Pa
 // 0..N-1. V3 has no top-level TransactionEvents, so the ledger-wide
 // before/after counters in state are not touched.
 //
-// Note: this view path emits SorobanMeta.Events whenever SorobanMeta is
-// present and relies on the core invariant "SorobanMeta present ⟺
-// soroban transaction" — it does NOT re-check the envelope via
-// IsSorobanTx the way the struct path does. This is why the differential
-// test's V3 fixtures, which always pair a present SorobanMeta with a
-// soroban envelope, agree on both paths.
+// Events are emitted whenever SorobanMeta is present, under the
+// trusted-input invariant in doc.go ("SorobanMeta present ⟺ soroban tx");
+// there is no envelope in hand here to re-check, unlike the read path's
+// gateV3ContractEvents.
 func payloadsFromV3SorobanMeta(metaView xdr.TransactionMetaView, state *txWalkState, dst []events.Payload) ([]events.Payload, error) {
 	v3, err := metaView.V3()
 	if err != nil {

--- a/cmd/stellar-rpc/internal/fullhistory/views/events_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/events_test.go
@@ -411,33 +411,27 @@ func TestExtractEvents_AliasesViewBuffer(t *testing.T) {
 	assert.NotEqual(t, before, payloads[0].ContractEventBytes[0])
 }
 
-// TestExtractEvents_NegativePaths covers the error returns of the view
-// extractor. The cheapest is an unsupported TransactionMeta version
-// (V0 union) hitting the unsupported-meta-version path.
-func TestExtractEvents_NegativePaths(t *testing.T) {
-	tests := []struct {
-		name    string
-		metas   []xdr.TransactionMeta
-		wantErr string
-	}{
-		{
-			name: "unsupported-meta-version-v0",
-			metas: []xdr.TransactionMeta{
-				{V: 0, Operations: &[]xdr.OperationMeta{}},
-			},
-			wantErr: "unsupported TransactionMeta V=0",
-		},
+// TestExtractEvents_LegacyMetaV0 asserts that a legacy TransactionMeta V0
+// (pre-Soroban, Operations only) carries no contract events and is skipped
+// rather than erroring — the SDK reference path (LCMToPayloads) actually
+// rejects V0 meta, but full-history backfills from genesis and must tolerate
+// it. A V0 meta mixed with a V4-event-bearing tx must yield only the V4 tx's
+// events, in order.
+func TestExtractEvents_LegacyMetaV0(t *testing.T) {
+	ev := buildContractEvent("after-v0")
+	metas := []xdr.TransactionMeta{
+		{V: 0, Operations: &[]xdr.OperationMeta{}}, // legacy, no events
+		txMetaWithOpEvents([][]xdr.ContractEvent{{ev}}),
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			lcm := buildLCM(t, 4301, 1_700_001_222, tc.metas)
-			raw, err := lcm.MarshalBinary()
-			require.NoError(t, err)
-			_, err = views.ExtractEvents(xdr.LedgerCloseMetaView(raw))
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tc.wantErr)
-		})
-	}
+	lcm := buildLCM(t, 4301, 1_700_001_222, metas)
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+
+	payloads, err := views.ExtractEvents(xdr.LedgerCloseMetaView(raw))
+	require.NoError(t, err, "V0 meta must be skipped, not error")
+	// Only the second (V4) tx emits an event; the V0 tx contributes none.
+	require.Len(t, payloads, 1)
+	assert.Equal(t, uint32(2), payloads[0].TxIdx, "the sole event belongs to the 2nd (V4) tx")
 }
 
 // assertViewMatchesStruct marshals lcm, runs both paths against the

--- a/cmd/stellar-rpc/internal/fullhistory/views/events_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/events_test.go
@@ -1,0 +1,523 @@
+package views_test
+
+import (
+	"fmt"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stellar/go-stellar-sdk/network"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/events"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/views"
+)
+
+const testPassphrase = "Test SDF Network ; September 2015"
+
+// buildContractEvent returns a ContractEvent with a contractID and a
+// single symbol topic.
+func buildContractEvent(topic string) xdr.ContractEvent {
+	var contractID xdr.ContractId
+	contractID[0] = 0xab
+	contractID[1] = 0xcd
+	sym := xdr.ScSymbol(topic)
+	return xdr.ContractEvent{
+		ContractId: &contractID,
+		Type:       xdr.ContractEventTypeContract,
+		Body: xdr.ContractEventBody{
+			V: 0,
+			V0: &xdr.ContractEventV0{
+				Topics: []xdr.ScVal{{Type: xdr.ScValTypeScvSymbol, Sym: &sym}},
+				Data:   xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &sym},
+			},
+		},
+	}
+}
+
+func transactionResult(success bool) xdr.TransactionResult {
+	code := xdr.TransactionResultCodeTxBadSeq
+	if success {
+		code = xdr.TransactionResultCodeTxSuccess
+	}
+	opResults := []xdr.OperationResult{}
+	return xdr.TransactionResult{
+		FeeCharged: 100,
+		Result: xdr.TransactionResultResult{
+			Code:    code,
+			Results: &opResults,
+		},
+	}
+}
+
+// txMetaWithOpEvents wraps the given operation-event slices (one outer
+// slice per operation, inner slice = events for that op) into a
+// TransactionMetaV4 with no transaction-level events.
+func txMetaWithOpEvents(opEvents [][]xdr.ContractEvent) xdr.TransactionMeta {
+	ops := make([]xdr.OperationMetaV2, len(opEvents))
+	for i, evs := range opEvents {
+		ops[i] = xdr.OperationMetaV2{Events: evs}
+	}
+	return xdr.TransactionMeta{
+		V:  4,
+		V4: &xdr.TransactionMetaV4{Operations: ops},
+	}
+}
+
+// txMetaWithStagedEvents builds a TransactionMetaV4 carrying the given
+// transaction-level events (with Stage) and no operation events.
+func txMetaWithStagedEvents(stageEvents []xdr.TransactionEvent) xdr.TransactionMeta {
+	return xdr.TransactionMeta{
+		V:  4,
+		V4: &xdr.TransactionMetaV4{Events: stageEvents},
+	}
+}
+
+// txMetaWithV3SorobanEvents builds a TransactionMetaV3 whose SorobanMeta
+// carries evs as op-0 events. A nil evs slice with a present SorobanMeta
+// exercises the zero-events case; pass a nil meta separately for the
+// absent-SorobanMeta case.
+func txMetaWithV3SorobanEvents(evs []xdr.ContractEvent) xdr.TransactionMeta {
+	return xdr.TransactionMeta{
+		V: 3,
+		V3: &xdr.TransactionMetaV3{
+			SorobanMeta: &xdr.SorobanTransactionMeta{
+				Events:      evs,
+				ReturnValue: xdr.ScVal{Type: xdr.ScValTypeScvVoid},
+			},
+		},
+	}
+}
+
+func buildLCM(t testing.TB, ledgerSeq uint32, closeTimestamp int64, txMetas []xdr.TransactionMeta) xdr.LedgerCloseMeta {
+	t.Helper()
+	return buildLCMVersion(t, 2, ledgerSeq, closeTimestamp, txMetas)
+}
+
+// buildTxEnvelopeAndHash constructs a deterministic soroban-shaped tx
+// envelope and its hash under testPassphrase. Shared by every LCM-version
+// builder so the differential arms differ only in the LCM/TxSet shape.
+func buildTxEnvelopeAndHash(t testing.TB) (xdr.TransactionEnvelope, xdr.Hash) {
+	t.Helper()
+	envelope := xdr.TransactionEnvelope{
+		Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+		V1: &xdr.TransactionV1Envelope{
+			Tx: xdr.Transaction{
+				SourceAccount: xdr.MustMuxedAddress(keypair.MustRandom().Address()),
+				Ext: xdr.TransactionExt{
+					V:           1,
+					SorobanData: &xdr.SorobanTransactionData{},
+				},
+			},
+		},
+	}
+	hash, err := network.HashTransactionInEnvelope(envelope, testPassphrase)
+	require.NoError(t, err)
+	return envelope, hash
+}
+
+// buildLCMVersion builds either an LCM V1 (LedgerCloseMetaV1 with
+// TransactionResultMeta — the *non*-V1 result-meta type — exercising
+// ExtractEvents/ExtractTxHashes case 1) or an LCM V2 (LedgerCloseMetaV2
+// with TransactionResultMetaV1, case 2). Both use a GeneralizedTransactionSet
+// (V1) which is already in apply order, so the struct-path
+// LedgerTransactionReader and the view path agree on ordering.
+func buildLCMVersion(t testing.TB, version int32, ledgerSeq uint32, closeTimestamp int64, txMetas []xdr.TransactionMeta) xdr.LedgerCloseMeta {
+	t.Helper()
+
+	phases := make([]xdr.TransactionPhase, 0, len(txMetas))
+	v2Processing := make([]xdr.TransactionResultMetaV1, 0, len(txMetas))
+	v1Processing := make([]xdr.TransactionResultMeta, 0, len(txMetas))
+
+	for _, meta := range txMetas {
+		envelope, hash := buildTxEnvelopeAndHash(t)
+		result := xdr.TransactionResultPair{
+			TransactionHash: hash,
+			Result:          transactionResult(true),
+		}
+		v2Processing = append(v2Processing, xdr.TransactionResultMetaV1{
+			TxApplyProcessing: meta,
+			Result:            result,
+		})
+		v1Processing = append(v1Processing, xdr.TransactionResultMeta{
+			TxApplyProcessing: meta,
+			Result:            result,
+		})
+		comp := []xdr.TxSetComponent{{
+			Type: xdr.TxSetComponentTypeTxsetCompTxsMaybeDiscountedFee,
+			TxsMaybeDiscountedFee: &xdr.TxSetComponentTxsMaybeDiscountedFee{
+				Txs: []xdr.TransactionEnvelope{envelope},
+			},
+		}}
+		phases = append(phases, xdr.TransactionPhase{V: 0, V0Components: &comp})
+	}
+
+	header := xdr.LedgerHeaderHistoryEntry{
+		Header: xdr.LedgerHeader{
+			ScpValue:  xdr.StellarValue{CloseTime: xdr.TimePoint(closeTimestamp)},
+			LedgerSeq: xdr.Uint32(ledgerSeq),
+		},
+	}
+	txSet := xdr.GeneralizedTransactionSet{
+		V:       1,
+		V1TxSet: &xdr.TransactionSetV1{Phases: phases},
+	}
+
+	switch version {
+	case 1:
+		return xdr.LedgerCloseMeta{
+			V: 1,
+			V1: &xdr.LedgerCloseMetaV1{
+				LedgerHeader: header,
+				TxSet:        txSet,
+				TxProcessing: v1Processing,
+			},
+		}
+	case 2:
+		return xdr.LedgerCloseMeta{
+			V: 2,
+			V2: &xdr.LedgerCloseMetaV2{
+				LedgerHeader: header,
+				TxSet:        txSet,
+				TxProcessing: v2Processing,
+			},
+		}
+	default:
+		t.Fatalf("buildLCMVersion: unsupported version %d", version)
+		return xdr.LedgerCloseMeta{}
+	}
+}
+
+// buildLCMV0 builds an LCM V0 (LedgerCloseMetaV0) using a plain
+// TransactionSet (NOT a GeneralizedTransactionSet) with PreviousLedgerHash
+// set, and TransactionResultMeta in TxProcessing. ExtractEvents rejects V0
+// (ErrV0Unsupported), but ExtractTxHashes supports it: TxProcessing is in
+// apply order so hash extraction needs no sort. PreviousLedgerHash must be
+// set so the struct-path LedgerTransactionReader can verify the tx set.
+func buildLCMV0(t testing.TB, ledgerSeq uint32, closeTimestamp int64, txMetas []xdr.TransactionMeta) xdr.LedgerCloseMeta {
+	t.Helper()
+
+	var prevHash xdr.Hash
+	prevHash[0] = 0x99
+	envelopes := make([]xdr.TransactionEnvelope, 0, len(txMetas))
+	txProcessing := make([]xdr.TransactionResultMeta, 0, len(txMetas))
+
+	for _, meta := range txMetas {
+		envelope, hash := buildTxEnvelopeAndHash(t)
+		envelopes = append(envelopes, envelope)
+		txProcessing = append(txProcessing, xdr.TransactionResultMeta{
+			TxApplyProcessing: meta,
+			Result: xdr.TransactionResultPair{
+				TransactionHash: hash,
+				Result:          transactionResult(true),
+			},
+		})
+	}
+
+	return xdr.LedgerCloseMeta{
+		V: 0,
+		V0: &xdr.LedgerCloseMetaV0{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+				Header: xdr.LedgerHeader{
+					ScpValue:  xdr.StellarValue{CloseTime: xdr.TimePoint(closeTimestamp)},
+					LedgerSeq: xdr.Uint32(ledgerSeq),
+				},
+			},
+			TxSet: xdr.TransactionSet{
+				PreviousLedgerHash: prevHash,
+				Txs:                envelopes,
+			},
+			TxProcessing: txProcessing,
+		},
+	}
+}
+
+// TestExtractEvents_MatchesStructPath cross-checks that the view-based
+// ExtractEvents produces the same per-event Payload metadata (TxHash,
+// LedgerSequence, TxIdx, OpIdx, LedgerClosedAt, EventIdx) AND the same
+// wire bytes as the struct-based events.LCMToPayloads, for every
+// supported meta shape.
+func TestExtractEvents_MatchesStructPath(t *testing.T) {
+	t.Run("v4-op-events-only", func(t *testing.T) {
+		evA := buildContractEvent("alpha")
+		evB := buildContractEvent("beta")
+		evC := buildContractEvent("gamma")
+		// Two txs, each with two ops carrying a single event.
+		metas := []xdr.TransactionMeta{
+			txMetaWithOpEvents([][]xdr.ContractEvent{{evA}, {evB}}),
+			txMetaWithOpEvents([][]xdr.ContractEvent{{evC}}),
+		}
+		lcm := buildLCM(t, 4001, 1_700_000_111, metas)
+		assertViewMatchesStruct(t, lcm)
+	})
+
+	t.Run("v4-top-level-stages-ledger-wide-counters", func(t *testing.T) {
+		// Three txs, each emitting a BeforeAllTxs + AfterAllTxs +
+		// AfterTx event so we can verify ledger-wide before/after
+		// counters increment across txs (not per-tx) AND AfterTx
+		// resets per-tx.
+		makeStaged := func(label string) xdr.TransactionMeta {
+			return txMetaWithStagedEvents([]xdr.TransactionEvent{
+				{Stage: xdr.TransactionEventStageTransactionEventStageBeforeAllTxs, Event: buildContractEvent(label + "-before")},
+				{Stage: xdr.TransactionEventStageTransactionEventStageAfterAllTxs, Event: buildContractEvent(label + "-after")},
+				{Stage: xdr.TransactionEventStageTransactionEventStageAfterTx, Event: buildContractEvent(label + "-aftertx")},
+			})
+		}
+		lcm := buildLCM(t, 4002, 1_700_000_222, []xdr.TransactionMeta{
+			makeStaged("a"), makeStaged("b"), makeStaged("c"),
+		})
+		assertViewMatchesStruct(t, lcm)
+	})
+
+	t.Run("v4-mixed-top-level-and-op-events", func(t *testing.T) {
+		// Tx with two top-level events (one BeforeAllTxs, one AfterTx)
+		// AND two ops each with their own event. The struct path
+		// emits top-level first, then per-op — view must match.
+		evIn := buildContractEvent("opA")
+		evOut := buildContractEvent("opB")
+		mixed := xdr.TransactionMeta{
+			V: 4,
+			V4: &xdr.TransactionMetaV4{
+				Events: []xdr.TransactionEvent{
+					{Stage: xdr.TransactionEventStageTransactionEventStageBeforeAllTxs, Event: buildContractEvent("pre")},
+					{Stage: xdr.TransactionEventStageTransactionEventStageAfterTx, Event: buildContractEvent("post")},
+				},
+				Operations: []xdr.OperationMetaV2{
+					{Events: []xdr.ContractEvent{evIn}},
+					{Events: []xdr.ContractEvent{evOut}},
+				},
+			},
+		}
+		lcm := buildLCM(t, 4003, 1_700_000_333, []xdr.TransactionMeta{mixed})
+		assertViewMatchesStruct(t, lcm)
+	})
+
+	t.Run("v1-and-v2-meta-skip", func(t *testing.T) {
+		// V1/V2 meta carry no events. Both paths should produce zero
+		// payloads.
+		metas := []xdr.TransactionMeta{
+			{V: 1, V1: &xdr.TransactionMetaV1{}},
+			{V: 2, V2: &xdr.TransactionMetaV2{}},
+		}
+		lcm := buildLCM(t, 4004, 1_700_000_444, metas)
+		assertViewMatchesStruct(t, lcm)
+	})
+
+	t.Run("v3-soroban-meta-events", func(t *testing.T) {
+		// V3 meta carries events via SorobanMeta.Events; the struct
+		// path emits them as op-0 events. Two txs verify the per-tx
+		// EventIdx reset and applyIdx incrementing; a third tx with an
+		// empty SorobanMeta.Events list checks the zero-events case
+		// stays a no-op on both sides.
+		evA := buildContractEvent("v3-alpha")
+		evB := buildContractEvent("v3-beta")
+		evC := buildContractEvent("v3-gamma")
+		metas := []xdr.TransactionMeta{
+			txMetaWithV3SorobanEvents([]xdr.ContractEvent{evA, evB}),
+			txMetaWithV3SorobanEvents([]xdr.ContractEvent{evC}),
+			txMetaWithV3SorobanEvents(nil),
+		}
+		lcm := buildLCM(t, 4005, 1_700_000_555, metas)
+		assertViewMatchesStruct(t, lcm)
+	})
+
+	t.Run("v3-soroban-meta-absent", func(t *testing.T) {
+		// V3 meta with SorobanMeta unset: both paths emit zero payloads.
+		metas := []xdr.TransactionMeta{
+			{V: 3, V3: &xdr.TransactionMetaV3{SorobanMeta: nil}},
+		}
+		lcm := buildLCM(t, 4006, 1_700_000_666, metas)
+		assertViewMatchesStruct(t, lcm)
+	})
+}
+
+// TestExtractEvents_V0Unsupported asserts a V0 LCM returns the sentinel.
+func TestExtractEvents_V0Unsupported(t *testing.T) {
+	lcm := xdr.LedgerCloseMeta{V: 0, V0: &xdr.LedgerCloseMetaV0{
+		LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+			Header: xdr.LedgerHeader{LedgerSeq: 7},
+		},
+	}}
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	_, err = views.ExtractEvents(xdr.LedgerCloseMetaView(raw))
+	require.ErrorIs(t, err, views.ErrV0Unsupported)
+}
+
+// TestExtractEvents_V1DifferentialArm exercises the LCM V1 dispatch arm
+// (case 1, TransactionResultMetaView) of ExtractEvents, which the V2-only
+// differential tests never run. V1 uses LedgerCloseMetaV1 + the non-V1
+// TransactionResultMeta result-meta type — the whole point of this case.
+func TestExtractEvents_V1DifferentialArm(t *testing.T) {
+	// Event-bearing mix: a V4 tx with a top-level event + two op events,
+	// and a V3 soroban tx, so the V1 arm walks real ContractEvent bytes.
+	evA := buildContractEvent("v1-opA")
+	evB := buildContractEvent("v1-opB")
+	mixed := xdr.TransactionMeta{
+		V: 4,
+		V4: &xdr.TransactionMetaV4{
+			Events: []xdr.TransactionEvent{
+				{Stage: xdr.TransactionEventStageTransactionEventStageBeforeAllTxs, Event: buildContractEvent("v1-pre")},
+			},
+			Operations: []xdr.OperationMetaV2{
+				{Events: []xdr.ContractEvent{evA}},
+				{Events: []xdr.ContractEvent{evB}},
+			},
+		},
+	}
+	metas := []xdr.TransactionMeta{
+		mixed,
+		txMetaWithV3SorobanEvents([]xdr.ContractEvent{buildContractEvent("v1-soroban")}),
+	}
+	lcm := buildLCMVersion(t, 1, 4101, 1_700_000_999, metas)
+	require.Equal(t, int32(1), lcm.V, "fixture must be LCM V1")
+	assertViewMatchesStruct(t, lcm)
+}
+
+// TestExtractEvents_AliasesViewBuffer asserts the zero-copy contract:
+// the returned ContractEventBytes alias the input view buffer rather than
+// being a copy. Verified two ways: (1) the slice's data pointer lies
+// within [raw, raw+len(raw)); (2) mutating raw after extraction changes
+// the bytes the payload sees.
+func TestExtractEvents_AliasesViewBuffer(t *testing.T) {
+	lcm := buildLCM(t, 4201, 1_700_001_111, []xdr.TransactionMeta{
+		txMetaWithOpEvents([][]xdr.ContractEvent{{buildContractEvent("aliasme")}}),
+	})
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+
+	payloads, err := views.ExtractEvents(xdr.LedgerCloseMetaView(raw))
+	require.NoError(t, err)
+	require.Len(t, payloads, 1)
+	require.NotEmpty(t, payloads[0].ContractEventBytes)
+
+	// (1) Pointer-containment: the event bytes must point inside raw.
+	rawBase := uintptr(unsafe.Pointer(unsafe.SliceData(raw)))
+	rawEnd := rawBase + uintptr(len(raw))
+	evBase := uintptr(unsafe.Pointer(unsafe.SliceData(payloads[0].ContractEventBytes)))
+	assert.GreaterOrEqual(t, evBase, rawBase, "event bytes start before view buffer")
+	assert.Less(t, evBase, rawEnd, "event bytes start past view buffer end")
+
+	// (2) Mutation-observation: flip a byte in the aliased region and
+	// confirm the payload slice reflects it (proving it is not a copy).
+	off := evBase - rawBase
+	before := raw[off]
+	raw[off] ^= 0xFF
+	assert.Equal(t, raw[off], payloads[0].ContractEventBytes[0],
+		"payload bytes did not track mutation of raw — not aliased")
+	assert.NotEqual(t, before, payloads[0].ContractEventBytes[0])
+}
+
+// TestExtractEvents_NegativePaths covers the error returns of the view
+// extractor. The cheapest is an unsupported TransactionMeta version
+// (V0 union) hitting the unsupported-meta-version path.
+func TestExtractEvents_NegativePaths(t *testing.T) {
+	tests := []struct {
+		name    string
+		metas   []xdr.TransactionMeta
+		wantErr string
+	}{
+		{
+			name: "unsupported-meta-version-v0",
+			metas: []xdr.TransactionMeta{
+				{V: 0, Operations: &[]xdr.OperationMeta{}},
+			},
+			wantErr: "unsupported TransactionMeta V=0",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lcm := buildLCM(t, 4301, 1_700_001_222, tc.metas)
+			raw, err := lcm.MarshalBinary()
+			require.NoError(t, err)
+			_, err = views.ExtractEvents(xdr.LedgerCloseMetaView(raw))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// assertViewMatchesStruct marshals lcm, runs both paths against the
+// same bytes, and asserts they agree on every Payload field including
+// ContractEventBytes (which both paths now populate: struct via
+// MarshalBinary, view via .Raw()).
+func assertViewMatchesStruct(t *testing.T, lcm xdr.LedgerCloseMeta) {
+	t.Helper()
+
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+
+	structPayloads, err := events.LCMToPayloads(testPassphrase, lcm)
+	require.NoError(t, err, "struct path LCMToPayloads")
+
+	viewPayloads, err := views.ExtractEvents(xdr.LedgerCloseMetaView(raw))
+	require.NoError(t, err, "view path ExtractEvents")
+
+	require.Len(t, viewPayloads, len(structPayloads),
+		"payload count differs (struct=%d view=%d)", len(structPayloads), len(viewPayloads))
+
+	for i := range structPayloads {
+		s := structPayloads[i]
+		v := viewPayloads[i]
+		ctx := func(field string) string {
+			return fmt.Sprintf("%s mismatch at payload %d", field, i)
+		}
+
+		assert.Equal(t, s.TxHash, v.TxHash, ctx("TxHash"))
+		assert.Equal(t, s.LedgerSequence, v.LedgerSequence, ctx("LedgerSequence"))
+		assert.Equal(t, s.TxIdx, v.TxIdx, ctx("TxIdx"))
+		assert.Equal(t, s.OpIdx, v.OpIdx, ctx("OpIdx"))
+		assert.Equal(t, s.LedgerClosedAt, v.LedgerClosedAt, ctx("LedgerClosedAt"))
+		assert.Equal(t, s.EventIdx, v.EventIdx, ctx("EventIdx"))
+
+		// Both paths populate ContractEventBytes; they must be
+		// wire-identical (struct path MarshalBinary vs view .Raw()).
+		assert.Equal(t, s.ContractEventBytes, v.ContractEventBytes,
+			ctx("ContractEventBytes (struct marshal vs view .Raw)"))
+
+		// And the term keys derived from those bytes must match, since
+		// downstream derives terms via events.TermsForBytes.
+		sTerms, err := events.TermsForBytes(s.ContractEventBytes)
+		require.NoError(t, err, ctx("struct TermsForBytes"))
+		vTerms, err := events.TermsForBytes(v.ContractEventBytes)
+		require.NoError(t, err, ctx("view TermsForBytes"))
+		assert.Equal(t, sTerms, vTerms, ctx("Terms"))
+	}
+}
+
+// BenchmarkExtractEvents measures the view extractor over a
+// representative event-bearing LCM (V4 mixed top-level + per-op events).
+func BenchmarkExtractEvents(b *testing.B) {
+	view := buildBenchEventsView(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := views.ExtractEvents(view); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func buildBenchEventsView(tb testing.TB) xdr.LedgerCloseMetaView {
+	tb.Helper()
+	var metas []xdr.TransactionMeta
+	for t := 0; t < 8; t++ {
+		ops := make([][]xdr.ContractEvent, 4)
+		for o := range ops {
+			ops[o] = []xdr.ContractEvent{
+				buildContractEvent(fmt.Sprintf("t%d-o%d-a", t, o)),
+				buildContractEvent(fmt.Sprintf("t%d-o%d-b", t, o)),
+			}
+		}
+		metas = append(metas, txMetaWithOpEvents(ops))
+	}
+	lcm := buildLCM(tb, 5001, 1_700_001_000, metas)
+	raw, err := lcm.MarshalBinary()
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return xdr.LedgerCloseMetaView(raw)
+}

--- a/cmd/stellar-rpc/internal/fullhistory/views/pairing_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/pairing_test.go
@@ -151,9 +151,6 @@ func buildLCMOrderMismatchGeneralized(t testing.TB, version int32, ledgerSeq uin
 // hand each returned Transaction another tx's Envelope/FeeBump; hash-keyed
 // pairing returns each tx's OWN envelope. We assert each returned Envelope
 // equals the envelope wire-bytes for that tx's OWN hash.
-//
-// This test FAILS on the old positional code and passes after the
-// hash-pairing fix.
 func TestExtractTransactions_HashPairing_OrderMismatch(t *testing.T) {
 	fixtures := map[string]xdr.LedgerCloseMeta{
 		"lcm-v1": buildLCMOrderMismatchGeneralized(t, 1, 8001, 1_700_030_001, buildOrderedTxs(t, 4)),
@@ -219,6 +216,72 @@ func TestExtractTransactions_HashPairing_OrderMismatchV0(t *testing.T) {
 		assertMatchesReference(t, refs[k], got[k])
 		wantEnv := envelopeWireForHash(t, lcm, got[k].Hash)
 		assert.Equal(t, wantEnv, got[k].Envelope, "tx %d: Envelope is not the tx's own", k)
+	}
+}
+
+// buildTxV0 returns a transaction wrapped in a legacy TX_V0 envelope
+// (pre-protocol-13). Its hash is defined as the hash of the V1 conversion
+// (network.HashTransactionV0); tb toggles the optional TimeBounds, whose
+// wire encoding the view-side hasher relies on being identical to the V1
+// Preconditions encoding.
+func buildTxV0(t testing.TB, tb *xdr.TimeBounds, seqNum int64, eventTopic string) txWithHash {
+	t.Helper()
+	accID := xdr.MustAddress(keypair.MustRandom().Address())
+	env := xdr.TransactionEnvelope{
+		Type: xdr.EnvelopeTypeEnvelopeTypeTxV0,
+		V0: &xdr.TransactionV0Envelope{
+			Tx: xdr.TransactionV0{
+				SourceAccountEd25519: *accID.Ed25519,
+				Fee:                  100,
+				SeqNum:               xdr.SequenceNumber(seqNum),
+				TimeBounds:           tb,
+				Memo:                 xdr.Memo{Type: xdr.MemoTypeMemoNone},
+			},
+		},
+	}
+	hash, err := network.HashTransactionInEnvelope(env, testPassphrase)
+	require.NoError(t, err)
+	return txWithHash{
+		env:  env,
+		hash: hash,
+		meta: txMetaWithOpEvents([][]xdr.ContractEvent{{buildContractEvent(eventTopic)}}),
+	}
+}
+
+// TestExtractTransactions_TxV0Envelopes covers legacy TX_V0 envelopes: one
+// with TimeBounds absent and one present (the two arms of the
+// optional-TimeBounds ≡ Preconditions wire equivalence the view-side hasher
+// depends on), plus a TX(V1) envelope for contrast. The TxSet is reversed
+// relative to apply order, so hash pairing is exercised for TX_V0 too.
+func TestExtractTransactions_TxV0Envelopes(t *testing.T) {
+	buildTxs := func() []txWithHash {
+		return append([]txWithHash{
+			buildTxV0(t, nil, 7, "v0-no-timebounds"),
+			buildTxV0(t, &xdr.TimeBounds{MinTime: 1, MaxTime: 1_900_000_000}, 8, "v0-timebounds"),
+		}, buildOrderedTxs(t, 1)...)
+	}
+	fixtures := map[string]xdr.LedgerCloseMeta{
+		"lcm-v0": buildLCMOrderMismatchV0(t, 8004, 1_700_030_004, buildTxs()),
+		"lcm-v1": buildLCMOrderMismatchGeneralized(t, 1, 8005, 1_700_030_005, buildTxs()),
+	}
+	for name, lcm := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			raw, err := lcm.MarshalBinary()
+			require.NoError(t, err)
+			view := xdr.LedgerCloseMetaView(raw)
+
+			refs := referenceTxs(t, raw)
+			require.Len(t, refs, 3)
+
+			got, gerr := views.ExtractTransactions(view, 0, 0, testPassphrase)
+			require.NoError(t, gerr)
+			require.Len(t, got, len(refs))
+			for k := range got {
+				assertMatchesReference(t, refs[k], got[k])
+				wantEnv := envelopeWireForHash(t, lcm, got[k].Hash)
+				assert.Equal(t, wantEnv, got[k].Envelope, "tx %d: Envelope is not the tx's own", k)
+			}
+		})
 	}
 }
 

--- a/cmd/stellar-rpc/internal/fullhistory/views/pairing_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/pairing_test.go
@@ -1,0 +1,240 @@
+package views_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stellar/go-stellar-sdk/network"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/views"
+)
+
+// txWithHash is one transaction's envelope + its computed hash + its meta,
+// used by the order-mismatch fixtures below.
+type txWithHash struct {
+	env  xdr.TransactionEnvelope
+	hash xdr.Hash
+	meta xdr.TransactionMeta
+}
+
+// buildOrderedTxs returns n distinct transactions (deterministic, hashed
+// under testPassphrase) with a mix of metas, in a stable "apply order".
+func buildOrderedTxs(t testing.TB, n int) []txWithHash {
+	t.Helper()
+	out := make([]txWithHash, 0, n)
+	for i := 0; i < n; i++ {
+		env := xdr.TransactionEnvelope{
+			Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+			V1: &xdr.TransactionV1Envelope{
+				Tx: xdr.Transaction{
+					SourceAccount: xdr.MustMuxedAddress(keypair.MustRandom().Address()),
+					Ext: xdr.TransactionExt{
+						V:           1,
+						SorobanData: &xdr.SorobanTransactionData{},
+					},
+				},
+			},
+		}
+		hash, err := network.HashTransactionInEnvelope(env, testPassphrase)
+		require.NoError(t, err)
+		out = append(out, txWithHash{
+			env:  env,
+			hash: hash,
+			meta: txMetaWithV3SorobanEvents([]xdr.ContractEvent{buildContractEvent(string(rune('A' + i)))}),
+		})
+	}
+	return out
+}
+
+// buildLCMOrderMismatchV0 builds an LCM V0 where TxProcessing is in apply
+// order (txs as given) but the TxSet's plain TransactionSet lists the
+// envelopes in REVERSED order — exactly the agreed-set vs apply-order skew
+// that breaks positional pairing.
+func buildLCMOrderMismatchV0(t testing.TB, ledgerSeq uint32, closeTimestamp int64, txs []txWithHash) xdr.LedgerCloseMeta {
+	t.Helper()
+
+	var prevHash xdr.Hash
+	prevHash[0] = 0x77
+
+	// TxProcessing in apply order.
+	processing := make([]xdr.TransactionResultMeta, 0, len(txs))
+	for _, tx := range txs {
+		processing = append(processing, xdr.TransactionResultMeta{
+			TxApplyProcessing: tx.meta,
+			Result: xdr.TransactionResultPair{
+				TransactionHash: tx.hash,
+				Result:          transactionResult(true),
+			},
+		})
+	}
+	// TxSet envelopes in REVERSED order.
+	envelopes := make([]xdr.TransactionEnvelope, 0, len(txs))
+	for i := len(txs) - 1; i >= 0; i-- {
+		envelopes = append(envelopes, txs[i].env)
+	}
+
+	return xdr.LedgerCloseMeta{
+		V: 0,
+		V0: &xdr.LedgerCloseMetaV0{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+				Header: xdr.LedgerHeader{
+					ScpValue:  xdr.StellarValue{CloseTime: xdr.TimePoint(closeTimestamp)},
+					LedgerSeq: xdr.Uint32(ledgerSeq),
+				},
+			},
+			TxSet: xdr.TransactionSet{
+				PreviousLedgerHash: prevHash,
+				Txs:                envelopes,
+			},
+			TxProcessing: processing,
+		},
+	}
+}
+
+// buildLCMOrderMismatchGeneralized builds an LCM V1/V2 where TxProcessing is
+// in apply order but the GeneralizedTransactionSet V0Components phase lists
+// the envelopes in REVERSED order.
+func buildLCMOrderMismatchGeneralized(t testing.TB, version int32, ledgerSeq uint32, closeTimestamp int64, txs []txWithHash) xdr.LedgerCloseMeta {
+	t.Helper()
+
+	v1Processing := make([]xdr.TransactionResultMeta, 0, len(txs))
+	v2Processing := make([]xdr.TransactionResultMetaV1, 0, len(txs))
+	for _, tx := range txs {
+		result := xdr.TransactionResultPair{
+			TransactionHash: tx.hash,
+			Result:          transactionResult(true),
+		}
+		v1Processing = append(v1Processing, xdr.TransactionResultMeta{TxApplyProcessing: tx.meta, Result: result})
+		v2Processing = append(v2Processing, xdr.TransactionResultMetaV1{TxApplyProcessing: tx.meta, Result: result})
+	}
+
+	// Single V0Components phase whose component lists envelopes REVERSED.
+	revEnvs := make([]xdr.TransactionEnvelope, 0, len(txs))
+	for i := len(txs) - 1; i >= 0; i-- {
+		revEnvs = append(revEnvs, txs[i].env)
+	}
+	comp := []xdr.TxSetComponent{{
+		Type: xdr.TxSetComponentTypeTxsetCompTxsMaybeDiscountedFee,
+		TxsMaybeDiscountedFee: &xdr.TxSetComponentTxsMaybeDiscountedFee{
+			Txs: revEnvs,
+		},
+	}}
+	phases := []xdr.TransactionPhase{{V: 0, V0Components: &comp}}
+
+	header := xdr.LedgerHeaderHistoryEntry{
+		Header: xdr.LedgerHeader{
+			ScpValue:  xdr.StellarValue{CloseTime: xdr.TimePoint(closeTimestamp)},
+			LedgerSeq: xdr.Uint32(ledgerSeq),
+		},
+	}
+	txSet := xdr.GeneralizedTransactionSet{V: 1, V1TxSet: &xdr.TransactionSetV1{Phases: phases}}
+
+	switch version {
+	case 1:
+		return xdr.LedgerCloseMeta{V: 1, V1: &xdr.LedgerCloseMetaV1{LedgerHeader: header, TxSet: txSet, TxProcessing: v1Processing}}
+	case 2:
+		return xdr.LedgerCloseMeta{V: 2, V2: &xdr.LedgerCloseMetaV2{LedgerHeader: header, TxSet: txSet, TxProcessing: v2Processing}}
+	default:
+		t.Fatalf("unsupported version %d", version)
+		return xdr.LedgerCloseMeta{}
+	}
+}
+
+// TestExtractTransactions_HashPairing_OrderMismatch is the P0 regression
+// guard: the TxSet (agreed-set order) is built REVERSED relative to
+// TxProcessing (apply order). Positional pairing (envs[k] -> parts[k]) would
+// hand each returned Transaction another tx's Envelope/FeeBump; hash-keyed
+// pairing returns each tx's OWN envelope. We assert each returned Envelope
+// equals the envelope wire-bytes for that tx's OWN hash.
+//
+// This test FAILS on the old positional code and passes after the
+// hash-pairing fix.
+func TestExtractTransactions_HashPairing_OrderMismatch(t *testing.T) {
+	fixtures := map[string]xdr.LedgerCloseMeta{
+		"lcm-v1": buildLCMOrderMismatchGeneralized(t, 1, 8001, 1_700_030_001, buildOrderedTxs(t, 4)),
+		"lcm-v2": buildLCMOrderMismatchGeneralized(t, 2, 8002, 1_700_030_002, buildOrderedTxs(t, 4)),
+	}
+	for name, lcm := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			raw, err := lcm.MarshalBinary()
+			require.NoError(t, err)
+			view := xdr.LedgerCloseMetaView(raw)
+
+			// db.ParseTransaction reference pairs by hash correctly.
+			refs := referenceTxs(t, raw)
+			require.Greater(t, len(refs), 3)
+
+			got, gerr := views.ExtractTransactions(view, 0, 0, testPassphrase)
+			require.NoError(t, gerr)
+			require.Len(t, got, len(refs))
+
+			for k := range got {
+				// Each returned tx must carry its OWN envelope, paired by hash.
+				assertMatchesReference(t, refs[k], got[k])
+
+				// Belt-and-suspenders: the returned Envelope wire bytes must
+				// be exactly the marshaled envelope whose hash matches this
+				// tx's own hash.
+				wantEnv := envelopeWireForHash(t, lcm, got[k].Hash)
+				assert.Equal(t, wantEnv, got[k].Envelope,
+					"tx %d (%s): Envelope is not the tx's own (positional mispairing)",
+					k, hex.EncodeToString(got[k].Hash[:]))
+			}
+
+			// And ExtractTxDetailsByHash must find each tx's own envelope.
+			for k := range refs {
+				hb, derr := hex.DecodeString(refs[k].TransactionHash)
+				require.NoError(t, derr)
+				var h [32]byte
+				copy(h[:], hb)
+				d, found, derr2 := views.ExtractTxDetailsByHash(view, h, testPassphrase)
+				require.NoError(t, derr2)
+				require.True(t, found)
+				assertMatchesReference(t, refs[k], d)
+			}
+		})
+	}
+}
+
+// TestExtractTransactions_HashPairing_OrderMismatchV0 runs the same P0
+// regression against an LCM V0 plain TransactionSet (reversed).
+func TestExtractTransactions_HashPairing_OrderMismatchV0(t *testing.T) {
+	lcm := buildLCMOrderMismatchV0(t, 8003, 1_700_030_003, buildOrderedTxs(t, 4))
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	view := xdr.LedgerCloseMetaView(raw)
+
+	refs := referenceTxs(t, raw)
+	require.Greater(t, len(refs), 3)
+
+	got, gerr := views.ExtractTransactions(view, 0, 0, testPassphrase)
+	require.NoError(t, gerr)
+	require.Len(t, got, len(refs))
+	for k := range got {
+		assertMatchesReference(t, refs[k], got[k])
+		wantEnv := envelopeWireForHash(t, lcm, got[k].Hash)
+		assert.Equal(t, wantEnv, got[k].Envelope, "tx %d: Envelope is not the tx's own", k)
+	}
+}
+
+// envelopeWireForHash returns the marshaled wire bytes of the envelope in lcm
+// whose transaction hash (under testPassphrase) equals target.
+func envelopeWireForHash(t testing.TB, lcm xdr.LedgerCloseMeta, target [32]byte) []byte {
+	t.Helper()
+	for _, env := range lcm.TransactionEnvelopes() {
+		h, err := network.HashTransactionInEnvelope(env, testPassphrase)
+		require.NoError(t, err)
+		if h == target {
+			b, merr := env.MarshalBinary()
+			require.NoError(t, merr)
+			return b
+		}
+	}
+	t.Fatalf("no envelope in lcm hashes to %x", target)
+	return nil
+}

--- a/cmd/stellar-rpc/internal/fullhistory/views/txdetails.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/txdetails.go
@@ -1,0 +1,588 @@
+package views
+
+import (
+	"bytes"
+	"fmt"
+	"iter"
+
+	"github.com/stellar/go-stellar-sdk/xdr"
+)
+
+// Transaction is the materialized detail for one transaction, with raw XDR
+// fields that ALIAS the source view buffer (zero-copy) — callers copy what
+// they retain. (Mirrors internal/db.Transaction's shape without the
+// dependency, keeping this package a clean leaf.)
+type Transaction struct {
+	Hash              [32]byte
+	ApplicationOrder  int32 // 1-based apply order within the ledger
+	FeeBump           bool
+	Successful        bool
+	Envelope          []byte     // raw xdr.TransactionEnvelope
+	Result            []byte     // raw xdr.TransactionResult
+	Meta              []byte     // raw xdr.TransactionMeta
+	Events            [][]byte   // raw xdr.DiagnosticEvent (V3/V4 diagnostic)
+	TransactionEvents [][]byte   // raw xdr.TransactionEvent (V4 top-level)
+	ContractEvents    [][][]byte // raw xdr.ContractEvent, per operation
+	LedgerSequence    uint32
+	LedgerCloseTime   int64
+}
+
+// lcmDispatch holds the version-specific handles the read-path extractors
+// need from one LedgerCloseMetaView: the ledger header view, the
+// TxProcessing iterable (apply order), and an enumerator that drives a
+// per-envelope yield over the version-specific TxSet (so the caller can
+// build a txhash -> envelope map, or stop early at a target hash). The TxSet
+// is in agreed-set / hash-sorted order, which differs from TxProcessing apply
+// order, so envelopes are paired to transactions BY HASH, never by array
+// position. V0 uses a plain TransactionSet; V1/V2 use a
+// GeneralizedTransactionSet.
+type lcmDispatch struct {
+	header        xdr.LedgerHeaderHistoryEntryView
+	tp            txProcessingIterable
+	enumerateEnvs func(passphrase string, yield envYield) (stopped bool, err error)
+}
+
+// dispatchLCM opens lcm, reads its discriminator, and returns the
+// version-specific handles for the read path (V0/V1/V2). Shared by
+// ExtractTxDetailsByHash and ExtractTransactions. The header + TxProcessing
+// opening is delegated to openHeaderAndTxProc; only the version-specific
+// TxSet open (TransactionSetView vs GeneralizedTransactionSetView) and its
+// envelope enumerator are handled here.
+func dispatchLCM(lcm xdr.LedgerCloseMetaView) (lcmDispatch, error) {
+	disc, header, tp, err := openHeaderAndTxProc(lcm)
+	if err != nil {
+		return lcmDispatch{}, err
+	}
+
+	d := lcmDispatch{header: header, tp: tp}
+	switch disc {
+	case 0:
+		v0, err := lcm.V0()
+		if err != nil {
+			return lcmDispatch{}, fmt.Errorf("views: LCM V0: %w", err)
+		}
+		txSet, err := v0.TxSet()
+		if err != nil {
+			return lcmDispatch{}, fmt.Errorf("views: V0 TxSet: %w", err)
+		}
+		d.enumerateEnvs = func(passphrase string, yield envYield) (bool, error) {
+			return enumerateEnvelopesFromV0TxSet(txSet, passphrase, yield)
+		}
+	case 1:
+		v1, err := lcm.V1()
+		if err != nil {
+			return lcmDispatch{}, fmt.Errorf("views: LCM V1: %w", err)
+		}
+		txSet, err := v1.TxSet()
+		if err != nil {
+			return lcmDispatch{}, fmt.Errorf("views: V1 TxSet: %w", err)
+		}
+		d.enumerateEnvs = func(passphrase string, yield envYield) (bool, error) {
+			return enumerateEnvelopesFromGeneralized(txSet, passphrase, yield)
+		}
+	case 2:
+		v2, err := lcm.V2()
+		if err != nil {
+			return lcmDispatch{}, fmt.Errorf("views: LCM V2: %w", err)
+		}
+		txSet, err := v2.TxSet()
+		if err != nil {
+			return lcmDispatch{}, fmt.Errorf("views: V2 TxSet: %w", err)
+		}
+		d.enumerateEnvs = func(passphrase string, yield envYield) (bool, error) {
+			return enumerateEnvelopesFromGeneralized(txSet, passphrase, yield)
+		}
+	default:
+		return lcmDispatch{}, fmt.Errorf("views: unknown LCM V=%d", disc)
+	}
+	return d, nil
+}
+
+// txViewParts holds the per-tx fields gathered from a single pass over a
+// TxProcessing view (everything except the envelope, which lives in the
+// TxSet — in agreed-set order, NOT TxProcessing apply order — and is paired
+// back to this entry by hash).
+type txViewParts struct {
+	resultRaw   []byte
+	metaRaw     []byte
+	txHash      [32]byte
+	successful  bool
+	diagRaws    [][]byte
+	txEventRaws [][]byte
+	opEventRaws [][][]byte
+	// metaIsV3 records whether TransactionMeta was V3, so the assembly path can
+	// gate V3 ContractEvents on the (envelope-derived) isSoroban check the way
+	// the struct path's GetTransactionEvents does. V4 emits per-op contract
+	// events unconditionally, so it is never gated.
+	metaIsV3 bool
+}
+
+// envelopesByHash builds the txhash -> envelope map mirroring
+// ingest.LedgerTransactionReader.storeTransactions: every TxSet envelope is
+// enumerated and hashed (the TxSet is in agreed-set order, NOT TxProcessing
+// apply order), so a TxProcessing entry's TransactionHash can locate its OWN
+// envelope rather than the one that happens to sit at the same array index.
+// The returned envPart raw bytes remain zero-copy aliases of the view buffer.
+func envelopesByHash(d lcmDispatch, passphrase string) (map[[32]byte]envPart, error) {
+	byHash := make(map[[32]byte]envPart)
+	_, err := d.enumerateEnvs(passphrase, func(e envPart) (bool, error) {
+		byHash[e.hash] = e
+		return false, nil // never stop: materialize ALL envelopes
+	})
+	if err != nil {
+		return nil, err
+	}
+	return byHash, nil
+}
+
+// findEnvelopeByHash enumerates the TxSet envelopes and returns the single
+// one whose transaction hash equals target, stopping as soon as it matches
+// (no full-map alloc, no hashing past the match). Returns the same
+// missing-hash error as the full-map path if target is absent. The returned
+// envPart's raw bytes remain the zero-copy .Raw() view slice.
+func findEnvelopeByHash(d lcmDispatch, passphrase string, target [32]byte) (envPart, error) {
+	var found envPart
+	stopped, err := d.enumerateEnvs(passphrase, func(e envPart) (bool, error) {
+		if e.hash == target {
+			found = e
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return envPart{}, err
+	}
+	if !stopped {
+		return envPart{}, fmt.Errorf(
+			"views: tx %x present in TxProcessing but missing from TxSet (inconsistent LCM)", target)
+	}
+	return found, nil
+}
+
+// ExtractTxDetailsByHash finds the transaction with the given hash in the
+// ledger and returns its materialized detail. found=false (nil error) if
+// the hash is not present. All byte fields alias the lcm view buffer
+// (zero-copy); callers copy what they retain. The passphrase is needed to
+// hash TxSet envelopes so each is paired to its TxProcessing entry by hash
+// (the TxSet is in agreed-set order, not TxProcessing apply order).
+func ExtractTxDetailsByHash(lcm xdr.LedgerCloseMetaView, hash [32]byte, passphrase string) (Transaction, bool, error) {
+	d, err := dispatchLCM(lcm)
+	if err != nil {
+		return Transaction{}, false, err
+	}
+
+	ledgerSeq, ledgerCloseTime, err := readLedgerHeader(d.header)
+	if err != nil {
+		return Transaction{}, false, err
+	}
+
+	// Single TxProcessing pass: find the apply index whose hash matches,
+	// gathering that entry's result/meta/events on the way past.
+	applyIdx := -1
+	var part txViewParts
+	idx := 0
+	for txView, iterErr := range d.tp.iter() {
+		if iterErr != nil {
+			return Transaction{}, false, fmt.Errorf("views: TxProcessing iter: %w", iterErr)
+		}
+		h, herr := readTxHash(txView)
+		if herr != nil {
+			return Transaction{}, false, herr
+		}
+		if bytes.Equal(h[:], hash[:]) {
+			part, err = collectTxParts(txView, h)
+			if err != nil {
+				return Transaction{}, false, err
+			}
+			applyIdx = idx
+			break
+		}
+		idx++
+	}
+	if applyIdx < 0 {
+		return Transaction{}, false, nil
+	}
+
+	env, err := findEnvelopeByHash(d, passphrase, part.txHash)
+	if err != nil {
+		return Transaction{}, false, err
+	}
+
+	return Transaction{
+		Hash:              part.txHash,
+		ApplicationOrder:  int32(applyIdx) + 1, //nolint:gosec // apply index fits int32
+		FeeBump:           env.typ == xdr.EnvelopeTypeEnvelopeTypeTxFeeBump,
+		Successful:        part.successful,
+		Envelope:          env.raw,
+		Result:            part.resultRaw,
+		Meta:              part.metaRaw,
+		Events:            part.diagRaws,
+		TransactionEvents: part.txEventRaws,
+		ContractEvents:    gateV3ContractEvents(part, env.isSoroban),
+		LedgerSequence:    ledgerSeq,
+		LedgerCloseTime:   ledgerCloseTime,
+	}, true, nil
+}
+
+// ExtractTransactions returns up to limit transactions in apply order
+// (TxProcessing order) starting at startIdx (0-based). The cursor
+// (startIdx/limit) is defined against apply order. limit == 0 returns all
+// from startIdx; limit < 0 is an error (symmetric with startIdx, not silently
+// treated as "all"). Supports the getTransactions cursor (which maps to
+// (ledgerSeq, txIdx)) by resuming mid-ledger. startIdx past the end yields an
+// empty slice (nil error); startIdx < 0 is an error (not silently clamped).
+// The passphrase is needed to hash TxSet envelopes so each is paired to its
+// TxProcessing entry by hash (the TxSet is in agreed-set order, not
+// TxProcessing apply order). All byte fields alias the lcm view buffer
+// (zero-copy).
+func ExtractTransactions(lcm xdr.LedgerCloseMetaView, startIdx, limit int, passphrase string) ([]Transaction, error) {
+	if startIdx < 0 {
+		return nil, fmt.Errorf("views: startIdx %d < 0", startIdx)
+	}
+	if limit < 0 {
+		return nil, fmt.Errorf("views: limit %d < 0", limit)
+	}
+	d, err := dispatchLCM(lcm)
+	if err != nil {
+		return nil, err
+	}
+
+	ledgerSeq, ledgerCloseTime, err := readLedgerHeader(d.header)
+	if err != nil {
+		return nil, err
+	}
+
+	// Single TxProcessing pass from startIdx, honoring limit.
+	parts, err := collectTxProcessingRange(d.tp, startIdx, limit)
+	if err != nil {
+		return nil, err
+	}
+	if len(parts) == 0 {
+		return nil, nil
+	}
+
+	byHash, err := envelopesByHash(d, passphrase)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]Transaction, len(parts))
+	for k := range parts {
+		applyIdx := startIdx + k
+		env, ok := byHash[parts[k].txHash]
+		if !ok {
+			return nil, fmt.Errorf(
+				"views: tx %x present in TxProcessing but missing from TxSet (inconsistent LCM)", parts[k].txHash)
+		}
+		out[k] = Transaction{
+			Hash:              parts[k].txHash,
+			ApplicationOrder:  int32(applyIdx) + 1, //nolint:gosec // apply index fits int32
+			FeeBump:           env.typ == xdr.EnvelopeTypeEnvelopeTypeTxFeeBump,
+			Successful:        parts[k].successful,
+			Envelope:          env.raw,
+			Result:            parts[k].resultRaw,
+			Meta:              parts[k].metaRaw,
+			Events:            parts[k].diagRaws,
+			TransactionEvents: parts[k].txEventRaws,
+			ContractEvents:    gateV3ContractEvents(parts[k], env.isSoroban),
+			LedgerSequence:    ledgerSeq,
+			LedgerCloseTime:   ledgerCloseTime,
+		}
+	}
+	return out, nil
+}
+
+// collectTxParts gathers the per-tx result/meta/events for one
+// TxProcessing entry view (hash already read by the caller).
+func collectTxParts(txView txResultMetaView, hash xdr.Hash) (txViewParts, error) {
+	var p txViewParts
+	p.txHash = [32]byte(hash)
+
+	rp, err := txView.Result()
+	if err != nil {
+		return p, fmt.Errorf("views: Result: %w", err)
+	}
+	rv, err := rp.Result()
+	if err != nil {
+		return p, fmt.Errorf("views: Result.Result: %w", err)
+	}
+	p.resultRaw, err = rv.Raw()
+	if err != nil {
+		return p, fmt.Errorf("views: Result.Raw: %w", err)
+	}
+	p.successful, err = isResultSuccessful(rv)
+	if err != nil {
+		return p, err
+	}
+
+	metaView, err := txView.TxApplyProcessing()
+	if err != nil {
+		return p, fmt.Errorf("views: TxApplyProcessing: %w", err)
+	}
+	p.metaRaw, err = metaView.Raw()
+	if err != nil {
+		return p, fmt.Errorf("views: Meta.Raw: %w", err)
+	}
+	me, err := extractEventRawsFromMeta(metaView)
+	if err != nil {
+		return p, err
+	}
+	p.diagRaws = me.diagnostic
+	p.txEventRaws = me.transaction
+	p.opEventRaws = me.contract
+	p.metaIsV3 = me.isV3
+	return p, nil
+}
+
+// gateV3ContractEvents zeroes ContractEvents for a V3 meta whose envelope is
+// NOT a Soroban tx, matching the struct path (GetTransactionEvents returns no
+// OperationEvents for a non-Soroban V3 tx). The read path computes
+// ContractEvents whenever SorobanMeta is present, so without this the read path
+// would over-emit relative to db.ParseTransaction. V4 (per-op events) and the
+// diagnostic-event field are unaffected — the struct path does not gate those.
+func gateV3ContractEvents(p txViewParts, isSoroban bool) [][][]byte {
+	if p.metaIsV3 && !isSoroban {
+		return [][][]byte{}
+	}
+	return p.opEventRaws
+}
+
+// collectTxProcessingRange walks the TxProcessing iterable once and gathers
+// per-tx fields for apply indices [start, start+count). count == 0 means
+// "all from start" (the caller rejects count < 0 before reaching here). A
+// start past the end yields an empty slice (not an error) so getTransactions
+// can detect end-of-ledger.
+func collectTxProcessingRange(tp txProcessingIterable, start, count int) ([]txViewParts, error) {
+	unbounded := count <= 0
+	end := start + count
+	var out []txViewParts
+	if !unbounded {
+		out = make([]txViewParts, 0, count)
+	}
+	idx := 0
+	for txView, iterErr := range tp.iter() {
+		if iterErr != nil {
+			return nil, fmt.Errorf("views: TxProcessing iter: %w", iterErr)
+		}
+		if !unbounded && idx >= end {
+			break
+		}
+		if idx >= start {
+			h, herr := readTxHash(txView)
+			if herr != nil {
+				return nil, herr
+			}
+			p, perr := collectTxParts(txView, h)
+			if perr != nil {
+				return nil, perr
+			}
+			out = append(out, p)
+		}
+		idx++
+	}
+	return out, nil
+}
+
+// isResultSuccessful inspects the TransactionResult code via views:
+// TxSuccess and TxFeeBumpInnerSuccess are the two success codes (matches
+// xdr.TransactionResult.Successful()).
+func isResultSuccessful(rv xdr.TransactionResultView) (bool, error) {
+	rr, err := rv.Result()
+	if err != nil {
+		return false, fmt.Errorf("views: TransactionResult.Result: %w", err)
+	}
+	cv, err := rr.Code()
+	if err != nil {
+		return false, fmt.Errorf("views: TransactionResult Code: %w", err)
+	}
+	code, err := cv.Value()
+	if err != nil {
+		return false, fmt.Errorf("views: TransactionResult Code value: %w", err)
+	}
+	return code == xdr.TransactionResultCodeTxSuccess ||
+		code == xdr.TransactionResultCodeTxFeeBumpInnerSuccess, nil
+}
+
+// metaEvents bundles the raw event byte slices extracted from one
+// TransactionMeta view (via .Raw() on each leaf event view), replacing what
+// would otherwise be a 5-value return. isV3 lets the caller gate V3
+// ContractEvents on the envelope-derived IsSorobanTx check (see
+// gateV3ContractEvents).
+type metaEvents struct {
+	diagnostic  [][]byte   // DiagnosticEvents (V3 SorobanMeta / V4)
+	transaction [][]byte   // top-level TransactionEvents (V4 only)
+	contract    [][][]byte // per-operation ContractEvents
+	isV3        bool
+}
+
+// extractEventRawsFromMeta dispatches on TransactionMeta version and returns a
+// metaEvents bundle of raw byte slices via .Raw() on each leaf event view.
+// metaEvents.isV3 lets the caller gate V3 ContractEvents on the
+// envelope-derived IsSorobanTx check (see gateV3ContractEvents) — this function
+// has no envelope, so it emits the present SorobanMeta.Events unconditionally
+// and leaves the soroban gate to the caller.
+//
+// V1/V2: no events.
+// V3:    SorobanMeta (optional) carries DiagnosticEvents + Events; if
+//
+//	present, OperationEvents[0] = Events (soroban tx has 1 op).
+//
+// V4:    top-level TransactionEvents + DiagnosticEvents; Operations[i]
+//
+//	carry per-op contract Events. Mirrors
+//	ingest.LedgerTransaction.GetTransactionEvents()/GetDiagnosticEvents().
+//
+// Empty (not nil) slices match db.ParseTransaction's behavior — it always
+// allocates via make([][]byte, 0, len(...)) regardless of whether the
+// source slice was nil, so returning nil here would diverge from the
+// struct path purely on the nil-vs-empty axis.
+//
+//nolint:cyclop,funlen // linear dispatch on meta version
+func extractEventRawsFromMeta(mv xdr.TransactionMetaView) (metaEvents, error) {
+	vv, err := mv.V()
+	if err != nil {
+		return metaEvents{}, fmt.Errorf("views: meta.V: %w", err)
+	}
+	v, err := vv.Value()
+	if err != nil {
+		return metaEvents{}, fmt.Errorf("views: meta.V value: %w", err)
+	}
+	emptyDiag := [][]byte{}
+	emptyTxEv := [][]byte{}
+	emptyOp := [][][]byte{}
+	switch v {
+	case 1, 2:
+		return metaEvents{diagnostic: emptyDiag, transaction: emptyTxEv, contract: emptyOp}, nil
+	case 3:
+		v3, err := mv.V3()
+		if err != nil {
+			return metaEvents{}, fmt.Errorf("views: meta V3: %w", err)
+		}
+		smOpt, err := v3.SorobanMeta()
+		if err != nil {
+			return metaEvents{}, fmt.Errorf("views: SorobanMeta opt: %w", err)
+		}
+		sm, present, err := smOpt.Unwrap()
+		if err != nil {
+			return metaEvents{}, fmt.Errorf("views: SorobanMeta unwrap: %w", err)
+		}
+		if !present {
+			return metaEvents{diagnostic: emptyDiag, transaction: emptyTxEv, contract: emptyOp, isV3: true}, nil
+		}
+		// SorobanMeta.Events are emitted whenever SorobanMeta is present; the
+		// per-tx soroban gate (matching the struct path's IsSorobanTx check) is
+		// applied by the caller via gateV3ContractEvents, which has the paired
+		// envelope. The diagnostic events are NOT gated — the struct path's
+		// GetDiagnosticEvents returns them regardless of IsSorobanTx.
+		diagView, err := sm.DiagnosticEvents()
+		if err != nil {
+			return metaEvents{}, fmt.Errorf("views: V3 DiagnosticEvents: %w", err)
+		}
+		diagRaws, err := collectDiagnosticEventRaws(diagView.Iter())
+		if err != nil {
+			return metaEvents{}, err
+		}
+		eventsView, err := sm.Events()
+		if err != nil {
+			return metaEvents{}, fmt.Errorf("views: V3 SorobanMeta.Events: %w", err)
+		}
+		contractRaws, err := collectContractEventRaws(eventsView.Iter())
+		if err != nil {
+			return metaEvents{}, err
+		}
+		// V3 has no top-level TransactionEvents.
+		return metaEvents{diagnostic: diagRaws, transaction: emptyTxEv, contract: [][][]byte{contractRaws}, isV3: true}, nil
+	case 4:
+		v4, err := mv.V4()
+		if err != nil {
+			return metaEvents{}, fmt.Errorf("views: meta V4: %w", err)
+		}
+		diagView, err := v4.DiagnosticEvents()
+		if err != nil {
+			return metaEvents{}, fmt.Errorf("views: V4 DiagnosticEvents: %w", err)
+		}
+		diagRaws, err := collectDiagnosticEventRaws(diagView.Iter())
+		if err != nil {
+			return metaEvents{}, err
+		}
+		txEventsView, err := v4.Events()
+		if err != nil {
+			return metaEvents{}, fmt.Errorf("views: V4 Events: %w", err)
+		}
+		txEventRaws, err := collectTransactionEventRaws(txEventsView.Iter())
+		if err != nil {
+			return metaEvents{}, err
+		}
+		opsView, err := v4.Operations()
+		if err != nil {
+			return metaEvents{}, fmt.Errorf("views: V4 Operations: %w", err)
+		}
+		opCount, err := opsView.Count()
+		if err != nil {
+			return metaEvents{}, fmt.Errorf("views: V4 Operations count: %w", err)
+		}
+		opEventRaws := make([][][]byte, 0, opCount)
+		for op, opErr := range opsView.Iter() {
+			if opErr != nil {
+				return metaEvents{}, fmt.Errorf("views: V4 op iter: %w", opErr)
+			}
+			evView, err := op.Events()
+			if err != nil {
+				return metaEvents{}, fmt.Errorf("views: V4 op.Events: %w", err)
+			}
+			evRaws, err := collectContractEventRaws(evView.Iter())
+			if err != nil {
+				return metaEvents{}, err
+			}
+			opEventRaws = append(opEventRaws, evRaws)
+		}
+		return metaEvents{diagnostic: diagRaws, transaction: txEventRaws, contract: opEventRaws}, nil
+	default:
+		return metaEvents{}, fmt.Errorf("views: unsupported TransactionMeta V=%d", v)
+	}
+}
+
+func collectDiagnosticEventRaws(it iter.Seq2[xdr.DiagnosticEventView, error]) ([][]byte, error) {
+	out := [][]byte{}
+	for ev, err := range it {
+		if err != nil {
+			return nil, fmt.Errorf("views: DiagnosticEvent iter: %w", err)
+		}
+		raw, err := ev.Raw()
+		if err != nil {
+			return nil, fmt.Errorf("views: DiagnosticEvent.Raw: %w", err)
+		}
+		out = append(out, raw)
+	}
+	return out, nil
+}
+
+func collectTransactionEventRaws(it iter.Seq2[xdr.TransactionEventView, error]) ([][]byte, error) {
+	out := [][]byte{}
+	for ev, err := range it {
+		if err != nil {
+			return nil, fmt.Errorf("views: TransactionEvent iter: %w", err)
+		}
+		raw, err := ev.Raw()
+		if err != nil {
+			return nil, fmt.Errorf("views: TransactionEvent.Raw: %w", err)
+		}
+		out = append(out, raw)
+	}
+	return out, nil
+}
+
+func collectContractEventRaws(it iter.Seq2[xdr.ContractEventView, error]) ([][]byte, error) {
+	out := [][]byte{}
+	for ev, err := range it {
+		if err != nil {
+			return nil, fmt.Errorf("views: ContractEvent iter: %w", err)
+		}
+		raw, err := ev.Raw()
+		if err != nil {
+			return nil, fmt.Errorf("views: ContractEvent.Raw: %w", err)
+		}
+		out = append(out, raw)
+	}
+	return out, nil
+}

--- a/cmd/stellar-rpc/internal/fullhistory/views/txdetails.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/txdetails.go
@@ -1,7 +1,6 @@
 package views
 
 import (
-	"bytes"
 	"fmt"
 	"iter"
 
@@ -27,77 +26,6 @@ type Transaction struct {
 	LedgerCloseTime   int64
 }
 
-// lcmDispatch holds the version-specific handles the read-path extractors
-// need from one LedgerCloseMetaView: the ledger header view, the
-// TxProcessing iterable (apply order), and an enumerator that drives a
-// per-envelope yield over the version-specific TxSet (so the caller can
-// build a txhash -> envelope map, or stop early at a target hash). The TxSet
-// is in agreed-set / hash-sorted order, which differs from TxProcessing apply
-// order, so envelopes are paired to transactions BY HASH, never by array
-// position. V0 uses a plain TransactionSet; V1/V2 use a
-// GeneralizedTransactionSet.
-type lcmDispatch struct {
-	header        xdr.LedgerHeaderHistoryEntryView
-	tp            txProcessingIterable
-	enumerateEnvs func(passphrase string, yield envYield) (stopped bool, err error)
-}
-
-// dispatchLCM opens lcm, reads its discriminator, and returns the
-// version-specific handles for the read path (V0/V1/V2). Shared by
-// ExtractTxDetailsByHash and ExtractTransactions. The header + TxProcessing
-// opening is delegated to openHeaderAndTxProc; only the version-specific
-// TxSet open (TransactionSetView vs GeneralizedTransactionSetView) and its
-// envelope enumerator are handled here.
-func dispatchLCM(lcm xdr.LedgerCloseMetaView) (lcmDispatch, error) {
-	disc, header, tp, err := openHeaderAndTxProc(lcm)
-	if err != nil {
-		return lcmDispatch{}, err
-	}
-
-	d := lcmDispatch{header: header, tp: tp}
-	switch disc {
-	case 0:
-		v0, err := lcm.V0()
-		if err != nil {
-			return lcmDispatch{}, fmt.Errorf("views: LCM V0: %w", err)
-		}
-		txSet, err := v0.TxSet()
-		if err != nil {
-			return lcmDispatch{}, fmt.Errorf("views: V0 TxSet: %w", err)
-		}
-		d.enumerateEnvs = func(passphrase string, yield envYield) (bool, error) {
-			return enumerateEnvelopesFromV0TxSet(txSet, passphrase, yield)
-		}
-	case 1:
-		v1, err := lcm.V1()
-		if err != nil {
-			return lcmDispatch{}, fmt.Errorf("views: LCM V1: %w", err)
-		}
-		txSet, err := v1.TxSet()
-		if err != nil {
-			return lcmDispatch{}, fmt.Errorf("views: V1 TxSet: %w", err)
-		}
-		d.enumerateEnvs = func(passphrase string, yield envYield) (bool, error) {
-			return enumerateEnvelopesFromGeneralized(txSet, passphrase, yield)
-		}
-	case 2:
-		v2, err := lcm.V2()
-		if err != nil {
-			return lcmDispatch{}, fmt.Errorf("views: LCM V2: %w", err)
-		}
-		txSet, err := v2.TxSet()
-		if err != nil {
-			return lcmDispatch{}, fmt.Errorf("views: V2 TxSet: %w", err)
-		}
-		d.enumerateEnvs = func(passphrase string, yield envYield) (bool, error) {
-			return enumerateEnvelopesFromGeneralized(txSet, passphrase, yield)
-		}
-	default:
-		return lcmDispatch{}, fmt.Errorf("views: unknown LCM V=%d", disc)
-	}
-	return d, nil
-}
-
 // txViewParts holds the per-tx fields gathered from a single pass over a
 // TxProcessing view (everything except the envelope, which lives in the
 // TxSet — in agreed-set order, NOT TxProcessing apply order — and is paired
@@ -117,17 +45,27 @@ type txViewParts struct {
 	metaIsV3 bool
 }
 
-// envelopesByHash builds the txhash -> envelope map mirroring
-// ingest.LedgerTransactionReader.storeTransactions: every TxSet envelope is
-// enumerated and hashed (the TxSet is in agreed-set order, NOT TxProcessing
-// apply order), so a TxProcessing entry's TransactionHash can locate its OWN
-// envelope rather than the one that happens to sit at the same array index.
-// The returned envPart raw bytes remain zero-copy aliases of the view buffer.
-func envelopesByHash(d lcmDispatch, passphrase string) (map[[32]byte]envPart, error) {
-	byHash := make(map[[32]byte]envPart)
-	_, err := d.enumerateEnvs(passphrase, func(e envPart) (bool, error) {
-		byHash[e.hash] = e
-		return false, nil // never stop: materialize ALL envelopes
+// envelopesForHashes enumerates the TxSet and returns the envelopes whose
+// transaction hashes appear in want, mirroring
+// ingest.LedgerTransactionReader.storeTransactions: every envelope is
+// hashed so a TxProcessing entry's TransactionHash locates its OWN envelope
+// (the TxSet is in agreed-set order, NOT TxProcessing apply order, so
+// positional pairing would mispair). Enumeration — and with it per-envelope
+// hashing — stops as soon as every wanted hash is resolved, so a small page
+// does not pay for the whole TxSet. The returned envPart raw bytes remain
+// zero-copy aliases of the view buffer.
+func envelopesForHashes(d lcmDispatch, th *txHasher, want [][32]byte) (map[[32]byte]envPart, error) {
+	need := make(map[[32]byte]struct{}, len(want))
+	for _, h := range want {
+		need[h] = struct{}{}
+	}
+	byHash := make(map[[32]byte]envPart, len(need))
+	_, err := d.enumerateEnvs(th, func(e envPart) (bool, error) {
+		if _, ok := need[e.hash]; ok {
+			byHash[e.hash] = e
+			delete(need, e.hash)
+		}
+		return len(need) == 0, nil
 	})
 	if err != nil {
 		return nil, err
@@ -138,11 +76,11 @@ func envelopesByHash(d lcmDispatch, passphrase string) (map[[32]byte]envPart, er
 // findEnvelopeByHash enumerates the TxSet envelopes and returns the single
 // one whose transaction hash equals target, stopping as soon as it matches
 // (no full-map alloc, no hashing past the match). Returns the same
-// missing-hash error as the full-map path if target is absent. The returned
+// missing-hash error as the multi-hash path if target is absent. The returned
 // envPart's raw bytes remain the zero-copy .Raw() view slice.
-func findEnvelopeByHash(d lcmDispatch, passphrase string, target [32]byte) (envPart, error) {
+func findEnvelopeByHash(d lcmDispatch, th *txHasher, target [32]byte) (envPart, error) {
 	var found envPart
-	stopped, err := d.enumerateEnvs(passphrase, func(e envPart) (bool, error) {
+	stopped, err := d.enumerateEnvs(th, func(e envPart) (bool, error) {
 		if e.hash == target {
 			found = e
 			return true, nil
@@ -170,6 +108,10 @@ func ExtractTxDetailsByHash(lcm xdr.LedgerCloseMetaView, hash [32]byte, passphra
 	if err != nil {
 		return Transaction{}, false, err
 	}
+	th, err := newTxHasher(passphrase)
+	if err != nil {
+		return Transaction{}, false, err
+	}
 
 	ledgerSeq, ledgerCloseTime, err := readLedgerHeader(d.header)
 	if err != nil {
@@ -181,7 +123,7 @@ func ExtractTxDetailsByHash(lcm xdr.LedgerCloseMetaView, hash [32]byte, passphra
 	applyIdx := -1
 	var part txViewParts
 	idx := 0
-	for txView, iterErr := range d.tp.iter() {
+	for txView, iterErr := range d.tp {
 		if iterErr != nil {
 			return Transaction{}, false, fmt.Errorf("views: TxProcessing iter: %w", iterErr)
 		}
@@ -189,7 +131,7 @@ func ExtractTxDetailsByHash(lcm xdr.LedgerCloseMetaView, hash [32]byte, passphra
 		if herr != nil {
 			return Transaction{}, false, herr
 		}
-		if bytes.Equal(h[:], hash[:]) {
+		if h == xdr.Hash(hash) {
 			part, err = collectTxParts(txView, h)
 			if err != nil {
 				return Transaction{}, false, err
@@ -203,7 +145,7 @@ func ExtractTxDetailsByHash(lcm xdr.LedgerCloseMetaView, hash [32]byte, passphra
 		return Transaction{}, false, nil
 	}
 
-	env, err := findEnvelopeByHash(d, passphrase, part.txHash)
+	env, err := findEnvelopeByHash(d, th, part.txHash)
 	if err != nil {
 		return Transaction{}, false, err
 	}
@@ -246,6 +188,10 @@ func ExtractTransactions(lcm xdr.LedgerCloseMetaView, startIdx, limit int, passp
 	if err != nil {
 		return nil, err
 	}
+	th, err := newTxHasher(passphrase)
+	if err != nil {
+		return nil, err
+	}
 
 	ledgerSeq, ledgerCloseTime, err := readLedgerHeader(d.header)
 	if err != nil {
@@ -261,7 +207,13 @@ func ExtractTransactions(lcm xdr.LedgerCloseMetaView, startIdx, limit int, passp
 		return nil, nil
 	}
 
-	byHash, err := envelopesByHash(d, passphrase)
+	// Resolve only this page's envelopes; TxSet enumeration stops as soon
+	// as every page hash is found.
+	want := make([][32]byte, len(parts))
+	for k := range parts {
+		want[k] = parts[k].txHash
+	}
+	byHash, err := envelopesForHashes(d, th, want)
 	if err != nil {
 		return nil, err
 	}
@@ -340,6 +292,8 @@ func collectTxParts(txView txResultMetaView, hash xdr.Hash) (txViewParts, error)
 // ContractEvents whenever SorobanMeta is present, so without this the read path
 // would over-emit relative to db.ParseTransaction. V4 (per-op events) and the
 // diagnostic-event field are unaffected — the struct path does not gate those.
+// See doc.go's trusted-input invariant for how this relates to ExtractEvents,
+// which has no envelope and trusts SorobanMeta presence alone.
 func gateV3ContractEvents(p txViewParts, isSoroban bool) [][][]byte {
 	if p.metaIsV3 && !isSoroban {
 		return [][][]byte{}
@@ -352,7 +306,7 @@ func gateV3ContractEvents(p txViewParts, isSoroban bool) [][][]byte {
 // "all from start" (the caller rejects count < 0 before reaching here). A
 // start past the end yields an empty slice (not an error) so getTransactions
 // can detect end-of-ledger.
-func collectTxProcessingRange(tp txProcessingIterable, start, count int) ([]txViewParts, error) {
+func collectTxProcessingRange(tp iter.Seq2[txResultMetaView, error], start, count int) ([]txViewParts, error) {
 	unbounded := count <= 0
 	end := start + count
 	var out []txViewParts
@@ -360,7 +314,7 @@ func collectTxProcessingRange(tp txProcessingIterable, start, count int) ([]txVi
 		out = make([]txViewParts, 0, count)
 	}
 	idx := 0
-	for txView, iterErr := range tp.iter() {
+	for txView, iterErr := range tp {
 		if iterErr != nil {
 			return nil, fmt.Errorf("views: TxProcessing iter: %w", iterErr)
 		}
@@ -422,18 +376,16 @@ type metaEvents struct {
 // has no envelope, so it emits the present SorobanMeta.Events unconditionally
 // and leaves the soroban gate to the caller.
 //
-// V0/V1/V2: no events (V0 is legacy pre-Soroban meta, Operations only; the
+// Supported meta versions:
 //
-//	SDK reference path rejects V0 but full-history backfill tolerates it).
-//
-// V3:    SorobanMeta (optional) carries DiagnosticEvents + Events; if
-//
-//	present, OperationEvents[0] = Events (soroban tx has 1 op).
-//
-// V4:    top-level TransactionEvents + DiagnosticEvents; Operations[i]
-//
-//	carry per-op contract Events. Mirrors
-//	ingest.LedgerTransaction.GetTransactionEvents()/GetDiagnosticEvents().
+//   - V0/V1/V2: no events (V0 is legacy pre-Soroban meta, Operations only;
+//     the SDK reference path rejects V0 but full-history backfill
+//     tolerates it).
+//   - V3: SorobanMeta (optional) carries DiagnosticEvents + Events; if
+//     present, OperationEvents[0] = Events (soroban tx has 1 op).
+//   - V4: top-level TransactionEvents + DiagnosticEvents; Operations[i]
+//     carry per-op contract Events. Mirrors
+//     ingest.LedgerTransaction.GetTransactionEvents()/GetDiagnosticEvents().
 //
 // Empty (not nil) slices match db.ParseTransaction's behavior — it always
 // allocates via make([][]byte, 0, len(...)) regardless of whether the

--- a/cmd/stellar-rpc/internal/fullhistory/views/txdetails.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/txdetails.go
@@ -422,7 +422,10 @@ type metaEvents struct {
 // has no envelope, so it emits the present SorobanMeta.Events unconditionally
 // and leaves the soroban gate to the caller.
 //
-// V1/V2: no events.
+// V0/V1/V2: no events (V0 is legacy pre-Soroban meta, Operations only; the
+//
+//	SDK reference path rejects V0 but full-history backfill tolerates it).
+//
 // V3:    SorobanMeta (optional) carries DiagnosticEvents + Events; if
 //
 //	present, OperationEvents[0] = Events (soroban tx has 1 op).
@@ -451,7 +454,10 @@ func extractEventRawsFromMeta(mv xdr.TransactionMetaView) (metaEvents, error) {
 	emptyTxEv := [][]byte{}
 	emptyOp := [][][]byte{}
 	switch v {
-	case 1, 2:
+	case 0, 1, 2:
+		// V0 (legacy pre-Soroban, Operations only), V1, V2 carry no contract
+		// events. The struct reference path errors on V0 meta; full-history
+		// backfills from genesis and must tolerate it (see ExtractEvents).
 		return metaEvents{diagnostic: emptyDiag, transaction: emptyTxEv, contract: emptyOp}, nil
 	case 3:
 		v3, err := mv.V3()

--- a/cmd/stellar-rpc/internal/fullhistory/views/txdetails_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/txdetails_test.go
@@ -3,6 +3,7 @@ package views_test
 import (
 	"encoding/hex"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -300,40 +301,23 @@ func TestExtractTxDetails_AliasesViewBuffer(t *testing.T) {
 	assertAliasesRaw(t, raw, got.Meta)
 }
 
+// assertAliasesRaw proves field aliases raw (rather than matching a copy)
+// by pointer containment — field's data pointer must lie within raw's
+// backing array — then confirms a mutation of raw is visible through field.
 func assertAliasesRaw(t *testing.T, raw, field []byte) {
 	t.Helper()
 	require.NotEmpty(t, field)
-	// Locate field within raw by scanning for its starting offset (the
-	// field is a sub-slice of raw, so its data pointer lies within raw).
-	off := indexOfSubslice(raw, field)
-	require.GreaterOrEqual(t, off, 0, "field bytes not found within raw buffer (not aliased)")
+	rawBase := uintptr(unsafe.Pointer(unsafe.SliceData(raw)))
+	rawEnd := rawBase + uintptr(len(raw))
+	fieldBase := uintptr(unsafe.Pointer(unsafe.SliceData(field)))
+	require.GreaterOrEqual(t, fieldBase, rawBase, "field bytes start before view buffer (not aliased)")
+	require.Less(t, fieldBase, rawEnd, "field bytes start past view buffer end (not aliased)")
+
+	off := fieldBase - rawBase
 	before := raw[off]
 	raw[off] ^= 0xFF
 	assert.Equal(t, raw[off], field[0], "field did not track mutation of raw — not aliased")
 	assert.NotEqual(t, before, field[0])
-}
-
-// indexOfSubslice returns the offset at which sub begins within buf such
-// that buf[off:off+len(sub)] shares backing storage with sub, or -1. Since
-// the view fields are sub-slices of buf, a content match at a unique offset
-// confirms aliasing for our fixtures.
-func indexOfSubslice(buf, sub []byte) int {
-	if len(sub) == 0 || len(sub) > len(buf) {
-		return -1
-	}
-	for i := 0; i+len(sub) <= len(buf); i++ {
-		match := true
-		for j := range sub {
-			if buf[i+j] != sub[j] {
-				match = false
-				break
-			}
-		}
-		if match {
-			return i
-		}
-	}
-	return -1
 }
 
 // buildClassicTxEnvelopeAndHash builds a CLASSIC (non-Soroban) tx envelope —

--- a/cmd/stellar-rpc/internal/fullhistory/views/txdetails_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/txdetails_test.go
@@ -1,0 +1,538 @@
+package views_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/ingest"
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stellar/go-stellar-sdk/network"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/db"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/views"
+)
+
+// referenceTxs decodes raw via the SDK ingest reader (the same source of
+// truth the read path mirrors) and returns one db.Transaction per tx in
+// apply order, keyed by application order. db.ParseTransaction provides the
+// wire-bytes reference (Envelope/Result/Meta via MarshalBinary, events via
+// per-element MarshalBinary) against which the zero-copy view path is
+// asserted byte-for-byte.
+func referenceTxs(t *testing.T, raw []byte) []db.Transaction {
+	t.Helper()
+	var lcm xdr.LedgerCloseMeta
+	require.NoError(t, lcm.UnmarshalBinary(raw))
+	reader, err := ingest.NewLedgerTransactionReaderFromLedgerCloseMeta(testPassphrase, lcm)
+	require.NoError(t, err)
+	n := lcm.CountTransactions()
+	out := make([]db.Transaction, 0, n)
+	for i := 0; i < n; i++ {
+		itx, rerr := reader.Read()
+		require.NoError(t, rerr)
+		ref, perr := db.ParseTransaction(lcm, itx)
+		require.NoError(t, perr)
+		out = append(out, ref)
+	}
+	return out
+}
+
+// assertMatchesReference checks a view Transaction against the
+// db.ParseTransaction reference for the same apply position.
+func assertMatchesReference(t *testing.T, ref db.Transaction, got views.Transaction) {
+	t.Helper()
+	assert.Equal(t, ref.TransactionHash, hex.EncodeToString(got.Hash[:]), "Hash")
+	assert.Equal(t, ref.ApplicationOrder, got.ApplicationOrder, "ApplicationOrder")
+	assert.Equal(t, ref.FeeBump, got.FeeBump, "FeeBump")
+	assert.Equal(t, ref.Successful, got.Successful, "Successful")
+	assert.Equal(t, ref.Envelope, got.Envelope, "Envelope wire bytes")
+	assert.Equal(t, ref.Result, got.Result, "Result wire bytes")
+	assert.Equal(t, ref.Meta, got.Meta, "Meta wire bytes")
+	assert.Equal(t, ref.Events, got.Events, "Events (diagnostic)")
+	assert.Equal(t, ref.TransactionEvents, got.TransactionEvents, "TransactionEvents")
+	assert.Equal(t, ref.ContractEvents, got.ContractEvents, "ContractEvents")
+	assert.Equal(t, ref.Ledger.Sequence, got.LedgerSequence, "LedgerSequence")
+	assert.Equal(t, ref.Ledger.CloseTime, got.LedgerCloseTime, "LedgerCloseTime")
+}
+
+// diffFixtureMetas is a representative mix of meta shapes (V1, V2, V3
+// soroban with/without events, V4 op-only, V4 top-level + op) shared across
+// the differential cases so order/cursor handling is exercised.
+func diffFixtureMetas() []xdr.TransactionMeta {
+	evA := buildContractEvent("dx-a")
+	evB := buildContractEvent("dx-b")
+	evC := buildContractEvent("dx-c")
+	mixedV4 := xdr.TransactionMeta{
+		V: 4,
+		V4: &xdr.TransactionMetaV4{
+			Events: []xdr.TransactionEvent{
+				{Stage: xdr.TransactionEventStageTransactionEventStageBeforeAllTxs, Event: buildContractEvent("dx-pre")},
+				{Stage: xdr.TransactionEventStageTransactionEventStageAfterTx, Event: buildContractEvent("dx-post")},
+			},
+			Operations: []xdr.OperationMetaV2{
+				{Events: []xdr.ContractEvent{evA}},
+				{Events: []xdr.ContractEvent{evB}},
+			},
+		},
+	}
+	return []xdr.TransactionMeta{
+		txMetaWithOpEvents([][]xdr.ContractEvent{{evA}, {evB, evC}}),
+		{V: 1, V1: &xdr.TransactionMetaV1{}},
+		{V: 2, V2: &xdr.TransactionMetaV2{}},
+		txMetaWithV3SorobanEvents([]xdr.ContractEvent{evA, evB}),
+		txMetaWithV3SorobanEvents(nil),
+		mixedV4,
+	}
+}
+
+// diffFixtures returns the LCM fixtures spanning LCM V0/V1/V2, each with the
+// representative meta mix.
+func diffFixtures(t testing.TB) map[string]xdr.LedgerCloseMeta {
+	return map[string]xdr.LedgerCloseMeta{
+		"lcm-v0": buildLCMV0(t, 7001, 1_700_010_001, diffFixtureMetas()),
+		"lcm-v1": buildLCMVersion(t, 1, 7002, 1_700_010_002, diffFixtureMetas()),
+		"lcm-v2": buildLCMVersion(t, 2, 7003, 1_700_010_003, diffFixtureMetas()),
+	}
+}
+
+// TestExtractTxDetailsByHash_MatchesReference asserts that for every tx in
+// every LCM-version fixture, ExtractTxDetailsByHash returns a Transaction
+// wire-identical to the db.ParseTransaction reference, and that an unknown
+// hash returns found=false with no error.
+func TestExtractTxDetailsByHash_MatchesReference(t *testing.T) {
+	for name, lcm := range diffFixtures(t) {
+		t.Run(name, func(t *testing.T) {
+			raw, err := lcm.MarshalBinary()
+			require.NoError(t, err)
+			view := xdr.LedgerCloseMetaView(raw)
+			refs := referenceTxs(t, raw)
+
+			// Hit: look up each tx by its real hash.
+			for i := range refs {
+				hashBytes, derr := hex.DecodeString(refs[i].TransactionHash)
+				require.NoError(t, derr)
+				var hash [32]byte
+				copy(hash[:], hashBytes)
+
+				got, found, gerr := views.ExtractTxDetailsByHash(view, hash, testPassphrase)
+				require.NoError(t, gerr)
+				require.True(t, found, "tx %d (%s) not found", i, refs[i].TransactionHash)
+				assertMatchesReference(t, refs[i], got)
+			}
+
+			// Miss: an unknown hash returns found=false, nil error.
+			var unknown [32]byte
+			for j := range unknown {
+				unknown[j] = 0xEE
+			}
+			_, found, gerr := views.ExtractTxDetailsByHash(view, unknown, testPassphrase)
+			require.NoError(t, gerr)
+			assert.False(t, found, "unknown hash unexpectedly found")
+		})
+	}
+}
+
+// TestExtractTransactions_MatchesReference exercises the paginated read path
+// across LCM versions: full ledger, a startIdx>0 page, a limit<count page,
+// and a startIdx past the end (empty). Each returned Transaction is asserted
+// wire-identical to the db.ParseTransaction reference at the same position.
+func TestExtractTransactions_MatchesReference(t *testing.T) {
+	for name, lcm := range diffFixtures(t) {
+		t.Run(name, func(t *testing.T) {
+			raw, err := lcm.MarshalBinary()
+			require.NoError(t, err)
+			view := xdr.LedgerCloseMetaView(raw)
+			refs := referenceTxs(t, raw)
+			n := len(refs)
+			require.Greater(t, n, 3, "fixture must be multi-tx")
+
+			check := func(start, limit int) {
+				got, gerr := views.ExtractTransactions(view, start, limit, testPassphrase)
+				require.NoError(t, gerr)
+				want := n - start
+				if want < 0 {
+					want = 0
+				}
+				if limit > 0 && limit < want {
+					want = limit
+				}
+				require.Len(t, got, want, "page len start=%d limit=%d", start, limit)
+				for k := range got {
+					assertMatchesReference(t, refs[start+k], got[k])
+				}
+			}
+
+			// Full ledger (limit==0 => all).
+			check(0, 0)
+			// startIdx>0 page to the end.
+			check(2, 0)
+			// limit<count page.
+			check(0, 2)
+			// startIdx>0 with a limit shorter than what remains.
+			check(1, 2)
+			// startIdx exactly at end and past the end => empty.
+			check(n, 0)
+			check(n+5, 10)
+		})
+	}
+}
+
+// TestExtractTransactions_FeeBump asserts the FeeBump flag is set from the
+// envelope discriminator (not assumed false), using a ledger that mixes a
+// fee-bump tx with a regular tx.
+func TestExtractTransactions_FeeBump(t *testing.T) {
+	lcm := buildLCMWithFeeBump(t, 7100, 1_700_011_000)
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	view := xdr.LedgerCloseMetaView(raw)
+	refs := referenceTxs(t, raw)
+
+	got, gerr := views.ExtractTransactions(view, 0, 0, testPassphrase)
+	require.NoError(t, gerr)
+	require.Len(t, got, len(refs))
+
+	sawFeeBump := false
+	for k := range got {
+		assertMatchesReference(t, refs[k], got[k])
+		if got[k].FeeBump {
+			sawFeeBump = true
+		}
+	}
+	assert.True(t, sawFeeBump, "expected at least one fee-bump tx in fixture")
+}
+
+// buildLCMWithFeeBump builds an LCM V2 whose first tx is a fee-bump
+// envelope and second is a plain tx, so FeeBump detection from the envelope
+// discriminator is exercised on the read path.
+func buildLCMWithFeeBump(t testing.TB, ledgerSeq uint32, closeTimestamp int64) xdr.LedgerCloseMeta {
+	t.Helper()
+
+	inner := xdr.TransactionV1Envelope{
+		Tx: xdr.Transaction{
+			SourceAccount: xdr.MustMuxedAddress(keypair.MustRandom().Address()),
+		},
+	}
+	feeBumpEnv := xdr.TransactionEnvelope{
+		Type: xdr.EnvelopeTypeEnvelopeTypeTxFeeBump,
+		FeeBump: &xdr.FeeBumpTransactionEnvelope{
+			Tx: xdr.FeeBumpTransaction{
+				FeeSource: xdr.MustMuxedAddress(keypair.MustRandom().Address()),
+				Fee:       1000,
+				InnerTx: xdr.FeeBumpTransactionInnerTx{
+					Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+					V1:   &inner,
+				},
+			},
+		},
+	}
+	feeBumpHash, err := network.HashTransactionInEnvelope(feeBumpEnv, testPassphrase)
+	require.NoError(t, err)
+
+	plainEnv, plainHash := buildTxEnvelopeAndHash(t)
+
+	envelopes := []xdr.TransactionEnvelope{feeBumpEnv, plainEnv}
+	hashes := []xdr.Hash{feeBumpHash, plainHash}
+	metas := []xdr.TransactionMeta{
+		{V: 1, V1: &xdr.TransactionMetaV1{}},
+		txMetaWithV3SorobanEvents([]xdr.ContractEvent{buildContractEvent("fb-soroban")}),
+	}
+
+	phases := make([]xdr.TransactionPhase, 0, len(envelopes))
+	processing := make([]xdr.TransactionResultMetaV1, 0, len(envelopes))
+	for i := range envelopes {
+		processing = append(processing, xdr.TransactionResultMetaV1{
+			TxApplyProcessing: metas[i],
+			Result: xdr.TransactionResultPair{
+				TransactionHash: hashes[i],
+				Result:          transactionResult(true),
+			},
+		})
+		comp := []xdr.TxSetComponent{{
+			Type: xdr.TxSetComponentTypeTxsetCompTxsMaybeDiscountedFee,
+			TxsMaybeDiscountedFee: &xdr.TxSetComponentTxsMaybeDiscountedFee{
+				Txs: []xdr.TransactionEnvelope{envelopes[i]},
+			},
+		}}
+		phases = append(phases, xdr.TransactionPhase{V: 0, V0Components: &comp})
+	}
+
+	return xdr.LedgerCloseMeta{
+		V: 2,
+		V2: &xdr.LedgerCloseMetaV2{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+				Header: xdr.LedgerHeader{
+					ScpValue:  xdr.StellarValue{CloseTime: xdr.TimePoint(closeTimestamp)},
+					LedgerSeq: xdr.Uint32(ledgerSeq),
+				},
+			},
+			TxSet:        xdr.GeneralizedTransactionSet{V: 1, V1TxSet: &xdr.TransactionSetV1{Phases: phases}},
+			TxProcessing: processing,
+		},
+	}
+}
+
+// TestExtractTxDetails_AliasesViewBuffer asserts the zero-copy contract: the
+// Envelope/Result/Meta byte fields point into the input view buffer.
+func TestExtractTxDetails_AliasesViewBuffer(t *testing.T) {
+	lcm := buildLCM(t, 7200, 1_700_012_000, []xdr.TransactionMeta{
+		txMetaWithOpEvents([][]xdr.ContractEvent{{buildContractEvent("aliasme")}}),
+	})
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	view := xdr.LedgerCloseMetaView(raw)
+	refs := referenceTxs(t, raw)
+
+	hashBytes, err := hex.DecodeString(refs[0].TransactionHash)
+	require.NoError(t, err)
+	var hash [32]byte
+	copy(hash[:], hashBytes)
+
+	got, found, err := views.ExtractTxDetailsByHash(view, hash, testPassphrase)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.NotEmpty(t, got.Meta)
+
+	// Mutate a byte the Meta field aliases and confirm it tracks (proving
+	// it is not a copy). Find the Meta region's offset within raw.
+	assertAliasesRaw(t, raw, got.Meta)
+}
+
+func assertAliasesRaw(t *testing.T, raw, field []byte) {
+	t.Helper()
+	require.NotEmpty(t, field)
+	// Locate field within raw by scanning for its starting offset (the
+	// field is a sub-slice of raw, so its data pointer lies within raw).
+	off := indexOfSubslice(raw, field)
+	require.GreaterOrEqual(t, off, 0, "field bytes not found within raw buffer (not aliased)")
+	before := raw[off]
+	raw[off] ^= 0xFF
+	assert.Equal(t, raw[off], field[0], "field did not track mutation of raw — not aliased")
+	assert.NotEqual(t, before, field[0])
+}
+
+// indexOfSubslice returns the offset at which sub begins within buf such
+// that buf[off:off+len(sub)] shares backing storage with sub, or -1. Since
+// the view fields are sub-slices of buf, a content match at a unique offset
+// confirms aliasing for our fixtures.
+func indexOfSubslice(buf, sub []byte) int {
+	if len(sub) == 0 || len(sub) > len(buf) {
+		return -1
+	}
+	for i := 0; i+len(sub) <= len(buf); i++ {
+		match := true
+		for j := range sub {
+			if buf[i+j] != sub[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i
+		}
+	}
+	return -1
+}
+
+// buildClassicTxEnvelopeAndHash builds a CLASSIC (non-Soroban) tx envelope —
+// no SorobanData in the Tx.Ext — and its hash. Pairing this with a V3
+// SorobanMeta meta yields a "SorobanMeta present but envelope is classic" tx,
+// which the struct path (GetTransactionEvents) treats as IsSorobanTx==false and
+// thus emits NO ContractEvents.
+func buildClassicTxEnvelopeAndHash(t testing.TB) (xdr.TransactionEnvelope, xdr.Hash) {
+	t.Helper()
+	envelope := xdr.TransactionEnvelope{
+		Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+		V1: &xdr.TransactionV1Envelope{
+			Tx: xdr.Transaction{
+				SourceAccount: xdr.MustMuxedAddress(keypair.MustRandom().Address()),
+				// No SorobanData ext → classic tx.
+			},
+		},
+	}
+	hash, err := network.HashTransactionInEnvelope(envelope, testPassphrase)
+	require.NoError(t, err)
+	return envelope, hash
+}
+
+// buildLCMV2SingleTx assembles a one-tx LCM V2 pairing the given envelope/hash
+// with the given meta, for differential cases that need a specific envelope
+// shape (rather than the shared soroban-shaped builder).
+func buildLCMV2SingleTx(t testing.TB, ledgerSeq uint32, closeTimestamp int64, env xdr.TransactionEnvelope, hash xdr.Hash, meta xdr.TransactionMeta) xdr.LedgerCloseMeta {
+	t.Helper()
+	comp := []xdr.TxSetComponent{{
+		Type: xdr.TxSetComponentTypeTxsetCompTxsMaybeDiscountedFee,
+		TxsMaybeDiscountedFee: &xdr.TxSetComponentTxsMaybeDiscountedFee{
+			Txs: []xdr.TransactionEnvelope{env},
+		},
+	}}
+	return xdr.LedgerCloseMeta{
+		V: 2,
+		V2: &xdr.LedgerCloseMetaV2{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+				Header: xdr.LedgerHeader{
+					ScpValue:  xdr.StellarValue{CloseTime: xdr.TimePoint(closeTimestamp)},
+					LedgerSeq: xdr.Uint32(ledgerSeq),
+				},
+			},
+			TxSet: xdr.GeneralizedTransactionSet{V: 1, V1TxSet: &xdr.TransactionSetV1{Phases: []xdr.TransactionPhase{{V: 0, V0Components: &comp}}}},
+			TxProcessing: []xdr.TransactionResultMetaV1{{
+				TxApplyProcessing: meta,
+				Result:            xdr.TransactionResultPair{TransactionHash: hash, Result: transactionResult(true)},
+			}},
+		},
+	}
+}
+
+// TestExtractTransactions_V3ClassicEnvelope_NoContractEvents is the V3
+// contract-event parity case: a present SorobanMeta carrying Events, paired with
+// a CLASSIC (non-Soroban) envelope. The struct path gates V3 ContractEvents on
+// IsSorobanTx (an ENVELOPE check), so the reference emits EMPTY ContractEvents.
+// The read path must match by gating on the same envelope-derived isSoroban
+// flag (gateV3ContractEvents), not on SorobanMeta presence.
+func TestExtractTransactions_V3ClassicEnvelope_NoContractEvents(t *testing.T) {
+	env, hash := buildClassicTxEnvelopeAndHash(t)
+	meta := txMetaWithV3SorobanEvents([]xdr.ContractEvent{
+		buildContractEvent("classic-v3-a"),
+		buildContractEvent("classic-v3-b"),
+	})
+	lcm := buildLCMV2SingleTx(t, 9001, 1_700_050_001, env, hash, meta)
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	view := xdr.LedgerCloseMetaView(raw)
+	refs := referenceTxs(t, raw)
+	require.Len(t, refs, 1)
+	require.False(t, refs[0].FeeBump)
+	// The reference (SDK) emits NO contract events for a classic V3 tx.
+	require.Empty(t, refs[0].ContractEvents, "sanity: reference V3-classic has no ContractEvents")
+
+	// ExtractTransactions path.
+	got, gerr := views.ExtractTransactions(view, 0, 0, testPassphrase)
+	require.NoError(t, gerr)
+	require.Len(t, got, 1)
+	assertMatchesReference(t, refs[0], got[0])
+	assert.Empty(t, got[0].ContractEvents, "read path must gate V3 ContractEvents on the classic envelope")
+
+	// ExtractTxDetailsByHash path.
+	gotOne, found, derr := views.ExtractTxDetailsByHash(view, [32]byte(hash), testPassphrase)
+	require.NoError(t, derr)
+	require.True(t, found)
+	assertMatchesReference(t, refs[0], gotOne)
+	assert.Empty(t, gotOne.ContractEvents, "by-hash read path must also gate V3 ContractEvents")
+}
+
+// TestExtractTransactions_DiagnosticEvents exercises collectDiagnosticEventRaws
+// with NON-empty data on both a V3 (SorobanMeta.DiagnosticEvents) and a V4
+// (TransactionMetaV4.DiagnosticEvents) fixture, asserting the read path's
+// Events field is wire-identical to the struct-path reference (so the
+// differential Events comparison is no longer empty-vs-empty). The V3 fixture
+// uses the shared soroban-shaped envelope so the SDK reference keeps the V3
+// SorobanMeta events too.
+func TestExtractTransactions_DiagnosticEvents(t *testing.T) {
+	diag := func(topic string) xdr.DiagnosticEvent {
+		return xdr.DiagnosticEvent{InSuccessfulContractCall: true, Event: buildContractEvent(topic)}
+	}
+
+	// V3 SorobanMeta with diagnostic events (soroban envelope, so events stay).
+	v3Meta := txMetaWithV3SorobanEvents([]xdr.ContractEvent{buildContractEvent("v3-ev")})
+	v3Meta.V3.SorobanMeta.DiagnosticEvents = []xdr.DiagnosticEvent{diag("v3-diag-a"), diag("v3-diag-b")}
+
+	// V4 with top-level diagnostic events.
+	v4Meta := xdr.TransactionMeta{
+		V: 4,
+		V4: &xdr.TransactionMetaV4{
+			Operations:       []xdr.OperationMetaV2{{Events: []xdr.ContractEvent{buildContractEvent("v4-op")}}},
+			DiagnosticEvents: []xdr.DiagnosticEvent{diag("v4-diag-a")},
+		},
+	}
+
+	lcm := buildLCM(t, 9101, 1_700_051_001, []xdr.TransactionMeta{v3Meta, v4Meta})
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	view := xdr.LedgerCloseMetaView(raw)
+	refs := referenceTxs(t, raw)
+	require.Len(t, refs, 2)
+	// Sanity: the reference Events are actually populated now.
+	require.NotEmpty(t, refs[0].Events, "V3 reference must carry diagnostic events")
+	require.NotEmpty(t, refs[1].Events, "V4 reference must carry diagnostic events")
+
+	got, gerr := views.ExtractTransactions(view, 0, 0, testPassphrase)
+	require.NoError(t, gerr)
+	require.Len(t, got, 2)
+	for k := range got {
+		assertMatchesReference(t, refs[k], got[k])
+		require.NotEmpty(t, got[k].Events, "read path Events must be non-empty for tx %d", k)
+	}
+}
+
+// TestExtractTransactions_NegativeLimit asserts limit<0 is an error (symmetric
+// with startIdx<0), while limit==0 still means "all".
+func TestExtractTransactions_NegativeLimit(t *testing.T) {
+	lcm := buildLCM(t, 9201, 1_700_052_001, []xdr.TransactionMeta{
+		{V: 1, V1: &xdr.TransactionMetaV1{}},
+		{V: 2, V2: &xdr.TransactionMetaV2{}},
+	})
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	view := xdr.LedgerCloseMetaView(raw)
+
+	_, gerr := views.ExtractTransactions(view, 0, -1, testPassphrase)
+	require.Error(t, gerr)
+	assert.Contains(t, gerr.Error(), "limit")
+
+	// limit==0 still returns all.
+	got, gerr := views.ExtractTransactions(view, 0, 0, testPassphrase)
+	require.NoError(t, gerr)
+	assert.Len(t, got, 2)
+}
+
+// BenchmarkExtractTxDetailsByHash measures the read-path single-tx extractor
+// over a representative multi-tx LCM, looking up the last tx (worst-case
+// scan).
+func BenchmarkExtractTxDetailsByHash(b *testing.B) {
+	var metas []xdr.TransactionMeta
+	for t := 0; t < 32; t++ {
+		metas = append(metas, txMetaWithOpEvents([][]xdr.ContractEvent{{buildContractEvent("bx")}}))
+	}
+	lcm := buildLCM(b, 6001, 1_700_020_000, metas)
+	raw, err := lcm.MarshalBinary()
+	if err != nil {
+		b.Fatal(err)
+	}
+	view := xdr.LedgerCloseMetaView(raw)
+	hash := [32]byte(lcm.TransactionHash(len(metas) - 1))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, found, err := views.ExtractTxDetailsByHash(view, hash, testPassphrase)
+		if err != nil || !found {
+			b.Fatalf("err=%v found=%v", err, found)
+		}
+	}
+}
+
+// BenchmarkExtractTransactions measures the paginated read-path extractor
+// materializing a full multi-tx ledger.
+func BenchmarkExtractTransactions(b *testing.B) {
+	var metas []xdr.TransactionMeta
+	for t := 0; t < 32; t++ {
+		metas = append(metas, txMetaWithOpEvents([][]xdr.ContractEvent{{buildContractEvent("bp")}}))
+	}
+	lcm := buildLCM(b, 6002, 1_700_021_000, metas)
+	raw, err := lcm.MarshalBinary()
+	if err != nil {
+		b.Fatal(err)
+	}
+	view := xdr.LedgerCloseMetaView(raw)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := views.ExtractTransactions(view, 0, 0, testPassphrase); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/cmd/stellar-rpc/internal/fullhistory/views/txhash.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/txhash.go
@@ -1,0 +1,43 @@
+package views
+
+import (
+	"fmt"
+
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash"
+)
+
+// ExtractTxHashes returns the 32-byte transaction hash of every
+// transaction in the ledger, in apply order, each paired with the ledger
+// sequence (derived internally from the ledger header, via the same
+// readLedgerHeader path the sibling extractors use). Hashes are copied (the
+// returned slice does not alias the view buffer).
+//
+// Unlike ExtractEvents, all LCM versions are supported (V0/V1/V2):
+// tx-hash extraction reads TxProcessing[i].Result.TransactionHash in
+// array order and needs no apply-order sort.
+func ExtractTxHashes(lcm xdr.LedgerCloseMetaView) ([]txhash.Entry, error) {
+	_, header, tp, err := openHeaderAndTxProc(lcm)
+	if err != nil {
+		return nil, err
+	}
+
+	ledgerSeq, _, err := readLedgerHeader(header)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []txhash.Entry
+	for tx, iterErr := range tp.iter() {
+		if iterErr != nil {
+			return nil, fmt.Errorf("views: TxProcessing iter: %w", iterErr)
+		}
+		h, err := readTxHash(tx)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, txhash.Entry{Hash: [32]byte(h), LedgerSeq: ledgerSeq})
+	}
+	return out, nil
+}

--- a/cmd/stellar-rpc/internal/fullhistory/views/txhash.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/txhash.go
@@ -18,18 +18,18 @@ import (
 // tx-hash extraction reads TxProcessing[i].Result.TransactionHash in
 // array order and needs no apply-order sort.
 func ExtractTxHashes(lcm xdr.LedgerCloseMetaView) ([]txhash.Entry, error) {
-	_, header, tp, err := openHeaderAndTxProc(lcm)
+	d, err := dispatchLCM(lcm)
 	if err != nil {
 		return nil, err
 	}
 
-	ledgerSeq, _, err := readLedgerHeader(header)
+	ledgerSeq, _, err := readLedgerHeader(d.header)
 	if err != nil {
 		return nil, err
 	}
 
 	var out []txhash.Entry
-	for tx, iterErr := range tp.iter() {
+	for tx, iterErr := range d.tp {
 		if iterErr != nil {
 			return nil, fmt.Errorf("views: TxProcessing iter: %w", iterErr)
 		}

--- a/cmd/stellar-rpc/internal/fullhistory/views/txhash_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/views/txhash_test.go
@@ -1,0 +1,131 @@
+package views_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/views"
+)
+
+// TestExtractTxHashes_MatchesStructPath cross-checks that the view-based
+// ExtractTxHashes returns the same hashes, in the same apply order, as
+// the struct path (lcm.CountTransactions / lcm.TransactionHash), each
+// paired with the given ledgerSeq.
+func TestExtractTxHashes_MatchesStructPath(t *testing.T) {
+	const seq = 9001
+
+	// A few txs with assorted metas; tx-hash extraction is independent
+	// of meta contents, so any mix exercises the TxProcessing walk.
+	metas := []xdr.TransactionMeta{
+		txMetaWithOpEvents([][]xdr.ContractEvent{{buildContractEvent("a")}}),
+		{V: 1, V1: &xdr.TransactionMetaV1{}},
+		txMetaWithV3SorobanEvents([]xdr.ContractEvent{buildContractEvent("b")}),
+	}
+	lcm := buildLCM(t, seq, 1_700_000_777, metas)
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+
+	got, err := views.ExtractTxHashes(xdr.LedgerCloseMetaView(raw))
+	require.NoError(t, err)
+
+	n := lcm.CountTransactions()
+	require.Len(t, got, n, "tx count differs")
+
+	for i := 0; i < n; i++ {
+		want := lcm.TransactionHash(i)
+		assert.Equal(t, [32]byte(want), got[i].Hash, "hash mismatch at tx %d", i)
+		assert.Equal(t, uint32(seq), got[i].LedgerSeq, "ledgerSeq mismatch at tx %d", i)
+	}
+}
+
+// TestExtractTxHashes_V0 exercises the LCM V0 dispatch arm (case 0),
+// which uses a plain TransactionSet (not GeneralizedTransactionSet) and
+// TransactionResultMeta. ExtractTxHashes supports V0 even though
+// ExtractEvents does not. Parity is asserted against lcm.TransactionHash.
+func TestExtractTxHashes_V0(t *testing.T) {
+	const seq = 9101
+	metas := []xdr.TransactionMeta{
+		txMetaWithOpEvents([][]xdr.ContractEvent{{buildContractEvent("v0a")}}),
+		{V: 1, V1: &xdr.TransactionMetaV1{}},
+		txMetaWithV3SorobanEvents([]xdr.ContractEvent{buildContractEvent("v0b")}),
+	}
+	lcm := buildLCMV0(t, seq, 1_700_001_010, metas)
+	require.Equal(t, int32(0), lcm.V, "fixture must be LCM V0")
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+
+	got, err := views.ExtractTxHashes(xdr.LedgerCloseMetaView(raw))
+	require.NoError(t, err)
+
+	n := lcm.CountTransactions()
+	require.Len(t, got, n, "tx count differs")
+	for i := 0; i < n; i++ {
+		want := lcm.TransactionHash(i)
+		assert.Equal(t, [32]byte(want), got[i].Hash, "hash mismatch at tx %d", i)
+		assert.Equal(t, uint32(seq), got[i].LedgerSeq, "ledgerSeq mismatch at tx %d", i)
+	}
+}
+
+// TestExtractTxHashes_V1 exercises the LCM V1 dispatch arm (case 1),
+// LedgerCloseMetaV1 + the non-V1 TransactionResultMeta type. Parity is
+// asserted against lcm.TransactionHash.
+func TestExtractTxHashes_V1(t *testing.T) {
+	const seq = 9102
+	metas := []xdr.TransactionMeta{
+		txMetaWithOpEvents([][]xdr.ContractEvent{{buildContractEvent("v1a")}}),
+		{V: 2, V2: &xdr.TransactionMetaV2{}},
+		txMetaWithV3SorobanEvents([]xdr.ContractEvent{buildContractEvent("v1b")}),
+	}
+	lcm := buildLCMVersion(t, 1, seq, 1_700_001_020, metas)
+	require.Equal(t, int32(1), lcm.V, "fixture must be LCM V1")
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+
+	got, err := views.ExtractTxHashes(xdr.LedgerCloseMetaView(raw))
+	require.NoError(t, err)
+
+	n := lcm.CountTransactions()
+	require.Len(t, got, n, "tx count differs")
+	for i := 0; i < n; i++ {
+		want := lcm.TransactionHash(i)
+		assert.Equal(t, [32]byte(want), got[i].Hash, "hash mismatch at tx %d", i)
+		assert.Equal(t, uint32(seq), got[i].LedgerSeq, "ledgerSeq mismatch at tx %d", i)
+	}
+}
+
+// TestExtractTxHashes_Empty checks a zero-tx ledger yields no entries.
+func TestExtractTxHashes_Empty(t *testing.T) {
+	lcm := buildLCM(t, 9002, 1_700_000_888, nil)
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	got, err := views.ExtractTxHashes(xdr.LedgerCloseMetaView(raw))
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// BenchmarkExtractTxHashes measures the view extractor over a
+// representative multi-tx LCM.
+func BenchmarkExtractTxHashes(b *testing.B) {
+	var metas []xdr.TransactionMeta
+	for t := 0; t < 32; t++ {
+		metas = append(metas, txMetaWithOpEvents([][]xdr.ContractEvent{{buildContractEvent("x")}}))
+	}
+	lcm := buildLCM(b, 5002, 1_700_002_000, metas)
+	raw, err := lcm.MarshalBinary()
+	if err != nil {
+		b.Fatal(err)
+	}
+	view := xdr.LedgerCloseMetaView(raw)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := views.ExtractTxHashes(view); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Implements #764 — the four zero-copy XDR view extractors, promoted from the `rpc-hack` bench harness into a production package `cmd/stellar-rpc/internal/fullhistory/views/`. Each turns a raw `LedgerCloseMeta` (wrapped as `xdr.LedgerCloseMetaView`) into the shape RPC v2 needs, **without** `UnmarshalBinary` — outputs alias the view buffer (callers copy what they retain).

> **Stacked.** Based on a throwaway integration base (`fh-ingest-base` = `feature/full-history` + #756 merged) so it compiles against the events index. Will retarget to `feature/full-history` once #756 lands. The ingestion PR (#765) stacks on this branch.

## The four extractors (all of #764)

| #764 requirement | Entrypoint | File |
|---|---|---|
| **events** — events-index payloads | `ExtractEvents(lcm) ([]events.Payload, error)` | `events.go` |
| **tx-hashes** — txHash per tx | `ExtractTxHashes(lcm) ([]txhash.Entry, error)` | `txhash.go` |
| **tx-details by hash** — envelope/result/meta for a target hash (`getTransaction`) | `ExtractTxDetailsByHash(lcm, hash, passphrase) (Transaction, bool, error)` | `txdetails.go` |
| **tx-pages** — transactions in order with cursor (`getTransactions`) | `ExtractTransactions(lcm, startIdx, limit, passphrase) ([]Transaction, error)` | `txdetails.go` |

- **events / tx-hashes** read only `TxProcessing` (which carries the hash + meta), so they take no passphrase; `ExtractEvents` returns `ErrV0Unsupported` for V0 (V0 has no contract events).
- **tx-details / tx-pages** also need each tx's **envelope** (in the `TxSet`, which is in agreed-set/hash-sorted order, not apply order), so they pair envelope→tx **by hash** (`network.HashTransactionInEnvelope`) and take the network passphrase. `startIdx`/`limit` are the `getTransactions` cursor. They return a package-local `views.Transaction`.
- Supporting: `envelopes.go` (version/phase-aware envelope enumeration + hashing, used by the two read-path extractors).

## Tests
- **Differential** vs the parsed path: `ExtractEvents`/`ExtractTxHashes` vs the struct `LCMToPayloads`/`lcm.TransactionHash`; `ExtractTxDetailsByHash`/`ExtractTransactions` vs `db.ParseTransaction` (driven by the SDK `LedgerTransactionReader`) — field-by-field, wire-identical bytes, across LCM **V0/V1/V2** and meta **V1–V4** (incl. V0Components + ParallelTxs phases, staged top-level + per-op events, diagnostic events).
- `pairing_test.go` — reversed-order regression (TxSet order ≠ apply order) guarding the by-hash pairing.
- Negative paths (unsupported meta version, missing-hash, `startIdx<0`/`limit<0`), a zero-copy aliasing assertion, and per-extractor `go test -bench` benchmarks.

## SDK vs stellar-rpc split (issue #764 acceptance item)

**Rule:** low-level XDR navigation → `go-stellar-sdk`; RPC-specific data shapes → stellar-rpc.

**Determination: nothing in this task belongs in the SDK** — the boundary already sat where the rule wants it. The SDK ships all the low-level navigation, so this package is a pure *consumer* that composes those primitives into RPC shapes.

**SDK-side (consumed, nothing added)** — production imports:
- `xdr.LedgerCloseMetaView` + the generated `*View` accessors (`.V()/.V0..V2()`, `.Iter()`, `.At()`, `.Count()`, `.Raw()`, `.Value()`) — zero-copy, schema-generated XDR navigation.
- `network.HashTransactionInEnvelope` — canonical protocol-level tx-hash (envelope↔tx pairing).
- `toid` — protocol-level transaction/operation-ID (apply order / cursor).

**stellar-rpc-side (this package)** — the four extractors plus the RPC-specific shapes (`events.Payload`, `txhash.Entry`, the package-local `views.Transaction`) and semantics (event-ID/term ordering, `startIdx/limit` paging, envelope-by-hash pairing). Documented in `views/doc.go`.

The differential tests pull in the SDK's `ingest.LedgerTransactionReader` only as the *reference oracle* to validate the view path against — it is deliberately **not** a production dependency.

**Related layering choice (within stellar-rpc):** the read-path extractors return a package-local `views.Transaction` rather than `internal/db.Transaction` (even though `db` doesn't import `views`, so there'd be no cycle) — keeping `views` a clean leaf and avoiding an inversion of the `db → views` layering.

## Differences from `rpc-hack`

A faithful promotion of rpc-hack's view-extraction logic (the V1–V4 event walk and XDR-view navigation are essentially line-for-line), with the bench-only scaffolding dropped (roundtrip-comparison harness, CLI/CSV/cache) and a few deliberate changes:

- **One correctness fix (the notable divergence):** rpc-hack paired each transaction's envelope to its TxProcessing entry **by array position**, which is only correct when TxSet order == apply order — it isn't in general. That's a latent bug still present on rpc-hack; its differential tests missed it because their fixtures built the TxSet in apply order. Here, envelopes are paired **by hash** (`envelopesByHash`, mirroring the SDK's `LedgerTransactionReader`), with `pairing_test.go` as a reversed-order regression.
- **Packaging:** moved from `package events` + the bench `package main` into one leaf `package views`; read-path extractors return `views.Transaction` (flat `LedgerSequence`/`LedgerCloseTime`, raw `[32]byte` hash) rather than `internal/db.Transaction`.
- **Events:** term keys are no longer precomputed inline onto the payload; they're derived downstream via `events.TermsForBytes`. The (previously ignored) passphrase param was dropped from `ExtractEvents`; it's now a real, used input on the read-path extractors.
- **Hardening not in rpc-hack:** V3 contract-event gating on `IsSorobanTx` (matches `db.ParseTransaction`; rpc-hack over-emitted for a classic-envelope V3 tx), `startIdx<0`/`limit<0` rejection, an explicit missing-hash error, and differential tests vs `db.ParseTransaction` across LCM V0/V1/V2.

## Follow-up (per #764 acceptance, not in this PR)
- Full-history sweep harness that walks every ledger and asserts view-extraction == full-decode (separate tracking issue).

## Test plan
- [x] `go test ./cmd/stellar-rpc/internal/fullhistory/views/` (+ `-bench`), `go vet`, `gofmt` — green.

