### PR TITLE
events,eventstore: single-chunk query engine (#663)

### DIFF
--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query.go
@@ -1,0 +1,738 @@
+package eventstore
+
+// query.go is the events-side coordinator that turns a {filters,
+// eventIDRange, maxEvents, order} spec into matching events for one
+// Chunk. It is built on the Reader interface, so it works against
+// HotStore and ColdReader without branching.
+//
+// Semantics:
+//
+//   - A Filter is a conjunction of equality constraints on the
+//     indexed fields (contract ID + topics 0..3). A field left
+//     nil/empty is a wildcard.
+//   - The query result is the union of the per-filter intersections,
+//     intersected with QueryOptions.Range, then truncated to
+//     QueryOptions.MaxEvents (when non-zero). Ascending order keeps
+//     the lowest event IDs; descending keeps the highest.
+//   - An empty []Filter is treated as one wildcard filter
+//     (match-all in the chunk), matching the getEvents convention.
+//
+// The engine's input window is a CHUNK-RELATIVE event-ID range
+// [Start, End), not a ledger range. This is deliberate: ledger-bounded
+// queries can't express "everything strictly after event X" without
+// the caller doing fragile post-skip work, which breaks down when a
+// single ledger holds more events than MaxEvents. Adapters that speak
+// ledgers (the eventual multi-chunk coordinator / RPC handler)
+// translate ledger bounds to event-ID bounds via the chunk's
+// LedgerOffsets before calling Query.
+//
+// Optimization shape: the caller guarantees ≤15 filters and ≤15
+// unique terms total across all filters. The implementation
+// dedupes terms across filters and issues a SINGLE Reader.LookupKeys
+// call for all unique terms, then assembles per-filter
+// intersections by re-using the returned bitmaps. On the cold path
+// this collapses what would otherwise be one MPHF+index.pack round
+// trip per filter into a single coalesced read.
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/RoaringBitmap/roaring/v2"
+
+	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/events"
+)
+
+// Filter is one item in the union of an events Query. Within a
+// single filter, every non-empty field is an equality constraint
+// AND-ed together against the corresponding indexed field of an
+// event. nil or empty slices are wildcards.
+//
+// Topics[i] constrains topic position i. Topic positions beyond
+// protocol.MaxTopicCount are not indexed (see events.TermsFor) and
+// must be left empty here.
+type Filter struct {
+	ContractID []byte
+	Topics     [protocol.MaxTopicCount][]byte
+}
+
+// Order selects the direction matches are returned (and, when
+// MaxEvents caps the result, which end of the range is kept).
+// The zero value is ascending, matching the getEvents v1 default.
+type Order int
+
+const (
+	// OrderAscending returns matches in ascending event-ID order
+	// (ledger-ascending, since event IDs are dense in [0, EventCount)).
+	// When MaxEvents caps, the lowest IDs win.
+	OrderAscending Order = iota
+	// OrderDescending returns matches in descending event-ID order.
+	// When MaxEvents caps, the highest IDs win.
+	OrderDescending
+)
+
+// EventIDRange restricts a Query to a half-open chunk-relative
+// event-ID window [Start, End). Both bounds are chunk-relative
+// event IDs in [0, EventCount).
+//
+// Zero values are interpreted as the chunk's endpoints:
+//
+//	Start == 0 → 0 (first event in chunk; this is also the literal value)
+//	End   == 0 → EventCount (last event +1; sentinel)
+//
+// An EventIDRange{} (the zero value) therefore means "every event
+// the chunk has ingested so far." End == 0 is treated as a sentinel
+// because a literal [0, 0) range would be trivially empty and there's
+// no productive use for that exact value as a query bound.
+//
+// Out-of-range End values are clipped to EventCount silently.
+// A clipped-empty range (post-clip Start >= End), or an empty chunk
+// (EventCount == 0), makes Query return (nil, nil) with no error.
+type EventIDRange struct {
+	Start, End uint32
+}
+
+// resolve returns the post-clip half-open bounds for this range
+// against the chunk's total event count. Returns (start, end, ok)
+// where ok is false when the chunk is empty or the clipped range
+// is empty.
+func (r EventIDRange) resolve(eventCount uint32) (uint32, uint32, bool) {
+	if eventCount == 0 {
+		return 0, 0, false
+	}
+	start, end := r.Start, r.End
+	if end == 0 || end > eventCount {
+		end = eventCount
+	}
+	return start, end, start < end
+}
+
+// EventIDRangeForLedgers translates an inclusive ledger window
+// [startLedger, endLedger] into the half-open EventIDRange covering
+// those ledgers' events, using ofs's per-ledger event-count snapshot.
+// Both bounds must lie inside ofs's [StartLedger, EndLedger) range;
+// out-of-range bounds surface a wrapped error from
+// LedgerOffsets.EventIDs.
+//
+// The engine works in event-ID space only — this is the canonical
+// adapter-side translation for callers that think in ledger ranges
+// (the multi-chunk coordinator / RPC handler converting a getEvents
+// request). Callers that already have chunk-relative event IDs (e.g.
+// cursor continuation past a specific event) build an EventIDRange
+// directly.
+func EventIDRangeForLedgers(ofs *events.LedgerOffsets, startLedger, endLedger uint32) (EventIDRange, error) {
+	firstID, _, err := ofs.EventIDs(startLedger)
+	if err != nil {
+		return EventIDRange{}, fmt.Errorf("events: range start ledger %d: %w", startLedger, err)
+	}
+	_, lastID, err := ofs.EventIDs(endLedger)
+	if err != nil {
+		return EventIDRange{}, fmt.Errorf("events: range end ledger %d: %w", endLedger, err)
+	}
+	return EventIDRange{Start: firstID, End: lastID}, nil
+}
+
+// QueryOptions configures a Query call.
+//
+// MaxEvents caps the result size (0 = unlimited). Must be
+// non-negative; Query rejects a negative value up-front. Which
+// events survive the cap depends on Order: ascending keeps the
+// lowest event IDs, descending the highest. MaxEvents is the
+// QUERY's intent — it stays per-call when the future multi-chunk
+// coordinator dispatches across chunks.
+//
+// Order selects ascending (default) or descending event-ID order.
+//
+// Range restricts matches to a chunk-relative event-ID window. Zero
+// value = whole chunk. See EventIDRange for clipping semantics.
+// Callers that think in ledger ranges (initial getEvents requests)
+// translate via EventIDRangeForLedgers before populating this field.
+type QueryOptions struct {
+	MaxEvents int
+	Order     Order
+	Range     EventIDRange
+}
+
+// topicFieldByPosition maps topic position 0..MaxTopicCount-1 to its
+// indexed events.Field. Mirrors the unexported events.topicField
+// switch — duplicated here rather than exported because Query is the
+// only caller in this package and exporting would invite misuse.
+//
+//nolint:gochecknoglobals // immutable lookup table; can't use const for array
+var topicFieldByPosition = [protocol.MaxTopicCount]events.Field{
+	events.FieldTopic0,
+	events.FieldTopic1,
+	events.FieldTopic2,
+	events.FieldTopic3,
+}
+
+// Query runs filters against r under opts and returns the matching
+// events in chunk-relative event-ID order (ascending by default,
+// descending when opts.Order == OrderDescending).
+//
+// Semantics:
+//
+//   - Within a filter: AND of equality constraints on each non-empty
+//     field. A filter with all fields empty matches every event.
+//   - Across filters: union of per-filter matches.
+//   - len(filters) == 0 is treated as a single match-all filter,
+//     consistent with getEvents.
+//   - opts.Range restricts to that event-ID window (clipped to the
+//     chunk). Zero value = whole chunk.
+//   - opts.MaxEvents caps the result size. 0 = unlimited.
+//   - opts.Order picks ascending or descending output.
+//
+// Bitmap ownership: Reader.LookupKeys returns BORROWED bitmaps in
+// both tiers. The hot path returns the live mirror snapshot
+// (ConcurrentBitmaps stores immutable snapshots via atomic.Pointer
+// COW; readers atomic-load and operate on pointers that no writer
+// will ever mutate). The cold path freshly unmarshals from
+// index.pack, so the caller owns the result; either way Query must
+// treat LookupKeys results as read-only. roaring.FastAnd and
+// roaring.FastOr produce fresh result bitmaps and never modify
+// their inputs. The range And is roaring.And on the (possibly
+// borrowed) single-filter union — non-mutating fresh-result — and
+// in-place And only on the FastOr-produced (owned) multi-filter
+// union.
+//
+//nolint:gocognit,cyclop,funlen,gocyclo
+func Query(ctx context.Context, r Reader, filters []Filter, opts QueryOptions) ([]events.Payload, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if opts.MaxEvents < 0 {
+		return nil, fmt.Errorf("events: MaxEvents must be non-negative, got %d", opts.MaxEvents)
+	}
+	if err := validateFilters(filters); err != nil {
+		return nil, err
+	}
+
+	eventCount, err := r.EventCount()
+	if err != nil {
+		return nil, fmt.Errorf("events: query event count: %w", err)
+	}
+	start, end, ok := opts.Range.resolve(eventCount)
+	if !ok {
+		return nil, nil
+	}
+	descending := opts.Order == OrderDescending
+
+	// Match-all path: empty filter slice or any all-wildcard filter.
+	// Serves without touching the index — translates the range
+	// directly to a contiguous FetchRange call. Cheaper than building
+	// the full chunk bitmap just to truncate to MaxEvents.
+	if hasMatchAllFilter(filters) {
+		return fetchAllInRange(ctx, r, start, end, opts.MaxEvents, descending)
+	}
+
+	// ───── 1. Dedupe terms across filters ─────
+	//
+	// Caller guarantees ≤15 filters × (1 contract + 4 topics) = ≤75
+	// candidate term slots and ≤15 unique terms. A linear-scan dedupe
+	// (indexOfOrAddTerm) is cheaper than a hash map at this size.
+	//
+	// filterPlans[i] holds the indices into uniqueKeys that filter i
+	// requires intersected. Empty plans were handled by the match-all
+	// short-circuit above.
+	filterPlans := make([][]int, len(filters))
+	var uniqueKeys []events.TermKey
+
+	for i := range filters {
+		f := &filters[i]
+		var slots []int
+		if len(f.ContractID) > 0 {
+			slots = append(slots, indexOfOrAddTerm(&uniqueKeys,
+				events.ComputeTermKey(f.ContractID, events.FieldContractID)))
+		}
+		for tIdx, t := range f.Topics {
+			if len(t) == 0 {
+				continue
+			}
+			slots = append(slots, indexOfOrAddTerm(&uniqueKeys,
+				events.ComputeTermKey(t, topicFieldByPosition[tIdx])))
+		}
+		filterPlans[i] = slots
+	}
+
+	// ───── 2. Single batched lookup for all unique terms ─────
+	bitmaps, err := r.LookupKeys(ctx, uniqueKeys)
+	if err != nil {
+		return nil, fmt.Errorf("events: query lookup: %w", err)
+	}
+
+	// ───── 3. Per-filter intersect ─────
+	//
+	// If any term in a filter is absent from the index (bitmaps[s] is
+	// nil), that filter's intersection is empty — skip it without
+	// contributing to the union.
+	//
+	// Bitmap ownership in perFilter is mixed:
+	//   - Single-constraint filter: we borrow bitmaps[s] directly (a
+	//     mirror snapshot from LookupKeys), skipping FastAnd's Clone.
+	//   - Multi-constraint filter: FastAnd allocates a fresh result.
+	// Either way the downstream union (FastOr) and selection never
+	// mutate their inputs, so a borrowed entry stays valid through
+	// the rest of the function. FastAnd never mutates its inputs
+	// either, so the same bitmap may appear across multiple filters
+	// safely.
+	perFilter := make([]*roaring.Bitmap, 0, len(filterPlans))
+	for _, slots := range filterPlans {
+		inputs := make([]*roaring.Bitmap, 0, len(slots))
+		missed := false
+		for _, s := range slots {
+			if bitmaps[s] == nil {
+				missed = true
+				break
+			}
+			inputs = append(inputs, bitmaps[s])
+		}
+		if missed {
+			continue
+		}
+		if len(inputs) == 1 {
+			perFilter = append(perFilter, inputs[0])
+			continue
+		}
+		// FastAnd intersects left-to-right — putting the smallest
+		// bitmap first shrinks the accumulator fastest. roaring's own
+		// docs call this out as the recommended caller-side prep.
+		slices.SortFunc(inputs, func(a, b *roaring.Bitmap) int {
+			ac, bc := a.GetCardinality(), b.GetCardinality()
+			switch {
+			case ac < bc:
+				return -1
+			case ac > bc:
+				return 1
+			default:
+				return 0
+			}
+		})
+		perFilter = append(perFilter, roaring.FastAnd(inputs...))
+	}
+
+	if len(perFilter) == 0 {
+		return nil, nil
+	}
+
+	// ───── 4. Union across filters ─────
+	// Single-filter case: FastOr would Clone — skip it and use the
+	// already-computed bitmap directly. The range And below would
+	// need to allocate fresh either way (single-filter union is
+	// borrowed, so in-place mutation is forbidden).
+	var union *roaring.Bitmap
+	singleFilter := len(perFilter) == 1
+	if singleFilter {
+		union = perFilter[0]
+	} else {
+		union = roaring.FastOr(perFilter...)
+	}
+
+	// ───── 5. Apply event-ID range ─────
+	//
+	// Always applied (even for the zero-value "whole chunk" case): the
+	// AND with [start, end) clips any phantom IDs that the mirror may
+	// have published beyond what r.EventCount() saw at entry. On the
+	// hot side a concurrent ingest publishes mirror entries BEFORE
+	// offsets, so LookupKeys can briefly surface IDs >= EventCount;
+	// applying the range bitmap eliminates them and keeps Query's
+	// result snapshot-consistent with the EventCount we read at entry.
+	rangeBM := roaring.New()
+	rangeBM.AddRange(uint64(start), uint64(end))
+	if singleFilter {
+		// union is a borrowed bitmap from LookupKeys; roaring.And
+		// returns a fresh result without mutating either input.
+		union = roaring.And(union, rangeBM)
+	} else {
+		// FastOr output is fresh — in-place And is fine.
+		union.And(rangeBM)
+	}
+
+	if union.IsEmpty() {
+		return nil, nil
+	}
+
+	// ───── 6. Fetch payloads ─────
+	//
+	// selectEventIDs drains the union into the ascending []uint32
+	// FetchEvents requires, keeping the lowest IDs (ascending) or
+	// highest IDs (descending) when MaxEvents caps. FetchEvents
+	// returns owned payloads in ascending order; the defensive
+	// post-filter preserves that order, and we reverse once at the
+	// end for descending output.
+	ids := selectEventIDs(union, opts.MaxEvents, descending)
+	payloads, err := r.FetchEvents(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	// Defensive post-filter: TermKey is xxh3_128(field || value), a
+	// non-cryptographic hash on attacker-controllable topic values.
+	// The index can in principle return false-positive event IDs from
+	// a collision; the post-filter verifies each materialized event's
+	// raw field bytes against the requested filter clauses and
+	// discards mismatches. The hash becomes load-bearing only for
+	// narrowing efficiency, not for result correctness.
+	matched, err := postFilter(payloads, filters)
+	if err != nil {
+		return nil, err
+	}
+	if descending {
+		slices.Reverse(matched)
+	}
+	return matched, nil
+}
+
+// validateFilters rejects filters that would silently never match
+// because of a malformed value. ContractId must be the canonical
+// 32-byte xdr.Hash form (or absent); a short ContractId would
+// bytes.Equal-mismatch every event without surfacing the bug to the
+// caller. Empty/wildcard fields are allowed.
+func validateFilters(filters []Filter) error {
+	for fi := range filters {
+		f := &filters[fi]
+		if l := len(f.ContractID); l != 0 && l != 32 {
+			return fmt.Errorf(
+				"events: filter[%d].ContractID must be 0 or 32 bytes, got %d", fi, l)
+		}
+	}
+	return nil
+}
+
+// hasMatchAllFilter reports whether any filter in filters is the
+// match-all filter (no contract ID, no topics). An empty filters
+// slice also counts (consistent with getEvents).
+func hasMatchAllFilter(filters []Filter) bool {
+	if len(filters) == 0 {
+		return true
+	}
+	for i := range filters {
+		f := &filters[i]
+		if len(f.ContractID) > 0 {
+			continue
+		}
+		allWildcardTopics := true
+		for _, t := range f.Topics {
+			if len(t) > 0 {
+				allWildcardTopics = false
+				break
+			}
+		}
+		if allWildcardTopics {
+			return true
+		}
+	}
+	return false
+}
+
+// indexOfOrAddTerm returns the index of key inside *keys, appending
+// it first if absent. The linear scan is fine at the caller's
+// guaranteed ≤15 unique-term ceiling.
+func indexOfOrAddTerm(keys *[]events.TermKey, key events.TermKey) int {
+	for i, k := range *keys {
+		if k == key {
+			return i
+		}
+	}
+	*keys = append(*keys, key)
+	return len(*keys) - 1
+}
+
+// fetchAllInRange returns every event in the chunk-relative event-ID
+// window [start, end), truncated to maxEvents (0 = unlimited) and
+// ordered per descending. Used for the match-all short-circuit. Streams
+// via Reader.FetchRange — no []uint32{0..count} materialization, and
+// on the cold path one direct ReadRange call instead of the
+// per-position coalescing logic FetchEvents would run.
+//
+// FetchRange yields BORROWED payloads (ContractEventBytes aliases the
+// reader's iteration buffer, valid only for the current step). We
+// retain them in the returned slice, so each event's bytes are cloned
+// before append. Descending keeps the highest `count` IDs by starting
+// the range at end-count, then reverses the materialized slice.
+//
+// Caller contract: start < end (the [start, end) window is non-empty)
+// and both bounds are valid chunk-relative event IDs. The resolve()
+// step in Query enforces both.
+func fetchAllInRange(
+	ctx context.Context, r Reader,
+	start, end uint32, maxEvents int, descending bool,
+) ([]events.Payload, error) {
+	count := end - start
+	// uint64 compare avoids the uint32(maxEvents) truncation footgun:
+	// for maxEvents > MaxUint32, uint32() would wrap to a small value
+	// (or 0 for exact multiples of 2^32) and over-cap the result.
+	if maxEvents > 0 && uint64(count) > uint64(maxEvents) {
+		count = uint32(maxEvents) //nolint:gosec // uint64(count)>uint64(maxEvents)>0 so maxEvents fits uint32
+	}
+	fetchStart := start
+	if descending {
+		fetchStart = end - count // keep the highest `count` event IDs
+	}
+	out := make([]events.Payload, 0, count)
+	for p, err := range r.FetchRange(ctx, fetchStart, count) {
+		if err != nil {
+			return nil, err
+		}
+		// Retained past this step → clone the borrowed bytes.
+		p.ContractEventBytes = bytes.Clone(p.ContractEventBytes)
+		out = append(out, p)
+	}
+	if descending {
+		slices.Reverse(out)
+	}
+	return out, nil
+}
+
+// selectEventIDs drains bm into the sorted-ascending []uint32 that
+// Reader.FetchEvents requires, applying MaxEvents. When the cap bites
+// it keeps the lowest IDs for ascending and the highest for
+// descending; the returned slice is always ascending (the caller
+// reverses materialized payloads for descending output).
+//
+// The descending-capped branch pulls exactly `limit` IDs off the
+// reverse iterator (O(limit)) rather than draining the whole bitmap,
+// then sorts them ascending. Every other case walks the forward
+// ManyIterator, which yields strictly ascending, deduplicated uint32s.
+func selectEventIDs(bm *roaring.Bitmap, maxEvents int, descending bool) []uint32 {
+	card := bm.GetCardinality()
+	limit := card
+	if maxEvents > 0 && uint64(maxEvents) < limit {
+		limit = uint64(maxEvents)
+	}
+	// limit ≤ card (a chunk's event-id space, max ~10M today) and ≤
+	// maxEvents (int), so int conversions below are safe.
+	if descending && limit < card {
+		ids := make([]uint32, 0, limit)
+		ri := bm.ReverseIterator()
+		for ri.HasNext() && uint64(len(ids)) < limit {
+			ids = append(ids, ri.Next())
+		}
+		slices.Reverse(ids) // reverse-iterator order is descending → ascending
+		return ids
+	}
+	ids := make([]uint32, limit)
+	mi := bm.ManyIterator()
+	filled := 0
+	for filled < int(limit) { //nolint:gosec // limit ≤ maxEvents (int) ≤ MaxInt
+		n := mi.NextMany(ids[filled:])
+		if n == 0 {
+			break
+		}
+		filled += n
+	}
+	return ids[:filled]
+}
+
+// postFilter verifies each materialized payload against the requested
+// filter clauses and discards mismatches. See Query's post-filter
+// comment for the collision-defense rationale.
+//
+// Within a clause: AND across non-empty fields. Across clauses: OR.
+// The match-all short-circuit upstream means this is only reached
+// when at least one filter clause has a constraint. The result slice
+// aliases the input — safe because the write cursor is always ≤ the
+// read cursor, and the input is owned (Reader.FetchEvents).
+//
+// Payloads carry only raw ContractEvent XDR (ContractEventBytes), so
+// matching navigates an xdr.ContractEventView — no per-event
+// UnmarshalBinary.
+func postFilter(payloads []events.Payload, filters []Filter) ([]events.Payload, error) {
+	if len(filters) == 0 {
+		return payloads, nil
+	}
+	plan := planFilters(filters)
+	out := payloads[:0]
+	for i := range payloads {
+		ok, err := matchesAnyFilterView(payloads[i].ContractEventBytes, filters, &plan)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			out = append(out, payloads[i])
+		}
+	}
+	return out, nil
+}
+
+// filterPlan caches per-query info computed once at postFilter entry
+// and consumed by the view path: the union of topic positions any
+// clause constrains, plus the highest constrained position (caps the
+// view-path topic walk). All booleans + ints — every access is O(1)
+// and the struct lives on the postFilter stack.
+//
+// ContractID is checked per-clause via len(f.ContractID) > 0; no
+// precomputed flag needed.
+type filterPlan struct {
+	anyTopic    bool
+	maxTopicIdx int // -1 if no clause constrains any topic
+	needsTopic  [protocol.MaxTopicCount]bool
+}
+
+func planFilters(filters []Filter) filterPlan {
+	plan := filterPlan{maxTopicIdx: -1}
+	for fi := range filters {
+		f := &filters[fi]
+		for i, want := range f.Topics {
+			if len(want) == 0 {
+				continue
+			}
+			plan.needsTopic[i] = true
+			plan.anyTopic = true
+			if i > plan.maxTopicIdx {
+				plan.maxTopicIdx = i
+			}
+		}
+	}
+	return plan
+}
+
+// matchesAnyFilterView reports whether the event encoded in raw
+// satisfies at least one filter clause. It lazily resolves
+// ContractId and each constrained topic position via
+// xdr.ContractEventView navigation, byte-comparing aliased .Raw()
+// slices against the filter clauses. Zero per-event allocation —
+// every byte slice involved aliases into raw.
+//
+// Lazy resolution: events that fail every clause's ContractId check
+// never trigger the topic walk; events that pass do exactly one
+// linear walk over Topics up to the highest constrained position
+// (single-call cache, multi-clause queries reuse). The cache state is
+// held in inline locals rather than closures so escape analysis keeps
+// the [4][]byte topic array on the stack.
+//
+//nolint:gocognit // linear clause loop with two-level lazy cache; splitting helpers fragments the lazy invariant
+func matchesAnyFilterView(raw []byte, filters []Filter, plan *filterPlan) (bool, error) {
+	ev := xdr.ContractEventView(raw)
+	var (
+		cidBytes     []byte
+		cidPresent   bool
+		cidResolved  bool
+		topicRaw     [protocol.MaxTopicCount][]byte
+		topicsWalked bool
+	)
+
+	for fi := range filters {
+		f := &filters[fi]
+		if len(f.ContractID) > 0 {
+			if !cidResolved {
+				present, b, err := resolveViewContractID(ev)
+				if err != nil {
+					return false, err
+				}
+				cidResolved = true
+				cidPresent = present
+				cidBytes = b
+			}
+			if !cidPresent || !bytes.Equal(cidBytes, f.ContractID) {
+				continue
+			}
+		}
+		matched := true
+		for i, want := range f.Topics {
+			if len(want) == 0 {
+				continue
+			}
+			if !topicsWalked {
+				if err := collectTopicViewBytes(ev, plan, &topicRaw); err != nil {
+					return false, err
+				}
+				topicsWalked = true
+			}
+			g := topicRaw[i]
+			if g == nil || !bytes.Equal(g, want) {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// resolveViewContractID extracts the optional ContractId from a
+// ContractEventView. Returns (present, bytes, err); when present is
+// false, bytes is nil. Factored out of matchesAnyFilterView so the
+// caller can hold its lazy-resolve state in plain locals instead of
+// closure-captured variables that would escape to the heap.
+func resolveViewContractID(ev xdr.ContractEventView) (bool, []byte, error) {
+	cidOpt, err := ev.ContractId()
+	if err != nil {
+		return false, nil, fmt.Errorf("events: post-filter view ContractId opt: %w", err)
+	}
+	cidView, present, err := cidOpt.Unwrap()
+	if err != nil {
+		return false, nil, fmt.Errorf("events: post-filter view ContractId unwrap: %w", err)
+	}
+	if !present {
+		return false, nil, nil
+	}
+	b, err := cidView.Value()
+	if err != nil {
+		return false, nil, fmt.Errorf("events: post-filter view ContractId value: %w", err)
+	}
+	return true, b, nil
+}
+
+// collectTopicViewBytes walks the ContractEventView's Body.V0.Topics
+// once linearly and captures each constrained position's .Raw() bytes
+// into topicRaw. Stops after the highest constrained position so the
+// walk is O(plan.maxTopicIdx+1) rather than the O(MaxTopicCount²)
+// that calling .At(j) for each j would produce (ScVecView.At is a
+// prefix walk under the hood). Body.V != 0 → no V0.Topics → topicRaw
+// stays zero (every constrained position will mismatch downstream).
+func collectTopicViewBytes(
+	ev xdr.ContractEventView,
+	plan *filterPlan,
+	topicRaw *[protocol.MaxTopicCount][]byte,
+) error {
+	if !plan.anyTopic {
+		return nil
+	}
+	body, err := ev.Body()
+	if err != nil {
+		return fmt.Errorf("events: post-filter view Body: %w", err)
+	}
+	bodyV, err := body.V()
+	if err != nil {
+		return fmt.Errorf("events: post-filter view Body.V: %w", err)
+	}
+	bodyVVal, err := bodyV.Value()
+	if err != nil {
+		return fmt.Errorf("events: post-filter view Body.V value: %w", err)
+	}
+	if bodyVVal != 0 {
+		return nil
+	}
+	v0, err := body.V0()
+	if err != nil {
+		return fmt.Errorf("events: post-filter view Body.V0: %w", err)
+	}
+	topicsArr, err := v0.Topics()
+	if err != nil {
+		return fmt.Errorf("events: post-filter view Body.V0.Topics: %w", err)
+	}
+	i := 0
+	for topic, ierr := range topicsArr.Iter() {
+		if ierr != nil {
+			return fmt.Errorf("events: post-filter view topic iter: %w", ierr)
+		}
+		if i > plan.maxTopicIdx || i >= protocol.MaxTopicCount {
+			break
+		}
+		if plan.needsTopic[i] {
+			rawBytes, err := topic.Raw()
+			if err != nil {
+				return fmt.Errorf("events: post-filter view topic[%d].Raw: %w", i, err)
+			}
+			topicRaw[i] = rawBytes
+		}
+		i++
+	}
+	return nil
+}

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query.go
@@ -77,20 +77,23 @@ const (
 )
 
 // EventIDRange restricts a Query to a half-open chunk-relative
-// event-ID window [Start, End). Both bounds are chunk-relative
-// event IDs in [0, EventCount).
+// event-ID window [Start, End). Both bounds are literal: there is no
+// "End == 0 means whole chunk" sentinel, because EventIDRangeForLedgers
+// can legitimately produce EventIDRange{0, 0} for an empty leading
+// ledger window (e.g. the chunk's first ledger has no events). A
+// sentinel there would silently expand the empty query to whole-chunk
+// scope.
 //
-// Zero values are interpreted as the chunk's endpoints:
+// End may exceed EventCount — the engine clips it to EventCount on
+// entry. So a caller that doesn't know the chunk size can pass any
+// upper bound; passing math.MaxUint32 is the canonical "from Start to
+// the chunk's tail" idiom.
 //
-//	Start == 0 → 0 (first event in chunk; this is also the literal value)
-//	End   == 0 → EventCount (last event +1; sentinel)
+// To query the whole chunk, leave QueryOptions.Range as nil rather
+// than passing an EventIDRange explicitly. QueryOptions.Range is a
+// pointer specifically to distinguish "no range constraint" (nil)
+// from "literal range, including {0, 0}" (non-nil).
 //
-// An EventIDRange{} (the zero value) therefore means "every event
-// the chunk has ingested so far." End == 0 is treated as a sentinel
-// because a literal [0, 0) range would be trivially empty and there's
-// no productive use for that exact value as a query bound.
-//
-// Out-of-range End values are clipped to EventCount silently.
 // A clipped-empty range (post-clip Start >= End), or an empty chunk
 // (EventCount == 0), makes Query return (nil, nil) with no error.
 type EventIDRange struct {
@@ -99,14 +102,18 @@ type EventIDRange struct {
 
 // resolve returns the post-clip half-open bounds for this range
 // against the chunk's total event count. Returns (start, end, ok)
-// where ok is false when the chunk is empty or the clipped range
+// where ok is false when the chunk is empty or the literal range
 // is empty.
+//
+// End values above EventCount are silently clipped; Start values
+// above End yield ok=false (empty range, not an error — the caller
+// gets (nil, nil) from Query).
 func (r EventIDRange) resolve(eventCount uint32) (uint32, uint32, bool) {
 	if eventCount == 0 {
 		return 0, 0, false
 	}
 	start, end := r.Start, r.End
-	if end == 0 || end > eventCount {
+	if end > eventCount {
 		end = eventCount
 	}
 	return start, end, start < end
@@ -146,16 +153,29 @@ func EventIDRangeForLedgers(ofs *events.LedgerOffsets, startLedger, endLedger ui
 // QUERY's intent — it stays per-call when the future multi-chunk
 // coordinator dispatches across chunks.
 //
+// MaxEvents caveat: the cap is applied to bitmap candidates BEFORE
+// the defensive post-filter runs (see Query's post-filter comment).
+// A term-hash collision that survives the bitmap stage then gets
+// dropped by post-filter consumes a cap slot, so Query may return
+// fewer than MaxEvents real matches even when more existed past the
+// cap. With xxh3_128 term keys the probability per term is ~2^-64,
+// so this is effectively unreachable in practice; a refill loop
+// would close the gap if a real workload ever exhibits it.
+//
 // Order selects ascending (default) or descending event-ID order.
 //
-// Range restricts matches to a chunk-relative event-ID window. Zero
-// value = whole chunk. See EventIDRange for clipping semantics.
-// Callers that think in ledger ranges (initial getEvents requests)
-// translate via EventIDRangeForLedgers before populating this field.
+// Range restricts matches to a chunk-relative event-ID window.
+// nil = whole chunk; non-nil = literal half-open [Start, End) bounds,
+// including EventIDRange{0, 0} for an explicitly empty query. The
+// pointer is load-bearing — it lets EventIDRangeForLedgers return a
+// genuinely-empty range (e.g. an empty leading ledger window)
+// without colliding with the whole-chunk default. Callers that think
+// in ledger ranges translate via EventIDRangeForLedgers before
+// populating this field.
 type QueryOptions struct {
 	MaxEvents int
 	Order     Order
-	Range     EventIDRange
+	Range     *EventIDRange
 }
 
 // topicFieldByPosition maps topic position 0..MaxTopicCount-1 to its
@@ -216,7 +236,13 @@ func Query(ctx context.Context, r Reader, filters []Filter, opts QueryOptions) (
 	if err != nil {
 		return nil, fmt.Errorf("events: query event count: %w", err)
 	}
-	start, end, ok := opts.Range.resolve(eventCount)
+	// Range nil = whole chunk; non-nil = literal half-open bounds.
+	// See QueryOptions.Range / EventIDRange docs for the pointer rationale.
+	effectiveRange := EventIDRange{Start: 0, End: eventCount}
+	if opts.Range != nil {
+		effectiveRange = *opts.Range
+	}
+	start, end, ok := effectiveRange.resolve(eventCount)
 	if !ok {
 		return nil, nil
 	}

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query.go
@@ -50,8 +50,7 @@ type Filter struct {
 	Topics     [protocol.MaxTopicCount][]byte
 }
 
-// isMatchAll reports whether f has no constraints (every field is a
-// wildcard) — equivalent to "this filter matches every event."
+// isMatchAll reports whether f has no constraints (every field is a wildcard).
 func (f *Filter) isMatchAll() bool {
 	if len(f.ContractID) > 0 {
 		return false
@@ -64,10 +63,7 @@ func (f *Filter) isMatchAll() bool {
 	return true
 }
 
-// termKeys returns the indexed (field, value) terms this filter
-// constrains. Each TermKey identifies one row in the per-Chunk
-// bitmap index; Query intersects their bitmaps to compute this
-// filter's matches.
+// termKeys returns the indexed (field, value) terms this filter constrains.
 func (f *Filter) termKeys() []events.TermKey {
 	var keys []events.TermKey
 	if len(f.ContractID) > 0 {
@@ -117,10 +113,9 @@ func (r EventIDRange) check() error {
 
 // EventIDRangeForLedgers translates the closed ledger window
 // [startLedger, endLedger] into the half-open EventIDRange
-// [firstID, lastID) covering those ledgers' events, using ofs's
-// per-ledger event-count snapshot. Both bounds must lie inside ofs's
-// [StartLedger, EndLedger) range; out-of-range bounds surface a
-// wrapped error from LedgerOffsets.EventIDs.
+// [firstID, lastID) covering those ledgers' events. Both bounds
+// must lie inside ofs's [StartLedger, EndLedger) range; out-of-range
+// bounds surface a wrapped error from LedgerOffsets.EventIDs.
 func EventIDRangeForLedgers(ofs *events.LedgerOffsets, startLedger, endLedger uint32) (EventIDRange, error) {
 	firstID, _, err := ofs.EventIDs(startLedger)
 	if err != nil {

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query.go
@@ -76,38 +76,41 @@ const (
 	OrderDescending
 )
 
-// EventIDRange restricts a Query to a half-open chunk-relative
-// event-ID window [Start, End). Both bounds are literal: there is no
-// "End == 0 means whole chunk" sentinel, because EventIDRangeForLedgers
-// can legitimately produce EventIDRange{0, 0} for an empty leading
-// ledger window (e.g. the chunk's first ledger has no events). A
-// sentinel there would silently expand the empty query to whole-chunk
-// scope.
+// EventIDRange is a literal half-open chunk-relative event-ID window
+// [Start, End). Both bounds are mandatory and authoritative; the
+// engine does NOT invent an upper bound from EventCount.
 //
-// End may exceed EventCount — the engine clips it to EventCount on
-// entry. So a caller that doesn't know the chunk size can pass any
-// upper bound; passing math.MaxUint32 is the canonical "from Start to
-// the chunk's tail" idiom.
+// Snapshot-isolation contract: the caller pins End once at request
+// entry from a snapshot of the chunk's offsets (typically
+// LedgerOffsets.TotalEvents()) and threads the same End through every
+// Query call for that request. Events ingested after the snapshot are
+// invisible to the in-flight request. Multi-page paginated requests
+// MUST share the same End across pages; multi-chunk requests MUST
+// snapshot per-chunk at request entry. This is the standard pattern
+// for queries over continuously-updated stores (Postgres MVCC,
+// RocksDB snapshots, Lucene IndexReader).
 //
-// To query the whole chunk, leave QueryOptions.Range as nil rather
-// than passing an EventIDRange explicitly. QueryOptions.Range is a
-// pointer specifically to distinguish "no range constraint" (nil)
-// from "literal range, including {0, 0}" (non-nil).
+// Both fields are required. There is no "End == 0 means whole chunk"
+// sentinel — that would silently expand a caller-pinned snapshot
+// against the engine's wishes. Use WholeChunkRange(r) to compute a
+// {0, EventCount} range when "everything visible right now" really is
+// the intent (initial query with no cursor).
 //
-// A clipped-empty range (post-clip Start >= End), or an empty chunk
-// (EventCount == 0), makes Query return (nil, nil) with no error.
+// End may exceed the chunk's EventCount — the engine clips it down
+// as defense-in-depth, but the contract is "caller pins End from a
+// trusted snapshot." Start > End is rejected as a malformed input
+// (programmer bug); Start == End is treated as a legitimate empty
+// range and returns (nil, nil).
 type EventIDRange struct {
 	Start, End uint32
 }
 
 // resolve returns the post-clip half-open bounds for this range
-// against the chunk's total event count. Returns (start, end, ok)
+// against the chunk's total event count, applying the defensive
+// upper clip (End down to EventCount). Returns (start, end, ok)
 // where ok is false when the chunk is empty or the literal range
-// is empty.
-//
-// End values above EventCount are silently clipped; Start values
-// above End yield ok=false (empty range, not an error — the caller
-// gets (nil, nil) from Query).
+// is empty (Start == End). Start > End is REJECTED upstream by
+// Query and never reaches this method.
 func (r EventIDRange) resolve(eventCount uint32) (uint32, uint32, bool) {
 	if eventCount == 0 {
 		return 0, 0, false
@@ -164,18 +167,24 @@ func EventIDRangeForLedgers(ofs *events.LedgerOffsets, startLedger, endLedger ui
 //
 // Order selects ascending (default) or descending event-ID order.
 //
-// Range restricts matches to a chunk-relative event-ID window.
-// nil = whole chunk; non-nil = literal half-open [Start, End) bounds,
-// including EventIDRange{0, 0} for an explicitly empty query. The
-// pointer is load-bearing — it lets EventIDRangeForLedgers return a
-// genuinely-empty range (e.g. an empty leading ledger window)
-// without colliding with the whole-chunk default. Callers that think
-// in ledger ranges translate via EventIDRangeForLedgers before
-// populating this field.
+// Range is the chunk-relative event-ID window the query operates on.
+// REQUIRED — both Range.Start and Range.End must be set explicitly by
+// the caller. The engine does not invent an upper bound. End is
+// typically pinned once at request entry from a snapshot of the
+// chunk's offsets (LedgerOffsets.TotalEvents()) and threaded through
+// every Query call for that request, giving snapshot-isolation across
+// pagination and multi-chunk fan-out. See EventIDRange for the full
+// contract.
+//
+// The zero value EventIDRange{} is a legitimately empty range
+// (Start == End == 0) and yields (nil, nil); it is NOT a sentinel for
+// "whole chunk" — that would silently expand the caller's pinned
+// snapshot. Range with End < Start is a malformed input and surfaces
+// as an explicit error.
 type QueryOptions struct {
 	MaxEvents int
 	Order     Order
-	Range     *EventIDRange
+	Range     EventIDRange
 }
 
 // topicFieldByPosition maps topic position 0..MaxTopicCount-1 to its
@@ -228,6 +237,11 @@ func Query(ctx context.Context, r Reader, filters []Filter, opts QueryOptions) (
 	if opts.MaxEvents < 0 {
 		return nil, fmt.Errorf("events: MaxEvents must be non-negative, got %d", opts.MaxEvents)
 	}
+	if opts.Range.End < opts.Range.Start {
+		return nil, fmt.Errorf(
+			"events: Range.End (%d) must be >= Range.Start (%d)",
+			opts.Range.End, opts.Range.Start)
+	}
 	if err := validateFilters(filters); err != nil {
 		return nil, err
 	}
@@ -236,13 +250,12 @@ func Query(ctx context.Context, r Reader, filters []Filter, opts QueryOptions) (
 	if err != nil {
 		return nil, fmt.Errorf("events: query event count: %w", err)
 	}
-	// Range nil = whole chunk; non-nil = literal half-open bounds.
-	// See QueryOptions.Range / EventIDRange docs for the pointer rationale.
-	effectiveRange := EventIDRange{Start: 0, End: eventCount}
-	if opts.Range != nil {
-		effectiveRange = *opts.Range
-	}
-	start, end, ok := effectiveRange.resolve(eventCount)
+	// Range is caller-pinned (snapshot-isolation contract). The
+	// engine clips End down to EventCount as defense-in-depth against
+	// stale snapshots, but does NOT extend End upward when it falls
+	// below EventCount — that would silently expand the caller's
+	// frozen view.
+	start, end, ok := opts.Range.resolve(eventCount)
 	if !ok {
 		return nil, nil
 	}

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query.go
@@ -1,9 +1,9 @@
 package eventstore
 
 // query.go is the events-side coordinator that turns a {filters,
-// eventIDRange, maxEvents, order} spec into matching events for one
-// Chunk. It is built on the Reader interface, so it works against
-// HotStore and ColdReader without branching.
+// Range, MaxEvents, Order} spec into matching events for one Chunk.
+// It is built on the Reader interface, so it works against HotStore
+// and ColdReader without branching.
 //
 // Semantics:
 //
@@ -17,22 +17,11 @@ package eventstore
 //   - An empty []Filter is treated as one wildcard filter
 //     (match-all in the chunk), matching the getEvents convention.
 //
-// The engine's input window is a CHUNK-RELATIVE event-ID range
-// [Start, End), not a ledger range. This is deliberate: ledger-bounded
-// queries can't express "everything strictly after event X" without
-// the caller doing fragile post-skip work, which breaks down when a
-// single ledger holds more events than MaxEvents. Adapters that speak
-// ledgers (the eventual multi-chunk coordinator / RPC handler)
-// translate ledger bounds to event-ID bounds via the chunk's
-// LedgerOffsets before calling Query.
-//
-// Optimization shape: the caller guarantees ≤15 filters and ≤15
-// unique terms total across all filters. The implementation
-// dedupes terms across filters and issues a SINGLE Reader.LookupKeys
-// call for all unique terms, then assembles per-filter
-// intersections by re-using the returned bitmaps. On the cold path
-// this collapses what would otherwise be one MPHF+index.pack round
-// trip per filter into a single coalesced read.
+// Optimization shape: terms are deduped across filters and issued
+// as a single Reader.LookupKeys call; per-filter intersections re-use
+// the returned bitmaps. On the cold path this collapses what would
+// otherwise be one MPHF+index.pack round trip per filter into a
+// single coalesced read.
 
 import (
 	"bytes"
@@ -53,9 +42,8 @@ import (
 // AND-ed together against the corresponding indexed field of an
 // event. nil or empty slices are wildcards.
 //
-// Topics[i] constrains topic position i. Topic positions beyond
-// protocol.MaxTopicCount are not indexed (see events.TermsFor) and
-// must be left empty here.
+// Topics[i] constrains topic position i. Positions beyond
+// protocol.MaxTopicCount are not indexed (see events.TermsFor).
 type Filter struct {
 	ContractID []byte
 	Topics     [protocol.MaxTopicCount][]byte
@@ -63,12 +51,11 @@ type Filter struct {
 
 // Order selects the direction matches are returned (and, when
 // MaxEvents caps the result, which end of the range is kept).
-// The zero value is ascending, matching the getEvents v1 default.
+// The zero value is ascending.
 type Order int
 
 const (
-	// OrderAscending returns matches in ascending event-ID order
-	// (ledger-ascending, since event IDs are dense in [0, EventCount)).
+	// OrderAscending returns matches in ascending event-ID order.
 	// When MaxEvents caps, the lowest IDs win.
 	OrderAscending Order = iota
 	// OrderDescending returns matches in descending event-ID order.
@@ -77,30 +64,19 @@ const (
 )
 
 // EventIDRange is a literal half-open chunk-relative event-ID window
-// [Start, End). Both bounds are mandatory and authoritative; the
-// engine does NOT invent an upper bound from EventCount.
+// [Start, End). Both bounds are mandatory.
 //
 // Snapshot-isolation contract: the caller pins End once at request
-// entry from a snapshot of the chunk's offsets (typically
-// LedgerOffsets.TotalEvents()) and threads the same End through every
-// Query call for that request. Events ingested after the snapshot are
+// entry from a snapshot of the chunk's offsets
+// (LedgerOffsets.TotalEvents()) and threads it through every Query
+// call for that request. Events ingested after the snapshot are
 // invisible to the in-flight request. Multi-page paginated requests
-// MUST share the same End across pages; multi-chunk requests MUST
-// snapshot per-chunk at request entry. This is the standard pattern
-// for queries over continuously-updated stores (Postgres MVCC,
-// RocksDB snapshots, Lucene IndexReader).
+// MUST share the same End across pages.
 //
-// Both fields are required. There is no "End == 0 means whole chunk"
-// sentinel — that would silently expand a caller-pinned snapshot
-// against the engine's wishes. Use WholeChunkRange(r) to compute a
-// {0, EventCount} range when "everything visible right now" really is
-// the intent (initial query with no cursor).
-//
-// End may exceed the chunk's EventCount — the engine clips it down
-// as defense-in-depth, but the contract is "caller pins End from a
-// trusted snapshot." Start > End is rejected as a malformed input
-// (programmer bug); Start == End is treated as a legitimate empty
-// range and returns (nil, nil).
+// End above EventCount is clipped down (defense-in-depth against
+// stale snapshots). Start > End is a malformed input and surfaces
+// as an explicit error from Query. Start == End is a legitimate
+// empty range; the query returns (nil, nil).
 type EventIDRange struct {
 	Start, End uint32
 }
@@ -109,8 +85,7 @@ type EventIDRange struct {
 // against the chunk's total event count, applying the defensive
 // upper clip (End down to EventCount). Returns (start, end, ok)
 // where ok is false when the chunk is empty or the literal range
-// is empty (Start == End). Start > End is REJECTED upstream by
-// Query and never reaches this method.
+// is empty (Start == End).
 func (r EventIDRange) resolve(eventCount uint32) (uint32, uint32, bool) {
 	if eventCount == 0 {
 		return 0, 0, false
@@ -128,13 +103,6 @@ func (r EventIDRange) resolve(eventCount uint32) (uint32, uint32, bool) {
 // Both bounds must lie inside ofs's [StartLedger, EndLedger) range;
 // out-of-range bounds surface a wrapped error from
 // LedgerOffsets.EventIDs.
-//
-// The engine works in event-ID space only — this is the canonical
-// adapter-side translation for callers that think in ledger ranges
-// (the multi-chunk coordinator / RPC handler converting a getEvents
-// request). Callers that already have chunk-relative event IDs (e.g.
-// cursor continuation past a specific event) build an EventIDRange
-// directly.
 func EventIDRangeForLedgers(ofs *events.LedgerOffsets, startLedger, endLedger uint32) (EventIDRange, error) {
 	firstID, _, err := ofs.EventIDs(startLedger)
 	if err != nil {
@@ -149,38 +117,13 @@ func EventIDRangeForLedgers(ofs *events.LedgerOffsets, startLedger, endLedger ui
 
 // QueryOptions configures a Query call.
 //
-// MaxEvents caps the result size (0 = unlimited). Must be
-// non-negative; Query rejects a negative value up-front. Which
-// events survive the cap depends on Order: ascending keeps the
-// lowest event IDs, descending the highest. MaxEvents is the
-// QUERY's intent — it stays per-call when the future multi-chunk
-// coordinator dispatches across chunks.
-//
-// MaxEvents caveat: the cap is applied to bitmap candidates BEFORE
-// the defensive post-filter runs (see Query's post-filter comment).
-// A term-hash collision that survives the bitmap stage then gets
-// dropped by post-filter consumes a cap slot, so Query may return
-// fewer than MaxEvents real matches even when more existed past the
-// cap. With xxh3_128 term keys the probability per term is ~2^-64,
-// so this is effectively unreachable in practice; a refill loop
-// would close the gap if a real workload ever exhibits it.
+// MaxEvents caps the result size (0 = unlimited; must be non-negative).
+// Ascending keeps the lowest IDs; descending keeps the highest.
 //
 // Order selects ascending (default) or descending event-ID order.
 //
-// Range is the chunk-relative event-ID window the query operates on.
-// REQUIRED — both Range.Start and Range.End must be set explicitly by
-// the caller. The engine does not invent an upper bound. End is
-// typically pinned once at request entry from a snapshot of the
-// chunk's offsets (LedgerOffsets.TotalEvents()) and threaded through
-// every Query call for that request, giving snapshot-isolation across
-// pagination and multi-chunk fan-out. See EventIDRange for the full
+// Range is REQUIRED. See EventIDRange for the snapshot-isolation
 // contract.
-//
-// The zero value EventIDRange{} is a legitimately empty range
-// (Start == End == 0) and yields (nil, nil); it is NOT a sentinel for
-// "whole chunk" — that would silently expand the caller's pinned
-// snapshot. Range with End < Start is a malformed input and surfaces
-// as an explicit error.
 type QueryOptions struct {
 	MaxEvents int
 	Order     Order
@@ -188,9 +131,7 @@ type QueryOptions struct {
 }
 
 // topicFieldByPosition maps topic position 0..MaxTopicCount-1 to its
-// indexed events.Field. Mirrors the unexported events.topicField
-// switch — duplicated here rather than exported because Query is the
-// only caller in this package and exporting would invite misuse.
+// indexed events.Field. Mirror of the unexported events.topicField.
 //
 //nolint:gochecknoglobals // immutable lookup table; can't use const for array
 var topicFieldByPosition = [protocol.MaxTopicCount]events.Field{
@@ -201,8 +142,7 @@ var topicFieldByPosition = [protocol.MaxTopicCount]events.Field{
 }
 
 // Query runs filters against r under opts and returns the matching
-// events in chunk-relative event-ID order (ascending by default,
-// descending when opts.Order == OrderDescending).
+// events in chunk-relative event-ID order.
 //
 // Semantics:
 //
@@ -211,23 +151,9 @@ var topicFieldByPosition = [protocol.MaxTopicCount]events.Field{
 //   - Across filters: union of per-filter matches.
 //   - len(filters) == 0 is treated as a single match-all filter,
 //     consistent with getEvents.
-//   - opts.Range restricts to that event-ID window (clipped to the
-//     chunk). Zero value = whole chunk.
-//   - opts.MaxEvents caps the result size. 0 = unlimited.
-//   - opts.Order picks ascending or descending output.
 //
-// Bitmap ownership: Reader.LookupKeys returns BORROWED bitmaps in
-// both tiers. The hot path returns the live mirror snapshot
-// (ConcurrentBitmaps stores immutable snapshots via atomic.Pointer
-// COW; readers atomic-load and operate on pointers that no writer
-// will ever mutate). The cold path freshly unmarshals from
-// index.pack, so the caller owns the result; either way Query must
-// treat LookupKeys results as read-only. roaring.FastAnd and
-// roaring.FastOr produce fresh result bitmaps and never modify
-// their inputs. The range And is roaring.And on the (possibly
-// borrowed) single-filter union — non-mutating fresh-result — and
-// in-place And only on the FastOr-produced (owned) multi-filter
-// union.
+// See QueryOptions / EventIDRange for the window, cap, and order
+// contract.
 //
 //nolint:gocognit,cyclop,funlen
 func Query(ctx context.Context, r Reader, filters []Filter, opts QueryOptions) ([]events.Payload, error) {
@@ -270,10 +196,6 @@ func Query(ctx context.Context, r Reader, filters []Filter, opts QueryOptions) (
 	}
 
 	// ───── 1. Dedupe terms across filters ─────
-	//
-	// Caller guarantees ≤15 filters × (1 contract + 4 topics) = ≤75
-	// candidate term slots and ≤15 unique terms. A linear-scan dedupe
-	// (indexOfOrAddTerm) is cheaper than a hash map at this size.
 	//
 	// filterPlans[i] holds the indices into uniqueKeys that filter i
 	// requires intersected. Empty plans were handled by the match-all
@@ -360,9 +282,9 @@ func Query(ctx context.Context, r Reader, filters []Filter, opts QueryOptions) (
 
 	// ───── 4. Union across filters ─────
 	// Single-filter case: FastOr would Clone — skip it and use the
-	// already-computed bitmap directly. The range And below would
-	// need to allocate fresh either way (single-filter union is
-	// borrowed, so in-place mutation is forbidden).
+	// already-computed bitmap directly. That bitmap may be borrowed
+	// (from LookupKeys), so step 5's range And uses the fresh-result
+	// variant on that path to avoid mutating shared state.
 	var union *roaring.Bitmap
 	singleFilter := len(perFilter) == 1
 	if singleFilter {
@@ -373,22 +295,17 @@ func Query(ctx context.Context, r Reader, filters []Filter, opts QueryOptions) (
 
 	// ───── 5. Apply event-ID range ─────
 	//
-	// Always applied (even for the zero-value "whole chunk" case): the
-	// AND with [start, end) clips any phantom IDs that the mirror may
-	// have published beyond what r.EventCount() saw at entry. On the
-	// hot side a concurrent ingest publishes mirror entries BEFORE
-	// offsets, so LookupKeys can briefly surface IDs >= EventCount;
-	// applying the range bitmap eliminates them and keeps Query's
-	// result snapshot-consistent with the EventCount we read at entry.
+	// The range AND enforces the caller's pinned window. It also clips
+	// phantom IDs from a concurrent hot-store ingest: the mirror
+	// publishes entries before offsets, so LookupKeys can briefly
+	// surface IDs past EventCount. The AND keeps Query's result
+	// strictly within the snapshot the caller pinned at request entry.
 	rangeBM := roaring.New()
 	rangeBM.AddRange(uint64(start), uint64(end))
 	if singleFilter {
-		// union is a borrowed bitmap from LookupKeys; roaring.And
-		// returns a fresh result without mutating either input.
-		union = roaring.And(union, rangeBM)
+		union = roaring.And(union, rangeBM) // fresh result; union may be borrowed
 	} else {
-		// FastOr output is fresh — in-place And is fine.
-		union.And(rangeBM)
+		union.And(rangeBM) // FastOr output is owned; in-place is fine
 	}
 
 	if union.IsEmpty() {
@@ -408,13 +325,7 @@ func Query(ctx context.Context, r Reader, filters []Filter, opts QueryOptions) (
 	if err != nil {
 		return nil, err
 	}
-	// Defensive post-filter: TermKey is xxh3_128(field || value), a
-	// non-cryptographic hash on attacker-controllable topic values.
-	// The index can in principle return false-positive event IDs from
-	// a collision; the post-filter verifies each materialized event's
-	// raw field bytes against the requested filter clauses and
-	// discards mismatches. The hash becomes load-bearing only for
-	// narrowing efficiency, not for result correctness.
+	// Drop bitmap-side false positives (see postFilter for the rationale).
 	matched, err := postFilter(payloads, filters)
 	if err != nil {
 		return nil, err
@@ -468,8 +379,7 @@ func hasMatchAllFilter(filters []Filter) bool {
 }
 
 // indexOfOrAddTerm returns the index of key inside *keys, appending
-// it first if absent. The linear scan is fine at the caller's
-// guaranteed ≤15 unique-term ceiling.
+// it first if absent.
 func indexOfOrAddTerm(keys *[]events.TermKey, key events.TermKey) int {
 	for i, k := range *keys {
 		if k == key {
@@ -486,12 +396,6 @@ func indexOfOrAddTerm(keys *[]events.TermKey, key events.TermKey) int {
 // via Reader.FetchRange — no []uint32{0..count} materialization, and
 // on the cold path one direct ReadRange call instead of the
 // per-position coalescing logic FetchEvents would run.
-//
-// FetchRange yields BORROWED payloads (ContractEventBytes aliases the
-// reader's iteration buffer, valid only for the current step). We
-// retain them in the returned slice, so each event's bytes are cloned
-// before append. Descending keeps the highest `count` IDs by starting
-// the range at end-count, then reverses the materialized slice.
 //
 // Caller contract: start < end (the [start, end) window is non-empty)
 // and both bounds are valid chunk-relative event IDs. The resolve()
@@ -566,19 +470,20 @@ func selectEventIDs(bm *roaring.Bitmap, maxEvents int, descending bool) []uint32
 	return ids[:filled]
 }
 
-// postFilter verifies each materialized payload against the requested
-// filter clauses and discards mismatches. See Query's post-filter
-// comment for the collision-defense rationale.
+// postFilter is the collision-defense pass: TermKey is
+// xxh3_128(field || value), a non-cryptographic hash on
+// attacker-controllable topic values, so the bitmap index can in
+// principle return false-positive event IDs from a collision.
+// postFilter verifies each materialized event's raw field bytes
+// against the requested filter clauses and discards mismatches. The
+// hash becomes load-bearing only for narrowing efficiency, not for
+// result correctness.
 //
 // Within a clause: AND across non-empty fields. Across clauses: OR.
 // The match-all short-circuit upstream means this is only reached
 // when at least one filter clause has a constraint. The result slice
 // aliases the input — safe because the write cursor is always ≤ the
 // read cursor, and the input is owned (Reader.FetchEvents).
-//
-// Payloads carry only raw ContractEvent XDR (ContractEventBytes), so
-// matching navigates an xdr.ContractEventView — no per-event
-// UnmarshalBinary.
 func postFilter(payloads []events.Payload, filters []Filter) ([]events.Payload, error) {
 	if len(filters) == 0 {
 		return payloads, nil
@@ -598,13 +503,9 @@ func postFilter(payloads []events.Payload, filters []Filter) ([]events.Payload, 
 }
 
 // filterPlan caches per-query info computed once at postFilter entry
-// and consumed by the view path: the union of topic positions any
-// clause constrains, plus the highest constrained position (caps the
-// view-path topic walk). All booleans + ints — every access is O(1)
-// and the struct lives on the postFilter stack.
-//
-// ContractID is checked per-clause via len(f.ContractID) > 0; no
-// precomputed flag needed.
+// and consumed by matchesAnyFilterView: the topic positions any
+// clause constrains and the highest constrained position (caps the
+// view-path topic walk).
 type filterPlan struct {
 	anyTopic    bool
 	maxTopicIdx int // -1 if no clause constrains any topic
@@ -639,9 +540,7 @@ func planFilters(filters []Filter) filterPlan {
 // Lazy resolution: events that fail every clause's ContractId check
 // never trigger the topic walk; events that pass do exactly one
 // linear walk over Topics up to the highest constrained position
-// (single-call cache, multi-clause queries reuse). The cache state is
-// held in inline locals rather than closures so escape analysis keeps
-// the [4][]byte topic array on the stack.
+// (single-call cache, multi-clause queries reuse).
 //
 //nolint:gocognit // linear clause loop with two-level lazy cache; splitting helpers fragments the lazy invariant
 func matchesAnyFilterView(raw []byte, filters []Filter, plan *filterPlan) (bool, error) {
@@ -696,9 +595,7 @@ func matchesAnyFilterView(raw []byte, filters []Filter, plan *filterPlan) (bool,
 
 // resolveViewContractID extracts the optional ContractId from a
 // ContractEventView. Returns (present, bytes, err); when present is
-// false, bytes is nil. Factored out of matchesAnyFilterView so the
-// caller can hold its lazy-resolve state in plain locals instead of
-// closure-captured variables that would escape to the heap.
+// false, bytes is nil.
 func resolveViewContractID(ev xdr.ContractEventView) (bool, []byte, error) {
 	cidOpt, err := ev.ContractId()
 	if err != nil {

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query.go
@@ -168,6 +168,9 @@ func Query(ctx context.Context, r Reader, filters []Filter, opts QueryOptions) (
 			"events: Range.End (%d) must be >= Range.Start (%d)",
 			opts.Range.End, opts.Range.Start)
 	}
+	if opts.Range.Start == opts.Range.End {
+		return nil, nil // empty range
+	}
 	if err := validateFilters(filters); err != nil {
 		return nil, err
 	}

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query.go
@@ -200,7 +200,7 @@ var topicFieldByPosition = [protocol.MaxTopicCount]events.Field{
 // in-place And only on the FastOr-produced (owned) multi-filter
 // union.
 //
-//nolint:gocognit,cyclop,funlen,gocyclo
+//nolint:gocognit,cyclop,funlen
 func Query(ctx context.Context, r Reader, filters []Filter, opts QueryOptions) ([]events.Payload, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query.go
@@ -49,20 +49,6 @@ type Filter struct {
 	Topics     [protocol.MaxTopicCount][]byte
 }
 
-// Order selects the direction matches are returned (and, when
-// MaxEvents caps the result, which end of the range is kept).
-// The zero value is ascending.
-type Order int
-
-const (
-	// OrderAscending returns matches in ascending event-ID order.
-	// When MaxEvents caps, the lowest IDs win.
-	OrderAscending Order = iota
-	// OrderDescending returns matches in descending event-ID order.
-	// When MaxEvents caps, the highest IDs win.
-	OrderDescending
-)
-
 // EventIDRange is a literal half-open chunk-relative event-ID window
 // [Start, End). Both bounds are mandatory.
 //
@@ -73,28 +59,12 @@ const (
 // invisible to the in-flight request. Multi-page paginated requests
 // MUST share the same End across pages.
 //
-// End above EventCount is clipped down (defense-in-depth against
-// stale snapshots). Start > End is a malformed input and surfaces
-// as an explicit error from Query. Start == End is a legitimate
-// empty range; the query returns (nil, nil).
+// End > EventCount is rejected as a caller bug (wrong chunk's
+// offsets or stale snapshot) — under the snapshot-isolation contract
+// a properly-pinned End never exceeds the chunk's current EventCount,
+// since chunks only grow.
 type EventIDRange struct {
 	Start, End uint32
-}
-
-// resolve returns the post-clip half-open bounds for this range
-// against the chunk's total event count, applying the defensive
-// upper clip (End down to EventCount). Returns (start, end, ok)
-// where ok is false when the chunk is empty or the literal range
-// is empty (Start == End).
-func (r EventIDRange) resolve(eventCount uint32) (uint32, uint32, bool) {
-	if eventCount == 0 {
-		return 0, 0, false
-	}
-	start, end := r.Start, r.End
-	if end > eventCount {
-		end = eventCount
-	}
-	return start, end, start < end
 }
 
 // EventIDRangeForLedgers translates an inclusive ledger window
@@ -120,14 +90,15 @@ func EventIDRangeForLedgers(ofs *events.LedgerOffsets, startLedger, endLedger ui
 // MaxEvents caps the result size (0 = unlimited; must be non-negative).
 // Ascending keeps the lowest IDs; descending keeps the highest.
 //
-// Order selects ascending (default) or descending event-ID order.
+// Descending selects descending event-ID order; the zero value (false)
+// is ascending — the getEvents v1 default.
 //
 // Range is REQUIRED. See EventIDRange for the snapshot-isolation
 // contract.
 type QueryOptions struct {
-	MaxEvents int
-	Order     Order
-	Range     EventIDRange
+	MaxEvents  int
+	Descending bool
+	Range      EventIDRange
 }
 
 // topicFieldByPosition maps topic position 0..MaxTopicCount-1 to its
@@ -179,16 +150,16 @@ func Query(ctx context.Context, r Reader, filters []Filter, opts QueryOptions) (
 	if err != nil {
 		return nil, fmt.Errorf("events: query event count: %w", err)
 	}
-	// Range is caller-pinned (snapshot-isolation contract). The
-	// engine clips End down to EventCount as defense-in-depth against
-	// stale snapshots, but does NOT extend End upward when it falls
-	// below EventCount — that would silently expand the caller's
-	// frozen view.
-	start, end, ok := opts.Range.resolve(eventCount)
-	if !ok {
-		return nil, nil
+	// Snapshot-isolation contract: a properly-pinned End is ≤ the
+	// chunk's current EventCount. Exceeding it signals a caller bug
+	// (wrong chunk's offsets, stale snapshot) — surface it loudly.
+	if opts.Range.End > eventCount {
+		return nil, fmt.Errorf(
+			"events: Range.End (%d) exceeds chunk EventCount (%d)",
+			opts.Range.End, eventCount)
 	}
-	descending := opts.Order == OrderDescending
+	start, end := opts.Range.Start, opts.Range.End
+	descending := opts.Descending
 
 	// Match-all path: empty filter slice or any all-wildcard filter.
 	// Serves without touching the index — translates the range

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query.go
@@ -608,11 +608,11 @@ func resolveViewContractID(ev xdr.ContractEventView) (bool, []byte, error) {
 	if !present {
 		return false, nil, nil
 	}
-	b, err := cidView.Value()
+	cid, err := cidView.Value()
 	if err != nil {
 		return false, nil, fmt.Errorf("events: post-filter view ContractId value: %w", err)
 	}
-	return true, b, nil
+	return true, cid[:], nil
 }
 
 // collectTopicViewBytes walks the ContractEventView's Body.V0.Topics
@@ -638,11 +638,7 @@ func collectTopicViewBytes(
 	if err != nil {
 		return fmt.Errorf("events: post-filter view Body.V: %w", err)
 	}
-	bodyVVal, err := bodyV.Value()
-	if err != nil {
-		return fmt.Errorf("events: post-filter view Body.V value: %w", err)
-	}
-	if bodyVVal != 0 {
+	if bodyV != 0 {
 		return nil
 	}
 	v0, err := body.V0()

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query.go
@@ -1,9 +1,9 @@
 package eventstore
 
 // query.go is the events-side coordinator that turns a {filters,
-// Range, MaxEvents, Order} spec into matching events for one Chunk.
-// It is built on the Reader interface, so it works against HotStore
-// and ColdReader without branching.
+// Range, MaxEvents, Descending} spec into matching events for one
+// Chunk. It is built on the Reader interface, so it works against
+// HotStore and ColdReader without branching.
 //
 // Semantics:
 //
@@ -25,6 +25,7 @@ package eventstore
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"fmt"
 	"slices"
@@ -49,6 +50,38 @@ type Filter struct {
 	Topics     [protocol.MaxTopicCount][]byte
 }
 
+// isMatchAll reports whether f has no constraints (every field is a
+// wildcard) — equivalent to "this filter matches every event."
+func (f *Filter) isMatchAll() bool {
+	if len(f.ContractID) > 0 {
+		return false
+	}
+	for _, t := range f.Topics {
+		if len(t) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// termKeys returns the indexed (field, value) terms this filter
+// constrains. Each TermKey identifies one row in the per-Chunk
+// bitmap index; Query intersects their bitmaps to compute this
+// filter's matches.
+func (f *Filter) termKeys() []events.TermKey {
+	var keys []events.TermKey
+	if len(f.ContractID) > 0 {
+		keys = append(keys, events.ComputeTermKey(f.ContractID, events.FieldContractID))
+	}
+	for tIdx, t := range f.Topics {
+		if len(t) == 0 {
+			continue
+		}
+		keys = append(keys, events.ComputeTermKey(t, topicFieldByPosition[tIdx]))
+	}
+	return keys
+}
+
 // EventIDRange is a literal half-open chunk-relative event-ID window
 // [Start, End). Both bounds are mandatory.
 //
@@ -67,12 +100,27 @@ type EventIDRange struct {
 	Start, End uint32
 }
 
-// EventIDRangeForLedgers translates an inclusive ledger window
-// [startLedger, endLedger] into the half-open EventIDRange covering
-// those ledgers' events, using ofs's per-ledger event-count snapshot.
-// Both bounds must lie inside ofs's [StartLedger, EndLedger) range;
-// out-of-range bounds surface a wrapped error from
-// LedgerOffsets.EventIDs.
+// isEmpty reports whether r covers zero events.
+func (r EventIDRange) isEmpty() bool { return r.Start == r.End }
+
+// check validates the structural invariant Start <= End. Does NOT
+// check End against the chunk's EventCount — that requires a Reader
+// and is enforced by Query.
+func (r EventIDRange) check() error {
+	if r.End < r.Start {
+		return fmt.Errorf(
+			"events: Range.End (%d) must be >= Range.Start (%d)",
+			r.End, r.Start)
+	}
+	return nil
+}
+
+// EventIDRangeForLedgers translates the closed ledger window
+// [startLedger, endLedger] into the half-open EventIDRange
+// [firstID, lastID) covering those ledgers' events, using ofs's
+// per-ledger event-count snapshot. Both bounds must lie inside ofs's
+// [StartLedger, EndLedger) range; out-of-range bounds surface a
+// wrapped error from LedgerOffsets.EventIDs.
 func EventIDRangeForLedgers(ofs *events.LedgerOffsets, startLedger, endLedger uint32) (EventIDRange, error) {
 	firstID, _, err := ofs.EventIDs(startLedger)
 	if err != nil {
@@ -134,13 +182,11 @@ func Query(ctx context.Context, r Reader, filters []Filter, opts QueryOptions) (
 	if opts.MaxEvents < 0 {
 		return nil, fmt.Errorf("events: MaxEvents must be non-negative, got %d", opts.MaxEvents)
 	}
-	if opts.Range.End < opts.Range.Start {
-		return nil, fmt.Errorf(
-			"events: Range.End (%d) must be >= Range.Start (%d)",
-			opts.Range.End, opts.Range.Start)
+	if err := opts.Range.check(); err != nil {
+		return nil, err
 	}
-	if opts.Range.Start == opts.Range.End {
-		return nil, nil // empty range
+	if opts.Range.isEmpty() {
+		return nil, nil
 	}
 	if err := validateFilters(filters); err != nil {
 		return nil, err
@@ -178,18 +224,10 @@ func Query(ctx context.Context, r Reader, filters []Filter, opts QueryOptions) (
 	var uniqueKeys []events.TermKey
 
 	for i := range filters {
-		f := &filters[i]
-		var slots []int
-		if len(f.ContractID) > 0 {
-			slots = append(slots, indexOfOrAddTerm(&uniqueKeys,
-				events.ComputeTermKey(f.ContractID, events.FieldContractID)))
-		}
-		for tIdx, t := range f.Topics {
-			if len(t) == 0 {
-				continue
-			}
-			slots = append(slots, indexOfOrAddTerm(&uniqueKeys,
-				events.ComputeTermKey(t, topicFieldByPosition[tIdx])))
+		keys := filters[i].termKeys()
+		slots := make([]int, len(keys))
+		for j, key := range keys {
+			slots[j] = indexOfOrAddTerm(&uniqueKeys, key)
 		}
 		filterPlans[i] = slots
 	}
@@ -237,15 +275,7 @@ func Query(ctx context.Context, r Reader, filters []Filter, opts QueryOptions) (
 		// bitmap first shrinks the accumulator fastest. roaring's own
 		// docs call this out as the recommended caller-side prep.
 		slices.SortFunc(inputs, func(a, b *roaring.Bitmap) int {
-			ac, bc := a.GetCardinality(), b.GetCardinality()
-			switch {
-			case ac < bc:
-				return -1
-			case ac > bc:
-				return 1
-			default:
-				return 0
-			}
+			return cmp.Compare(a.GetCardinality(), b.GetCardinality())
 		})
 		perFilter = append(perFilter, roaring.FastAnd(inputs...))
 	}
@@ -334,18 +364,7 @@ func hasMatchAllFilter(filters []Filter) bool {
 		return true
 	}
 	for i := range filters {
-		f := &filters[i]
-		if len(f.ContractID) > 0 {
-			continue
-		}
-		allWildcardTopics := true
-		for _, t := range f.Topics {
-			if len(t) > 0 {
-				allWildcardTopics = false
-				break
-			}
-		}
-		if allWildcardTopics {
+		if filters[i].isMatchAll() {
 			return true
 		}
 	}
@@ -355,10 +374,8 @@ func hasMatchAllFilter(filters []Filter) bool {
 // indexOfOrAddTerm returns the index of key inside *keys, appending
 // it first if absent.
 func indexOfOrAddTerm(keys *[]events.TermKey, key events.TermKey) int {
-	for i, k := range *keys {
-		if k == key {
-			return i
-		}
+	if i := slices.Index(*keys, key); i >= 0 {
+		return i
 	}
 	*keys = append(*keys, key)
 	return len(*keys) - 1
@@ -372,8 +389,9 @@ func indexOfOrAddTerm(keys *[]events.TermKey, key events.TermKey) int {
 // per-position coalescing logic FetchEvents would run.
 //
 // Caller contract: start < end (the [start, end) window is non-empty)
-// and both bounds are valid chunk-relative event IDs. The resolve()
-// step in Query enforces both.
+// and both bounds are valid chunk-relative event IDs. Query enforces
+// both via its empty-range short-circuit and the End ≤ EventCount
+// check before dispatching here.
 func fetchAllInRange(
 	ctx context.Context, r Reader,
 	start, end uint32, maxEvents int, descending bool,

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query_test.go
@@ -580,7 +580,7 @@ func TestQuery_ChunkWithLedgersButZeroEvents(t *testing.T) {
 	first := chunkID.FirstLedger()
 
 	// Ingest three empty ledgers — recorded in offsets, no events.
-	for i := uint32(0); i < 3; i++ {
+	for i := range uint32(3) {
 		require.NoError(t, h.store.IngestLedgerEvents(first+i, nil))
 	}
 	require.Equal(t, uint32(0), mustEventCount(t, h.store))
@@ -725,7 +725,6 @@ func freezeFixtureToColdReader(t *testing.T, fx *queryFixture, chunkID chunk.ID)
 
 	eventID := uint32(0)
 	for rel, cum := range hotOffsets.Offsets() {
-		//nolint:gosec // rel is bounded by LedgersPerChunk; fits uint32
 		ledger := hotOffsets.StartLedger() + uint32(rel)
 		var count uint32
 		if rel == 0 {

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query_test.go
@@ -127,16 +127,17 @@ func dataSyms(t *testing.T, payloads []events.Payload) []string {
 
 // eventIDRangeFor is a test-side convenience wrapper over the
 // public EventIDRangeForLedgers helper: it pulls the fixture's
-// offsets snapshot and translates the inclusive ledger window. The
+// offsets snapshot, translates the inclusive ledger window, and
+// returns a *EventIDRange suitable for QueryOptions.Range. The
 // production adapter calls EventIDRangeForLedgers directly with its
 // own offsets handle.
-func eventIDRangeFor(t *testing.T, fx *queryFixture, startLedger, endLedger uint32) EventIDRange {
+func eventIDRangeFor(t *testing.T, fx *queryFixture, startLedger, endLedger uint32) *EventIDRange {
 	t.Helper()
 	ofs, err := fx.store.Offsets()
 	require.NoError(t, err)
 	r, err := EventIDRangeForLedgers(ofs, startLedger, endLedger)
 	require.NoError(t, err)
-	return r
+	return &r
 }
 
 func TestQuery_MatchAllOnEmptyFiltersSlice(t *testing.T) {
@@ -365,7 +366,7 @@ func TestQuery_RangeEndBeyondChunkClips(t *testing.T) {
 	// End past EventCount clips silently. With Start=0, this is
 	// equivalent to the whole-chunk query: all 7 events.
 	got, err := Query(context.Background(), fx.store, nil,
-		QueryOptions{Range: EventIDRange{Start: 0, End: 1_000_000}})
+		QueryOptions{Range: &EventIDRange{Start: 0, End: 1_000_000}})
 	require.NoError(t, err)
 	assert.Len(t, got, 7)
 }
@@ -375,7 +376,7 @@ func TestQuery_RangeStartAtOrAboveEventCountReturnsEmpty(t *testing.T) {
 	// Start at or above EventCount: after clipping End down to
 	// EventCount, the resolved window is empty (start >= end).
 	got, err := Query(context.Background(), fx.store, nil,
-		QueryOptions{Range: EventIDRange{Start: 100_000, End: 200_000}})
+		QueryOptions{Range: &EventIDRange{Start: 100_000, End: 200_000}})
 	require.NoError(t, err)
 	assert.Empty(t, got)
 }
@@ -595,7 +596,7 @@ func TestQuery_ChunkWithLedgersButZeroEvents(t *testing.T) {
 	// window.
 	_ = first
 	got, err = Query(context.Background(), h.store, nil,
-		QueryOptions{Range: EventIDRange{Start: 0, End: 100}})
+		QueryOptions{Range: &EventIDRange{Start: 0, End: 100}})
 	require.NoError(t, err)
 	assert.Empty(t, got)
 
@@ -661,6 +662,80 @@ func TestQuery_RangeAndEmptiesUnion(t *testing.T) {
 		QueryOptions{Range: eventIDRangeFor(t, fx, first+1, first+1)})
 	require.NoError(t, err)
 	assert.Empty(t, got, "non-empty per-filter bitmap intersected with disjoint range must yield empty")
+}
+
+// TestQuery_EmptyLeadingLedgerRangeStaysEmpty pins the fix for the
+// Codex-flagged bug: when a chunk's first ledger has zero events but
+// later ledgers have events, EventIDRangeForLedgers(ofs, first, first)
+// legitimately returns EventIDRange{0, 0}. A prior implementation
+// treated End == 0 as a "whole chunk" sentinel and silently expanded
+// the empty query to return events from later ledgers. With Range as
+// a pointer and the sentinel dropped, the literal {0, 0} stays empty.
+func TestQuery_EmptyLeadingLedgerRangeStaysEmpty(t *testing.T) {
+	const chunkID = chunk.ID(0)
+	h := openHotStoreForTest(t, chunkID)
+	first := chunkID.FirstLedger()
+
+	// Ledger `first` is ingested with 0 events; ledger `first+1` has
+	// real events. After ingest the chunk's offsets read:
+	//   [first]   → [0, 0)   (empty)
+	//   [first+1] → [0, 5)   (5 events)
+	require.NoError(t, h.store.IngestLedgerEvents(first, nil))
+	require.NoError(t, h.store.IngestLedgerEvents(first+1, []events.Payload{
+		makeSimplePayload(t, "evt-0"),
+		makeSimplePayload(t, "evt-1"),
+		makeSimplePayload(t, "evt-2"),
+		makeSimplePayload(t, "evt-3"),
+		makeSimplePayload(t, "evt-4"),
+	}))
+
+	// EventIDRangeForLedgers translates the empty-prefix request to
+	// EventIDRange{0, 0}. This is what the future adapter / coordinator
+	// will hand to Query for a getEvents call restricted to ledger `first`.
+	ofs, err := h.store.Offsets()
+	require.NoError(t, err)
+	emptyRange, err := EventIDRangeForLedgers(ofs, first, first)
+	require.NoError(t, err)
+	require.Equal(t, EventIDRange{Start: 0, End: 0}, emptyRange,
+		"fixture sanity: empty leading-ledger window must produce {0, 0}")
+
+	got, err := Query(context.Background(), h.store, nil,
+		QueryOptions{Range: &emptyRange})
+	require.NoError(t, err)
+	assert.Empty(t, got, "empty leading-ledger window must stay empty, not expand to whole chunk")
+
+	// Sanity: the same call WITHOUT a Range (nil = whole chunk) still
+	// returns all 5 events from ledger first+1.
+	got, err = Query(context.Background(), h.store, nil, QueryOptions{})
+	require.NoError(t, err)
+	require.Len(t, got, 5, "whole-chunk default must still see the later-ledger events")
+}
+
+// makeSimplePayload builds an events.Payload with a unique Data symbol
+// and a single trivial topic. Used by tests that don't care about the
+// indexed-field layout, only event counts and ordering.
+func makeSimplePayload(t *testing.T, dataSymbol string) events.Payload {
+	t.Helper()
+	var cid xdr.ContractId
+	cid[0] = 0xab
+	sym := xdr.ScSymbol(dataSymbol)
+	ev := xdr.ContractEvent{
+		ContractId: &cid,
+		Type:       xdr.ContractEventTypeContract,
+		Body: xdr.ContractEventBody{
+			V: 0,
+			V0: &xdr.ContractEventV0{
+				Topics: []xdr.ScVal{{Type: xdr.ScValTypeScvSymbol, Sym: &sym}},
+				Data:   xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &sym},
+			},
+		},
+	}
+	raw, err := ev.MarshalBinary()
+	require.NoError(t, err)
+	return events.Payload{
+		TxHash:             xdr.Hash{0xde, 0xad},
+		ContractEventBytes: raw,
+	}
 }
 
 // ─── Cold-reader parity coverage ────────────────────────────────────────

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query_test.go
@@ -1,0 +1,906 @@
+package eventstore
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/RoaringBitmap/roaring/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/events"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
+)
+
+// countingReader wraps a Reader and counts LookupKeys traffic so a
+// test can pin Query's term-dedupe behavior — without a wrapper the
+// best we can do is assert correctness, not the number of unique
+// keys handed to the storage layer.
+type countingReader struct {
+	Reader
+
+	lookupKeysCalls int
+	totalKeys       int
+}
+
+func (c *countingReader) LookupKeys(ctx context.Context, keys []events.TermKey) ([]*roaring.Bitmap, error) {
+	c.lookupKeysCalls++
+	c.totalKeys += len(keys)
+	return c.Reader.LookupKeys(ctx, keys)
+}
+
+// queryFixture seeds a hot chunk with a small, hand-crafted event set
+// the Query tests can match against by name. Each event has a known
+// contract ID, a 1- or 2-topic body, and a payload Data symbol that
+// uniquely identifies it across the chunk.
+//
+// Layout:
+//
+//	id 0: contract A, topics [t0a, t0b]               → "evt-a-ab"
+//	id 1: contract A, topics [t0a, t0c]               → "evt-a-ac"
+//	id 2: contract B, topics [t0a, t0b]               → "evt-b-ab"
+//	id 3: contract B, topics [t0a]                    → "evt-b-a"
+//	id 4: contract A, topics [t0b]                    → "evt-a-b"
+type queryFixture struct {
+	store *HotStore
+
+	contractA, contractB xdr.ContractId
+	t0a, t0b, t0c        xdr.ScVal // raw topic ScVals
+
+	// Pre-marshaled topic bytes so test filters can use them directly.
+	t0aRaw, t0bRaw, t0cRaw []byte
+}
+
+// payloadFor builds a Payload carrying the marshaled ContractEvent XDR
+// in ContractEventBytes — the only shape this branch's Payload supports.
+// dataSym labels the event so tests can match against the layout above.
+func payloadFor(t *testing.T, cid xdr.ContractId, dataSym string, topics ...xdr.ScVal) events.Payload {
+	t.Helper()
+	sym := xdr.ScSymbol(dataSym)
+	cidCopy := cid
+	ev := xdr.ContractEvent{
+		ContractId: &cidCopy,
+		Type:       xdr.ContractEventTypeContract,
+		Body: xdr.ContractEventBody{
+			V: 0,
+			V0: &xdr.ContractEventV0{
+				Topics: topics,
+				Data:   xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &sym},
+			},
+		},
+	}
+	raw, err := ev.MarshalBinary()
+	require.NoError(t, err)
+	return events.Payload{
+		TxHash:             xdr.Hash{0xde, 0xad},
+		ContractEventBytes: raw,
+	}
+}
+
+func newQueryFixture(t *testing.T) *queryFixture {
+	t.Helper()
+	const chunkID = chunk.ID(0)
+	h := openHotStoreForTest(t, chunkID)
+	fx := &queryFixture{store: h.store}
+	fx.contractA[0] = 0x01
+	fx.contractB[0] = 0x02
+	a := xdr.ScSymbol("alpha")
+	b := xdr.ScSymbol("beta")
+	c := xdr.ScSymbol("gamma")
+	fx.t0a = xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &a}
+	fx.t0b = xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &b}
+	fx.t0c = xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &c}
+	var err error
+	fx.t0aRaw, err = fx.t0a.MarshalBinary()
+	require.NoError(t, err)
+	fx.t0bRaw, err = fx.t0b.MarshalBinary()
+	require.NoError(t, err)
+	fx.t0cRaw, err = fx.t0c.MarshalBinary()
+	require.NoError(t, err)
+
+	first := chunkID.FirstLedger()
+	require.NoError(t, fx.store.IngestLedgerEvents(first, []events.Payload{
+		payloadFor(t, fx.contractA, "evt-a-ab", fx.t0a, fx.t0b),
+		payloadFor(t, fx.contractA, "evt-a-ac", fx.t0a, fx.t0c),
+		payloadFor(t, fx.contractB, "evt-b-ab", fx.t0a, fx.t0b),
+		payloadFor(t, fx.contractB, "evt-b-a", fx.t0a),
+		payloadFor(t, fx.contractA, "evt-a-b", fx.t0b),
+	}))
+	return fx
+}
+
+// dataSyms extracts each payload's Data symbol as a string so test
+// assertions can match against the fixture's labels above.
+func dataSyms(t *testing.T, payloads []events.Payload) []string {
+	t.Helper()
+	out := make([]string, len(payloads))
+	for i, p := range payloads {
+		out[i] = dataSym(t, p)
+	}
+	return out
+}
+
+// eventIDRangeFor is a test-side convenience wrapper over the
+// public EventIDRangeForLedgers helper: it pulls the fixture's
+// offsets snapshot and translates the inclusive ledger window. The
+// production adapter calls EventIDRangeForLedgers directly with its
+// own offsets handle.
+func eventIDRangeFor(t *testing.T, fx *queryFixture, startLedger, endLedger uint32) EventIDRange {
+	t.Helper()
+	ofs, err := fx.store.Offsets()
+	require.NoError(t, err)
+	r, err := EventIDRangeForLedgers(ofs, startLedger, endLedger)
+	require.NoError(t, err)
+	return r
+}
+
+func TestQuery_MatchAllOnEmptyFiltersSlice(t *testing.T) {
+	fx := newQueryFixture(t)
+	got, err := Query(context.Background(), fx.store, nil, QueryOptions{})
+	require.NoError(t, err)
+	assert.Equal(t,
+		[]string{"evt-a-ab", "evt-a-ac", "evt-b-ab", "evt-b-a", "evt-a-b"},
+		dataSyms(t, got))
+}
+
+func TestQuery_MatchAllOnEmptyFilterObject(t *testing.T) {
+	fx := newQueryFixture(t)
+	got, err := Query(context.Background(), fx.store, []Filter{{}}, QueryOptions{})
+	require.NoError(t, err)
+	require.Len(t, got, 5)
+}
+
+func TestQuery_ContractIDOnly(t *testing.T) {
+	fx := newQueryFixture(t)
+	got, err := Query(context.Background(), fx.store, []Filter{
+		{ContractID: fx.contractA[:]},
+	}, QueryOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evt-a-ab", "evt-a-ac", "evt-a-b"}, dataSyms(t, got))
+}
+
+func TestQuery_SingleTopic(t *testing.T) {
+	fx := newQueryFixture(t)
+	got, err := Query(context.Background(), fx.store, []Filter{
+		{Topics: [protocol.MaxTopicCount][]byte{nil, fx.t0bRaw}},
+	}, QueryOptions{})
+	require.NoError(t, err)
+	// topic1 == beta: id 0 (a,ab) and id 2 (b,ab).
+	assert.Equal(t, []string{"evt-a-ab", "evt-b-ab"}, dataSyms(t, got))
+}
+
+func TestQuery_ContractIDAndTopicIntersection(t *testing.T) {
+	fx := newQueryFixture(t)
+	got, err := Query(context.Background(), fx.store, []Filter{
+		{ContractID: fx.contractA[:], Topics: [protocol.MaxTopicCount][]byte{fx.t0aRaw}},
+	}, QueryOptions{})
+	require.NoError(t, err)
+	// contract A AND topic0 == alpha: id 0 and id 1.
+	assert.Equal(t, []string{"evt-a-ab", "evt-a-ac"}, dataSyms(t, got))
+}
+
+func TestQuery_UnionOfTwoFilters(t *testing.T) {
+	fx := newQueryFixture(t)
+	got, err := Query(context.Background(), fx.store, []Filter{
+		{ContractID: fx.contractA[:], Topics: [protocol.MaxTopicCount][]byte{nil, fx.t0cRaw}},
+		{ContractID: fx.contractB[:], Topics: [protocol.MaxTopicCount][]byte{nil, fx.t0bRaw}},
+	}, QueryOptions{})
+	require.NoError(t, err)
+	// A∩topic1=gamma → id 1; B∩topic1=beta → id 2.
+	assert.Equal(t, []string{"evt-a-ac", "evt-b-ab"}, dataSyms(t, got))
+}
+
+func TestQuery_MatchAllAmongOtherFiltersShortCircuits(t *testing.T) {
+	fx := newQueryFixture(t)
+	// One match-all filter alongside a real one — the union should
+	// expand to the whole chunk regardless of the second filter.
+	got, err := Query(context.Background(), fx.store, []Filter{
+		{ContractID: fx.contractA[:]},
+		{}, // match-all
+	}, QueryOptions{})
+	require.NoError(t, err)
+	require.Len(t, got, 5)
+}
+
+func TestQuery_FilterWithUnknownTermReturnsEmpty(t *testing.T) {
+	fx := newQueryFixture(t)
+	// A non-existent contract ID: the only filter contributes nothing
+	// to the union, so the result is empty (not an error).
+	var missing xdr.ContractId
+	missing[0] = 0xff
+	got, err := Query(context.Background(), fx.store, []Filter{
+		{ContractID: missing[:]},
+	}, QueryOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestQuery_DuplicateTermsAcrossFiltersDedupedInLookup(t *testing.T) {
+	fx := newQueryFixture(t)
+	// Both filters reference the same topic0=alpha term. The
+	// implementation must collapse it to a single unique key in the
+	// LookupKeys call — pinned via countingReader. Filters carry
+	// 4 candidate terms total (contractA + topic0a + contractB +
+	// topic0a) but only 3 unique (topic0a is shared).
+	cr := &countingReader{Reader: fx.store}
+	got, err := Query(context.Background(), cr, []Filter{
+		{ContractID: fx.contractA[:], Topics: [protocol.MaxTopicCount][]byte{fx.t0aRaw}},
+		{ContractID: fx.contractB[:], Topics: [protocol.MaxTopicCount][]byte{fx.t0aRaw}},
+	}, QueryOptions{})
+	require.NoError(t, err)
+	// A∩topic0=alpha → ids 0,1; B∩topic0=alpha → ids 2,3. Union → all four.
+	assert.Equal(t, []string{"evt-a-ab", "evt-a-ac", "evt-b-ab", "evt-b-a"},
+		dataSyms(t, got))
+	assert.Equal(t, 1, cr.lookupKeysCalls, "Query must batch all terms into one LookupKeys call")
+	assert.Equal(t, 3, cr.totalKeys, "Query must dedupe the shared topic0=alpha term")
+}
+
+func TestQuery_DoesNotMutateMirrorBitmaps(t *testing.T) {
+	fx := newQueryFixture(t)
+	// Snapshot the mirror's bitmap for topic0=alpha before any query.
+	key := events.ComputeTermKey(fx.t0aRaw, events.FieldTopic0)
+	before, err := fx.store.Lookup(context.Background(), key)
+	require.NoError(t, err)
+	beforeCard := before.GetCardinality()
+
+	// Run several queries that all touch the topic0=alpha term.
+	for range 3 {
+		_, err := Query(context.Background(), fx.store, []Filter{
+			{ContractID: fx.contractA[:], Topics: [protocol.MaxTopicCount][]byte{fx.t0aRaw}},
+			{ContractID: fx.contractB[:], Topics: [protocol.MaxTopicCount][]byte{fx.t0aRaw}},
+		}, QueryOptions{})
+		require.NoError(t, err)
+	}
+
+	after, err := fx.store.Lookup(context.Background(), key)
+	require.NoError(t, err)
+	assert.Equal(t, beforeCard, after.GetCardinality(),
+		"Query must not mutate the mirror's bitmaps")
+}
+
+func TestQuery_CanceledContextReturnsError(t *testing.T) {
+	fx := newQueryFixture(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := Query(ctx, fx.store, []Filter{{ContractID: fx.contractA[:]}}, QueryOptions{})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestQuery_NegativeMaxEventsRejected(t *testing.T) {
+	fx := newQueryFixture(t)
+	_, err := Query(context.Background(), fx.store, nil, QueryOptions{MaxEvents: -1})
+	require.Error(t, err)
+}
+
+func TestQuery_ShortContractIDRejected(t *testing.T) {
+	fx := newQueryFixture(t)
+	// A 31-byte ContractID would silently never match every event; the
+	// query layer must surface this loudly rather than accept it.
+	bogus := make([]byte, 31)
+	_, err := Query(context.Background(), fx.store, []Filter{{ContractID: bogus}}, QueryOptions{})
+	require.Error(t, err)
+}
+
+func TestQuery_EmptyChunkReturnsNothing(t *testing.T) {
+	const chunkID = chunk.ID(0)
+	h := openHotStoreForTest(t, chunkID)
+
+	// Match-all on an empty chunk.
+	got, err := Query(context.Background(), h.store, nil, QueryOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+
+	// And with a real filter — Lookup returns nil → empty result.
+	var cid xdr.ContractId
+	cid[0] = 0x01
+	got, err = Query(context.Background(), h.store, []Filter{{ContractID: cid[:]}}, QueryOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// TestQuery_ManyFiltersAtCallerCap pins behavior at the documented
+// caller cap (15 filters, 15 unique terms). Stresses the linear-scan
+// dedupe path on uniqueKeys at its largest expected size.
+func TestQuery_ManyFiltersAtCallerCap(t *testing.T) {
+	const chunkID = chunk.ID(0)
+	h := openHotStoreForTest(t, chunkID)
+
+	// 15 unique contracts; one filter per contract.
+	first := chunkID.FirstLedger()
+	const n = 15
+	payloads := make([]events.Payload, n)
+	contracts := make([]xdr.ContractId, n)
+	for i := range n {
+		contracts[i][0] = byte(i + 1)
+		payloads[i] = payloadFor(t, contracts[i], fmt.Sprintf("evt-%02d", i))
+	}
+	require.NoError(t, h.store.IngestLedgerEvents(first, payloads))
+
+	filters := make([]Filter, n)
+	for i := range n {
+		filters[i] = Filter{ContractID: contracts[i][:]}
+	}
+	got, err := Query(context.Background(), h.store, filters, QueryOptions{})
+	require.NoError(t, err)
+	assert.Len(t, got, n)
+}
+
+// newMultiLedgerQueryFixture extends newQueryFixture with a second
+// ledger that holds two additional events. Used to exercise the
+// Range option, which is a no-op against the single-ledger
+// base fixture. Layout:
+//
+//	ledger first   :  id 0..4 (5 events, same as newQueryFixture)
+//	ledger first+1 :  id 5..6 ("evt-extra-0", "evt-extra-1")
+func newMultiLedgerQueryFixture(t *testing.T) *queryFixture {
+	t.Helper()
+	fx := newQueryFixture(t)
+	first := chunk.ID(0).FirstLedger()
+	require.NoError(t, fx.store.IngestLedgerEvents(first+1, []events.Payload{
+		payloadFor(t, fx.contractA, "evt-extra-0", fx.t0a),
+		payloadFor(t, fx.contractA, "evt-extra-1", fx.t0a),
+	}))
+	return fx
+}
+
+func TestQuery_RangeWithinChunk(t *testing.T) {
+	fx := newMultiLedgerQueryFixture(t)
+	first := chunk.ID(0).FirstLedger()
+
+	// Restrict to ledger `first` only — should return the base
+	// fixture's five events and exclude the second ledger's two.
+	got, err := Query(context.Background(), fx.store, nil,
+		QueryOptions{Range: eventIDRangeFor(t, fx, first, first)})
+	require.NoError(t, err)
+	require.Len(t, got, 5)
+}
+
+func TestQuery_RangeEndBeyondChunkClips(t *testing.T) {
+	fx := newMultiLedgerQueryFixture(t)
+	// End past EventCount clips silently. With Start=0, this is
+	// equivalent to the whole-chunk query: all 7 events.
+	got, err := Query(context.Background(), fx.store, nil,
+		QueryOptions{Range: EventIDRange{Start: 0, End: 1_000_000}})
+	require.NoError(t, err)
+	assert.Len(t, got, 7)
+}
+
+func TestQuery_RangeStartAtOrAboveEventCountReturnsEmpty(t *testing.T) {
+	fx := newMultiLedgerQueryFixture(t)
+	// Start at or above EventCount: after clipping End down to
+	// EventCount, the resolved window is empty (start >= end).
+	got, err := Query(context.Background(), fx.store, nil,
+		QueryOptions{Range: EventIDRange{Start: 100_000, End: 200_000}})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestQuery_RangeIntersectsWithFilter(t *testing.T) {
+	fx := newMultiLedgerQueryFixture(t)
+	first := chunk.ID(0).FirstLedger()
+
+	// Contract A filter — base fixture has 3 events under A in
+	// ledger `first`, plus 2 more under A in ledger `first+1`.
+	// Restrict to second ledger only — expect 2 events.
+	got, err := Query(context.Background(), fx.store,
+		[]Filter{{ContractID: fx.contractA[:]}},
+		QueryOptions{Range: eventIDRangeFor(t, fx, first+1, first+1)})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evt-extra-0", "evt-extra-1"}, dataSyms(t, got))
+}
+
+func TestQuery_MaxEventsTruncates(t *testing.T) {
+	fx := newQueryFixture(t)
+	// Base fixture has 5 events. Cap to 2 — expect the two lowest IDs.
+	got, err := Query(context.Background(), fx.store, nil, QueryOptions{MaxEvents: 2})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, []string{"evt-a-ab", "evt-a-ac"}, dataSyms(t, got))
+}
+
+func TestQuery_MaxEventsZeroMeansUnlimited(t *testing.T) {
+	fx := newQueryFixture(t)
+	got, err := Query(context.Background(), fx.store, nil, QueryOptions{MaxEvents: 0})
+	require.NoError(t, err)
+	assert.Len(t, got, 5)
+}
+
+func TestQuery_MaxEventsCombinesWithRange(t *testing.T) {
+	fx := newMultiLedgerQueryFixture(t)
+	first := chunk.ID(0).FirstLedger()
+
+	// Range covers both ledgers (7 events). Cap to 6 → first 6 lowest IDs.
+	got, err := Query(context.Background(), fx.store, nil, QueryOptions{
+		MaxEvents: 6,
+		Range:     eventIDRangeFor(t, fx, first, first+1),
+	})
+	require.NoError(t, err)
+	assert.Len(t, got, 6)
+}
+
+func TestQuery_MaxEventsAppliesToFilteredPath(t *testing.T) {
+	fx := newMultiLedgerQueryFixture(t)
+	// Contract A has 5 events total (3 base + 2 extra). Cap to 2.
+	got, err := Query(context.Background(), fx.store,
+		[]Filter{{ContractID: fx.contractA[:]}},
+		QueryOptions{MaxEvents: 2})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, []string{"evt-a-ab", "evt-a-ac"}, dataSyms(t, got))
+}
+
+// ─── Descending-order coverage (added in this PR; rpc-hack was asc-only) ───
+
+func TestQuery_DescendingMatchAll(t *testing.T) {
+	fx := newQueryFixture(t)
+	got, err := Query(context.Background(), fx.store, nil,
+		QueryOptions{Order: OrderDescending})
+	require.NoError(t, err)
+	assert.Equal(t,
+		[]string{"evt-a-b", "evt-b-a", "evt-b-ab", "evt-a-ac", "evt-a-ab"},
+		dataSyms(t, got))
+}
+
+func TestQuery_DescendingMatchAllWithMaxEventsKeepsHighestIDs(t *testing.T) {
+	fx := newQueryFixture(t)
+	// Cap to 2 descending: should keep ids 4 and 3 (highest), in
+	// descending order.
+	got, err := Query(context.Background(), fx.store, nil,
+		QueryOptions{Order: OrderDescending, MaxEvents: 2})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evt-a-b", "evt-b-a"}, dataSyms(t, got))
+}
+
+func TestQuery_DescendingFiltered(t *testing.T) {
+	fx := newQueryFixture(t)
+	// contract A matches ids 0,1,4 → descending: 4,1,0.
+	got, err := Query(context.Background(), fx.store,
+		[]Filter{{ContractID: fx.contractA[:]}},
+		QueryOptions{Order: OrderDescending})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evt-a-b", "evt-a-ac", "evt-a-ab"}, dataSyms(t, got))
+}
+
+func TestQuery_DescendingFilteredWithMaxEventsKeepsHighestIDs(t *testing.T) {
+	fx := newQueryFixture(t)
+	// contract A descending capped to 2: keep highest two (ids 4, 1).
+	got, err := Query(context.Background(), fx.store,
+		[]Filter{{ContractID: fx.contractA[:]}},
+		QueryOptions{Order: OrderDescending, MaxEvents: 2})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evt-a-b", "evt-a-ac"}, dataSyms(t, got))
+}
+
+func TestQuery_DescendingWithRange(t *testing.T) {
+	fx := newMultiLedgerQueryFixture(t)
+	first := chunk.ID(0).FirstLedger()
+	// All 7 events descending, range covers both ledgers.
+	got, err := Query(context.Background(), fx.store, nil, QueryOptions{
+		Order: OrderDescending,
+		Range: eventIDRangeFor(t, fx, first, first+1),
+	})
+	require.NoError(t, err)
+	assert.Equal(t,
+		[]string{"evt-extra-1", "evt-extra-0", "evt-a-b", "evt-b-a", "evt-b-ab", "evt-a-ac", "evt-a-ab"},
+		dataSyms(t, got))
+}
+
+// TestQuery_PostFilterRejectsTermHashCollision pins the defensive
+// post-filter: if a bitmap entry survives the index lookup but the
+// underlying event's bytes don't actually match the filter clause,
+// Query must drop it. TermKey is xxh3_128(field || value), a
+// non-cryptographic hash on attacker-controllable values; a
+// collision (or a corrupt index) could otherwise leak the wrong
+// event through Query.
+//
+// We force the case by injecting a false-positive entry directly
+// into the mirror's bitmap for the "topic1 == gamma" term —
+// equivalent to what a real collision would produce.
+func TestQuery_PostFilterRejectsTermHashCollision(t *testing.T) {
+	fx := newQueryFixture(t)
+
+	// gamma's term legitimately matches id=1 only (evt-a-ac with
+	// topic1=gamma). Inject id=4 (evt-a-b — topic0=beta only,
+	// no topic1) into the same bitmap to simulate a collision.
+	gammaKey := events.ComputeTermKey(fx.t0cRaw, events.FieldTopic1)
+	before, err := fx.store.Lookup(context.Background(), gammaKey)
+	require.NoError(t, err)
+	require.True(t, before.Contains(1), "fixture sanity: id=1 indexes topic1=gamma")
+	require.False(t, before.Contains(4), "fixture sanity: id=4 not yet in topic1=gamma bitmap")
+
+	// ConcurrentBitmaps.AddTo is the writer-side API the ingest path uses
+	// to register (term, eventID) pairs. No concurrent ingest is running
+	// in this test, so the single-writer contract is satisfied.
+	fx.store.Index().AddTo(gammaKey, 4)
+
+	after, err := fx.store.Lookup(context.Background(), gammaKey)
+	require.NoError(t, err)
+	require.True(t, after.Contains(4), "fixture sanity: collision id=4 is now in the bitmap")
+
+	// Query with the colliding term: only id=1 should survive the
+	// post-filter; id=4's bytes don't actually have topic1=gamma.
+	got, err := Query(context.Background(), fx.store,
+		[]Filter{{Topics: [protocol.MaxTopicCount][]byte{nil, fx.t0cRaw}}},
+		QueryOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evt-a-ac"}, dataSyms(t, got),
+		"post-filter must drop the collision-injected id=4")
+}
+
+// ─── Additional coverage: gap-closing tests ────────────────────────────────
+
+// TestQuery_MixedSuccessFilterList exercises a filter list where one
+// filter has every term present in the index and the other references
+// a term that no event in the chunk carries. The "missing" filter
+// contributes nothing to the union (no events have that term); the
+// other filter's results must still come through. This pins step ❸'s
+// "skip filter on missed term" behavior — a regression that propagated
+// the missed-term error globally would empty the result.
+func TestQuery_MixedSuccessFilterList(t *testing.T) {
+	fx := newQueryFixture(t)
+
+	// Construct a topic that no fixture event uses, so its term key
+	// has no entry in the index (LookupKeys returns nil for it).
+	missingSym := xdr.ScSymbol("nonexistent")
+	missingTopic := xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &missingSym}
+	missingRaw, err := missingTopic.MarshalBinary()
+	require.NoError(t, err)
+	// Sanity check: this term really isn't in the index. The
+	// LookupKeys path (which Query uses) signals miss with a nil
+	// slot; the single-key Lookup surfaces ErrTermNotFound.
+	missingKey := events.ComputeTermKey(missingRaw, events.FieldTopic0)
+	_, err = fx.store.Lookup(context.Background(), missingKey)
+	require.ErrorIs(t, err, ErrTermNotFound,
+		"fixture sanity: 'nonexistent' must not be indexed")
+
+	got, err := Query(context.Background(), fx.store, []Filter{
+		// Filter A: matches contractA — 3 events (ids 0, 1, 4).
+		{ContractID: fx.contractA[:]},
+		// Filter B: requires a term that doesn't exist → contributes nothing.
+		{ContractID: fx.contractB[:], Topics: [protocol.MaxTopicCount][]byte{missingRaw}},
+	}, QueryOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evt-a-ab", "evt-a-ac", "evt-a-b"}, dataSyms(t, got),
+		"missing-term filter must be skipped, but the succeeding filter's events must still surface")
+}
+
+// TestQuery_ChunkWithLedgersButZeroEvents pins the path where the
+// chunk has ingested ledgers (LedgerCount > 0) but every ledger held
+// zero events (TotalEvents == 0). EventCount == 0 so EventIDRange.resolve
+// returns ok=false; Query short-circuits to (nil, nil) on both the
+// match-all and filtered paths.
+func TestQuery_ChunkWithLedgersButZeroEvents(t *testing.T) {
+	const chunkID = chunk.ID(0)
+	h := openHotStoreForTest(t, chunkID)
+	first := chunkID.FirstLedger()
+
+	// Ingest three empty ledgers — recorded in offsets, no events.
+	for i := uint32(0); i < 3; i++ {
+		require.NoError(t, h.store.IngestLedgerEvents(first+i, nil))
+	}
+	require.Equal(t, uint32(0), mustEventCount(t, h.store))
+
+	// Match-all path: range path through fetchAllInRange, firstID == lastID.
+	got, err := Query(context.Background(), h.store, nil, QueryOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, got, "match-all on a chunk with only empty ledgers must return nothing")
+
+	// Match-all + explicit range: same outcome — the chunk's EventCount
+	// is 0, so resolve() returns ok=false regardless of the requested
+	// window.
+	_ = first
+	got, err = Query(context.Background(), h.store, nil,
+		QueryOptions{Range: EventIDRange{Start: 0, End: 100}})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+
+	// Filtered path: every term lookup misses, perFilter empty.
+	var cid xdr.ContractId
+	cid[0] = 0x01
+	got, err = Query(context.Background(), h.store, []Filter{{ContractID: cid[:]}}, QueryOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// TestQuery_DescendingWithRangeAndMaxEvents covers the
+// three-way combination — order × range × cap — that no other test
+// hits together. Forces the descending-capped branch of
+// selectEventIDs (ReverseIterator → reverse) over a range-narrowed
+// union, then the final descending-reverse in Query.
+func TestQuery_DescendingWithRangeAndMaxEvents(t *testing.T) {
+	fx := newMultiLedgerQueryFixture(t)
+	first := chunk.ID(0).FirstLedger()
+
+	// Filter on contractA — base ledger has 3 events (ids 0, 1, 4),
+	// extra ledger has 2 more events (ids 5, 6). Restrict to both
+	// ledgers (whole chunk) and cap to 2 descending: expect highest
+	// two IDs = 6, 5 → in descending order = ["evt-extra-1", "evt-extra-0"].
+	got, err := Query(context.Background(), fx.store,
+		[]Filter{{ContractID: fx.contractA[:]}},
+		QueryOptions{
+			Order:     OrderDescending,
+			MaxEvents: 2,
+			Range:     eventIDRangeFor(t, fx, first, first+1),
+		})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evt-extra-1", "evt-extra-0"}, dataSyms(t, got))
+
+	// Narrow further: restrict to the second ledger only. contractA has
+	// 2 events there. Cap to 1 descending: highest = id 6 = "evt-extra-1".
+	got, err = Query(context.Background(), fx.store,
+		[]Filter{{ContractID: fx.contractA[:]}},
+		QueryOptions{
+			Order:     OrderDescending,
+			MaxEvents: 1,
+			Range:     eventIDRangeFor(t, fx, first+1, first+1),
+		})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evt-extra-1"}, dataSyms(t, got))
+}
+
+// TestQuery_RangeAndEmptiesUnion pins step ❺'s post-range empty-bitmap
+// short-circuit. The per-filter bitmap is non-empty (contractB has
+// events) but lies entirely outside the requested Range — pick the
+// second ledger, where contractB has no events.
+func TestQuery_RangeAndEmptiesUnion(t *testing.T) {
+	fx := newMultiLedgerQueryFixture(t)
+	first := chunk.ID(0).FirstLedger()
+
+	// contractB has events only in the base ledger (ids 2, 3). The
+	// extra ledger adds events under contractA only. So a query for
+	// contractB constrained to the extra ledger (event IDs 5..6)
+	// is non-empty at the filter level (contractB's bitmap has ids
+	// 2, 3) but empty after And-ing with the range bitmap (ids 5, 6).
+	got, err := Query(context.Background(), fx.store,
+		[]Filter{{ContractID: fx.contractB[:]}},
+		QueryOptions{Range: eventIDRangeFor(t, fx, first+1, first+1)})
+	require.NoError(t, err)
+	assert.Empty(t, got, "non-empty per-filter bitmap intersected with disjoint range must yield empty")
+}
+
+// ─── Cold-reader parity coverage ────────────────────────────────────────
+//
+// The hot tests above prove Query works against *HotStore. The whole
+// point of the Reader interface is that the engine is tier-agnostic —
+// the cold side must produce the same answers for the same queries.
+// The harness below builds a ColdReader whose on-disk state mirrors a
+// hot fixture's event layout and runs a representative slice of the
+// hot tests against it.
+//
+// Coverage choices: we don't replay every hot test — once the engine
+// is shown to go through both readers' LookupKeys/FetchEvents/FetchRange
+// surfaces correctly, additional scenarios add little. The selected
+// subset hits each major code path through Query:
+//
+//   - match-all asc                  → fetchAllInRange + cold FetchRange
+//   - match-all desc + cap           → reversed range + slices.Reverse
+//   - single-filter (contractID)     → LookupKeys + selectEventIDs asc
+//   - multi-term filter (AND)        → FastAnd over multiple cold bitmaps
+//   - cross-filter (OR)              → FastOr across filters
+//   - ledger range + filter          → ledgerRangeBitmap And on cold ids
+//   - descending + range + cap       → ReverseIterator on cold-derived
+//                                      union, single-filter And path
+//
+// What we don't replay against cold:
+//   - The mirror-poisoning collision test (mutating an mmap'd cold
+//     index.pack would require writing a malformed fixture; the post-
+//     filter itself is the same code regardless of which Reader fed it).
+//   - Per-call options validation (negative MaxEvents, short ContractID)
+//     short-circuit before any Reader call, so cold/hot are indistinguishable.
+
+// freezeFixtureToColdReader converts an already-ingested hot query
+// fixture into an equivalent ColdReader by replaying its payloads
+// through the cold-write path, then opening a fresh reader against the
+// resulting on-disk artifacts.
+//
+// Walks the hot store one ledger at a time using its Offsets snapshot
+// (which tracks the ingest-time ledger sequence) rather than reading
+// LedgerSequence off each Payload — the test fixture's payloadFor
+// builder doesn't set Payload.LedgerSequence, and HotStore.IngestLedgerEvents
+// stores them verbatim, so the per-event field is the zero value and
+// can't be used to recover ledger boundaries.
+//
+//nolint:unparam // chunkID is conceptually a fixture knob even though tests use chunk.ID(0) today
+func freezeFixtureToColdReader(t *testing.T, fx *queryFixture, chunkID chunk.ID) *ColdReader {
+	t.Helper()
+	dir := t.TempDir()
+
+	cw, err := NewColdWriter(chunkID, dir, ColdWriterOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cw.Close() })
+
+	idx := events.NewBitmaps()
+	coldOffsets := events.NewLedgerOffsets(chunkID.FirstLedger())
+
+	// Read the hot store's offsets snapshot so we know exactly how many
+	// events sit in each ledger. Walking per-ledger via FetchRange lets
+	// us drive the cold writer in the same shape the freeze loop would.
+	hotOffsets, err := fx.store.Offsets()
+	require.NoError(t, err)
+
+	eventID := uint32(0)
+	for rel, cum := range hotOffsets.Offsets() {
+		//nolint:gosec // rel is bounded by LedgersPerChunk; fits uint32
+		ledger := hotOffsets.StartLedger() + uint32(rel)
+		var count uint32
+		if rel == 0 {
+			count = cum
+		} else {
+			count = cum - hotOffsets.Offsets()[rel-1]
+		}
+		require.NoError(t, coldOffsets.Append(ledger, count))
+
+		if count == 0 {
+			continue
+		}
+		// Pull this ledger's events in order. FetchRange yields borrowed
+		// bytes — clone before handing to the cold writer and the term
+		// indexer.
+		for p, err := range fx.store.FetchRange(context.Background(), eventID, count) {
+			require.NoError(t, err)
+			p.ContractEventBytes = bytes.Clone(p.ContractEventBytes)
+			require.NoError(t, cw.Append(p))
+			keys, err := events.TermsForBytes(p.ContractEventBytes)
+			require.NoError(t, err)
+			for _, k := range keys {
+				idx.AddTo(k, eventID)
+			}
+			eventID++
+		}
+	}
+
+	require.NoError(t, cw.Finish(coldOffsets))
+	require.NoError(t, WriteColdIndex(context.Background(), chunkID, idx, dir))
+
+	cr, err := OpenColdReader(chunkID, dir, ColdReaderOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cr.Close() })
+	return cr
+}
+
+func TestQuery_ColdReaderParity_MatchAllAscending(t *testing.T) {
+	hotFx := newQueryFixture(t)
+	cr := freezeFixtureToColdReader(t, hotFx, chunk.ID(0))
+
+	got, err := Query(context.Background(), cr, nil, QueryOptions{})
+	require.NoError(t, err)
+	assert.Equal(t,
+		[]string{"evt-a-ab", "evt-a-ac", "evt-b-ab", "evt-b-a", "evt-a-b"},
+		dataSyms(t, got))
+}
+
+func TestQuery_ColdReaderParity_MatchAllDescendingWithCap(t *testing.T) {
+	hotFx := newQueryFixture(t)
+	cr := freezeFixtureToColdReader(t, hotFx, chunk.ID(0))
+
+	got, err := Query(context.Background(), cr, nil,
+		QueryOptions{Order: OrderDescending, MaxEvents: 2})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evt-a-b", "evt-b-a"}, dataSyms(t, got))
+}
+
+func TestQuery_ColdReaderParity_ContractIDOnly(t *testing.T) {
+	hotFx := newQueryFixture(t)
+	cr := freezeFixtureToColdReader(t, hotFx, chunk.ID(0))
+
+	got, err := Query(context.Background(), cr,
+		[]Filter{{ContractID: hotFx.contractA[:]}}, QueryOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evt-a-ab", "evt-a-ac", "evt-a-b"}, dataSyms(t, got))
+}
+
+func TestQuery_ColdReaderParity_ContractAndTopicAnd(t *testing.T) {
+	hotFx := newQueryFixture(t)
+	cr := freezeFixtureToColdReader(t, hotFx, chunk.ID(0))
+
+	// contract A AND topic0 == alpha → ids 0, 1. Exercises FastAnd
+	// over two cold-loaded bitmaps.
+	got, err := Query(context.Background(), cr, []Filter{
+		{ContractID: hotFx.contractA[:], Topics: [protocol.MaxTopicCount][]byte{hotFx.t0aRaw}},
+	}, QueryOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evt-a-ab", "evt-a-ac"}, dataSyms(t, got))
+}
+
+func TestQuery_ColdReaderParity_UnionOfTwoFilters(t *testing.T) {
+	hotFx := newQueryFixture(t)
+	cr := freezeFixtureToColdReader(t, hotFx, chunk.ID(0))
+
+	// A∩topic1=gamma → id 1; B∩topic1=beta → id 2.
+	got, err := Query(context.Background(), cr, []Filter{
+		{ContractID: hotFx.contractA[:], Topics: [protocol.MaxTopicCount][]byte{nil, hotFx.t0cRaw}},
+		{ContractID: hotFx.contractB[:], Topics: [protocol.MaxTopicCount][]byte{nil, hotFx.t0bRaw}},
+	}, QueryOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evt-a-ac", "evt-b-ab"}, dataSyms(t, got))
+}
+
+func TestQuery_ColdReaderParity_RangeAndFilter(t *testing.T) {
+	hotFx := newMultiLedgerQueryFixture(t)
+	cr := freezeFixtureToColdReader(t, hotFx, chunk.ID(0))
+	first := chunk.ID(0).FirstLedger()
+
+	// contractA filtered, second ledger only → 2 extra events.
+	got, err := Query(context.Background(), cr,
+		[]Filter{{ContractID: hotFx.contractA[:]}},
+		QueryOptions{Range: eventIDRangeFor(t, hotFx, first+1, first+1)})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evt-extra-0", "evt-extra-1"}, dataSyms(t, got))
+}
+
+func TestQuery_ColdReaderParity_DescendingRangeWithCap(t *testing.T) {
+	hotFx := newMultiLedgerQueryFixture(t)
+	cr := freezeFixtureToColdReader(t, hotFx, chunk.ID(0))
+	first := chunk.ID(0).FirstLedger()
+
+	// contractA, whole chunk, descending capped to 2 → highest two A's = ids 6, 5.
+	got, err := Query(context.Background(), cr,
+		[]Filter{{ContractID: hotFx.contractA[:]}},
+		QueryOptions{
+			Order:     OrderDescending,
+			MaxEvents: 2,
+			Range:     eventIDRangeFor(t, hotFx, first, first+1),
+		})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evt-extra-1", "evt-extra-0"}, dataSyms(t, got))
+}
+
+// ─── EventIDRangeForLedgers helper coverage ──────────────────────────────
+
+func TestEventIDRangeForLedgers_TranslatesLedgerWindow(t *testing.T) {
+	fx := newMultiLedgerQueryFixture(t)
+	first := chunk.ID(0).FirstLedger()
+	ofs, err := fx.store.Offsets()
+	require.NoError(t, err)
+
+	// Whole multi-ledger range: covers ids [0, 7).
+	r, err := EventIDRangeForLedgers(ofs, first, first+1)
+	require.NoError(t, err)
+	assert.Equal(t, EventIDRange{Start: 0, End: 7}, r)
+
+	// First ledger only: ids [0, 5).
+	r, err = EventIDRangeForLedgers(ofs, first, first)
+	require.NoError(t, err)
+	assert.Equal(t, EventIDRange{Start: 0, End: 5}, r)
+
+	// Second ledger only: ids [5, 7).
+	r, err = EventIDRangeForLedgers(ofs, first+1, first+1)
+	require.NoError(t, err)
+	assert.Equal(t, EventIDRange{Start: 5, End: 7}, r)
+}
+
+func TestEventIDRangeForLedgers_OutOfRangeLedgerErrors(t *testing.T) {
+	fx := newMultiLedgerQueryFixture(t)
+	first := chunk.ID(0).FirstLedger()
+	ofs, err := fx.store.Offsets()
+	require.NoError(t, err)
+
+	// startLedger past the chunk's ingested window — surfaced loudly,
+	// not silently clipped (matches LedgerOffsets.EventIDs contract).
+	_, err = EventIDRangeForLedgers(ofs, first+100, first+100)
+	require.Error(t, err)
+
+	// startLedger below the chunk's ingested window.
+	_, err = EventIDRangeForLedgers(ofs, 1, first)
+	require.Error(t, err)
+}
+
+func TestQuery_ColdReaderParity_FilterWithUnknownContract(t *testing.T) {
+	hotFx := newQueryFixture(t)
+	cr := freezeFixtureToColdReader(t, hotFx, chunk.ID(0))
+
+	// Cold path: LookupKeys returns nil for the missing term (no panic,
+	// no error — same as hot). The filter contributes nothing, union is
+	// empty, Query returns (nil, nil).
+	var missing xdr.ContractId
+	missing[0] = 0xff
+	got, err := Query(context.Background(), cr,
+		[]Filter{{ContractID: missing[:]}}, QueryOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query_test.go
@@ -396,24 +396,14 @@ func TestQuery_RangeWithinChunk(t *testing.T) {
 	require.Len(t, got, 5)
 }
 
-func TestQuery_RangeEndBeyondChunkClips(t *testing.T) {
+func TestQuery_RangeEndBeyondChunkRejected(t *testing.T) {
 	fx := newMultiLedgerQueryFixture(t)
-	// End past EventCount clips silently. With Start=0, this is
-	// equivalent to the whole-chunk query: all 7 events.
-	got, err := Query(context.Background(), fx.store, nil,
+	// Under the snapshot-isolation contract, End > EventCount is a
+	// caller bug (wrong chunk's offsets, stale snapshot). Surface it
+	// loudly rather than silently clipping.
+	_, err := Query(context.Background(), fx.store, nil,
 		QueryOptions{Range: EventIDRange{Start: 0, End: 1_000_000}})
-	require.NoError(t, err)
-	assert.Len(t, got, 7)
-}
-
-func TestQuery_RangeStartAtOrAboveEventCountReturnsEmpty(t *testing.T) {
-	fx := newMultiLedgerQueryFixture(t)
-	// Start at or above EventCount: after clipping End down to
-	// EventCount, the resolved window is empty (start >= end).
-	got, err := Query(context.Background(), fx.store, nil,
-		QueryOptions{Range: EventIDRange{Start: 100_000, End: 200_000}})
-	require.NoError(t, err)
-	assert.Empty(t, got)
+	require.Error(t, err)
 }
 
 func TestQuery_RangeIntersectsWithFilter(t *testing.T) {
@@ -477,7 +467,7 @@ func TestQuery_MaxEventsAppliesToFilteredPath(t *testing.T) {
 func TestQuery_DescendingMatchAll(t *testing.T) {
 	fx := newQueryFixture(t)
 	got, err := Query(context.Background(), fx.store, nil,
-		QueryOptions{Order: OrderDescending, Range: wholeChunk(t, fx.store)})
+		QueryOptions{Descending: true, Range: wholeChunk(t, fx.store)})
 	require.NoError(t, err)
 	assert.Equal(t,
 		[]string{"evt-a-b", "evt-b-a", "evt-b-ab", "evt-a-ac", "evt-a-ab"},
@@ -489,7 +479,7 @@ func TestQuery_DescendingMatchAllWithMaxEventsKeepsHighestIDs(t *testing.T) {
 	// Cap to 2 descending: should keep ids 4 and 3 (highest), in
 	// descending order.
 	got, err := Query(context.Background(), fx.store, nil,
-		QueryOptions{Order: OrderDescending, MaxEvents: 2, Range: wholeChunk(t, fx.store)})
+		QueryOptions{Descending: true, MaxEvents: 2, Range: wholeChunk(t, fx.store)})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"evt-a-b", "evt-b-a"}, dataSyms(t, got))
 }
@@ -499,7 +489,7 @@ func TestQuery_DescendingFiltered(t *testing.T) {
 	// contract A matches ids 0,1,4 → descending: 4,1,0.
 	got, err := Query(context.Background(), fx.store,
 		[]Filter{{ContractID: fx.contractA[:]}},
-		QueryOptions{Order: OrderDescending, Range: wholeChunk(t, fx.store)})
+		QueryOptions{Descending: true, Range: wholeChunk(t, fx.store)})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"evt-a-b", "evt-a-ac", "evt-a-ab"}, dataSyms(t, got))
 }
@@ -509,7 +499,7 @@ func TestQuery_DescendingFilteredWithMaxEventsKeepsHighestIDs(t *testing.T) {
 	// contract A descending capped to 2: keep highest two (ids 4, 1).
 	got, err := Query(context.Background(), fx.store,
 		[]Filter{{ContractID: fx.contractA[:]}},
-		QueryOptions{Order: OrderDescending, MaxEvents: 2, Range: wholeChunk(t, fx.store)})
+		QueryOptions{Descending: true, MaxEvents: 2, Range: wholeChunk(t, fx.store)})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"evt-a-b", "evt-a-ac"}, dataSyms(t, got))
 }
@@ -519,8 +509,8 @@ func TestQuery_DescendingWithRange(t *testing.T) {
 	first := chunk.ID(0).FirstLedger()
 	// All 7 events descending, range covers both ledgers.
 	got, err := Query(context.Background(), fx.store, nil, QueryOptions{
-		Order: OrderDescending,
-		Range: eventIDRangeFor(t, fx, first, first+1),
+		Descending: true,
+		Range:      eventIDRangeFor(t, fx, first, first+1),
 	})
 	require.NoError(t, err)
 	assert.Equal(t,
@@ -609,9 +599,9 @@ func TestQuery_MixedSuccessFilterList(t *testing.T) {
 
 // TestQuery_ChunkWithLedgersButZeroEvents pins the path where the
 // chunk has ingested ledgers (LedgerCount > 0) but every ledger held
-// zero events (TotalEvents == 0). EventCount == 0 so EventIDRange.resolve
-// returns ok=false; Query short-circuits to (nil, nil) on both the
-// match-all and filtered paths regardless of the supplied Range.
+// zero events (TotalEvents == 0). The pinned whole-chunk snapshot is
+// {0, 0} (empty range), and Query short-circuits to (nil, nil) before
+// touching the bitmap pipeline.
 func TestQuery_ChunkWithLedgersButZeroEvents(t *testing.T) {
 	const chunkID = chunk.ID(0)
 	h := openHotStoreForTest(t, chunkID)
@@ -624,21 +614,14 @@ func TestQuery_ChunkWithLedgersButZeroEvents(t *testing.T) {
 	require.Equal(t, uint32(0), mustEventCount(t, h.store))
 
 	// Match-all path with the pinned snapshot's whole-chunk range —
-	// EventCount==0 makes wholeChunk return {0, 0}, which resolves to
-	// empty without touching the bitmap pipeline.
+	// EventCount==0 makes wholeChunk return {0, 0}, which is the
+	// empty-range early return.
 	got, err := Query(context.Background(), h.store, nil,
 		QueryOptions{Range: wholeChunk(t, h.store)})
 	require.NoError(t, err)
 	assert.Empty(t, got, "match-all on a chunk with only empty ledgers must return nothing")
 
-	// Match-all with a deliberately-overshot range: still empty,
-	// because EventCount==0 dominates regardless of the requested End.
-	got, err = Query(context.Background(), h.store, nil,
-		QueryOptions{Range: EventIDRange{Start: 0, End: 100}})
-	require.NoError(t, err)
-	assert.Empty(t, got)
-
-	// Filtered path: every term lookup misses, perFilter empty.
+	// Filtered path: same pinned snapshot, same empty-range short-circuit.
 	var cid xdr.ContractId
 	cid[0] = 0x01
 	got, err = Query(context.Background(), h.store, []Filter{{ContractID: cid[:]}},
@@ -663,9 +646,9 @@ func TestQuery_DescendingWithRangeAndMaxEvents(t *testing.T) {
 	got, err := Query(context.Background(), fx.store,
 		[]Filter{{ContractID: fx.contractA[:]}},
 		QueryOptions{
-			Order:     OrderDescending,
-			MaxEvents: 2,
-			Range:     eventIDRangeFor(t, fx, first, first+1),
+			Descending: true,
+			MaxEvents:  2,
+			Range:      eventIDRangeFor(t, fx, first, first+1),
 		})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"evt-extra-1", "evt-extra-0"}, dataSyms(t, got))
@@ -675,9 +658,9 @@ func TestQuery_DescendingWithRangeAndMaxEvents(t *testing.T) {
 	got, err = Query(context.Background(), fx.store,
 		[]Filter{{ContractID: fx.contractA[:]}},
 		QueryOptions{
-			Order:     OrderDescending,
-			MaxEvents: 1,
-			Range:     eventIDRangeFor(t, fx, first+1, first+1),
+			Descending: true,
+			MaxEvents:  1,
+			Range:      eventIDRangeFor(t, fx, first+1, first+1),
 		})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"evt-extra-1"}, dataSyms(t, got))
@@ -899,7 +882,7 @@ func TestQuery_ColdReaderParity_MatchAllDescendingWithCap(t *testing.T) {
 	cr := freezeFixtureToColdReader(t, hotFx, chunk.ID(0))
 
 	got, err := Query(context.Background(), cr, nil,
-		QueryOptions{Order: OrderDescending, MaxEvents: 2, Range: wholeChunk(t, cr)})
+		QueryOptions{Descending: true, MaxEvents: 2, Range: wholeChunk(t, cr)})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"evt-a-b", "evt-b-a"}, dataSyms(t, got))
 }
@@ -963,9 +946,9 @@ func TestQuery_ColdReaderParity_DescendingRangeWithCap(t *testing.T) {
 	got, err := Query(context.Background(), cr,
 		[]Filter{{ContractID: hotFx.contractA[:]}},
 		QueryOptions{
-			Order:     OrderDescending,
-			MaxEvents: 2,
-			Range:     eventIDRangeFor(t, hotFx, first, first+1),
+			Descending: true,
+			MaxEvents:  2,
+			Range:      eventIDRangeFor(t, hotFx, first, first+1),
 		})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"evt-extra-1", "evt-extra-0"}, dataSyms(t, got))

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query_test.go
@@ -296,8 +296,11 @@ func TestQuery_ShortContractIDRejected(t *testing.T) {
 	fx := newQueryFixture(t)
 	// A 31-byte ContractID would silently never match every event; the
 	// query layer must surface this loudly rather than accept it.
+	// Pin a non-empty Range so the validation actually runs (an empty
+	// range short-circuits before filter validation).
 	bogus := make([]byte, 31)
-	_, err := Query(context.Background(), fx.store, []Filter{{ContractID: bogus}}, QueryOptions{})
+	_, err := Query(context.Background(), fx.store, []Filter{{ContractID: bogus}},
+		QueryOptions{Range: wholeChunk(t, fx.store)})
 	require.Error(t, err)
 }
 

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/query_test.go
@@ -127,22 +127,35 @@ func dataSyms(t *testing.T, payloads []events.Payload) []string {
 
 // eventIDRangeFor is a test-side convenience wrapper over the
 // public EventIDRangeForLedgers helper: it pulls the fixture's
-// offsets snapshot, translates the inclusive ledger window, and
-// returns a *EventIDRange suitable for QueryOptions.Range. The
+// offsets snapshot and translates the inclusive ledger window. The
 // production adapter calls EventIDRangeForLedgers directly with its
 // own offsets handle.
-func eventIDRangeFor(t *testing.T, fx *queryFixture, startLedger, endLedger uint32) *EventIDRange {
+func eventIDRangeFor(t *testing.T, fx *queryFixture, startLedger, endLedger uint32) EventIDRange {
 	t.Helper()
 	ofs, err := fx.store.Offsets()
 	require.NoError(t, err)
 	r, err := EventIDRangeForLedgers(ofs, startLedger, endLedger)
 	require.NoError(t, err)
-	return &r
+	return r
+}
+
+// wholeChunk returns the EventIDRange covering everything r has
+// ingested at this moment — the test-side equivalent of the
+// snapshot the multi-chunk coordinator pins at request entry.
+// Each test that wants "scan the whole chunk" pins its OWN snapshot
+// via this helper rather than relying on a hidden engine default,
+// keeping the snapshot-isolation contract visible at every call site.
+func wholeChunk(t *testing.T, r Reader) EventIDRange {
+	t.Helper()
+	ec, err := r.EventCount()
+	require.NoError(t, err)
+	return EventIDRange{End: ec}
 }
 
 func TestQuery_MatchAllOnEmptyFiltersSlice(t *testing.T) {
 	fx := newQueryFixture(t)
-	got, err := Query(context.Background(), fx.store, nil, QueryOptions{})
+	got, err := Query(context.Background(), fx.store, nil,
+		QueryOptions{Range: wholeChunk(t, fx.store)})
 	require.NoError(t, err)
 	assert.Equal(t,
 		[]string{"evt-a-ab", "evt-a-ac", "evt-b-ab", "evt-b-a", "evt-a-b"},
@@ -151,7 +164,8 @@ func TestQuery_MatchAllOnEmptyFiltersSlice(t *testing.T) {
 
 func TestQuery_MatchAllOnEmptyFilterObject(t *testing.T) {
 	fx := newQueryFixture(t)
-	got, err := Query(context.Background(), fx.store, []Filter{{}}, QueryOptions{})
+	got, err := Query(context.Background(), fx.store, []Filter{{}},
+		QueryOptions{Range: wholeChunk(t, fx.store)})
 	require.NoError(t, err)
 	require.Len(t, got, 5)
 }
@@ -160,7 +174,7 @@ func TestQuery_ContractIDOnly(t *testing.T) {
 	fx := newQueryFixture(t)
 	got, err := Query(context.Background(), fx.store, []Filter{
 		{ContractID: fx.contractA[:]},
-	}, QueryOptions{})
+	}, QueryOptions{Range: wholeChunk(t, fx.store)})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"evt-a-ab", "evt-a-ac", "evt-a-b"}, dataSyms(t, got))
 }
@@ -169,7 +183,7 @@ func TestQuery_SingleTopic(t *testing.T) {
 	fx := newQueryFixture(t)
 	got, err := Query(context.Background(), fx.store, []Filter{
 		{Topics: [protocol.MaxTopicCount][]byte{nil, fx.t0bRaw}},
-	}, QueryOptions{})
+	}, QueryOptions{Range: wholeChunk(t, fx.store)})
 	require.NoError(t, err)
 	// topic1 == beta: id 0 (a,ab) and id 2 (b,ab).
 	assert.Equal(t, []string{"evt-a-ab", "evt-b-ab"}, dataSyms(t, got))
@@ -179,7 +193,7 @@ func TestQuery_ContractIDAndTopicIntersection(t *testing.T) {
 	fx := newQueryFixture(t)
 	got, err := Query(context.Background(), fx.store, []Filter{
 		{ContractID: fx.contractA[:], Topics: [protocol.MaxTopicCount][]byte{fx.t0aRaw}},
-	}, QueryOptions{})
+	}, QueryOptions{Range: wholeChunk(t, fx.store)})
 	require.NoError(t, err)
 	// contract A AND topic0 == alpha: id 0 and id 1.
 	assert.Equal(t, []string{"evt-a-ab", "evt-a-ac"}, dataSyms(t, got))
@@ -190,7 +204,7 @@ func TestQuery_UnionOfTwoFilters(t *testing.T) {
 	got, err := Query(context.Background(), fx.store, []Filter{
 		{ContractID: fx.contractA[:], Topics: [protocol.MaxTopicCount][]byte{nil, fx.t0cRaw}},
 		{ContractID: fx.contractB[:], Topics: [protocol.MaxTopicCount][]byte{nil, fx.t0bRaw}},
-	}, QueryOptions{})
+	}, QueryOptions{Range: wholeChunk(t, fx.store)})
 	require.NoError(t, err)
 	// A∩topic1=gamma → id 1; B∩topic1=beta → id 2.
 	assert.Equal(t, []string{"evt-a-ac", "evt-b-ab"}, dataSyms(t, got))
@@ -203,7 +217,7 @@ func TestQuery_MatchAllAmongOtherFiltersShortCircuits(t *testing.T) {
 	got, err := Query(context.Background(), fx.store, []Filter{
 		{ContractID: fx.contractA[:]},
 		{}, // match-all
-	}, QueryOptions{})
+	}, QueryOptions{Range: wholeChunk(t, fx.store)})
 	require.NoError(t, err)
 	require.Len(t, got, 5)
 }
@@ -216,7 +230,7 @@ func TestQuery_FilterWithUnknownTermReturnsEmpty(t *testing.T) {
 	missing[0] = 0xff
 	got, err := Query(context.Background(), fx.store, []Filter{
 		{ContractID: missing[:]},
-	}, QueryOptions{})
+	}, QueryOptions{Range: wholeChunk(t, fx.store)})
 	require.NoError(t, err)
 	assert.Empty(t, got)
 }
@@ -232,7 +246,7 @@ func TestQuery_DuplicateTermsAcrossFiltersDedupedInLookup(t *testing.T) {
 	got, err := Query(context.Background(), cr, []Filter{
 		{ContractID: fx.contractA[:], Topics: [protocol.MaxTopicCount][]byte{fx.t0aRaw}},
 		{ContractID: fx.contractB[:], Topics: [protocol.MaxTopicCount][]byte{fx.t0aRaw}},
-	}, QueryOptions{})
+	}, QueryOptions{Range: wholeChunk(t, fx.store)})
 	require.NoError(t, err)
 	// A∩topic0=alpha → ids 0,1; B∩topic0=alpha → ids 2,3. Union → all four.
 	assert.Equal(t, []string{"evt-a-ab", "evt-a-ac", "evt-b-ab", "evt-b-a"},
@@ -254,7 +268,7 @@ func TestQuery_DoesNotMutateMirrorBitmaps(t *testing.T) {
 		_, err := Query(context.Background(), fx.store, []Filter{
 			{ContractID: fx.contractA[:], Topics: [protocol.MaxTopicCount][]byte{fx.t0aRaw}},
 			{ContractID: fx.contractB[:], Topics: [protocol.MaxTopicCount][]byte{fx.t0aRaw}},
-		}, QueryOptions{})
+		}, QueryOptions{Range: wholeChunk(t, fx.store)})
 		require.NoError(t, err)
 	}
 
@@ -285,6 +299,23 @@ func TestQuery_ShortContractIDRejected(t *testing.T) {
 	bogus := make([]byte, 31)
 	_, err := Query(context.Background(), fx.store, []Filter{{ContractID: bogus}}, QueryOptions{})
 	require.Error(t, err)
+}
+
+func TestQuery_InvertedRangeRejected(t *testing.T) {
+	// Range.End < Range.Start is a programmer bug (swapped args,
+	// off-by-one in cursor arithmetic, etc.). Surface it explicitly
+	// rather than silently returning empty — the engine never produces
+	// such a range, so receiving one is always a calling bug.
+	fx := newQueryFixture(t)
+	_, err := Query(context.Background(), fx.store, nil,
+		QueryOptions{Range: EventIDRange{Start: 500, End: 100}})
+	require.Error(t, err)
+
+	// Start == End is a legitimate empty range, NOT an error.
+	got, err := Query(context.Background(), fx.store, nil,
+		QueryOptions{Range: EventIDRange{Start: 3, End: 3}})
+	require.NoError(t, err)
+	assert.Empty(t, got)
 }
 
 func TestQuery_EmptyChunkReturnsNothing(t *testing.T) {
@@ -326,7 +357,8 @@ func TestQuery_ManyFiltersAtCallerCap(t *testing.T) {
 	for i := range n {
 		filters[i] = Filter{ContractID: contracts[i][:]}
 	}
-	got, err := Query(context.Background(), h.store, filters, QueryOptions{})
+	got, err := Query(context.Background(), h.store, filters,
+		QueryOptions{Range: wholeChunk(t, h.store)})
 	require.NoError(t, err)
 	assert.Len(t, got, n)
 }
@@ -366,7 +398,7 @@ func TestQuery_RangeEndBeyondChunkClips(t *testing.T) {
 	// End past EventCount clips silently. With Start=0, this is
 	// equivalent to the whole-chunk query: all 7 events.
 	got, err := Query(context.Background(), fx.store, nil,
-		QueryOptions{Range: &EventIDRange{Start: 0, End: 1_000_000}})
+		QueryOptions{Range: EventIDRange{Start: 0, End: 1_000_000}})
 	require.NoError(t, err)
 	assert.Len(t, got, 7)
 }
@@ -376,7 +408,7 @@ func TestQuery_RangeStartAtOrAboveEventCountReturnsEmpty(t *testing.T) {
 	// Start at or above EventCount: after clipping End down to
 	// EventCount, the resolved window is empty (start >= end).
 	got, err := Query(context.Background(), fx.store, nil,
-		QueryOptions{Range: &EventIDRange{Start: 100_000, End: 200_000}})
+		QueryOptions{Range: EventIDRange{Start: 100_000, End: 200_000}})
 	require.NoError(t, err)
 	assert.Empty(t, got)
 }
@@ -398,7 +430,8 @@ func TestQuery_RangeIntersectsWithFilter(t *testing.T) {
 func TestQuery_MaxEventsTruncates(t *testing.T) {
 	fx := newQueryFixture(t)
 	// Base fixture has 5 events. Cap to 2 — expect the two lowest IDs.
-	got, err := Query(context.Background(), fx.store, nil, QueryOptions{MaxEvents: 2})
+	got, err := Query(context.Background(), fx.store, nil,
+		QueryOptions{MaxEvents: 2, Range: wholeChunk(t, fx.store)})
 	require.NoError(t, err)
 	require.Len(t, got, 2)
 	assert.Equal(t, []string{"evt-a-ab", "evt-a-ac"}, dataSyms(t, got))
@@ -406,7 +439,8 @@ func TestQuery_MaxEventsTruncates(t *testing.T) {
 
 func TestQuery_MaxEventsZeroMeansUnlimited(t *testing.T) {
 	fx := newQueryFixture(t)
-	got, err := Query(context.Background(), fx.store, nil, QueryOptions{MaxEvents: 0})
+	got, err := Query(context.Background(), fx.store, nil,
+		QueryOptions{MaxEvents: 0, Range: wholeChunk(t, fx.store)})
 	require.NoError(t, err)
 	assert.Len(t, got, 5)
 }
@@ -429,7 +463,7 @@ func TestQuery_MaxEventsAppliesToFilteredPath(t *testing.T) {
 	// Contract A has 5 events total (3 base + 2 extra). Cap to 2.
 	got, err := Query(context.Background(), fx.store,
 		[]Filter{{ContractID: fx.contractA[:]}},
-		QueryOptions{MaxEvents: 2})
+		QueryOptions{MaxEvents: 2, Range: wholeChunk(t, fx.store)})
 	require.NoError(t, err)
 	require.Len(t, got, 2)
 	assert.Equal(t, []string{"evt-a-ab", "evt-a-ac"}, dataSyms(t, got))
@@ -440,7 +474,7 @@ func TestQuery_MaxEventsAppliesToFilteredPath(t *testing.T) {
 func TestQuery_DescendingMatchAll(t *testing.T) {
 	fx := newQueryFixture(t)
 	got, err := Query(context.Background(), fx.store, nil,
-		QueryOptions{Order: OrderDescending})
+		QueryOptions{Order: OrderDescending, Range: wholeChunk(t, fx.store)})
 	require.NoError(t, err)
 	assert.Equal(t,
 		[]string{"evt-a-b", "evt-b-a", "evt-b-ab", "evt-a-ac", "evt-a-ab"},
@@ -452,7 +486,7 @@ func TestQuery_DescendingMatchAllWithMaxEventsKeepsHighestIDs(t *testing.T) {
 	// Cap to 2 descending: should keep ids 4 and 3 (highest), in
 	// descending order.
 	got, err := Query(context.Background(), fx.store, nil,
-		QueryOptions{Order: OrderDescending, MaxEvents: 2})
+		QueryOptions{Order: OrderDescending, MaxEvents: 2, Range: wholeChunk(t, fx.store)})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"evt-a-b", "evt-b-a"}, dataSyms(t, got))
 }
@@ -462,7 +496,7 @@ func TestQuery_DescendingFiltered(t *testing.T) {
 	// contract A matches ids 0,1,4 → descending: 4,1,0.
 	got, err := Query(context.Background(), fx.store,
 		[]Filter{{ContractID: fx.contractA[:]}},
-		QueryOptions{Order: OrderDescending})
+		QueryOptions{Order: OrderDescending, Range: wholeChunk(t, fx.store)})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"evt-a-b", "evt-a-ac", "evt-a-ab"}, dataSyms(t, got))
 }
@@ -472,7 +506,7 @@ func TestQuery_DescendingFilteredWithMaxEventsKeepsHighestIDs(t *testing.T) {
 	// contract A descending capped to 2: keep highest two (ids 4, 1).
 	got, err := Query(context.Background(), fx.store,
 		[]Filter{{ContractID: fx.contractA[:]}},
-		QueryOptions{Order: OrderDescending, MaxEvents: 2})
+		QueryOptions{Order: OrderDescending, MaxEvents: 2, Range: wholeChunk(t, fx.store)})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"evt-a-b", "evt-a-ac"}, dataSyms(t, got))
 }
@@ -527,7 +561,7 @@ func TestQuery_PostFilterRejectsTermHashCollision(t *testing.T) {
 	// post-filter; id=4's bytes don't actually have topic1=gamma.
 	got, err := Query(context.Background(), fx.store,
 		[]Filter{{Topics: [protocol.MaxTopicCount][]byte{nil, fx.t0cRaw}}},
-		QueryOptions{})
+		QueryOptions{Range: wholeChunk(t, fx.store)})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"evt-a-ac"}, dataSyms(t, got),
 		"post-filter must drop the collision-injected id=4")
@@ -564,7 +598,7 @@ func TestQuery_MixedSuccessFilterList(t *testing.T) {
 		{ContractID: fx.contractA[:]},
 		// Filter B: requires a term that doesn't exist → contributes nothing.
 		{ContractID: fx.contractB[:], Topics: [protocol.MaxTopicCount][]byte{missingRaw}},
-	}, QueryOptions{})
+	}, QueryOptions{Range: wholeChunk(t, fx.store)})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"evt-a-ab", "evt-a-ac", "evt-a-b"}, dataSyms(t, got),
 		"missing-term filter must be skipped, but the succeeding filter's events must still surface")
@@ -574,7 +608,7 @@ func TestQuery_MixedSuccessFilterList(t *testing.T) {
 // chunk has ingested ledgers (LedgerCount > 0) but every ledger held
 // zero events (TotalEvents == 0). EventCount == 0 so EventIDRange.resolve
 // returns ok=false; Query short-circuits to (nil, nil) on both the
-// match-all and filtered paths.
+// match-all and filtered paths regardless of the supplied Range.
 func TestQuery_ChunkWithLedgersButZeroEvents(t *testing.T) {
 	const chunkID = chunk.ID(0)
 	h := openHotStoreForTest(t, chunkID)
@@ -586,24 +620,26 @@ func TestQuery_ChunkWithLedgersButZeroEvents(t *testing.T) {
 	}
 	require.Equal(t, uint32(0), mustEventCount(t, h.store))
 
-	// Match-all path: range path through fetchAllInRange, firstID == lastID.
-	got, err := Query(context.Background(), h.store, nil, QueryOptions{})
+	// Match-all path with the pinned snapshot's whole-chunk range —
+	// EventCount==0 makes wholeChunk return {0, 0}, which resolves to
+	// empty without touching the bitmap pipeline.
+	got, err := Query(context.Background(), h.store, nil,
+		QueryOptions{Range: wholeChunk(t, h.store)})
 	require.NoError(t, err)
 	assert.Empty(t, got, "match-all on a chunk with only empty ledgers must return nothing")
 
-	// Match-all + explicit range: same outcome — the chunk's EventCount
-	// is 0, so resolve() returns ok=false regardless of the requested
-	// window.
-	_ = first
+	// Match-all with a deliberately-overshot range: still empty,
+	// because EventCount==0 dominates regardless of the requested End.
 	got, err = Query(context.Background(), h.store, nil,
-		QueryOptions{Range: &EventIDRange{Start: 0, End: 100}})
+		QueryOptions{Range: EventIDRange{Start: 0, End: 100}})
 	require.NoError(t, err)
 	assert.Empty(t, got)
 
 	// Filtered path: every term lookup misses, perFilter empty.
 	var cid xdr.ContractId
 	cid[0] = 0x01
-	got, err = Query(context.Background(), h.store, []Filter{{ContractID: cid[:]}}, QueryOptions{})
+	got, err = Query(context.Background(), h.store, []Filter{{ContractID: cid[:]}},
+		QueryOptions{Range: wholeChunk(t, h.store)})
 	require.NoError(t, err)
 	assert.Empty(t, got)
 }
@@ -669,8 +705,10 @@ func TestQuery_RangeAndEmptiesUnion(t *testing.T) {
 // later ledgers have events, EventIDRangeForLedgers(ofs, first, first)
 // legitimately returns EventIDRange{0, 0}. A prior implementation
 // treated End == 0 as a "whole chunk" sentinel and silently expanded
-// the empty query to return events from later ledgers. With Range as
-// a pointer and the sentinel dropped, the literal {0, 0} stays empty.
+// the empty query to return events from later ledgers. Under the
+// snapshot-isolation contract (Range mandatory and authoritative), the
+// literal {0, 0} resolves to an empty range and the query returns no
+// events.
 func TestQuery_EmptyLeadingLedgerRangeStaysEmpty(t *testing.T) {
 	const chunkID = chunk.ID(0)
 	h := openHotStoreForTest(t, chunkID)
@@ -700,15 +738,19 @@ func TestQuery_EmptyLeadingLedgerRangeStaysEmpty(t *testing.T) {
 		"fixture sanity: empty leading-ledger window must produce {0, 0}")
 
 	got, err := Query(context.Background(), h.store, nil,
-		QueryOptions{Range: &emptyRange})
+		QueryOptions{Range: emptyRange})
 	require.NoError(t, err)
 	assert.Empty(t, got, "empty leading-ledger window must stay empty, not expand to whole chunk")
 
-	// Sanity: the same call WITHOUT a Range (nil = whole chunk) still
-	// returns all 5 events from ledger first+1.
-	got, err = Query(context.Background(), h.store, nil, QueryOptions{})
+	// Sanity: the same call WITH a freshly-pinned whole-chunk range
+	// returns all 5 events from ledger first+1. The two callers
+	// (empty leading-ledger window vs. whole chunk) produce different
+	// EventIDRanges and the engine respects each literally — that's
+	// the whole point of the snapshot-isolation contract.
+	got, err = Query(context.Background(), h.store, nil,
+		QueryOptions{Range: wholeChunk(t, h.store)})
 	require.NoError(t, err)
-	require.Len(t, got, 5, "whole-chunk default must still see the later-ledger events")
+	require.Len(t, got, 5, "whole-chunk pin must still see the later-ledger events")
 }
 
 // makeSimplePayload builds an events.Payload with a unique Data symbol
@@ -841,7 +883,8 @@ func TestQuery_ColdReaderParity_MatchAllAscending(t *testing.T) {
 	hotFx := newQueryFixture(t)
 	cr := freezeFixtureToColdReader(t, hotFx, chunk.ID(0))
 
-	got, err := Query(context.Background(), cr, nil, QueryOptions{})
+	got, err := Query(context.Background(), cr, nil,
+		QueryOptions{Range: wholeChunk(t, cr)})
 	require.NoError(t, err)
 	assert.Equal(t,
 		[]string{"evt-a-ab", "evt-a-ac", "evt-b-ab", "evt-b-a", "evt-a-b"},
@@ -853,7 +896,7 @@ func TestQuery_ColdReaderParity_MatchAllDescendingWithCap(t *testing.T) {
 	cr := freezeFixtureToColdReader(t, hotFx, chunk.ID(0))
 
 	got, err := Query(context.Background(), cr, nil,
-		QueryOptions{Order: OrderDescending, MaxEvents: 2})
+		QueryOptions{Order: OrderDescending, MaxEvents: 2, Range: wholeChunk(t, cr)})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"evt-a-b", "evt-b-a"}, dataSyms(t, got))
 }
@@ -863,7 +906,8 @@ func TestQuery_ColdReaderParity_ContractIDOnly(t *testing.T) {
 	cr := freezeFixtureToColdReader(t, hotFx, chunk.ID(0))
 
 	got, err := Query(context.Background(), cr,
-		[]Filter{{ContractID: hotFx.contractA[:]}}, QueryOptions{})
+		[]Filter{{ContractID: hotFx.contractA[:]}},
+		QueryOptions{Range: wholeChunk(t, cr)})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"evt-a-ab", "evt-a-ac", "evt-a-b"}, dataSyms(t, got))
 }
@@ -876,7 +920,7 @@ func TestQuery_ColdReaderParity_ContractAndTopicAnd(t *testing.T) {
 	// over two cold-loaded bitmaps.
 	got, err := Query(context.Background(), cr, []Filter{
 		{ContractID: hotFx.contractA[:], Topics: [protocol.MaxTopicCount][]byte{hotFx.t0aRaw}},
-	}, QueryOptions{})
+	}, QueryOptions{Range: wholeChunk(t, cr)})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"evt-a-ab", "evt-a-ac"}, dataSyms(t, got))
 }
@@ -889,7 +933,7 @@ func TestQuery_ColdReaderParity_UnionOfTwoFilters(t *testing.T) {
 	got, err := Query(context.Background(), cr, []Filter{
 		{ContractID: hotFx.contractA[:], Topics: [protocol.MaxTopicCount][]byte{nil, hotFx.t0cRaw}},
 		{ContractID: hotFx.contractB[:], Topics: [protocol.MaxTopicCount][]byte{nil, hotFx.t0bRaw}},
-	}, QueryOptions{})
+	}, QueryOptions{Range: wholeChunk(t, cr)})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"evt-a-ac", "evt-b-ab"}, dataSyms(t, got))
 }
@@ -974,7 +1018,8 @@ func TestQuery_ColdReaderParity_FilterWithUnknownContract(t *testing.T) {
 	var missing xdr.ContractId
 	missing[0] = 0xff
 	got, err := Query(context.Background(), cr,
-		[]Filter{{ContractID: missing[:]}}, QueryOptions{})
+		[]Filter{{ContractID: missing[:]}},
+		QueryOptions{Range: wholeChunk(t, cr)})
 	require.NoError(t, err)
 	assert.Empty(t, got)
 }


### PR DESCRIPTION
Implements #663 — the per-chunk query coordinator. Built on the `Reader` interface (PR #756) so it serves `HotStore` and `ColdReader` without tier branching. Rebased onto `feature/full-history` now that #779 has landed; consumes that PR's `EventIdx` payload field and the SDK view-extractor API.

## Scope coverage

Each bullet from the issue:

- **Filter semantics** — AND within a filter (contract ID + topics 0..3), union across filters, restricted to an optional window. ✅
- **Cap at `MaxEvents`, ascending or descending** — `Order` enum; descending is added here (rpc-hack was asc-only). ✅
- **Post-filter to drop term-hash collision false positives** — view-path navigation over `ContractEventBytes`, lazy ContractId + topic resolution, zero per-event allocation. ✅

## Notable deltas vs the rpc-hack reference

The issue says the rpc-hack `query.go` is "a reference, not a spec." Two substantive changes from that reference:

1. **Window input is `EventIDRange`, not `LedgerRange`** — chunk-relative event-ID bounds. Ledger-bounded engines force the adapter to post-skip events at-or-before the cursor within the first ledger, which stalls when a single ledger holds more events than `MaxEvents` (realistic for Soroban traffic — busy DEXes, token launches). Event-ID windowing lets the adapter express "strictly after event X" directly, eliminating the stall. Adapters that think in ledgers call `EventIDRangeForLedgers(ofs, L1, L2)` to translate. The rationale is documented on top of `query.go`.

2. **Latent bug fixed in the match-all path** — rpc-hack's `fetchAllInRange` appended `events.Payload` values whose `ContractEventBytes` aliased the reader's iteration buffer. Once the iterator advanced, every retained slice pointed at stale memory. Fix: `bytes.Clone(p.ContractEventBytes)` before append.

The struct post-filter path is gone — this branch's `events.Payload` carries only `ContractEventBytes`, so the rpc-hack view/struct dispatch collapses to the view path only.

## What's out of scope

Per the issue: routing a query across multiple chunks. That coordinator is the immediate follow-up; it owns the `protocol.EventFilter` translation, cursor mapping, and `payload → EventInfo` shaping.

## Tests

43 tests, `-race` clean, `go vet` / `gofmt` clean.

- Filter combinations (single contract, single topic, AND, OR across filters, match-all, mixed-success, unknown terms).
- Ordering and limit in both directions (asc/desc match-all, asc/desc filtered, both with `MaxEvents` cap).
- Range clipping (in-window, end-beyond-chunk, start-past-chunk, range-empties-union).
- Range × filter × cap × order combinations.
- Post-filter collision rejection (mirror-poisoned via `ConcurrentBitmaps.AddTo`).
- Validation (negative `MaxEvents`, short ContractID, cancelled ctx).
- Empty chunk, chunk-with-empty-ledgers paths.
- `EventIDRangeForLedgers` helper translation + out-of-range error.
- **HotStore/ColdReader parity** — 8 scenarios covering the major code paths through `Query` against a `ColdReader` built by freezing a hot fixture. Validates the Reader-abstraction claim.

## Test plan

- [x] \`go test -race ./cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore/\`
- [x] \`go vet\`, \`gofmt\`
- [x] \`go build ./...\`