### PR TITLE
Streaming daemon: Slice 1 — Layer 1 (foundations)

### DIFF
--- a/cmd/stellar-rpc/internal/fullhistory/streaming/artifacts.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/artifacts.go
@@ -1,0 +1,102 @@
+package streaming
+
+import (
+	"strings"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/ingest"
+)
+
+// ArtifactSet is the subset of per-chunk artifact Kinds a processChunk pass must
+// produce (design-docs rule 2). It is a small immutable set over the per-chunk
+// kinds (currently just ledgers); the resolver builds it from the catalog
+// difference and processChunk narrows it further by dropping already-frozen
+// kinds (rule 1's per-kind idempotency).
+//
+// The representation is a fixed-width bitmask over allKinds' canonical order, so
+// Kinds() yields kinds in that order (the same order buildColdIngesters uses)
+// and membership tests are allocation-free.
+type ArtifactSet struct {
+	mask uint8
+}
+
+// kindBit maps a Kind to its bit in ArtifactSet.mask via its index in allKinds.
+// An unknown kind returns (0,false) so callers never set a phantom bit.
+func kindBit(k Kind) (uint8, bool) {
+	for i, kk := range allKinds {
+		if kk == k {
+			return uint8(1) << i, true //nolint:gosec // len(allKinds) small, no overflow
+		}
+	}
+	return 0, false
+}
+
+// NewArtifactSet builds a set from the given kinds. Unknown kinds are ignored
+// (the kind registry in keys.go is the authority); duplicates are idempotent.
+func NewArtifactSet(kinds ...Kind) ArtifactSet {
+	var s ArtifactSet
+	for _, k := range kinds {
+		if bit, ok := kindBit(k); ok {
+			s.mask |= bit
+		}
+	}
+	return s
+}
+
+// AllArtifacts is the full set (currently just ledgers) — what a from-scratch
+// chunk freeze requests before per-kind idempotency narrows it.
+func AllArtifacts() ArtifactSet { return NewArtifactSet(allKinds...) }
+
+// Has reports whether kind is in the set.
+func (s ArtifactSet) Has(kind Kind) bool {
+	bit, ok := kindBit(kind)
+	return ok && s.mask&bit != 0
+}
+
+// Empty reports whether the set requests no kinds.
+func (s ArtifactSet) Empty() bool { return s.mask == 0 }
+
+// Remove returns a copy of the set without kind (idempotent if absent).
+func (s ArtifactSet) Remove(kind Kind) ArtifactSet {
+	if bit, ok := kindBit(kind); ok {
+		s.mask &^= bit
+	}
+	return s
+}
+
+// Add returns a copy of the set with kind included (idempotent if present).
+func (s ArtifactSet) Add(kind Kind) ArtifactSet {
+	if bit, ok := kindBit(kind); ok {
+		s.mask |= bit
+	}
+	return s
+}
+
+// Kinds returns the requested kinds in canonical (allKinds) order.
+func (s ArtifactSet) Kinds() []Kind {
+	var out []Kind
+	for i, k := range allKinds {
+		if s.mask&(uint8(1)<<i) != 0 { //nolint:gosec // len(allKinds) small, no overflow
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
+// String renders the set as a comma-joined kind list (debug/error messages).
+func (s ArtifactSet) String() string {
+	ks := s.Kinds()
+	parts := make([]string, len(ks))
+	for i, k := range ks {
+		parts[i] = string(k)
+	}
+	return "{" + strings.Join(parts, ",") + "}"
+}
+
+// ingestConfig translates the set into the merged ingest.Config (which selects
+// data types by bool). Only the requested kinds are enabled, so RunColdChunk
+// drives exactly the cold ingesters processChunk asked for.
+func (s ArtifactSet) ingestConfig() ingest.Config {
+	return ingest.Config{
+		Ledgers: s.Has(KindLedgers),
+	}
+}

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/artifacts.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/artifacts.go
@@ -7,14 +7,12 @@ import (
 )
 
 // ArtifactSet is the subset of per-chunk artifact Kinds a processChunk pass must
-// produce (design-docs rule 2). It is a small immutable set over the per-chunk
-// kinds (currently just ledgers); the resolver builds it from the catalog
-// difference and processChunk narrows it further by dropping already-frozen
-// kinds (rule 1's per-kind idempotency).
+// produce (design rule 2). The resolver builds it from the catalog difference;
+// processChunk narrows it by dropping already-frozen kinds (per-kind
+// idempotency).
 //
-// The representation is a fixed-width bitmask over allKinds' canonical order, so
-// Kinds() yields kinds in that order (the same order buildColdIngesters uses)
-// and membership tests are allocation-free.
+// It is a fixed-width bitmask over allKinds' canonical order, so Kinds() yields
+// that order and membership tests are allocation-free.
 type ArtifactSet struct {
 	mask uint8
 }

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/artifacts.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/artifacts.go
@@ -24,7 +24,7 @@ type ArtifactSet struct {
 func kindBit(k Kind) (uint8, bool) {
 	for i, kk := range allKinds {
 		if kk == k {
-			return uint8(1) << i, true //nolint:gosec // len(allKinds) small, no overflow
+			return uint8(1) << i, true
 		}
 	}
 	return 0, false
@@ -75,7 +75,7 @@ func (s ArtifactSet) Add(kind Kind) ArtifactSet {
 func (s ArtifactSet) Kinds() []Kind {
 	var out []Kind
 	for i, k := range allKinds {
-		if s.mask&(uint8(1)<<i) != 0 { //nolint:gosec // len(allKinds) small, no overflow
+		if s.mask&(uint8(1)<<i) != 0 {
 			out = append(out, k)
 		}
 	}
@@ -95,7 +95,7 @@ func (s ArtifactSet) String() string {
 // ingestConfig translates the set into the merged ingest.Config (which selects
 // data types by bool). Only the requested kinds are enabled, so RunColdChunk
 // drives exactly the cold ingesters processChunk asked for.
-func (s ArtifactSet) ingestConfig() ingest.Config {
+func (s ArtifactSet) ingestConfig() ingest.Config { //nolint:unused // called from processChunk in a later layer
 	return ingest.Config{
 		Ledgers: s.Has(KindLedgers),
 	}

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/artifacts_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/artifacts_test.go
@@ -1,0 +1,28 @@
+package streaming
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
+)
+
+// TestArtifactPaths_EveryKindMapped guards the two separate sources of truth —
+// the kind registry (allKinds, keys.go) and the file mapping
+// (Layout.ArtifactPaths, paths.go) — against silent drift. Once a kind is in
+// allKinds, parseChunkKey accepts it and ChunkArtifactKeys returns refs for it,
+// so SweepChunkArtifacts calls ArtifactPaths(chunk, kind) on it. If that kind
+// has no ArtifactPaths case, the default returns nil: the sweep unlinks nothing,
+// deletes the key, and leaves the artifact files on disk with no catalog key —
+// the one orphan class the key-driven sweep is designed to prevent. Adding a
+// kind without its path mapping fails HERE, at CI, rather than orphaning files
+// at runtime. (This test naturally extends as later slices add kinds, since it
+// iterates allKinds.)
+func TestArtifactPaths_EveryKindMapped(t *testing.T) {
+	layout := NewLayout(t.TempDir())
+	for _, k := range allKinds {
+		assert.NotEmpty(t, layout.ArtifactPaths(chunk.ID(0), k),
+			"kind %q is in allKinds but ArtifactPaths returns no path — the sweep would orphan its files", k)
+	}
+}

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/artifacts_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/artifacts_test.go
@@ -8,17 +8,12 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
 )
 
-// TestArtifactPaths_EveryKindMapped guards the two separate sources of truth —
-// the kind registry (allKinds, keys.go) and the file mapping
-// (Layout.ArtifactPaths, paths.go) — against silent drift. Once a kind is in
-// allKinds, parseChunkKey accepts it and ChunkArtifactKeys returns refs for it,
-// so SweepChunkArtifacts calls ArtifactPaths(chunk, kind) on it. If that kind
-// has no ArtifactPaths case, the default returns nil: the sweep unlinks nothing,
-// deletes the key, and leaves the artifact files on disk with no catalog key —
-// the one orphan class the key-driven sweep is designed to prevent. Adding a
-// kind without its path mapping fails HERE, at CI, rather than orphaning files
-// at runtime. (This test naturally extends as later slices add kinds, since it
-// iterates allKinds.)
+// TestArtifactPaths_EveryKindMapped guards the two sources of truth — the kind
+// registry (allKinds, keys.go) and the file mapping (Layout.ArtifactPaths,
+// paths.go) — against drift. A kind in allKinds with no ArtifactPaths case
+// makes the sweep unlink nothing, delete the key, and orphan the files on disk
+// — the one orphan class the key-driven sweep prevents. Adding a kind without
+// its path mapping fails HERE at CI rather than orphaning files at runtime.
 func TestArtifactPaths_EveryKindMapped(t *testing.T) {
 	layout := NewLayout(t.TempDir())
 	for _, k := range allKinds {

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/catalog.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/catalog.go
@@ -11,17 +11,14 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/metastore"
 )
 
-// Catalog is the streaming daemon's view of durable state. It WRAPS
-// metastore.Store — the merged RocksDB KV store with sync Put/Delete, atomic
-// Batch, and PrefixScan — and never reaches around it to RocksDB directly. The
-// catalog adds: the key schema and its bijection to disk paths (keys.go,
-// paths.go), the one-write protocol (protocol.go), and the key-driven sweeps
-// (sweep.go).
+// Catalog is the streaming daemon's view of durable state: a wrapper over
+// metastore.Store (sync Put/Delete, atomic Batch, PrefixScan) that never
+// reaches around it to RocksDB directly. It adds the key schema and its path
+// bijection (keys.go, paths.go), the one-write protocol (catalog_protocol.go),
+// and the key-driven sweeps (catalog_sweep.go).
 //
-// Every method here is a pure function of meta-store keys plus the on-disk
-// layout. The catalog stays a *pure* catalog — every key names a file/dir
-// state or a config pin; progress is derived, never stored (see the data
-// model's "Progress is derived, never stored").
+// It stays a *pure* catalog: every key names a file/dir state or a config pin,
+// and progress is always derived, never stored.
 type Catalog struct {
 	store  *metastore.Store
 	layout Layout
@@ -41,9 +38,7 @@ func NewCatalog(store *metastore.Store, layout Layout) *Catalog {
 // Layout returns the path layout bound to this catalog.
 func (c *Catalog) Layout() Layout { return c.layout }
 
-// ---------------------------------------------------------------------------
-// Raw key access. Get/Has are the value-blind primitives the rest build on.
-// ---------------------------------------------------------------------------
+// Raw key access — Get/Has are the value-blind primitives the rest build on.
 
 // Get returns the value at key. The bool is false (and err nil) on a clean
 // miss, distinguishing "absent" from a real backing-store error.
@@ -64,9 +59,7 @@ func (c *Catalog) Has(key string) (bool, error) {
 	return ok, err
 }
 
-// ---------------------------------------------------------------------------
 // Typed artifact-state accessors.
-// ---------------------------------------------------------------------------
 
 // State returns the lifecycle State of a per-chunk artifact key, or the empty
 // State (key absent). Empty State means neither file nor in-progress write
@@ -91,11 +84,8 @@ func (c *Catalog) HotState(chunkID chunk.ID) (HotState, error) {
 	return HotState(v), nil
 }
 
-// ---------------------------------------------------------------------------
-// Scans. Every "find work" operation iterates keys via PrefixScan; nothing
-// lists a directory. Results are returned sorted so callers (maxChunk,
-// uniqueness checks) need no second pass.
-// ---------------------------------------------------------------------------
+// Scans. Every "find work" operation iterates keys via PrefixScan; results
+// are sorted so callers (maxChunk, uniqueness checks) need no second pass.
 
 // ChunkArtifactKeys returns every per-chunk artifact key (all kinds, all
 // chunks) with its value, sorted by key. This is the deletion/audit surface
@@ -129,9 +119,7 @@ func (c *Catalog) ReadyHotChunkKeys() ([]chunk.ID, error) {
 	return c.hotChunkKeysWith(func(s HotState) bool { return s == HotReady })
 }
 
-// ---------------------------------------------------------------------------
 // Config pins. Written once on first start, immutable thereafter.
-// ---------------------------------------------------------------------------
 
 // EarliestLedger returns the pinned config:earliest_ledger (chunk-aligned).
 // ok is false if the pin has not been written yet (a pristine store).
@@ -146,11 +134,9 @@ func (c *Catalog) PutEarliestLedger(ledger uint32) error {
 	return c.store.Put(configEarliestLedger, strconv.FormatUint(uint64(ledger), 10))
 }
 
-// PinLayout commits the layout pin (config:earliest_ledger) in ONE atomic
-// synced batch — the first-start commit the design's validateConfig mandates.
-// Its presence ⟹ a prior first start completed and the layout is immutable;
-// otherwise startup never got past config validation and re-validating +
-// re-pinning is safe.
+// PinLayout commits the layout pin (config:earliest_ledger) in one atomic
+// synced batch — the first-start commit validateConfig mandates. Its presence
+// ⟹ a prior first start completed and the layout is immutable.
 func (c *Catalog) PinLayout(earliestLedger uint32) error {
 	return c.store.Batch(func(w *metastore.BatchWriter) error {
 		w.Put(configEarliestLedger, strconv.FormatUint(uint64(earliestLedger), 10))
@@ -158,10 +144,8 @@ func (c *Catalog) PinLayout(earliestLedger uint32) error {
 	})
 }
 
-// ---------------------------------------------------------------------------
-// ArtifactRef — a (chunk, kind) handle with its observed State. The unit the
+// ArtifactRef — a (chunk, kind) handle with its observed State, the unit the
 // sweeps and resolver pass around.
-// ---------------------------------------------------------------------------
 
 // ArtifactRef names one per-chunk artifact and the State observed for it.
 type ArtifactRef struct {
@@ -173,9 +157,7 @@ type ArtifactRef struct {
 // Key returns the meta-store key for this ref.
 func (r ArtifactRef) Key() string { return chunkKey(r.Chunk, r.Kind) }
 
-// ---------------------------------------------------------------------------
 // Unexported helpers backing the scans and pin getters above.
-// ---------------------------------------------------------------------------
 
 // hotChunkKeysWith returns the chunks whose hot-DB key matches keep, sorted
 // ascending. A nil keep matches every value (value-blind).
@@ -194,8 +176,8 @@ func (c *Catalog) hotChunkKeysWith(keep func(HotState) bool) ([]chunk.ID, error)
 		}
 	}
 	// PrefixScan yields byte-lex order; the 8-digit zero-padded ids make
-	// lex == numeric, so the slice is already ascending. Sort defensively in
-	// case the key width ever changes — cheap and keeps maxChunk honest.
+	// lex == numeric, so this is already ascending. Sort defensively against a
+	// future key-width change.
 	slices.Sort(ids)
 	return ids, nil
 }

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/catalog.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/catalog.go
@@ -1,0 +1,214 @@
+package streaming
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/metastore"
+)
+
+// Catalog is the streaming daemon's view of durable state. It WRAPS
+// metastore.Store — the merged RocksDB KV store with sync Put/Delete, atomic
+// Batch, and PrefixScan — and never reaches around it to RocksDB directly. The
+// catalog adds: the key schema and its bijection to disk paths (keys.go,
+// paths.go), the one-write protocol (protocol.go), and the key-driven sweeps
+// (sweep.go).
+//
+// Every method here is a pure function of meta-store keys plus the on-disk
+// layout. The catalog stays a *pure* catalog — every key names a file/dir
+// state or a config pin; progress is derived, never stored (see the data
+// model's "Progress is derived, never stored").
+type Catalog struct {
+	store  *metastore.Store
+	layout Layout
+
+	// hooks are test-only fault-injection points (see hooks.go); every field
+	// is nil in production, making each call site a no-op nil-check.
+	hooks crashHooks
+}
+
+// NewCatalog binds a catalog to an open metastore.Store and the on-disk layout.
+// The store is owned by the caller (the catalog does not close it) so a single
+// Store can back both the catalog and any other consumer in the process.
+func NewCatalog(store *metastore.Store, layout Layout) *Catalog {
+	return &Catalog{store: store, layout: layout}
+}
+
+// Layout returns the path layout bound to this catalog.
+func (c *Catalog) Layout() Layout { return c.layout }
+
+// ---------------------------------------------------------------------------
+// Raw key access. Get/Has are the value-blind primitives the rest build on.
+// ---------------------------------------------------------------------------
+
+// Get returns the value at key. The bool is false (and err nil) on a clean
+// miss, distinguishing "absent" from a real backing-store error.
+func (c *Catalog) Get(key string) (string, bool, error) {
+	v, err := c.store.Get(key)
+	if errors.Is(err, stores.ErrNotFound) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return v, true, nil
+}
+
+// Has reports whether key exists (value-blind).
+func (c *Catalog) Has(key string) (bool, error) {
+	_, ok, err := c.Get(key)
+	return ok, err
+}
+
+// ---------------------------------------------------------------------------
+// Typed artifact-state accessors.
+// ---------------------------------------------------------------------------
+
+// State returns the lifecycle State of a per-chunk artifact key, or the empty
+// State (key absent). Empty State means neither file nor in-progress write
+// exists — the absent case in the per-chunk lifecycle.
+func (c *Catalog) State(chunkID chunk.ID, kind Kind) (State, error) {
+	v, ok, err := c.Get(chunkKey(chunkID, kind))
+	if err != nil || !ok {
+		return "", err
+	}
+	return State(v), nil
+}
+
+// HotState returns the HotState of a chunk's hot-DB key, or the empty HotState
+// (key absent). The value-blind existence of the key — any value — marks the
+// chunk as owned by ingestion (the live-chunk partition); only the watermark
+// derivation cares which value (see readyHotChunkKeys).
+func (c *Catalog) HotState(chunkID chunk.ID) (HotState, error) {
+	v, ok, err := c.Get(hotChunkKey(chunkID))
+	if err != nil || !ok {
+		return "", err
+	}
+	return HotState(v), nil
+}
+
+// ---------------------------------------------------------------------------
+// Scans. Every "find work" operation iterates keys via PrefixScan; nothing
+// lists a directory. Results are returned sorted so callers (maxChunk,
+// uniqueness checks) need no second pass.
+// ---------------------------------------------------------------------------
+
+// ChunkArtifactKeys returns every per-chunk artifact key (all kinds, all
+// chunks) with its value, sorted by key. This is the deletion/audit surface
+// for chunk:* keys.
+func (c *Catalog) ChunkArtifactKeys() ([]ArtifactRef, error) {
+	var refs []ArtifactRef
+	for e, err := range c.store.PrefixScan(chunkPrefix) {
+		if err != nil {
+			return nil, err
+		}
+		id, kind, ok := parseChunkKey(e.Key)
+		if !ok {
+			return nil, fmt.Errorf("streaming: malformed chunk key %q", e.Key)
+		}
+		refs = append(refs, ArtifactRef{Chunk: id, Kind: kind, State: State(e.Value)})
+	}
+	return refs, nil
+}
+
+// HotChunkKeys returns every hot-DB chunk id (value-blind), sorted ascending.
+// The highest is the live chunk — the ingestion/lifecycle partition boundary.
+func (c *Catalog) HotChunkKeys() ([]chunk.ID, error) {
+	return c.hotChunkKeysWith(nil)
+}
+
+// ReadyHotChunkKeys returns only the chunks whose hot-DB key is "ready",
+// sorted ascending. The watermark derivation counts only these — a "transient"
+// key never advances the bound on its own, which is what lets recovery demote
+// any hot key without disturbing the watermark.
+func (c *Catalog) ReadyHotChunkKeys() ([]chunk.ID, error) {
+	return c.hotChunkKeysWith(func(s HotState) bool { return s == HotReady })
+}
+
+// ---------------------------------------------------------------------------
+// Config pins. Written once on first start, immutable thereafter.
+// ---------------------------------------------------------------------------
+
+// EarliestLedger returns the pinned config:earliest_ledger (chunk-aligned).
+// ok is false if the pin has not been written yet (a pristine store).
+func (c *Catalog) EarliestLedger() (uint32, bool, error) {
+	return c.uint32Pin(configEarliestLedger)
+}
+
+// PutEarliestLedger writes the config:earliest_ledger pin (decimal string).
+// The immutability check (abort if a later value differs) is the caller's
+// validateConfig responsibility, not the catalog's.
+func (c *Catalog) PutEarliestLedger(ledger uint32) error {
+	return c.store.Put(configEarliestLedger, strconv.FormatUint(uint64(ledger), 10))
+}
+
+// PinLayout commits the layout pin (config:earliest_ledger) in ONE atomic
+// synced batch — the first-start commit the design's validateConfig mandates.
+// Its presence ⟹ a prior first start completed and the layout is immutable;
+// otherwise startup never got past config validation and re-validating +
+// re-pinning is safe.
+func (c *Catalog) PinLayout(earliestLedger uint32) error {
+	return c.store.Batch(func(w *metastore.BatchWriter) error {
+		w.Put(configEarliestLedger, strconv.FormatUint(uint64(earliestLedger), 10))
+		return nil
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ArtifactRef — a (chunk, kind) handle with its observed State. The unit the
+// sweeps and resolver pass around.
+// ---------------------------------------------------------------------------
+
+// ArtifactRef names one per-chunk artifact and the State observed for it.
+type ArtifactRef struct {
+	Chunk chunk.ID
+	Kind  Kind
+	State State
+}
+
+// Key returns the meta-store key for this ref.
+func (r ArtifactRef) Key() string { return chunkKey(r.Chunk, r.Kind) }
+
+// ---------------------------------------------------------------------------
+// Unexported helpers backing the scans and pin getters above.
+// ---------------------------------------------------------------------------
+
+// hotChunkKeysWith returns the chunks whose hot-DB key matches keep, sorted
+// ascending. A nil keep matches every value (value-blind).
+func (c *Catalog) hotChunkKeysWith(keep func(HotState) bool) ([]chunk.ID, error) {
+	var ids []chunk.ID
+	for e, err := range c.store.PrefixScan(hotPrefix) {
+		if err != nil {
+			return nil, err
+		}
+		id, ok := parseHotChunkKey(e.Key)
+		if !ok {
+			return nil, fmt.Errorf("streaming: malformed hot key %q", e.Key)
+		}
+		if keep == nil || keep(HotState(e.Value)) {
+			ids = append(ids, id)
+		}
+	}
+	// PrefixScan yields byte-lex order; the 8-digit zero-padded ids make
+	// lex == numeric, so the slice is already ascending. Sort defensively in
+	// case the key width ever changes — cheap and keeps maxChunk honest.
+	slices.Sort(ids)
+	return ids, nil
+}
+
+// uint32Pin reads a config pin as a uint32 decimal string.
+func (c *Catalog) uint32Pin(key string) (uint32, bool, error) {
+	v, ok, err := c.Get(key)
+	if err != nil || !ok {
+		return 0, false, err
+	}
+	n, parseErr := strconv.ParseUint(v, 10, 32)
+	if parseErr != nil {
+		return 0, false, fmt.Errorf("streaming: config pin %q is not a uint32: %q", key, v)
+	}
+	return uint32(n), true, nil
+}

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/catalog_protocol.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/catalog_protocol.go
@@ -1,0 +1,86 @@
+package streaming
+
+import (
+	"errors"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/metastore"
+)
+
+// The one write protocol — mark-then-write. Every durable per-chunk artifact
+// flows through here:
+//
+//  1. Put the key "freezing" via metastore BEFORE any I/O.
+//  2. The caller writes the file.
+//  3. The caller fsyncs the FILE + its PARENT dirent (+ the GRANDPARENT dirent
+//     when the parent dir was just created) — barrierNewFile in paths.go.
+//  4. Flip to "frozen": a single Put for per-chunk artifacts.
+//
+// The pre-mark gives "every file on disk has its meta key"; the dirent
+// barriers guarantee the key never outlives the file's creation; the frozen
+// flip is the only transition readers trust. The catalog owns steps 1 and 4
+// (meta-store writes); the caller owns steps 2 and 3 (I/O), calling
+// MarkChunkFreezing before and FlipChunkFrozen after.
+
+// MarkChunkFreezing puts every requested kind's key to "freezing" in one
+// atomic synced batch, BEFORE any file I/O. Re-marking a "freezing"/"pruning"/
+// absent key is the idempotent re-materialization entry; a "frozen" kind is
+// the caller's to skip (rule 1's per-kind idempotency), not this helper's.
+func (c *Catalog) MarkChunkFreezing(chunkID chunk.ID, kinds ...Kind) error {
+	if len(kinds) == 0 {
+		return errors.New("streaming: MarkChunkFreezing requires at least one kind")
+	}
+	return c.store.Batch(func(w *metastore.BatchWriter) error {
+		for _, kind := range kinds {
+			w.Put(chunkKey(chunkID, kind), string(StateFreezing))
+		}
+		return nil
+	})
+}
+
+// FlipChunkFrozen flips every requested kind's key to "frozen" in one atomic
+// synced batch. The caller MUST have completed barrierNewFile for every file
+// first — "frozen" means durable and complete, trusted blindly downstream.
+func (c *Catalog) FlipChunkFrozen(chunkID chunk.ID, kinds ...Kind) error {
+	if len(kinds) == 0 {
+		return errors.New("streaming: FlipChunkFrozen requires at least one kind")
+	}
+	return c.store.Batch(func(w *metastore.BatchWriter) error {
+		for _, kind := range kinds {
+			w.Put(chunkKey(chunkID, kind), string(StateFrozen))
+		}
+		return nil
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Hot-DB key bracket. The directory operation's two ends: PutHotTransient
+// before the dir is created (or before a discard rmdirs it), FlipHotReady
+// after the dir is durable, DeleteHotKey after the rmdir completes. The
+// "transient"/"ready" bracket is the same two ideas the file protocol uses,
+// applied to a directory.
+// ---------------------------------------------------------------------------
+
+// PutHotTransient marks a hot-DB key "transient" — the bracket's open end,
+// written before the directory is created or before a discard begins removing
+// it. A crash mid-operation is detectable from this value alone.
+func (c *Catalog) PutHotTransient(chunkID chunk.ID) error {
+	// Test-only observation point at the exact instant a hot key is about to be
+	// created (a no-op in production). At a boundary handoff this is when the
+	// next chunk's key appears — the ingestion loop guarantees the predecessor's
+	// write handle is already closed here (close-before-create-key).
+	c.hooks.fireBeforeHotTransient(chunkID)
+	return c.store.Put(hotChunkKey(chunkID), string(HotTransient))
+}
+
+// FlipHotReady marks a hot-DB key "ready" — the dir exists and is usable. The
+// caller MUST have fsynced the dir (and its parent on creation) first.
+func (c *Catalog) FlipHotReady(chunkID chunk.ID) error {
+	return c.store.Put(hotChunkKey(chunkID), string(HotReady))
+}
+
+// DeleteHotKey removes a hot-DB key — the bracket's close end, after rmdir
+// completes. Idempotent on a missing key.
+func (c *Catalog) DeleteHotKey(chunkID chunk.ID) error {
+	return c.store.Delete(hotChunkKey(chunkID))
+}

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/catalog_protocol.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/catalog_protocol.go
@@ -53,13 +53,10 @@ func (c *Catalog) FlipChunkFrozen(chunkID chunk.ID, kinds ...Kind) error {
 	})
 }
 
-// ---------------------------------------------------------------------------
-// Hot-DB key bracket. The directory operation's two ends: PutHotTransient
-// before the dir is created (or before a discard rmdirs it), FlipHotReady
-// after the dir is durable, DeleteHotKey after the rmdir completes. The
-// "transient"/"ready" bracket is the same two ideas the file protocol uses,
-// applied to a directory.
-// ---------------------------------------------------------------------------
+// Hot-DB key bracket — the directory operation's two ends: PutHotTransient
+// before the dir is created (or before a discard rmdirs it), FlipHotReady after
+// it is durable, DeleteHotKey after the rmdir completes. Same transient/ready
+// idea as the file protocol, applied to a directory.
 
 // PutHotTransient marks a hot-DB key "transient" — the bracket's open end,
 // written before the directory is created or before a discard begins removing

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/catalog_sweep.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/catalog_sweep.go
@@ -1,0 +1,79 @@
+package streaming
+
+import (
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/metastore"
+)
+
+// Key-driven sweep — the ONLY deletion body in the system. Its ordering is
+// load-bearing:
+//
+//	demote-if-still-"frozen"  (never unlink under a frozen key)
+//	  -> unlink file(s)
+//	  -> fsyncDir(parent)     (the unlink becomes durable BEFORE the key goes)
+//	  -> delete key           (batched)
+//
+// This gives the exit-side invariant "key absent => file gone": because the
+// key outlives the durable unlink, a crash anywhere leaves the key in place
+// and the sweep re-runs. Deleting the key first would, on a crash, leave a
+// file with no key — the one orphan class this design cannot find.
+
+// SweepChunkArtifacts deletes the files for a batch of per-chunk artifact refs
+// and removes their keys. Refs already past "frozen" (i.e. "freezing" or
+// "pruning") are unlinked directly; a still-"frozen" ref is demoted to
+// "pruning" first, in one atomic batch, so no unlink ever happens under a
+// frozen key.
+//
+// The whole batch shares three barriers: one demote batch, one fsync pass over
+// the affected parent dirs, one key-delete batch — so sweeping many refs at
+// once pays a single round of each.
+func (c *Catalog) SweepChunkArtifacts(refs []ArtifactRef) error {
+	if len(refs) == 0 {
+		return nil
+	}
+
+	// Demote first — never unlink under a "frozen" key. A crash after this
+	// batch but before the unlinks leaves "pruning" keys the next sweep
+	// finishes.
+	if err := c.store.Batch(func(w *metastore.BatchWriter) error {
+		for _, ref := range refs {
+			if ref.State == StateFrozen {
+				w.Put(ref.Key(), string(StatePruning))
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	// Between the demote and the unlink: every "frozen" ref must now read
+	// "pruning". Dropping the demote above would leave it "frozen" here.
+	c.hooks.fireBeforeUnlink()
+
+	// Unlink every file (idempotent on already-gone paths), collecting parents
+	// for the durability barrier.
+	var paths []string
+	for _, ref := range refs {
+		for _, p := range c.layout.ArtifactPaths(ref.Chunk, ref.Kind) {
+			if err := deleteFileIfExists(p); err != nil {
+				return err
+			}
+			paths = append(paths, p)
+		}
+	}
+	if err := fsyncParentDirs(paths); err != nil { // unlinks durable BEFORE keys
+		return err
+	}
+
+	// Between the durable unlink and the key delete: the files are gone but the
+	// keys still exist. Reordering the delete ahead of the unlink would leave a
+	// file present here under no key — the one orphan class this order forbids.
+	c.hooks.fireBeforeKeyDelete()
+
+	// Delete the keys — only now that the unlinks are durable.
+	return c.store.Batch(func(w *metastore.BatchWriter) error {
+		for _, ref := range refs {
+			w.Delete(ref.Key())
+		}
+		return nil
+	})
+}

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/catalog_sweep.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/catalog_sweep.go
@@ -18,10 +18,10 @@ import (
 // file with no key — the one orphan class this design cannot find.
 
 // SweepChunkArtifacts deletes the files for a batch of per-chunk artifact refs
-// and removes their keys. Refs already past "frozen" (i.e. "freezing" or
-// "pruning") are unlinked directly; a still-"frozen" ref is demoted to
-// "pruning" first, in one atomic batch, so no unlink ever happens under a
-// frozen key.
+// and removes their keys. Refs NOT in the canonical "frozen" state (i.e.
+// "freezing" — a crashed write — or "pruning" — a resumed delete) are unlinked
+// directly; a still-"frozen" ref is demoted to "pruning" first, in one atomic
+// batch, so no unlink ever happens under a frozen key.
 //
 // The whole batch shares three barriers: one demote batch, one fsync pass over
 // the affected parent dirs, one key-delete batch — so sweeping many refs at

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/config.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/config.go
@@ -66,8 +66,8 @@ type BSBConfig struct {
 	NumWorkers *int `toml:"num_workers"`
 }
 
-// ImmutableStorageConfig is [immutable_storage.*] — one optional path per
-// artifact tree. An empty path means "default under default_data_dir".
+// ImmutableStorageConfig is [immutable_storage] — the single cold-tier root
+// (empty ⇒ default under default_data_dir).
 type ImmutableStorageConfig struct {
 	// Path is the single cold-tier root: every immutable artifact tree (ledger
 	// .pack, events segments, tx-hash .bin/.idx) lives in a fixed subdirectory
@@ -77,8 +77,8 @@ type ImmutableStorageConfig struct {
 	Path string `toml:"path"`
 }
 
-// StoragePathConfig is one [immutable_storage.*] / [catalog] / [hot_storage]
-// section: an optional path override.
+// StoragePathConfig is the [streaming.hot_storage] section: an optional path
+// override.
 type StoragePathConfig struct {
 	Path string `toml:"path"`
 }

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/config.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/config.go
@@ -70,11 +70,10 @@ type BSBConfig struct {
 // artifact tree. An empty path means "default under default_data_dir".
 type ImmutableStorageConfig struct {
 	// Path is the single cold-tier root: every immutable artifact tree (ledger
-	// .pack, events segments, tx-hash .bin/.idx) lives as a fixed subdirectory
+	// .pack, events segments, tx-hash .bin/.idx) lives in a fixed subdirectory
 	// beneath it. Empty ⇒ default_data_dir. One knob relocates the whole cold
-	// tier to a separate (cheap/large/durable) volume; the per-data-type subdirs
-	// are not independently configurable. (Slice 3 adds an optional txhash-index
-	// override for the one artifact with a distinct read profile.)
+	// tier to a separate volume; the per-data-type subdirs are not independently
+	// configurable. (Slice 3 adds an optional txhash-index override.)
 	Path string `toml:"path"`
 }
 
@@ -148,14 +147,10 @@ func LoadConfig(path string) (Config, error) {
 // ParseConfig parses TOML bytes into a Config with defaults applied. Split from
 // LoadConfig so tests parse in-memory documents without a temp file.
 //
-// Decoding is STRICT (Decoder.Strict(true)): any key in the document with no
-// corresponding struct field is an error rather than silently ignored. This is
-// what backs the LoadConfig docstring's "unknown keys are rejected" promise — a
-// typo in an immutable, layout-defining key (earliest_ledger) must fail loudly,
-// not silently fall back to a default and pin the wrong value on first start.
-// go-toml v1's plain Unmarshal ignores
-// unknown keys (it mirrors the encoding/json decoder), so strict decoding is
-// required here.
+// Decoding is STRICT: an unknown key is an error, not silently ignored (go-toml
+// v1's plain Unmarshal ignores them). This backs LoadConfig's "unknown keys are
+// rejected" promise — a typo in a layout-defining key like earliest_ledger must
+// fail loudly, not pin the wrong value on first start.
 func ParseConfig(data []byte) (Config, error) {
 	var cfg Config
 	if err := toml.NewDecoder(bytes.NewReader(data)).Strict(true).Decode(&cfg); err != nil {
@@ -234,11 +229,9 @@ func (cfg Config) ResolvePaths() Paths {
 
 // LockRoots returns the distinct storage roots that must each carry a
 // single-process flock: the catalog, the cold-tier root, and the hot_storage
-// tree (design "Single-process enforcement"). The data dir itself is NOT locked
-// — only the leaf roots a second daemon could independently point at; locking
-// the shared parent would not catch two daemons with disjoint data dirs that
-// nonetheless share one artifact tree. (Slice 3 adds the txhash-index root when
-// it is relocated off the cold tree.)
+// tree. The data dir itself is NOT locked — only the leaf roots a second daemon
+// could independently point at, since two daemons with disjoint data dirs could
+// still share one artifact tree. (Slice 3 adds the relocated txhash-index root.)
 func (p Paths) LockRoots() []string {
 	return []string{
 		p.Catalog,

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/config.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/config.go
@@ -69,7 +69,13 @@ type BSBConfig struct {
 // ImmutableStorageConfig is [immutable_storage.*] — one optional path per
 // artifact tree. An empty path means "default under default_data_dir".
 type ImmutableStorageConfig struct {
-	Ledgers StoragePathConfig `toml:"ledgers"`
+	// Path is the single cold-tier root: every immutable artifact tree (ledger
+	// .pack, events segments, tx-hash .bin/.idx) lives as a fixed subdirectory
+	// beneath it. Empty ⇒ default_data_dir. One knob relocates the whole cold
+	// tier to a separate (cheap/large/durable) volume; the per-data-type subdirs
+	// are not independently configurable. (Slice 3 adds an optional txhash-index
+	// override for the one artifact with a distinct read profile.)
+	Path string `toml:"path"`
 }
 
 // StoragePathConfig is one [immutable_storage.*] / [catalog] / [hot_storage]
@@ -202,7 +208,7 @@ func (cfg Config) WithDefaults() Config {
 type Paths struct {
 	DataDir    string // default_data_dir (the data root)
 	Catalog    string // catalog RocksDB dir
-	Ledgers    string // immutable ledger packs root
+	Cold       string // immutable cold-tier root (ledgers/events/txhash subdirs)
 	HotStorage string // per-chunk hot RocksDB root
 }
 
@@ -221,21 +227,22 @@ func (cfg Config) ResolvePaths() Paths {
 	return Paths{
 		DataDir:    dataDir,
 		Catalog:    pick(cfg.Catalog.Path, filepath.Join(dataDir, "catalog", "rocksdb")),
-		Ledgers:    pick(cfg.ImmutableStorage.Ledgers.Path, filepath.Join(dataDir, "ledgers")),
+		Cold:       pick(cfg.ImmutableStorage.Path, dataDir),
 		HotStorage: pick(cfg.Streaming.HotStorage.Path, filepath.Join(dataDir, "hot")),
 	}
 }
 
 // LockRoots returns the distinct storage roots that must each carry a
-// single-process flock: the catalog, every immutable_storage tree, and the
-// hot_storage tree (design "Single-process enforcement"). The data dir itself
-// is NOT locked — only the leaf roots a second daemon could independently point
-// at; locking the shared parent would not catch two daemons with disjoint data
-// dirs that nonetheless share one artifact tree.
+// single-process flock: the catalog, the cold-tier root, and the hot_storage
+// tree (design "Single-process enforcement"). The data dir itself is NOT locked
+// — only the leaf roots a second daemon could independently point at; locking
+// the shared parent would not catch two daemons with disjoint data dirs that
+// nonetheless share one artifact tree. (Slice 3 adds the txhash-index root when
+// it is relocated off the cold tree.)
 func (p Paths) LockRoots() []string {
 	return []string{
 		p.Catalog,
-		p.Ledgers,
+		p.Cold,
 		p.HotStorage,
 	}
 }

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/config.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/config.go
@@ -1,0 +1,241 @@
+package streaming
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/pelletier/go-toml"
+)
+
+// Config is the on-disk TOML schema for the full-history streaming daemon — the
+// one --config file (design "Configuration"). Every section maps to a nested
+// struct; optional scalars are pointers so an absent key is distinguishable
+// from an explicit zero and the documented default applies in WithDefaults.
+//
+// The TOML form is the daemon's INPUT; validateConfig turns it (plus the
+// catalog's pins and a network-tip backend) into the resolved StartConfig that
+// startStreaming consumes. The two layout-defining values
+// (chunks_per_txhash_index, earliest_ledger) are pinned immutably on first
+// start and validated against their pins on every restart.
+type Config struct {
+	Service          ServiceConfig          `toml:"service"`
+	Backfill         BackfillConfig         `toml:"backfill"`
+	ImmutableStorage ImmutableStorageConfig `toml:"immutable_storage"`
+	Catalog          CatalogConfig          `toml:"catalog"`
+	Streaming        StreamingConfig        `toml:"streaming"`
+	Logging          LoggingConfig          `toml:"logging"`
+}
+
+// ServiceConfig is [service].
+type ServiceConfig struct {
+	// DefaultDataDir is the base directory for the catalog and the default
+	// storage paths. Required.
+	DefaultDataDir string `toml:"default_data_dir"`
+}
+
+// BackfillConfig is [backfill] plus the nested [backfill.bsb].
+type BackfillConfig struct {
+	// Workers is the concurrent task-slot count for bulk catch-up. Default
+	// GOMAXPROCS. Must be >= 1.
+	Workers *int `toml:"workers"`
+
+	// MaxRetries is per-task retries before the daemon aborts. Default
+	// DefaultMaxRetries. Must be >= 0 (0 = run once, no retry).
+	MaxRetries *int `toml:"max_retries"`
+
+	// BSB is the Buffered Storage Backend — the default bulk LedgerBackend.
+	BSB BSBConfig `toml:"bsb"`
+}
+
+// BSBConfig is [backfill.bsb] — the Buffered Storage Backend. Required unless
+// another conformant LedgerBackend is wired as the bulk source.
+type BSBConfig struct {
+	// BucketPath is the remote object-store path for LedgerCloseMeta (no gs://
+	// prefix for GCS). Required when BSB is the bulk source.
+	BucketPath string `toml:"bucket_path"`
+
+	// BufferSize is the prefetch buffer depth per connection. Default
+	// DefaultBSBBufferSize.
+	BufferSize *int `toml:"buffer_size"`
+
+	// NumWorkers is the download workers per connection. Default
+	// DefaultBSBNumWorkers.
+	NumWorkers *int `toml:"num_workers"`
+}
+
+// ImmutableStorageConfig is [immutable_storage.*] — one optional path per
+// artifact tree. An empty path means "default under default_data_dir".
+type ImmutableStorageConfig struct {
+	Ledgers StoragePathConfig `toml:"ledgers"`
+}
+
+// StoragePathConfig is one [immutable_storage.*] / [catalog] / [hot_storage]
+// section: an optional path override.
+type StoragePathConfig struct {
+	Path string `toml:"path"`
+}
+
+// CatalogConfig is [catalog] — optional path override
+// (default {default_data_dir}/catalog/rocksdb).
+type CatalogConfig struct {
+	Path string `toml:"path"`
+}
+
+// StreamingConfig is [streaming] plus the nested [streaming.hot_storage].
+type StreamingConfig struct {
+	// RetentionChunks is the retention window in chunks; 0 = full history.
+	// Default 0.
+	RetentionChunks *uint32 `toml:"retention_chunks"`
+
+	// EarliestLedger is the earliest ledger this daemon will ever have data
+	// for: "genesis", "now", or a chunk-aligned decimal ledger. Default
+	// "genesis". Pinned immutably on first start.
+	EarliestLedger string `toml:"earliest_ledger"`
+
+	// CaptiveCoreConfig is the path to the CaptiveStellarCore config file.
+	// Required.
+	CaptiveCoreConfig string `toml:"captive_core_config"`
+
+	// HotStorage is [streaming.hot_storage].
+	HotStorage StoragePathConfig `toml:"hot_storage"`
+}
+
+// LoggingConfig is [logging].
+type LoggingConfig struct {
+	// Level is debug/info/warn/error. Default "info".
+	Level string `toml:"level"`
+	// Format is text/json. Default "text".
+	Format string `toml:"format"`
+}
+
+// Documented defaults (design "Configuration").
+const (
+	DefaultMaxRetries    int = 3
+	DefaultBSBBufferSize int = 1000
+	DefaultBSBNumWorkers int = 20
+
+	DefaultEarliestLedger = "genesis"
+	DefaultLogLevel       = "info"
+	DefaultLogFormat      = "text"
+
+	// EarliestGenesis / EarliestNow are the two symbolic earliest_ledger forms.
+	EarliestGenesis = "genesis"
+	EarliestNow     = "now"
+)
+
+// LoadConfig reads and parses the TOML config at path. It applies documented
+// defaults but does NOT validate semantics or touch any pin — that is
+// validateConfig's job, which needs the catalog and a tip backend. Unknown
+// top-level/section keys are rejected so a typo'd key never silently keeps a
+// default.
+func LoadConfig(path string) (Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Config{}, fmt.Errorf("streaming: read config %q: %w", path, err)
+	}
+	return ParseConfig(data)
+}
+
+// ParseConfig parses TOML bytes into a Config with defaults applied. Split from
+// LoadConfig so tests parse in-memory documents without a temp file.
+//
+// Decoding is STRICT (Decoder.Strict(true)): any key in the document with no
+// corresponding struct field is an error rather than silently ignored. This is
+// what backs the LoadConfig docstring's "unknown keys are rejected" promise — a
+// typo in an immutable, layout-defining key (earliest_ledger) must fail loudly,
+// not silently fall back to a default and pin the wrong value on first start.
+// go-toml v1's plain Unmarshal ignores
+// unknown keys (it mirrors the encoding/json decoder), so strict decoding is
+// required here.
+func ParseConfig(data []byte) (Config, error) {
+	var cfg Config
+	if err := toml.NewDecoder(bytes.NewReader(data)).Strict(true).Decode(&cfg); err != nil {
+		return Config{}, fmt.Errorf("streaming: parse config: %w", err)
+	}
+	return cfg.WithDefaults(), nil
+}
+
+// WithDefaults returns a copy of cfg with every documented default filled for
+// an unset (nil pointer / empty string) field. Numeric pointers left nil are
+// resolved to their defaults; explicit zeros are preserved (and later rejected
+// by validateConfig where a zero is illegal, e.g. workers).
+func (cfg Config) WithDefaults() Config {
+	if cfg.Backfill.Workers == nil {
+		v := runtime.GOMAXPROCS(0)
+		cfg.Backfill.Workers = &v
+	}
+	if cfg.Backfill.MaxRetries == nil {
+		v := DefaultMaxRetries
+		cfg.Backfill.MaxRetries = &v
+	}
+	if cfg.Backfill.BSB.BufferSize == nil {
+		v := DefaultBSBBufferSize
+		cfg.Backfill.BSB.BufferSize = &v
+	}
+	if cfg.Backfill.BSB.NumWorkers == nil {
+		v := DefaultBSBNumWorkers
+		cfg.Backfill.BSB.NumWorkers = &v
+	}
+	if cfg.Streaming.RetentionChunks == nil {
+		v := uint32(0)
+		cfg.Streaming.RetentionChunks = &v
+	}
+	if cfg.Streaming.EarliestLedger == "" {
+		cfg.Streaming.EarliestLedger = DefaultEarliestLedger
+	}
+	if cfg.Logging.Level == "" {
+		cfg.Logging.Level = DefaultLogLevel
+	}
+	if cfg.Logging.Format == "" {
+		cfg.Logging.Format = DefaultLogFormat
+	}
+	return cfg
+}
+
+// Paths resolves the on-disk paths the daemon uses, filling each unset storage
+// path with its documented default under default_data_dir. It is the single
+// place the {default_data_dir}/... layout lives, so locking and store-opening
+// agree on every root.
+type Paths struct {
+	DataDir    string // default_data_dir (the data root)
+	Catalog    string // catalog RocksDB dir
+	Ledgers    string // immutable ledger packs root
+	HotStorage string // per-chunk hot RocksDB root
+}
+
+// ResolvePaths fills every storage path, defaulting under default_data_dir per
+// the design's directory layout. Relative overrides are kept relative (the
+// caller's working dir resolves them); only the defaults are joined to the data
+// dir.
+func (cfg Config) ResolvePaths() Paths {
+	dataDir := cfg.Service.DefaultDataDir
+	pick := func(override, def string) string {
+		if override != "" {
+			return override
+		}
+		return def
+	}
+	return Paths{
+		DataDir:    dataDir,
+		Catalog:    pick(cfg.Catalog.Path, filepath.Join(dataDir, "catalog", "rocksdb")),
+		Ledgers:    pick(cfg.ImmutableStorage.Ledgers.Path, filepath.Join(dataDir, "ledgers")),
+		HotStorage: pick(cfg.Streaming.HotStorage.Path, filepath.Join(dataDir, "hot")),
+	}
+}
+
+// LockRoots returns the distinct storage roots that must each carry a
+// single-process flock: the catalog, every immutable_storage tree, and the
+// hot_storage tree (design "Single-process enforcement"). The data dir itself
+// is NOT locked — only the leaf roots a second daemon could independently point
+// at; locking the shared parent would not catch two daemons with disjoint data
+// dirs that nonetheless share one artifact tree.
+func (p Paths) LockRoots() []string {
+	return []string{
+		p.Catalog,
+		p.Ledgers,
+		p.HotStorage,
+	}
+}

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/config.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/config.go
@@ -85,7 +85,7 @@ type CatalogConfig struct {
 }
 
 // StreamingConfig is [streaming] plus the nested [streaming.hot_storage].
-type StreamingConfig struct {
+type StreamingConfig struct { //nolint:revive // matches the XxxConfig section-struct convention
 	// RetentionChunks is the retention window in chunks; 0 = full history.
 	// Default 0.
 	RetentionChunks *uint32 `toml:"retention_chunks"`

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/config_lock.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/config_lock.go
@@ -11,8 +11,8 @@ import (
 
 // Single-process enforcement (design "Single-process enforcement"). The daemon
 // holds a kernel flock on a LOCK file under EVERY independently configurable
-// storage root — the catalog, each immutable_storage tree, and the hot_storage
-// tree. A second daemon touching any shared root fails fast.
+// storage root — the catalog, the immutable_storage cold-tier root, and the
+// hot_storage tree. A second daemon touching any shared root fails fast.
 //
 // Why all roots, not just the catalog: those paths are independently
 // configurable, so two daemons with different catalogs could still share an

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/config_lock.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/config_lock.go
@@ -1,0 +1,119 @@
+package streaming
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+// Single-process enforcement (design "Single-process enforcement"). The daemon
+// holds a kernel flock on a LOCK file under EVERY independently configurable
+// storage root — the catalog, each immutable_storage tree, AND the
+// hot_storage tree. A second daemon that touches any shared root fails fast.
+//
+// Why all roots and not just the catalog: [catalog], each
+// [immutable_storage.*] path, and [streaming.hot_storage] are independently
+// configurable, so two daemons with DIFFERENT catalogs could still share an
+// artifact tree or a hot-DB tree. The hot root matters most — its hot/{chunk}
+// DBs are the only copy of recently-ingested ledgers, independently
+// created/opened/deleted by ingestion and discard, so two daemons sharing it
+// would corrupt or delete that sole copy.
+//
+// A kernel flock is the right primitive: it releases on ANY process exit
+// (including kill -9 / a crash), so a stale lock never strands the next start —
+// nothing on disk to clean up.
+
+// ErrRootLocked is returned when a LOCK file in a configured root is already
+// held by another process. It wraps the offending root so the daemon can name
+// it in the operator-facing error.
+var ErrRootLocked = errors.New("streaming: storage root is locked by another process")
+
+// lockFileName is the per-root lock file. Kept distinct from RocksDB's own
+// "LOCK" so the catalog root's flock and RocksDB's internal lock never
+// collide — the catalog root carries both, on different files.
+const lockFileName = "stellar-rpc-fullhistory.lock"
+
+// RootLocks holds the flock handles for every configured storage root. Release
+// (defer'd by the daemon for the process's whole life) unlocks and closes them
+// all; the kernel also drops them on any process exit.
+type RootLocks struct {
+	files []*os.File
+}
+
+// LockRoots takes a non-blocking exclusive flock on the LOCK file in each
+// distinct root in roots, in the order given. Duplicate paths (e.g. the
+// immutable trees all defaulting under default_data_dir is NOT a duplicate —
+// they are distinct subdirs — but a caller passing the same root twice) are
+// de-duplicated so one root is locked once. On the FIRST root that is already
+// held by another process it releases everything acquired so far and returns
+// ErrRootLocked naming that root — fail fast, leak nothing.
+//
+// Each root directory is created if absent (MkdirAll): a fresh deployment locks
+// before any store opens, and the lock file must have a directory to live in.
+func LockRoots(roots ...string) (*RootLocks, error) {
+	locks := &RootLocks{}
+	seen := make(map[string]struct{}, len(roots))
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		abs, err := filepath.Abs(root)
+		if err != nil {
+			locks.Release()
+			return nil, fmt.Errorf("streaming: resolve lock root %q: %w", root, err)
+		}
+		if _, dup := seen[abs]; dup {
+			continue
+		}
+		seen[abs] = struct{}{}
+
+		f, err := lockOne(abs)
+		if err != nil {
+			locks.Release()
+			return nil, err
+		}
+		locks.files = append(locks.files, f)
+	}
+	return locks, nil
+}
+
+// lockOne creates root (if absent), opens its LOCK file, and takes a
+// non-blocking exclusive flock. An EWOULDBLOCK means another live process holds
+// it — surfaced as ErrRootLocked, the fail-fast case. Any other error (mkdir,
+// open, a non-contention flock failure) surfaces verbatim.
+func lockOne(root string) (*os.File, error) {
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return nil, fmt.Errorf("streaming: create lock root %q: %w", root, err)
+	}
+	path := filepath.Join(root, lockFileName)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("streaming: open lock file %q: %w", path, err)
+	}
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, unix.EWOULDBLOCK) {
+			return nil, fmt.Errorf("%w: %q (another daemon is using it)", ErrRootLocked, root)
+		}
+		return nil, fmt.Errorf("streaming: flock %q: %w", path, err)
+	}
+	return f, nil
+}
+
+// Release unlocks and closes every held lock file. Idempotent: a second call is
+// a no-op. Closing the fd drops the flock; the explicit unix.Flock(LOCK_UN) is
+// belt-and-suspenders so the lock is gone the instant Release returns rather
+// than whenever the fd's last reference is collected.
+func (l *RootLocks) Release() {
+	if l == nil {
+		return
+	}
+	for _, f := range l.files {
+		_ = unix.Flock(int(f.Fd()), unix.LOCK_UN)
+		_ = f.Close()
+	}
+	l.files = nil
+}

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/config_lock.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/config_lock.go
@@ -93,6 +93,7 @@ func lockOne(root string) (*os.File, error) {
 	if err != nil {
 		return nil, fmt.Errorf("streaming: open lock file %q: %w", path, err)
 	}
+	//nolint:gosec // a file descriptor always fits in int
 	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
 		_ = f.Close()
 		if errors.Is(err, unix.EWOULDBLOCK) {
@@ -112,6 +113,7 @@ func (l *RootLocks) Release() {
 		return
 	}
 	for _, f := range l.files {
+		//nolint:gosec // a file descriptor always fits in int
 		_ = unix.Flock(int(f.Fd()), unix.LOCK_UN)
 		_ = f.Close()
 	}

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/config_lock.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/config_lock.go
@@ -11,20 +11,17 @@ import (
 
 // Single-process enforcement (design "Single-process enforcement"). The daemon
 // holds a kernel flock on a LOCK file under EVERY independently configurable
-// storage root — the catalog, each immutable_storage tree, AND the
-// hot_storage tree. A second daemon that touches any shared root fails fast.
+// storage root — the catalog, each immutable_storage tree, and the hot_storage
+// tree. A second daemon touching any shared root fails fast.
 //
-// Why all roots and not just the catalog: [catalog], each
-// [immutable_storage.*] path, and [streaming.hot_storage] are independently
-// configurable, so two daemons with DIFFERENT catalogs could still share an
-// artifact tree or a hot-DB tree. The hot root matters most — its hot/{chunk}
-// DBs are the only copy of recently-ingested ledgers, independently
-// created/opened/deleted by ingestion and discard, so two daemons sharing it
-// would corrupt or delete that sole copy.
+// Why all roots, not just the catalog: those paths are independently
+// configurable, so two daemons with different catalogs could still share an
+// artifact or hot-DB tree. The hot root matters most — its hot/{chunk} DBs are
+// the only copy of recently-ingested ledgers, so sharing it would corrupt or
+// delete that sole copy.
 //
-// A kernel flock is the right primitive: it releases on ANY process exit
-// (including kill -9 / a crash), so a stale lock never strands the next start —
-// nothing on disk to clean up.
+// A kernel flock releases on ANY process exit (including kill -9 / a crash), so
+// a stale lock never strands the next start — nothing on disk to clean up.
 
 // ErrRootLocked is returned when a LOCK file in a configured root is already
 // held by another process. It wraps the offending root so the daemon can name
@@ -44,15 +41,13 @@ type RootLocks struct {
 }
 
 // LockRoots takes a non-blocking exclusive flock on the LOCK file in each
-// distinct root in roots, in the order given. Duplicate paths (e.g. the
-// immutable trees all defaulting under default_data_dir is NOT a duplicate —
-// they are distinct subdirs — but a caller passing the same root twice) are
-// de-duplicated so one root is locked once. On the FIRST root that is already
-// held by another process it releases everything acquired so far and returns
-// ErrRootLocked naming that root — fail fast, leak nothing.
+// distinct root, in the order given; duplicate paths are de-duplicated so a
+// root is locked once. On the FIRST root already held by another process it
+// releases everything acquired so far and returns ErrRootLocked naming that
+// root — fail fast, leak nothing.
 //
-// Each root directory is created if absent (MkdirAll): a fresh deployment locks
-// before any store opens, and the lock file must have a directory to live in.
+// Each root is created if absent (MkdirAll): a fresh deployment locks before
+// any store opens, and the lock file needs a directory to live in.
 func LockRoots(roots ...string) (*RootLocks, error) {
 	locks := &RootLocks{}
 	seen := make(map[string]struct{}, len(roots))

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/config_lock_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/config_lock_test.go
@@ -1,0 +1,96 @@
+package streaming
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLockRoots_AcquiresAndReleases(t *testing.T) {
+	root := t.TempDir()
+	locks, err := LockRoots(root)
+	require.NoError(t, err)
+	require.NotNil(t, locks)
+
+	// The lock file was created.
+	_, statErr := os.Stat(filepath.Join(root, lockFileName))
+	require.NoError(t, statErr)
+
+	// After release a second holder can take it.
+	locks.Release()
+	again, err := LockRoots(root)
+	require.NoError(t, err)
+	again.Release()
+}
+
+func TestLockRoots_SecondHolderFailsFast(t *testing.T) {
+	root := t.TempDir()
+	first, err := LockRoots(root)
+	require.NoError(t, err)
+	defer first.Release()
+
+	// A second holder on the SAME root is rejected immediately (non-blocking).
+	second, err := LockRoots(root)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrRootLocked)
+	assert.Contains(t, err.Error(), root)
+	assert.Nil(t, second, "no partial RootLocks handed back on the rejected attempt")
+}
+
+func TestLockRoots_SharedRootAmongManyFailsFast(t *testing.T) {
+	// Two daemons with different meta stores but a SHARED hot/immutable root:
+	// the shared root's lock is what stops them.
+	shared := t.TempDir()
+	meta1 := t.TempDir()
+	meta2 := t.TempDir()
+
+	first, err := LockRoots(meta1, shared)
+	require.NoError(t, err)
+	defer first.Release()
+
+	// Daemon 2: distinct meta store, same shared artifact tree -> rejected, and
+	// the meta2 lock it grabbed first must be released on the failure.
+	_, err = LockRoots(meta2, shared)
+	require.ErrorIs(t, err, ErrRootLocked)
+
+	// Proof meta2 was released on the partial failure: a fresh holder gets it.
+	m2, err := LockRoots(meta2)
+	require.NoError(t, err)
+	m2.Release()
+}
+
+func TestLockRoots_DeDuplicatesRepeatedRoot(t *testing.T) {
+	root := t.TempDir()
+	// The same root twice must not self-deadlock (flock is per-fd, but a second
+	// fd on the same file from the same process would still EWOULDBLOCK).
+	locks, err := LockRoots(root, root)
+	require.NoError(t, err)
+	defer locks.Release()
+	assert.Len(t, locks.files, 1, "the repeated root is locked once")
+}
+
+func TestLockRoots_CreatesMissingRoot(t *testing.T) {
+	parent := t.TempDir()
+	missing := filepath.Join(parent, "not", "yet", "there")
+	locks, err := LockRoots(missing)
+	require.NoError(t, err)
+	defer locks.Release()
+	info, err := os.Stat(missing)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+func TestLockRoots_SkipsEmptyRoot(t *testing.T) {
+	locks, err := LockRoots("")
+	require.NoError(t, err)
+	defer locks.Release()
+	assert.Empty(t, locks.files)
+}
+
+func TestRootLocks_ReleaseNilSafe(t *testing.T) {
+	var l *RootLocks
+	assert.NotPanics(t, l.Release)
+}

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/config_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/config_test.go
@@ -1,0 +1,224 @@
+package streaming
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A fully-populated, documented-valid config. Every section present with
+// non-default values so the parse-and-resolve round-trip is exercised end to
+// end.
+const fullValidConfig = `
+[service]
+default_data_dir = "/var/lib/fullhistory"
+
+[backfill]
+workers = 8
+max_retries = 5
+
+[backfill.bsb]
+bucket_path = "my-bucket/ledgers"
+buffer_size = 2000
+num_workers = 40
+
+[immutable_storage.ledgers]
+path = "/mnt/ledgers"
+
+[catalog]
+path = "/mnt/catalog"
+
+[streaming]
+retention_chunks = 100
+earliest_ledger = "now"
+captive_core_config = "/etc/captive-core.toml"
+
+[streaming.hot_storage]
+path = "/mnt/hot"
+
+[logging]
+level = "debug"
+format = "json"
+`
+
+// A minimal config: only the required keys, everything else defaulted.
+const minimalValidConfig = `
+[service]
+default_data_dir = "/data"
+
+[backfill.bsb]
+bucket_path = "bucket/path"
+
+[streaming]
+captive_core_config = "/etc/cc.toml"
+`
+
+func TestParseConfig_FullDocument(t *testing.T) {
+	cfg, err := ParseConfig([]byte(fullValidConfig))
+	require.NoError(t, err)
+
+	assert.Equal(t, "/var/lib/fullhistory", cfg.Service.DefaultDataDir)
+	assert.Equal(t, 8, *cfg.Backfill.Workers)
+	assert.Equal(t, 5, *cfg.Backfill.MaxRetries)
+	assert.Equal(t, "my-bucket/ledgers", cfg.Backfill.BSB.BucketPath)
+	assert.Equal(t, 2000, *cfg.Backfill.BSB.BufferSize)
+	assert.Equal(t, 40, *cfg.Backfill.BSB.NumWorkers)
+	assert.Equal(t, "/mnt/ledgers", cfg.ImmutableStorage.Ledgers.Path)
+	assert.Equal(t, "/mnt/catalog", cfg.Catalog.Path)
+	assert.Equal(t, uint32(100), *cfg.Streaming.RetentionChunks)
+	assert.Equal(t, "now", cfg.Streaming.EarliestLedger)
+	assert.Equal(t, "/etc/captive-core.toml", cfg.Streaming.CaptiveCoreConfig)
+	assert.Equal(t, "/mnt/hot", cfg.Streaming.HotStorage.Path)
+	assert.Equal(t, "debug", cfg.Logging.Level)
+	assert.Equal(t, "json", cfg.Logging.Format)
+}
+
+func TestParseConfig_MinimalAppliesDefaults(t *testing.T) {
+	cfg, err := ParseConfig([]byte(minimalValidConfig))
+	require.NoError(t, err)
+
+	// Required keys preserved.
+	assert.Equal(t, "/data", cfg.Service.DefaultDataDir)
+	assert.Equal(t, "bucket/path", cfg.Backfill.BSB.BucketPath)
+	assert.Equal(t, "/etc/cc.toml", cfg.Streaming.CaptiveCoreConfig)
+
+	// Documented defaults filled.
+	assert.Equal(t, runtime.GOMAXPROCS(0), *cfg.Backfill.Workers)
+	assert.Equal(t, DefaultMaxRetries, *cfg.Backfill.MaxRetries)
+	assert.Equal(t, DefaultBSBBufferSize, *cfg.Backfill.BSB.BufferSize)
+	assert.Equal(t, DefaultBSBNumWorkers, *cfg.Backfill.BSB.NumWorkers)
+	assert.Equal(t, uint32(0), *cfg.Streaming.RetentionChunks)
+	assert.Equal(t, DefaultEarliestLedger, cfg.Streaming.EarliestLedger)
+	assert.Equal(t, DefaultLogLevel, cfg.Logging.Level)
+	assert.Equal(t, DefaultLogFormat, cfg.Logging.Format)
+}
+
+func TestParseConfig_ExplicitZeroPreserved(t *testing.T) {
+	// An explicit zero must NOT be overwritten by the default — validateConfig
+	// is what rejects an illegal zero (e.g. workers), so the defaulting layer
+	// must preserve it for that rejection to fire.
+	const cfgText = `
+[service]
+default_data_dir = "/d"
+[backfill]
+workers = 0
+max_retries = 0
+[streaming]
+captive_core_config = "/cc"
+`
+	cfg, err := ParseConfig([]byte(cfgText))
+	require.NoError(t, err)
+	assert.Equal(t, 0, *cfg.Backfill.Workers)
+	assert.Equal(t, 0, *cfg.Backfill.MaxRetries)
+}
+
+func TestParseConfig_Malformed(t *testing.T) {
+	_, err := ParseConfig([]byte(`this is = = not valid toml [[[`))
+	require.Error(t, err)
+}
+
+// A typo'd key must be REJECTED, not silently dropped to a default. The
+// layout-defining key (earliest_ledger) is pinned immutably on first start, so
+// a silent fallback would permanently pin the wrong value. Strict decoding
+// catches the typo before any pin is written.
+func TestParseConfig_RejectsUnknownKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+	}{
+		{
+			name: "typo'd workers",
+			text: `
+[service]
+default_data_dir = "/d"
+[backfill]
+workrs = 7
+[streaming]
+captive_core_config = "/cc"
+`,
+		},
+		{
+			name: "typo'd earliest_ledger",
+			text: `
+[service]
+default_data_dir = "/d"
+[streaming]
+earliest_ledgr = "now"
+captive_core_config = "/cc"
+`,
+		},
+		{
+			name: "unknown top-level key",
+			text: `
+default_data_dirr = "/d"
+[service]
+default_data_dir = "/d"
+[streaming]
+captive_core_config = "/cc"
+`,
+		},
+		{
+			name: "unknown section",
+			text: `
+[service]
+default_data_dir = "/d"
+[bogus_section]
+foo = "bar"
+[streaming]
+captive_core_config = "/cc"
+`,
+		},
+		{
+			name: "unknown nested key under known section",
+			text: `
+[service]
+default_data_dir = "/d"
+[backfill.bsb]
+bucket_path = "b/p"
+bufer_size = 10
+[streaming]
+captive_core_config = "/cc"
+`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseConfig([]byte(tc.text))
+			require.Error(t, err, "an unknown/typo'd key must be rejected, not silently defaulted")
+			assert.Contains(t, err.Error(), "parse config")
+		})
+	}
+}
+
+func TestResolvePaths_DefaultsUnderDataDir(t *testing.T) {
+	cfg, err := ParseConfig([]byte(minimalValidConfig))
+	require.NoError(t, err)
+	p := cfg.ResolvePaths()
+
+	assert.Equal(t, "/data", p.DataDir)
+	assert.Equal(t, filepath.Join("/data", "catalog", "rocksdb"), p.Catalog)
+	assert.Equal(t, filepath.Join("/data", "ledgers"), p.Ledgers)
+	assert.Equal(t, filepath.Join("/data", "hot"), p.HotStorage)
+}
+
+func TestResolvePaths_OverridesWin(t *testing.T) {
+	cfg, err := ParseConfig([]byte(fullValidConfig))
+	require.NoError(t, err)
+	p := cfg.ResolvePaths()
+
+	assert.Equal(t, "/mnt/catalog", p.Catalog)
+	assert.Equal(t, "/mnt/ledgers", p.Ledgers)
+	assert.Equal(t, "/mnt/hot", p.HotStorage)
+}
+
+func TestLockRoots_AllDistinctRoots(t *testing.T) {
+	cfg, err := ParseConfig([]byte(minimalValidConfig))
+	require.NoError(t, err)
+	roots := cfg.ResolvePaths().LockRoots()
+	// Meta store + ledgers tree + hot storage = three roots.
+	require.Len(t, roots, 3)
+	assert.NotContains(t, roots, "/data", "the data dir parent is not itself locked")
+}

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/config_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/config_test.go
@@ -120,10 +120,9 @@ func TestParseConfig_Malformed(t *testing.T) {
 	require.Error(t, err)
 }
 
-// A typo'd key must be REJECTED, not silently dropped to a default. The
-// layout-defining key (earliest_ledger) is pinned immutably on first start, so
-// a silent fallback would permanently pin the wrong value. Strict decoding
-// catches the typo before any pin is written.
+// A typo'd key must be REJECTED, not silently defaulted: earliest_ledger is
+// pinned immutably on first start, so a silent fallback would permanently pin
+// the wrong value. Strict decoding catches the typo before any pin is written.
 func TestParseConfig_RejectsUnknownKeys(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/config_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/config_test.go
@@ -25,8 +25,8 @@ bucket_path = "my-bucket/ledgers"
 buffer_size = 2000
 num_workers = 40
 
-[immutable_storage.ledgers]
-path = "/mnt/ledgers"
+[immutable_storage]
+path = "/mnt/cold"
 
 [catalog]
 path = "/mnt/catalog"
@@ -66,7 +66,7 @@ func TestParseConfig_FullDocument(t *testing.T) {
 	assert.Equal(t, "my-bucket/ledgers", cfg.Backfill.BSB.BucketPath)
 	assert.Equal(t, 2000, *cfg.Backfill.BSB.BufferSize)
 	assert.Equal(t, 40, *cfg.Backfill.BSB.NumWorkers)
-	assert.Equal(t, "/mnt/ledgers", cfg.ImmutableStorage.Ledgers.Path)
+	assert.Equal(t, "/mnt/cold", cfg.ImmutableStorage.Path)
 	assert.Equal(t, "/mnt/catalog", cfg.Catalog.Path)
 	assert.Equal(t, uint32(100), *cfg.Streaming.RetentionChunks)
 	assert.Equal(t, "now", cfg.Streaming.EarliestLedger)
@@ -200,7 +200,7 @@ func TestResolvePaths_DefaultsUnderDataDir(t *testing.T) {
 
 	assert.Equal(t, "/data", p.DataDir)
 	assert.Equal(t, filepath.Join("/data", "catalog", "rocksdb"), p.Catalog)
-	assert.Equal(t, filepath.Join("/data", "ledgers"), p.Ledgers)
+	assert.Equal(t, "/data", p.Cold, "the cold root defaults to the data dir")
 	assert.Equal(t, filepath.Join("/data", "hot"), p.HotStorage)
 }
 
@@ -210,7 +210,7 @@ func TestResolvePaths_OverridesWin(t *testing.T) {
 	p := cfg.ResolvePaths()
 
 	assert.Equal(t, "/mnt/catalog", p.Catalog)
-	assert.Equal(t, "/mnt/ledgers", p.Ledgers)
+	assert.Equal(t, "/mnt/cold", p.Cold)
 	assert.Equal(t, "/mnt/hot", p.HotStorage)
 }
 
@@ -218,7 +218,9 @@ func TestLockRoots_AllDistinctRoots(t *testing.T) {
 	cfg, err := ParseConfig([]byte(minimalValidConfig))
 	require.NoError(t, err)
 	roots := cfg.ResolvePaths().LockRoots()
-	// Meta store + ledgers tree + hot storage = three roots.
+	// Meta store + cold-tier root + hot storage = three roots.
 	require.Len(t, roots, 3)
-	assert.NotContains(t, roots, "/data", "the data dir parent is not itself locked")
+	assert.Contains(t, roots, filepath.Join("/data", "catalog", "rocksdb"))
+	assert.Contains(t, roots, "/data", "the cold-tier root (defaulting to the data dir) is locked")
+	assert.Contains(t, roots, filepath.Join("/data", "hot"))
 }

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/doc.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/doc.go
@@ -1,13 +1,12 @@
 // Package streaming holds the orchestration spine for the full-history
 // streaming daemon: catch-up on startup, live ingestion from captive core, and
 // the freeze → discard → prune lifecycle over the merged storage layer
-// (fullhistory/pkg/...). It is built ON that layer — the catalog WRAPS
-// metastore.Store rather than reinventing a RocksDB wrapper.
+// (fullhistory/pkg/...). The catalog WRAPS metastore.Store rather than
+// reinventing a RocksDB wrapper.
 //
-// This file map covers Slice 1 · Layer 1 (foundations): the durable-state
-// substrate only, with no daemon goroutines yet. The storage primitives,
-// orchestration, and daemon assembly stack on top in later layers (see "Later
-// layers" below).
+// This covers Slice 1 · Layer 1 (foundations): the durable-state substrate
+// only, no daemon goroutines yet. Storage, orchestration, and daemon assembly
+// stack on top in later layers.
 //
 // # Data model (keys-first)
 //
@@ -20,12 +19,10 @@
 //
 // # File map
 //
-// This is intentionally one cohesive package, not a flat dump: the crash-safety
-// invariants are verified by fault-injection hooks fired from INSIDE the real
-// methods (see hooks.go), so the catalog, the one-write protocol, the sweeps,
-// and the I/O paths they protect must share a package to keep those hooks
-// package-private and the invariant tests meaningful. The files group by layer;
-// this layer adds:
+// One cohesive package by design: the crash-safety invariants are verified by
+// fault-injection hooks fired from INSIDE the real methods (hooks.go), so the
+// catalog, protocol, sweeps, and the I/O paths they protect must share a
+// package to keep those hooks package-private. This layer adds:
 //
 //	Foundation     keys.go, paths.go
 //	                 the catalog key schema, the key↔path bijection, and chunk
@@ -43,12 +40,6 @@
 //	                 test-only crash-injection points fired from inside the real
 //	                 protocol/sweep methods (every field nil in production).
 //
-// # Later layers
-//
-// Slice 1 stacks on this foundation: Layer 2 adds the per-chunk hot DB and
-// processChunk (storage primitives); Layer 3 adds the postcondition
-// resolver/executor, the live ingestion loop, and the lifecycle tick
-// (orchestration); Layer 4 adds startStreaming, validateConfig, surgical
-// recovery, and the audit command (daemon assembly). Slices 2 and 3 then weave
-// in the events and tx-hash data types.
+// Layers 2–4 stack on this foundation (storage → orchestration → daemon
+// assembly); slices 2–3 add the events and tx-hash data types.
 package streaming

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/doc.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/doc.go
@@ -4,15 +4,19 @@
 // (fullhistory/pkg/...). It is built ON that layer — the catalog WRAPS
 // metastore.Store rather than reinventing a RocksDB wrapper.
 //
+// This file map covers Slice 1 · Layer 1 (foundations): the durable-state
+// substrate only, with no daemon goroutines yet. The storage primitives,
+// orchestration, and daemon assembly stack on top in later layers (see "Later
+// layers" below).
+//
 // # Data model (keys-first)
 //
 // Every durable artifact (a per-chunk file) and every per-chunk hot DB is named
-// by exactly one meta-store key, and the path on disk is a fixed bijection of
-// that key. Nothing ever lists a directory to find work; every scan and sweep
+// by exactly one catalog key, and the path on disk is a fixed bijection of that
+// key. Nothing ever lists a directory to find work; every scan and sweep
 // iterates keys. The authoritative spec is
 // design-docs/full-history-streaming-workflow.md (Data model, One write
-// protocol). See also design-docs/full-history-implementation-status.md for the
-// issue-by-issue map of this package.
+// protocol).
 //
 // # File map
 //
@@ -20,38 +24,31 @@
 // invariants are verified by fault-injection hooks fired from INSIDE the real
 // methods (see hooks.go), so the catalog, the one-write protocol, the sweeps,
 // and the I/O paths they protect must share a package to keep those hooks
-// package-private and the invariant tests meaningful. The files group by layer:
+// package-private and the invariant tests meaningful. The files group by layer;
+// this layer adds:
 //
 //	Foundation     keys.go, paths.go
-//	                 key schema, the key↔path bijection, and chunk geometry.
+//	                 the catalog key schema, the key↔path bijection, and chunk
+//	                 geometry.
 //	Catalog        catalog.go, catalog_protocol.go, catalog_sweep.go
-//	                 the meta-store wrapper, the one-write protocol
-//	                 (mark "freezing" → fsync file+dirent → flip "frozen"), and
-//	                 the key-driven sweep (the only deletion body).
-//	Config         config.go, config_validate.go, config_lock.go
-//	                 the TOML schema, validateConfig, and single-process flock.
-//	Freeze engine  process.go, artifacts.go, eligibility.go,
-//	               resolve.go, execute.go
-//	                 processChunk + backfillSource materialize a chunk's cold
-//	                 artifacts; resolve/execute are the postcondition planner and
-//	                 the bounded-worker executor.
-//	Ingestion      ingest.go, hotsource.go
-//	                 the live hot-DB ingestion loop (indexed GetLedger, one
-//	                 synced WriteBatch per ledger) and the hot freeze source.
-//	Orchestration  progress.go, lifecycle.go, retention.go, startup.go, daemon.go
-//	                 derived progress, the lifecycle tick, retention arithmetic,
-//	                 startStreaming, and the daemon/CLI wiring.
-//	Operability    recovery.go, audit.go, audit_invariants.go, observability.go
-//	                 surgical recovery, the audit command (INV-1..4) plus its
-//	                 invariant walks, and the metrics + structured-logging sink.
+//	                 the catalog (a metastore.Store wrapper), the one-write
+//	                 protocol (mark "freezing" → fsync file+dirent → flip
+//	                 "frozen"), and the key-driven sweep (the only deletion body).
+//	Config         config.go, config_lock.go
+//	                 the TOML schema/loader/defaults and the single-process flock
+//	                 over the catalog + storage roots.
+//	Cross-cutting  artifacts.go
+//	                 the ArtifactSet/Kind abstraction the later layers subset.
 //	Test seam      hooks.go
 //	                 test-only crash-injection points fired from inside the real
-//	                 protocol/sweep/ingest methods (every field nil in production).
+//	                 protocol/sweep methods (every field nil in production).
 //
-// Dependencies flow downward — foundation ← catalog ← {config, freeze engine,
-// ingestion} ← orchestration — wired by a config-struct hierarchy
-// (ProcessConfig → ExecConfig → LifecycleConfig → StartConfig) and by
-// consumer-defined interfaces (LedgerGetter, CoreOpener, NetworkTipBackend,
-// Metrics, DeepDeriver, HotProbe/HotChunk/BackendWaiter), so each layer is
-// wired at the edges and independently testable.
+// # Later layers
+//
+// Slice 1 stacks on this foundation: Layer 2 adds the per-chunk hot DB and
+// processChunk (storage primitives); Layer 3 adds the postcondition
+// resolver/executor, the live ingestion loop, and the lifecycle tick
+// (orchestration); Layer 4 adds startStreaming, validateConfig, surgical
+// recovery, and the audit command (daemon assembly). Slices 2 and 3 then weave
+// in the events and tx-hash data types.
 package streaming

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/doc.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/doc.go
@@ -1,0 +1,57 @@
+// Package streaming holds the orchestration spine for the full-history
+// streaming daemon: catch-up on startup, live ingestion from captive core, and
+// the freeze → discard → prune lifecycle over the merged storage layer
+// (fullhistory/pkg/...). It is built ON that layer — the catalog WRAPS
+// metastore.Store rather than reinventing a RocksDB wrapper.
+//
+// # Data model (keys-first)
+//
+// Every durable artifact (a per-chunk file) and every per-chunk hot DB is named
+// by exactly one meta-store key, and the path on disk is a fixed bijection of
+// that key. Nothing ever lists a directory to find work; every scan and sweep
+// iterates keys. The authoritative spec is
+// design-docs/full-history-streaming-workflow.md (Data model, One write
+// protocol). See also design-docs/full-history-implementation-status.md for the
+// issue-by-issue map of this package.
+//
+// # File map
+//
+// This is intentionally one cohesive package, not a flat dump: the crash-safety
+// invariants are verified by fault-injection hooks fired from INSIDE the real
+// methods (see hooks.go), so the catalog, the one-write protocol, the sweeps,
+// and the I/O paths they protect must share a package to keep those hooks
+// package-private and the invariant tests meaningful. The files group by layer:
+//
+//	Foundation     keys.go, paths.go
+//	                 key schema, the key↔path bijection, and chunk geometry.
+//	Catalog        catalog.go, catalog_protocol.go, catalog_sweep.go
+//	                 the meta-store wrapper, the one-write protocol
+//	                 (mark "freezing" → fsync file+dirent → flip "frozen"), and
+//	                 the key-driven sweep (the only deletion body).
+//	Config         config.go, config_validate.go, config_lock.go
+//	                 the TOML schema, validateConfig, and single-process flock.
+//	Freeze engine  process.go, artifacts.go, eligibility.go,
+//	               resolve.go, execute.go
+//	                 processChunk + backfillSource materialize a chunk's cold
+//	                 artifacts; resolve/execute are the postcondition planner and
+//	                 the bounded-worker executor.
+//	Ingestion      ingest.go, hotsource.go
+//	                 the live hot-DB ingestion loop (indexed GetLedger, one
+//	                 synced WriteBatch per ledger) and the hot freeze source.
+//	Orchestration  progress.go, lifecycle.go, retention.go, startup.go, daemon.go
+//	                 derived progress, the lifecycle tick, retention arithmetic,
+//	                 startStreaming, and the daemon/CLI wiring.
+//	Operability    recovery.go, audit.go, audit_invariants.go, observability.go
+//	                 surgical recovery, the audit command (INV-1..4) plus its
+//	                 invariant walks, and the metrics + structured-logging sink.
+//	Test seam      hooks.go
+//	                 test-only crash-injection points fired from inside the real
+//	                 protocol/sweep/ingest methods (every field nil in production).
+//
+// Dependencies flow downward — foundation ← catalog ← {config, freeze engine,
+// ingestion} ← orchestration — wired by a config-struct hierarchy
+// (ProcessConfig → ExecConfig → LifecycleConfig → StartConfig) and by
+// consumer-defined interfaces (LedgerGetter, CoreOpener, NetworkTipBackend,
+// Metrics, DeepDeriver, HotProbe/HotChunk/BackendWaiter), so each layer is
+// wired at the edges and independently testable.
+package streaming

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/hooks.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/hooks.go
@@ -33,7 +33,7 @@ import "github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/
 type crashHooks struct {
 	beforeKeyDelete    func()
 	beforeUnlink       func()
-	failCommitBatch    func() bool //nolint:unused // fired from a later layer (recovery/CommitIndex)
+	failCommitBatch    func() bool //nolint:unused // fired from a later layer (recovery)
 	afterMarkFreezing  func()      //nolint:unused // fired from a later layer (processChunk)
 	beforeHotTransient func(chunkID chunk.ID)
 }
@@ -50,7 +50,7 @@ func (h crashHooks) fireBeforeUnlink() {
 	}
 }
 
-//nolint:unused // called from a later layer (catalog_protocol/recovery)
+//nolint:unused // called from a later layer (recovery)
 func (h crashHooks) commitBatchShouldFail() bool {
 	return h.failCommitBatch != nil && h.failCommitBatch()
 }

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/hooks.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/hooks.go
@@ -1,0 +1,76 @@
+package streaming
+
+import "github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
+
+// crashHooks are test-only fault-injection points interposed at the
+// load-bearing instants of the one-write protocol and the sweeps. In
+// production every field is nil and every call site is a no-op, so the hooks
+// add one nil-check per protected step and nothing else.
+//
+// They exist because the crash-safety invariants are properties of the ORDER
+// of operations inside the real catalog methods (sweep.go, protocol.go), not
+// of a test that hand-replays those steps. A hand-inlined sweep can stay green
+// even after the production order is broken; a hook fired from INSIDE the real
+// method cannot. Each hook observes durable state at the exact instant between
+// two steps and lets the test assert the invariant that the step ORDER is
+// meant to guarantee:
+//
+//   - beforeKeyDelete fires AFTER the unlink+fsync and BEFORE the key delete.
+//     Asserts file-gone-implies-key-present: if the key delete were reordered
+//     ahead of the unlink, the file would still be on disk here.
+//   - beforeUnlink fires AFTER the frozen->pruning demote and BEFORE the
+//     unlink. Asserts never-unlink-under-a-frozen-key: the value must already
+//     be "pruning"; if the demote were dropped, it would still be "frozen".
+//   - failCommitBatch, when it returns true, forces a recovery batch callback to
+//     return an error so the batch is dropped wholesale. Asserts all-or-nothing:
+//     nothing the batch would have written may be observable.
+//   - afterMarkFreezing fires INSIDE processChunk, AFTER MarkChunkFreezing has
+//     put every requested kind's key to "freezing" and BEFORE any file I/O.
+//     Asserts mark-then-write: at this instant every requested kind reads
+//     "freezing" and no artifact file exists yet. Dropping the mark (or
+//     reordering the write ahead of it) would leave the keys absent (or a file
+//     on disk) here — defeating "every file on disk is reachable from a key"
+//     and crash detectability.
+//   - beforeHotTransient fires INSIDE PutHotTransient, BEFORE the hot:chunk key
+//     is written "transient", carrying the chunk whose key is about to appear.
+//     At a boundary handoff this is the exact instant the next chunk's key is
+//     created: the ingestion loop guarantees the just-completed chunk's write
+//     handle is already CLOSED here (close-before-create-key), so a test can
+//     assert the closed-ness of the predecessor's DB at the one instant the
+//     partition moves. Dropping the close-before-open order would leave the
+//     predecessor's DB open under a live writer here.
+type crashHooks struct {
+	beforeKeyDelete    func()
+	beforeUnlink       func()
+	failCommitBatch    func() bool
+	afterMarkFreezing  func()
+	beforeHotTransient func(chunkID chunk.ID)
+}
+
+func (h crashHooks) fireBeforeKeyDelete() {
+	if h.beforeKeyDelete != nil {
+		h.beforeKeyDelete()
+	}
+}
+
+func (h crashHooks) fireBeforeUnlink() {
+	if h.beforeUnlink != nil {
+		h.beforeUnlink()
+	}
+}
+
+func (h crashHooks) commitBatchShouldFail() bool {
+	return h.failCommitBatch != nil && h.failCommitBatch()
+}
+
+func (h crashHooks) fireAfterMarkFreezing() {
+	if h.afterMarkFreezing != nil {
+		h.afterMarkFreezing()
+	}
+}
+
+func (h crashHooks) fireBeforeHotTransient(chunkID chunk.ID) {
+	if h.beforeHotTransient != nil {
+		h.beforeHotTransient(chunkID)
+	}
+}

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/hooks.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/hooks.go
@@ -2,43 +2,34 @@ package streaming
 
 import "github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
 
-// crashHooks are test-only fault-injection points interposed at the
-// load-bearing instants of the one-write protocol and the sweeps. In
-// production every field is nil and every call site is a no-op, so the hooks
-// add one nil-check per protected step and nothing else.
+// crashHooks are test-only fault-injection points at the load-bearing instants
+// of the one-write protocol and the sweeps. In production every field is nil
+// and every call site is a no-op nil-check.
 //
-// They exist because the crash-safety invariants are properties of the ORDER
-// of operations inside the real catalog methods (sweep.go, protocol.go), not
-// of a test that hand-replays those steps. A hand-inlined sweep can stay green
-// even after the production order is broken; a hook fired from INSIDE the real
-// method cannot. Each hook observes durable state at the exact instant between
-// two steps and lets the test assert the invariant that the step ORDER is
-// meant to guarantee:
+// They exist because the crash-safety invariants are properties of the ORDER of
+// operations inside the real methods (catalog_sweep.go, catalog_protocol.go): a
+// hand-replayed sweep can stay green after the production order breaks, but a
+// hook fired from INSIDE the real method cannot. Each fires at the exact instant
+// between two steps so a test can assert the invariant that order guarantees:
 //
-//   - beforeKeyDelete fires AFTER the unlink+fsync and BEFORE the key delete.
-//     Asserts file-gone-implies-key-present: if the key delete were reordered
-//     ahead of the unlink, the file would still be on disk here.
-//   - beforeUnlink fires AFTER the frozen->pruning demote and BEFORE the
-//     unlink. Asserts never-unlink-under-a-frozen-key: the value must already
-//     be "pruning"; if the demote were dropped, it would still be "frozen".
-//   - failCommitBatch, when it returns true, forces a recovery batch callback to
-//     return an error so the batch is dropped wholesale. Asserts all-or-nothing:
-//     nothing the batch would have written may be observable.
-//   - afterMarkFreezing fires INSIDE processChunk, AFTER MarkChunkFreezing has
-//     put every requested kind's key to "freezing" and BEFORE any file I/O.
-//     Asserts mark-then-write: at this instant every requested kind reads
-//     "freezing" and no artifact file exists yet. Dropping the mark (or
-//     reordering the write ahead of it) would leave the keys absent (or a file
-//     on disk) here — defeating "every file on disk is reachable from a key"
-//     and crash detectability.
+//   - beforeKeyDelete fires AFTER unlink+fsync, BEFORE the key delete. Asserts
+//     file-gone-implies-key-present: reorder the delete ahead of the unlink and
+//     the file would still be on disk here.
+//   - beforeUnlink fires AFTER the frozen→pruning demote, BEFORE the unlink.
+//     Asserts never-unlink-under-a-frozen-key: the value must read "pruning";
+//     drop the demote and it would still be "frozen".
+//   - failCommitBatch, when true, forces a recovery batch callback to error so
+//     the batch is dropped wholesale. Asserts all-or-nothing: nothing it would
+//     have written is observable.
+//   - afterMarkFreezing fires INSIDE processChunk, AFTER MarkChunkFreezing and
+//     BEFORE any file I/O. Asserts mark-then-write: every requested kind reads
+//     "freezing" and no artifact file exists yet, so every file on disk stays
+//     reachable from a key.
 //   - beforeHotTransient fires INSIDE PutHotTransient, BEFORE the hot:chunk key
-//     is written "transient", carrying the chunk whose key is about to appear.
-//     At a boundary handoff this is the exact instant the next chunk's key is
-//     created: the ingestion loop guarantees the just-completed chunk's write
-//     handle is already CLOSED here (close-before-create-key), so a test can
-//     assert the closed-ness of the predecessor's DB at the one instant the
-//     partition moves. Dropping the close-before-open order would leave the
-//     predecessor's DB open under a live writer here.
+//     is written, carrying the chunk about to appear. At a boundary handoff this
+//     is when the next chunk's key is created: the ingestion loop guarantees the
+//     predecessor's write handle is already CLOSED (close-before-create-key), so
+//     a test can assert that at the one instant the partition moves.
 type crashHooks struct {
 	beforeKeyDelete    func()
 	beforeUnlink       func()

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/hooks.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/hooks.go
@@ -42,8 +42,8 @@ import "github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/
 type crashHooks struct {
 	beforeKeyDelete    func()
 	beforeUnlink       func()
-	failCommitBatch    func() bool
-	afterMarkFreezing  func()
+	failCommitBatch    func() bool //nolint:unused // fired from a later layer (recovery/CommitIndex)
+	afterMarkFreezing  func()      //nolint:unused // fired from a later layer (processChunk)
 	beforeHotTransient func(chunkID chunk.ID)
 }
 
@@ -59,10 +59,12 @@ func (h crashHooks) fireBeforeUnlink() {
 	}
 }
 
+//nolint:unused // called from a later layer (catalog_protocol/recovery)
 func (h crashHooks) commitBatchShouldFail() bool {
 	return h.failCommitBatch != nil && h.failCommitBatch()
 }
 
+//nolint:unused // called from a later layer (processChunk)
 func (h crashHooks) fireAfterMarkFreezing() {
 	if h.afterMarkFreezing != nil {
 		h.afterMarkFreezing()

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/keys.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/keys.go
@@ -1,0 +1,139 @@
+package streaming
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
+)
+
+// State is an artifact key's lifecycle value. The empty State (key absent)
+// means "neither file nor in-progress write exists".
+type State string
+
+const (
+	// StateFreezing — the immutable file is being written. Set BEFORE any I/O
+	// (the mark-then-write rule), so a crash mid-write is detectable from the
+	// key alone and every file on disk is reachable from a key.
+	StateFreezing State = "freezing"
+	// StateFrozen — the file and its dirent are fsynced and durable. Truth:
+	// readers and the resolver trust it blindly.
+	StateFrozen State = "frozen"
+	// StatePruning — the file is queued for removal; it may or may not still be
+	// on disk. A sweep finishes the unlink and then deletes the key.
+	StatePruning State = "pruning"
+)
+
+// HotState is a hot-DB key's value. One key per chunk brackets the chunk's
+// hot RocksDB directory; the column families inside carry no individual key.
+type HotState string
+
+const (
+	// HotTransient — a directory operation is in flight (creation or
+	// deletion), or a recovery demoted the key. The recovery is identical
+	// either way: the open path wipes and recreates, the discard scan re-runs.
+	HotTransient HotState = "transient"
+	// HotReady — the dir exists and is usable for reads and writes.
+	HotReady HotState = "ready"
+)
+
+// Kind is a per-chunk artifact kind. Each maps to one meta-store key suffix
+// and one set of on-disk files.
+type Kind string
+
+const (
+	// KindLedgers is the ledger pack file (.pack).
+	KindLedgers Kind = "ledgers"
+)
+
+// allKinds is the canonical iteration order for per-chunk artifact kinds.
+//
+//nolint:gochecknoglobals // immutable kind registry, single source of truth
+var allKinds = []Kind{KindLedgers}
+
+// AllKinds returns the per-chunk artifact kinds in canonical order.
+func AllKinds() []Kind { return append([]Kind(nil), allKinds...) }
+
+// ---------------------------------------------------------------------------
+// Key prefixes and constructors. Every key is built here so the key<->path
+// bijection has exactly one source of truth (see paths.go for the inverse).
+// ---------------------------------------------------------------------------
+
+const (
+	chunkPrefix = "chunk:"
+	hotPrefix   = "hot:chunk:"
+
+	// Config pins.
+	configEarliestLedger = "config:earliest_ledger"
+)
+
+// chunkKey returns the per-chunk artifact key chunk:{chunk:08d}:{kind}.
+func chunkKey(c chunk.ID, kind Kind) string {
+	return chunkPrefix + c.String() + ":" + string(kind)
+}
+
+// hotChunkKey returns the hot-DB key hot:chunk:{chunk:08d}.
+func hotChunkKey(c chunk.ID) string {
+	return hotPrefix + c.String()
+}
+
+// ---------------------------------------------------------------------------
+// Key parsing. The inverse of the constructors above; every parser is the
+// reverse bijection of exactly one constructor.
+// ---------------------------------------------------------------------------
+
+// parseChunkKey decodes chunk:{chunk:08d}:{kind}. ok is false for any key that
+// is not a well-formed per-chunk artifact key.
+func parseChunkKey(key string) (chunk.ID, Kind, bool) {
+	rest, found := strings.CutPrefix(key, chunkPrefix)
+	if !found {
+		return 0, "", false
+	}
+	id, suffix, found := strings.Cut(rest, ":")
+	if !found {
+		return 0, "", false
+	}
+	n, err := parsePadded(id)
+	if err != nil {
+		return 0, "", false
+	}
+	kind := Kind(suffix)
+	if !isKnownKind(kind) {
+		return 0, "", false
+	}
+	return chunk.ID(n), kind, true
+}
+
+// parseHotChunkKey decodes hot:chunk:{chunk:08d}.
+func parseHotChunkKey(key string) (chunk.ID, bool) {
+	rest, found := strings.CutPrefix(key, hotPrefix)
+	if !found {
+		return 0, false
+	}
+	n, err := parsePadded(rest)
+	if err != nil {
+		return 0, false
+	}
+	return chunk.ID(n), true
+}
+
+// parsePadded parses an 8-digit zero-padded decimal segment as produced by
+// chunk.ID.String(). It enforces the fixed 8-char width so the bijection is
+// exact — a non-padded or wrong-width segment is rejected, not silently
+// accepted.
+func parsePadded(s string) (uint32, error) {
+	if len(s) != 8 {
+		return 0, fmt.Errorf("streaming: %q is not an 8-digit padded id", s)
+	}
+	n, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("streaming: %q is not numeric: %w", s, err)
+	}
+	return uint32(n), nil
+}
+
+func isKnownKind(k Kind) bool {
+	return slices.Contains(allKinds, k)
+}

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/keys.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/keys.go
@@ -14,15 +14,14 @@ import (
 type State string
 
 const (
-	// StateFreezing — the immutable file is being written. Set BEFORE any I/O
-	// (the mark-then-write rule), so a crash mid-write is detectable from the
-	// key alone and every file on disk is reachable from a key.
+	// StateFreezing — file being written; set before any I/O. See the one-write
+	// protocol in catalog_protocol.go.
 	StateFreezing State = "freezing"
-	// StateFrozen — the file and its dirent are fsynced and durable. Truth:
-	// readers and the resolver trust it blindly.
+	// StateFrozen — file and dirent fsynced and durable; readers and the
+	// resolver trust it blindly.
 	StateFrozen State = "frozen"
-	// StatePruning — the file is queued for removal; it may or may not still be
-	// on disk. A sweep finishes the unlink and then deletes the key.
+	// StatePruning — file queued for removal (may still be on disk); a sweep
+	// finishes the unlink, then deletes the key. See catalog_sweep.go.
 	StatePruning State = "pruning"
 )
 
@@ -31,9 +30,9 @@ const (
 type HotState string
 
 const (
-	// HotTransient — a directory operation is in flight (creation or
-	// deletion), or a recovery demoted the key. The recovery is identical
-	// either way: the open path wipes and recreates, the discard scan re-runs.
+	// HotTransient — a directory operation is in flight (creation or deletion),
+	// or recovery demoted the key. Recovery is identical either way: the open
+	// path wipes and recreates, the discard scan re-runs.
 	HotTransient HotState = "transient"
 	// HotReady — the dir exists and is usable for reads and writes.
 	HotReady HotState = "ready"
@@ -56,10 +55,8 @@ var allKinds = []Kind{KindLedgers}
 // AllKinds returns the per-chunk artifact kinds in canonical order.
 func AllKinds() []Kind { return append([]Kind(nil), allKinds...) }
 
-// ---------------------------------------------------------------------------
-// Key prefixes and constructors. Every key is built here so the key<->path
-// bijection has exactly one source of truth (see paths.go for the inverse).
-// ---------------------------------------------------------------------------
+// Key prefixes and constructors. Every key is built here so the key↔path
+// bijection has one source of truth (paths.go holds the inverse).
 
 const (
 	chunkPrefix = "chunk:"
@@ -79,10 +76,8 @@ func hotChunkKey(c chunk.ID) string {
 	return hotPrefix + c.String()
 }
 
-// ---------------------------------------------------------------------------
-// Key parsing. The inverse of the constructors above; every parser is the
-// reverse bijection of exactly one constructor.
-// ---------------------------------------------------------------------------
+// Key parsing — the inverse of the constructors above; one parser per
+// constructor.
 
 // parseChunkKey decodes chunk:{chunk:08d}:{kind}. ok is false for any key that
 // is not a well-formed per-chunk artifact key.

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/paths.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/paths.go
@@ -54,7 +54,7 @@ func NewLayoutFromPaths(p Paths) Layout {
 	return Layout{
 		catalogRoot: p.Catalog,
 		hotRoot:     p.HotStorage,
-		ledgersRoot: p.Ledgers,
+		ledgersRoot: filepath.Join(p.Cold, "ledgers"),
 	}
 }
 

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/paths.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/paths.go
@@ -7,10 +7,10 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
 )
 
-// Layout resolves meta-store keys to on-disk paths. It holds one root PER
-// artifact tree — the key<->path mapping is fixed
-// (design-docs/full-history-streaming-workflow.md "Directory layout"), so a
-// Layout plus a key is enough to find any file without listing a directory.
+// Layout resolves meta-store keys to on-disk paths. It holds one root per
+// artifact tree — the key↔path mapping is fixed
+// (design-docs/full-history-streaming-workflow.md "Directory layout") — so a
+// Layout plus a key finds any file without listing a directory.
 //
 // In the default deployment all roots sit under one data dir (NewLayout):
 //
@@ -19,13 +19,10 @@ import (
 //	├── hot/{chunk:08d}/
 //	└── ledgers/{bucket:05d}/{chunk:08d}.pack
 //
-// But each tree's root is independently settable (NewLayoutFromPaths) so an
-// operator's [catalog]/[immutable_storage.*]/[streaming.hot_storage] path
-// overrides are honored — Layout is the SINGLE source of truth for storage
-// paths, and the same roots that get flocked (Paths.LockRoots) are the ones the
-// data path reads/writes. Below each per-tree root the bucket structure is
-// fixed (a bucket is a filesystem concern only; bucket ids never appear in
-// meta-store keys).
+// Each root is independently settable (NewLayoutFromPaths) to honor operator
+// path overrides; Layout is the SINGLE source of truth for storage paths, so
+// the roots that get flocked (Paths.LockRoots) are exactly those the data path
+// reads/writes. Bucket ids are a filesystem concern only — never in keys.
 type Layout struct {
 	catalogRoot string // meta-store RocksDB dir (a leaf, not a tree root)
 	hotRoot     string // per-chunk hot RocksDB dirs live directly under here
@@ -91,13 +88,10 @@ func (l Layout) ArtifactPaths(c chunk.ID, kind Kind) []string {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// fsync barriers — the os-level durability primitives the one-write protocol
-// and the sweeps depend on. A file's creation is durable only once both the
-// file's data AND the directory entry that names it are fsynced; a directory
-// freshly created needs its own parent fsynced too. See the One write
-// protocol section: "the key never outlives the file's creation".
-// ---------------------------------------------------------------------------
+// fsync barriers — the durability primitives the one-write protocol and the
+// sweeps depend on. A file's creation is durable only once both its data AND
+// the dirent that names it are fsynced; a freshly created directory needs its
+// own parent fsynced too.
 
 // fsyncFile opens path and fsyncs its data + metadata. The caller is
 // responsible for fsyncing the parent dirent separately (a file's own fsync

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/paths.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/paths.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
 )
 
-// Layout resolves meta-store keys to on-disk paths. It holds one root per
-// artifact tree — the key↔path mapping is fixed
+// Layout resolves meta-store keys to on-disk paths. It holds a root per storage
+// tree (catalog, hot, ledgers) — the key↔path mapping is fixed
 // (design-docs/full-history-streaming-workflow.md "Directory layout") — so a
 // Layout plus a key finds any file without listing a directory.
 //
@@ -19,10 +19,11 @@ import (
 //	├── hot/{chunk:08d}/
 //	└── ledgers/{bucket:05d}/{chunk:08d}.pack
 //
-// Each root is independently settable (NewLayoutFromPaths) to honor operator
-// path overrides; Layout is the SINGLE source of truth for storage paths, so
-// the roots that get flocked (Paths.LockRoots) are exactly those the data path
-// reads/writes. Bucket ids are a filesystem concern only — never in keys.
+// The configurable boundaries are catalog / cold-tier / hot (NewLayoutFromPaths);
+// the ledgers tree lives under the cold root. Layout is the SINGLE source of
+// truth for storage paths, so the roots that get flocked (Paths.LockRoots) are
+// exactly those the data path reads/writes. Bucket ids are a filesystem concern
+// only — never in keys.
 type Layout struct {
 	catalogRoot string // meta-store RocksDB dir (a leaf, not a tree root)
 	hotRoot     string // per-chunk hot RocksDB dirs live directly under here
@@ -41,12 +42,12 @@ func NewLayout(root string) Layout {
 	}
 }
 
-// NewLayoutFromPaths binds a Layout to RESOLVED per-tree roots — the roots
-// Config.ResolvePaths produced (each override applied, each unset tree defaulted
-// under default_data_dir) and that Paths.LockRoots flocked. This is the binding
-// the daemon/audit/recovery use so the lock and the data location can never
-// disagree: every artifact and hot path below honors the same override the
-// flock was taken on.
+// NewLayoutFromPaths binds a Layout to the RESOLVED roots Config.ResolvePaths
+// produced — catalog, cold-tier, and hot (each override applied, unset roots
+// defaulted under default_data_dir) — and that Paths.LockRoots flocked; the
+// ledgers tree is derived under the cold root. This is the binding the
+// daemon/audit/recovery use so the lock and the data location can never
+// disagree: every path below honors the same root the flock was taken on.
 func NewLayoutFromPaths(p Paths) Layout {
 	return Layout{
 		catalogRoot: p.Catalog,

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/paths.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/paths.go
@@ -1,0 +1,195 @@
+package streaming
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
+)
+
+// Layout resolves meta-store keys to on-disk paths. It holds one root PER
+// artifact tree — the key<->path mapping is fixed
+// (design-docs/full-history-streaming-workflow.md "Directory layout"), so a
+// Layout plus a key is enough to find any file without listing a directory.
+//
+// In the default deployment all roots sit under one data dir (NewLayout):
+//
+//	{root}/
+//	├── catalog/rocksdb/
+//	├── hot/{chunk:08d}/
+//	└── ledgers/{bucket:05d}/{chunk:08d}.pack
+//
+// But each tree's root is independently settable (NewLayoutFromPaths) so an
+// operator's [catalog]/[immutable_storage.*]/[streaming.hot_storage] path
+// overrides are honored — Layout is the SINGLE source of truth for storage
+// paths, and the same roots that get flocked (Paths.LockRoots) are the ones the
+// data path reads/writes. Below each per-tree root the bucket structure is
+// fixed (a bucket is a filesystem concern only; bucket ids never appear in
+// meta-store keys).
+type Layout struct {
+	catalogRoot string // meta-store RocksDB dir (a leaf, not a tree root)
+	hotRoot     string // per-chunk hot RocksDB dirs live directly under here
+	ledgersRoot string // {ledgersRoot}/{bucket}/{chunk}.pack
+}
+
+// NewLayout returns a Layout with every tree defaulting under a single data
+// directory root — the no-override deployment. Equivalent to feeding
+// NewLayoutFromPaths the Paths that Config.ResolvePaths produces when no path
+// override is set. Tests and the default production layout use this.
+func NewLayout(root string) Layout {
+	return Layout{
+		catalogRoot: filepath.Join(root, "catalog", "rocksdb"),
+		hotRoot:     filepath.Join(root, "hot"),
+		ledgersRoot: filepath.Join(root, "ledgers"),
+	}
+}
+
+// NewLayoutFromPaths binds a Layout to RESOLVED per-tree roots — the roots
+// Config.ResolvePaths produced (each override applied, each unset tree defaulted
+// under default_data_dir) and that Paths.LockRoots flocked. This is the binding
+// the daemon/audit/recovery use so the lock and the data location can never
+// disagree: every artifact and hot path below honors the same override the
+// flock was taken on.
+func NewLayoutFromPaths(p Paths) Layout {
+	return Layout{
+		catalogRoot: p.Catalog,
+		hotRoot:     p.HotStorage,
+		ledgersRoot: p.Ledgers,
+	}
+}
+
+// CatalogPath is the meta-store RocksDB directory.
+func (l Layout) CatalogPath() string { return l.catalogRoot }
+
+// HotRoot is the directory under which per-chunk hot RocksDB dirs are created.
+func (l Layout) HotRoot() string { return l.hotRoot }
+
+// HotChunkPath is the per-chunk hot RocksDB directory {hotRoot}/{chunk:08d}/.
+func (l Layout) HotChunkPath(c chunk.ID) string {
+	return filepath.Join(l.hotRoot, c.String())
+}
+
+// LedgerPackPath is {ledgersRoot}/{bucket:05d}/{chunk:08d}.pack.
+func (l Layout) LedgerPackPath(c chunk.ID) string {
+	return filepath.Join(l.ledgersRoot, c.BucketID(), c.String()+".pack")
+}
+
+// LedgersRoot is the directory under which per-chunk ledger packs are bucketed.
+// A cold ledger ingester rooted here composes the {bucket:05d}/{chunk:08d}.pack
+// path matching LedgerPackPath.
+func (l Layout) LedgersRoot() string { return l.ledgersRoot }
+
+// ArtifactPaths returns every file a per-chunk artifact kind owns on disk.
+// One path for ledgers. The single place that maps a (chunk, kind) to its
+// files, so the sweep and the freeze writer agree.
+func (l Layout) ArtifactPaths(c chunk.ID, kind Kind) []string {
+	switch kind {
+	case KindLedgers:
+		return []string{l.LedgerPackPath(c)}
+	default:
+		return nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// fsync barriers — the os-level durability primitives the one-write protocol
+// and the sweeps depend on. A file's creation is durable only once both the
+// file's data AND the directory entry that names it are fsynced; a directory
+// freshly created needs its own parent fsynced too. See the One write
+// protocol section: "the key never outlives the file's creation".
+// ---------------------------------------------------------------------------
+
+// fsyncFile opens path and fsyncs its data + metadata. The caller is
+// responsible for fsyncing the parent dirent separately (a file's own fsync
+// does not make its directory entry durable).
+func fsyncFile(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	syncErr := f.Sync()
+	closeErr := f.Close()
+	if syncErr != nil {
+		return syncErr
+	}
+	return closeErr
+}
+
+// fsyncDir fsyncs a directory entry, making creations and unlinks within it
+// durable. Opening a directory read-only and Sync-ing it is the portable
+// dirent barrier on Linux and macOS. A missing directory is not an error: a
+// sweep may run where the file (and its on-demand bucket/window dir) was never
+// created, in which case there is no dirent to make durable.
+func fsyncDir(dir string) error {
+	f, err := os.Open(dir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	syncErr := f.Sync()
+	closeErr := f.Close()
+	if syncErr != nil {
+		return syncErr
+	}
+	return closeErr
+}
+
+// fsyncDirs fsyncs a set of directories, de-duplicating so a batch of unlinks
+// in one directory pays a single barrier.
+func fsyncDirs(dirs []string) error {
+	seen := make(map[string]struct{}, len(dirs))
+	for _, d := range dirs {
+		if _, ok := seen[d]; ok {
+			continue
+		}
+		seen[d] = struct{}{}
+		if err := fsyncDir(d); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// fsyncParentDirs fsyncs the parent directory of each path (de-duplicated). It
+// is the barrier the sweeps place between unlinks and the key delete: the
+// unlinks become durable BEFORE the key goes.
+func fsyncParentDirs(paths []string) error {
+	dirs := make([]string, 0, len(paths))
+	for _, p := range paths {
+		dirs = append(dirs, filepath.Dir(p))
+	}
+	return fsyncDirs(dirs)
+}
+
+// barrierNewFile makes a freshly written file's creation durable: fsync the
+// file, its parent dirent, and — when newParent is true (the write created the
+// parent directory, e.g. a new bucket dir every 1000th chunk, or a window's
+// first index build) — the grandparent dirent too. This is the exact two-level
+// barrier the one-write protocol mandates before a key flips to "frozen".
+func barrierNewFile(path string, newParent bool) error {
+	if err := fsyncFile(path); err != nil {
+		return err
+	}
+	parent := filepath.Dir(path)
+	if err := fsyncDir(parent); err != nil {
+		return err
+	}
+	if newParent {
+		if err := fsyncDir(filepath.Dir(parent)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// deleteFileIfExists unlinks path, treating an already-absent path as success
+// (sweeps are idempotent and re-run after a crash). Any other error surfaces.
+func deleteFileIfExists(path string) error {
+	err := os.Remove(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/streaming_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/streaming_test.go
@@ -48,9 +48,7 @@ func writeArtifact(t *testing.T, path string) {
 	require.NoError(t, os.WriteFile(path, []byte("artifact"), 0o644))
 }
 
-// ---------------------------------------------------------------------------
-// Key <-> path bijection, both directions.
-// ---------------------------------------------------------------------------
+// Key↔path bijection, both directions.
 
 func TestKeyConstructorsMatchSpec(t *testing.T) {
 	require.Equal(t, "chunk:00005350:ledgers", chunkKey(5350, KindLedgers))
@@ -104,9 +102,7 @@ func TestParseRejectsMalformed(t *testing.T) {
 	require.False(t, ok)
 }
 
-// ---------------------------------------------------------------------------
 // Round-trip every key family through the real metastore.
-// ---------------------------------------------------------------------------
 
 func TestRoundTripChunkKeys(t *testing.T) {
 	cat, _ := testCatalog(t)
@@ -171,9 +167,7 @@ func TestConfigPins(t *testing.T) {
 	require.Equal(t, uint32(2), el)
 }
 
-// ---------------------------------------------------------------------------
 // Scans: HotChunkKeys (value-blind) vs ReadyHotChunkKeys (ready-only).
-// ---------------------------------------------------------------------------
 
 func TestHotChunkKeysValueBlindVsReadyOnly(t *testing.T) {
 	cat, _ := testCatalog(t)
@@ -206,9 +200,7 @@ func TestChunkArtifactKeys(t *testing.T) {
 	require.Equal(t, ArtifactRef{Chunk: 2, Kind: KindLedgers, State: StateFrozen}, refs[1])
 }
 
-// ---------------------------------------------------------------------------
 // Sweep: the deletion body.
-// ---------------------------------------------------------------------------
 
 func TestSweepChunkArtifacts(t *testing.T) {
 	cat, _ := testCatalog(t)
@@ -246,11 +238,8 @@ func TestSweepChunkArtifactsIdempotentOnMissingFiles(t *testing.T) {
 	require.Equal(t, State(""), s)
 }
 
-// ---------------------------------------------------------------------------
 // CRASH-SAFETY tests — interpose at the two dangerous instants and assert both
-// invariants: (A) every file on disk has its meta key; (B) key absent => file
-// gone.
-// ---------------------------------------------------------------------------
+// invariants: (A) every file on disk has its meta key; (B) key absent => file gone.
 
 // assertEveryFileHasKey walks every artifact file under root and asserts a
 // non-empty meta-store key exists for it (Design invariant: "every key
@@ -319,13 +308,9 @@ func TestCrashSafety_FileWrittenKeyNotFlipped(t *testing.T) {
 }
 
 // Crash instant (ii): inside the REAL sweep, between the durable unlink and the
-// key delete.
-//
-// We fire a hook from INSIDE SweepChunkArtifacts at the exact instant after
-// unlink+fsync and before the key-delete batch, and assert the EXIT-side
-// invariant there: file gone => key still present. If the key delete were
-// reordered ahead of the unlink, the file would still be on disk when the hook
-// fires and the in-hook assertion fails.
+// key delete. A hook fires at that exact instant and asserts the EXIT-side
+// invariant: file gone => key still present. Reorder the delete ahead of the
+// unlink and the file would still be on disk when the hook fires.
 func TestCrashSafety_SweepUnlinkDurableKeyNotDeleted(t *testing.T) {
 	cat, root := testCatalog(t)
 

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/streaming_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/streaming_test.go
@@ -1,0 +1,426 @@
+package streaming
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/metastore"
+)
+
+func silentLogger() *supportlog.Entry {
+	var buf bytes.Buffer
+	log := supportlog.New()
+	log.SetLevel(logrus.DebugLevel)
+	log.SetOutput(&buf)
+	return log
+}
+
+// testCatalog builds a Catalog over a real metastore.Store on a temp dir plus
+// a temp artifact dir (the Layout root). Returns the catalog and the artifact
+// root so tests can assert against real files on disk.
+func testCatalog(t *testing.T) (*Catalog, string) {
+	t.Helper()
+	metaDir := t.TempDir()
+	artifactRoot := t.TempDir()
+
+	store, err := metastore.New(filepath.Join(metaDir, "rocksdb"), silentLogger())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	return NewCatalog(store, NewLayout(artifactRoot)), artifactRoot
+}
+
+// writeArtifact materializes a placeholder file at path (creating parents) so a
+// sweep has something real to unlink.
+func writeArtifact(t *testing.T, path string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("artifact"), 0o644))
+}
+
+// ---------------------------------------------------------------------------
+// Key <-> path bijection, both directions.
+// ---------------------------------------------------------------------------
+
+func TestKeyConstructorsMatchSpec(t *testing.T) {
+	require.Equal(t, "chunk:00005350:ledgers", chunkKey(5350, KindLedgers))
+	require.Equal(t, "hot:chunk:00005350", hotChunkKey(5350))
+}
+
+func TestChunkKeyBijection(t *testing.T) {
+	for _, kind := range AllKinds() {
+		for _, id := range []chunk.ID{0, 1, 999, 1000, 5350} {
+			key := chunkKey(id, kind)
+			gotID, gotKind, ok := parseChunkKey(key)
+			require.True(t, ok, "parse %q", key)
+			require.Equal(t, id, gotID)
+			require.Equal(t, kind, gotKind)
+		}
+	}
+}
+
+func TestHotKeyBijection(t *testing.T) {
+	for _, id := range []chunk.ID{0, 7, 5350} {
+		key := hotChunkKey(id)
+		got, ok := parseHotChunkKey(key)
+		require.True(t, ok)
+		require.Equal(t, id, got)
+	}
+}
+
+func TestKeyToPathBijection(t *testing.T) {
+	l := NewLayout("/data")
+
+	// The doc's directory-layout examples.
+	require.Equal(t, "/data/ledgers/00005/00005350.pack", l.LedgerPackPath(5350))
+	require.Equal(t, "/data/hot/00005350", l.HotChunkPath(5350))
+}
+
+func TestParseRejectsMalformed(t *testing.T) {
+	bad := []string{
+		"chunk:5350:ledgers",   // not 8-digit padded
+		"chunk:00005350:bogus", // unknown kind
+		"chunk:00005350",       // missing kind
+		"hot:chunk:5350",       // not padded
+		"unrelated:key",        // wrong family
+	}
+	for _, key := range bad {
+		_, _, okChunk := parseChunkKey(key)
+		_, okHot := parseHotChunkKey(key)
+		require.False(t, okChunk && okHot, "expected %q to be rejected by all parsers", key)
+	}
+	// Specific rejection.
+	_, _, ok := parseChunkKey("chunk:00005350:bogus")
+	require.False(t, ok)
+}
+
+// ---------------------------------------------------------------------------
+// Round-trip every key family through the real metastore.
+// ---------------------------------------------------------------------------
+
+func TestRoundTripChunkKeys(t *testing.T) {
+	cat, _ := testCatalog(t)
+
+	for _, kind := range AllKinds() {
+		state, err := cat.State(42, kind)
+		require.NoError(t, err)
+		require.Equal(t, State(""), state, "absent key reads as empty State")
+	}
+
+	require.NoError(t, cat.MarkChunkFreezing(42, AllKinds()...))
+	for _, kind := range AllKinds() {
+		state, err := cat.State(42, kind)
+		require.NoError(t, err)
+		require.Equal(t, StateFreezing, state)
+	}
+
+	require.NoError(t, cat.FlipChunkFrozen(42, AllKinds()...))
+	for _, kind := range AllKinds() {
+		state, err := cat.State(42, kind)
+		require.NoError(t, err)
+		require.Equal(t, StateFrozen, state)
+	}
+}
+
+func TestRoundTripHotKeys(t *testing.T) {
+	cat, _ := testCatalog(t)
+
+	state, err := cat.HotState(7)
+	require.NoError(t, err)
+	require.Equal(t, HotState(""), state)
+
+	require.NoError(t, cat.PutHotTransient(7))
+	state, err = cat.HotState(7)
+	require.NoError(t, err)
+	require.Equal(t, HotTransient, state)
+
+	require.NoError(t, cat.FlipHotReady(7))
+	state, err = cat.HotState(7)
+	require.NoError(t, err)
+	require.Equal(t, HotReady, state)
+
+	require.NoError(t, cat.DeleteHotKey(7))
+	state, err = cat.HotState(7)
+	require.NoError(t, err)
+	require.Equal(t, HotState(""), state)
+	// Idempotent on a missing key.
+	require.NoError(t, cat.DeleteHotKey(7))
+}
+
+func TestConfigPins(t *testing.T) {
+	cat, _ := testCatalog(t)
+
+	_, ok, err := cat.EarliestLedger()
+	require.NoError(t, err)
+	require.False(t, ok, "pristine store has no earliest_ledger pin")
+
+	require.NoError(t, cat.PutEarliestLedger(2))
+	el, ok, err := cat.EarliestLedger()
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint32(2), el)
+}
+
+// ---------------------------------------------------------------------------
+// Scans: HotChunkKeys (value-blind) vs ReadyHotChunkKeys (ready-only).
+// ---------------------------------------------------------------------------
+
+func TestHotChunkKeysValueBlindVsReadyOnly(t *testing.T) {
+	cat, _ := testCatalog(t)
+
+	require.NoError(t, cat.PutHotTransient(3))
+	require.NoError(t, cat.FlipHotReady(5))
+	require.NoError(t, cat.PutHotTransient(9))
+	require.NoError(t, cat.FlipHotReady(12))
+
+	all, err := cat.HotChunkKeys()
+	require.NoError(t, err)
+	require.Equal(t, []chunk.ID{3, 5, 9, 12}, all, "value-blind: every hot key")
+
+	ready, err := cat.ReadyHotChunkKeys()
+	require.NoError(t, err)
+	require.Equal(t, []chunk.ID{5, 12}, ready, "ready-only excludes transient")
+}
+
+func TestChunkArtifactKeys(t *testing.T) {
+	cat, _ := testCatalog(t)
+
+	require.NoError(t, cat.MarkChunkFreezing(1, KindLedgers))
+	require.NoError(t, cat.FlipChunkFrozen(2, KindLedgers))
+
+	refs, err := cat.ChunkArtifactKeys()
+	require.NoError(t, err)
+	require.Len(t, refs, 2)
+	// Sorted by key: chunk:00000001 before chunk:00000002.
+	require.Equal(t, ArtifactRef{Chunk: 1, Kind: KindLedgers, State: StateFreezing}, refs[0])
+	require.Equal(t, ArtifactRef{Chunk: 2, Kind: KindLedgers, State: StateFrozen}, refs[1])
+}
+
+// ---------------------------------------------------------------------------
+// Sweep: the deletion body.
+// ---------------------------------------------------------------------------
+
+func TestSweepChunkArtifacts(t *testing.T) {
+	cat, _ := testCatalog(t)
+
+	// Set up a frozen ledgers for chunk 3, with a real file.
+	lfsPath := cat.layout.LedgerPackPath(3)
+	writeArtifact(t, lfsPath)
+	require.NoError(t, cat.MarkChunkFreezing(3, KindLedgers))
+	require.NoError(t, cat.FlipChunkFrozen(3, KindLedgers))
+
+	refs := []ArtifactRef{
+		{Chunk: 3, Kind: KindLedgers, State: StateFrozen},
+	}
+	require.NoError(t, cat.SweepChunkArtifacts(refs))
+
+	// File gone.
+	require.NoFileExists(t, lfsPath)
+	// Key gone (key absent => file gone).
+	s, err := cat.State(3, KindLedgers)
+	require.NoError(t, err)
+	require.Equal(t, State(""), s)
+}
+
+func TestSweepChunkArtifactsIdempotentOnMissingFiles(t *testing.T) {
+	cat, _ := testCatalog(t)
+
+	// Key present, file never written (a "pruning" leftover whose file is
+	// already gone).
+	require.NoError(t, cat.store.Put(chunkKey(8, KindLedgers), string(StatePruning)))
+	require.NoError(t, cat.SweepChunkArtifacts([]ArtifactRef{
+		{Chunk: 8, Kind: KindLedgers, State: StatePruning},
+	}))
+	s, err := cat.State(8, KindLedgers)
+	require.NoError(t, err)
+	require.Equal(t, State(""), s)
+}
+
+// ---------------------------------------------------------------------------
+// CRASH-SAFETY tests — interpose at the two dangerous instants and assert both
+// invariants: (A) every file on disk has its meta key; (B) key absent => file
+// gone.
+// ---------------------------------------------------------------------------
+
+// assertEveryFileHasKey walks every artifact file under root and asserts a
+// non-empty meta-store key exists for it (Design invariant: "every key
+// precedes its file"). This is INV-3's disk->meta direction.
+func assertEveryFileHasKey(t *testing.T, cat *Catalog, root string) {
+	t.Helper()
+	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		require.NoError(t, err)
+		if info.IsDir() {
+			return nil
+		}
+		key, present := keyForArtifactFile(t, cat, path)
+		require.True(t, present, "file %q has no resolvable meta key", path)
+		ok, err := cat.Has(key)
+		require.NoError(t, err)
+		require.True(t, ok, "file %q on disk but key %q absent", path, key)
+		return nil
+	})
+}
+
+// keyForArtifactFile maps an on-disk artifact path back to its meta-store key
+// by inverting the Layout bijection. Returns present=false for paths outside
+// the artifact tree (e.g. the meta rocksdb dir, which lives elsewhere here).
+func keyForArtifactFile(t *testing.T, cat *Catalog, path string) (string, bool) {
+	t.Helper()
+
+	// Per-chunk files: identify by reconstructing each kind's path for the
+	// chunk id embedded in the filename (the leading 8-digit stem, before any
+	// ".pack" suffix).
+	base := filepath.Base(path)
+	stem, _, _ := strings.Cut(base, ".")
+	cid, errC := parsePadded(stem)
+	require.NoError(t, errC)
+	c := chunk.ID(cid)
+	for _, kind := range AllKinds() {
+		if slices.Contains(cat.layout.ArtifactPaths(c, kind), path) {
+			return chunkKey(c, kind), true
+		}
+	}
+	return "", false
+}
+
+// Crash instant (i): file written but key not yet flipped to "frozen".
+//
+// Reproduces the mark-then-write protocol stopped after barrierNewFile but
+// before FlipChunkFrozen. The key is "freezing", the file is on disk. INV-3
+// disk->meta must still hold: the file is reachable from its key.
+func TestCrashSafety_FileWrittenKeyNotFlipped(t *testing.T) {
+	cat, root := testCatalog(t)
+
+	// Per-chunk: mark freezing, write+barrier the file, then "crash" before the
+	// flip.
+	require.NoError(t, cat.MarkChunkFreezing(4, KindLedgers))
+	lfsPath := cat.layout.LedgerPackPath(4)
+	writeArtifact(t, lfsPath)
+	require.NoError(t, barrierNewFile(lfsPath, true))
+	// <-- crash here: no FlipChunkFrozen.
+
+	// INV-3 (disk -> meta): every file on disk has its key.
+	assertEveryFileHasKey(t, cat, root)
+
+	// The key is observable as "freezing" — the recovery signal.
+	s, err := cat.State(4, KindLedgers)
+	require.NoError(t, err)
+	require.Equal(t, StateFreezing, s)
+}
+
+// Crash instant (ii): inside the REAL sweep, between the durable unlink and the
+// key delete.
+//
+// We fire a hook from INSIDE SweepChunkArtifacts at the exact instant after
+// unlink+fsync and before the key-delete batch, and assert the EXIT-side
+// invariant there: file gone => key still present. If the key delete were
+// reordered ahead of the unlink, the file would still be on disk when the hook
+// fires and the in-hook assertion fails.
+func TestCrashSafety_SweepUnlinkDurableKeyNotDeleted(t *testing.T) {
+	cat, root := testCatalog(t)
+
+	// A frozen ledgers (one file) for chunk 6.
+	lfsPath := cat.layout.LedgerPackPath(6)
+	writeArtifact(t, lfsPath)
+	require.NoError(t, cat.MarkChunkFreezing(6, KindLedgers))
+	require.NoError(t, cat.FlipChunkFrozen(6, KindLedgers))
+
+	refs := []ArtifactRef{
+		{Chunk: 6, Kind: KindLedgers, State: StateFrozen},
+	}
+	allPaths := []string{lfsPath}
+
+	// The hook fires once, between the durable unlink and the key delete.
+	fired := false
+	cat.hooks.beforeKeyDelete = func() {
+		fired = true
+		for _, p := range allPaths {
+			require.NoFileExists(t, p, "EXIT invariant: file must be unlinked before its key is deleted")
+		}
+		// ...and the keys must still be present (they are about to be deleted).
+		for _, ref := range refs {
+			ok, err := cat.Has(ref.Key())
+			require.NoError(t, err)
+			require.True(t, ok, "key %q must still exist at the pre-delete instant", ref.Key())
+		}
+	}
+
+	require.NoError(t, cat.SweepChunkArtifacts(refs))
+	require.True(t, fired, "beforeKeyDelete hook must have fired inside SweepChunkArtifacts")
+
+	// After the sweep both invariants hold globally.
+	assertEveryFileHasKey(t, cat, root) // (A), vacuous — files gone
+	for _, ref := range refs {          // (B) key absent => file gone
+		s, err := cat.State(ref.Chunk, ref.Kind)
+		require.NoError(t, err)
+		require.Equal(t, State(""), s)
+	}
+	for _, p := range allPaths {
+		require.NoFileExists(t, p)
+	}
+}
+
+// Per-chunk never-unlink-under-frozen-key assertion: fire INSIDE
+// SweepChunkArtifacts between the demote batch and the unlinks; every "frozen"
+// ref must read "pruning" by then. Dropping the demote batch leaves them
+// "frozen" here and this fails.
+func TestSweepChunk_NeverUnlinksUnderFrozenKey(t *testing.T) {
+	cat, _ := testCatalog(t)
+
+	lfsPath := cat.layout.LedgerPackPath(6)
+	writeArtifact(t, lfsPath)
+	require.NoError(t, cat.MarkChunkFreezing(6, KindLedgers))
+	require.NoError(t, cat.FlipChunkFrozen(6, KindLedgers))
+
+	ref := ArtifactRef{Chunk: 6, Kind: KindLedgers, State: StateFrozen}
+
+	fired := false
+	cat.hooks.beforeUnlink = func() {
+		fired = true
+		v, ok, err := cat.Get(ref.Key())
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, string(StatePruning), v,
+			"value at the pre-unlink instant must be pruning, never frozen")
+		require.FileExists(t, lfsPath, "file must still be on disk before the unlink")
+	}
+
+	require.NoError(t, cat.SweepChunkArtifacts([]ArtifactRef{ref}))
+	require.True(t, fired, "beforeUnlink hook must have fired inside SweepChunkArtifacts")
+
+	require.NoFileExists(t, lfsPath)
+	s, err := cat.State(6, KindLedgers)
+	require.NoError(t, err)
+	require.Equal(t, State(""), s)
+}
+
+func TestSweepEmptyRefsNoop(t *testing.T) {
+	cat, _ := testCatalog(t)
+	require.NoError(t, cat.SweepChunkArtifacts(nil))
+}
+
+func TestMarkRequiresKinds(t *testing.T) {
+	cat, _ := testCatalog(t)
+	require.Error(t, cat.MarkChunkFreezing(1))
+	require.Error(t, cat.FlipChunkFrozen(1))
+}
+
+func TestGetHasMissReturnsCleanly(t *testing.T) {
+	cat, _ := testCatalog(t)
+	_, ok, err := cat.Get("nope")
+	require.NoError(t, err)
+	require.False(t, ok)
+	has, err := cat.Has("nope")
+	require.NoError(t, err)
+	require.False(t, has)
+}


### PR DESCRIPTION
**Slice 1, Layer 1 of 4 — Foundations.** First of a layered split of the ledgers-skeleton streaming daemon (the slice was ~13.5k; layered into reviewable concerns). Base: `feature/full-history`.

The durable-state substrate, with no daemon yet — reviewable in isolation:
- the **catalog** (meta-store) key schema + the **one-write protocol** (mark→fsync→flip) + key-driven sweeps;
- **geometry** (keys/paths, chunk↔bucket layout);
- the **config** struct + loader + single-process `flock` locking;
- the **retention gate** and the `ArtifactSet`/`Kind` abstraction;
- crash-safety hooks.

Compiles and passes its `-short` tests on its own. Layers 2–4 (storage → orchestration → daemon) stack on top; events and tx-hash follow as later slices.
