### PR TITLE
Streaming daemon: Slice 1 — Layer 2 (storage)

### DIFF
--- a/cmd/stellar-rpc/internal/fullhistory/ingest/config.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/config.go
@@ -3,8 +3,13 @@ package ingest
 import "errors"
 
 // Config selects which data types the ingest drivers write. At least one of
-// Ledgers/Txhash/Events must be enabled. Per-ledger hot fan-out is always
-// parallel; that is not configurable.
+// Ledgers/Txhash/Events must be enabled. Each ledger commits to the per-chunk
+// hot DB as one atomic synced WriteBatch across the enabled CFs (decision (a)) —
+// there is no per-data-type fan-out.
+//
+// Txhash and Events are forward-declared here but only honored where a slice has
+// wired their cold/hot ingesters (Events in slice 2, Txhash in slice 3);
+// selecting an unwired type is accepted by validate but writes nothing.
 //
 // The view-based event path derives payloads from the LedgerCloseMetaView and
 // needs no network passphrase, so Config carries no passphrase.

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/driver.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/driver.go
@@ -17,13 +17,10 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/hotchunk"
 )
 
-// HotStores holds the long-lived, caller-owned per-chunk hot DB injected into
-// RunHot. The caller (the daemon) opens and closes it; RunHot only borrows it
-// to drive the per-ledger atomic ingest. The DB is chunk-bound (it accumulates
-// exactly one chunk before being frozen into cold artifacts), so the injected
-// DB must already be bound to the chunk being ingested — RunHot rejects a
-// mismatch up front. A nil DB with any data type enabled in cfg is a
-// configuration error caught by RunHot.
+// HotStores holds the caller-owned per-chunk hot DB injected into RunHot: the
+// daemon opens and closes it, RunHot only borrows it. The DB is chunk-bound, so
+// it must already match the chunk being ingested (RunHot rejects a mismatch); a
+// nil DB with any data type enabled in cfg is a config error.
 type HotStores struct {
 	// HotDB is the per-chunk hot DB. Required when any hot data type is enabled.
 	HotDB *hotchunk.DB
@@ -95,13 +92,11 @@ func closeColdAll(ings []ColdIngester, err error) error {
 	return err
 }
 
-// RunHot opens one stream for chunkID from source and feeds each ledger (as a
-// view) to a HotService backed by the INJECTED, caller-owned shared per-chunk
-// hot DB in hotStores. Each ledger commits as ONE atomic synced WriteBatch
-// across all enabled CFs (decision (a)); Ingest errors abort fast, and
-// HotService.Ingest consumes the borrowed view synchronously before the loop
-// pulls the next ledger. The hot DB is NOT closed here — the caller owns its
-// lifecycle.
+// RunHot opens one stream for chunkID and feeds each ledger (as a borrowed view)
+// to a HotService over the INJECTED, caller-owned hot DB in hotStores. Each
+// ledger commits as one atomic synced WriteBatch (decision (a)); the view is
+// consumed synchronously before the next pull. The hot DB is NOT closed here —
+// the caller owns its lifecycle.
 func RunHot(
 	ctx context.Context,
 	logger *supportlog.Entry,
@@ -118,11 +113,8 @@ func RunHot(
 	if anyEnabled && hotStores.HotDB == nil {
 		return errors.New("ingest: a hot data type is enabled but HotStores.HotDB is nil")
 	}
-	// The hot DB is chunk-bound — it accumulates exactly one chunk's data
-	// before being frozen into the chunk's cold artifacts — and records its
-	// chunk at open time. An injected DB bound to a different chunk than we're
-	// ingesting would silently interleave two chunks' data, so catch the
-	// mismatch up front with a clear message.
+	// Chunk-bound: an injected DB bound to a different chunk would silently
+	// interleave two chunks' data, so catch the mismatch up front.
 	if hotStores.HotDB != nil && hotStores.HotDB.ChunkID() != chunkID {
 		return fmt.Errorf("ingest: RunHot chunk %d but injected hot DB is bound to chunk %d",
 			uint32(chunkID), uint32(hotStores.HotDB.ChunkID()))
@@ -193,20 +185,15 @@ func drain(ctx context.Context, stream ledgerbackend.LedgerStream, chunkID chunk
 // constructor (NewLedgerColdIngester) takes. A field left "" for a data type
 // enabled in cfg is a configuration error caught by RunColdChunk.
 //
-// RunCold derives this root from a single coldDir by appending the fixed
-// dataType subdirectory (coldDir/ledgers). ColdDirs exists so a caller with a
-// DIFFERENT on-disk layout can place each artifact at its own canonical path
-// while reusing the very same cold ingesters, ColdService, and drain loop.
+// ColdDirs lets a caller whose layout is not coldDir/<dataType> place each
+// artifact at its own canonical path while reusing the cold pipeline verbatim.
 type ColdDirs struct {
 	Ledgers string
 }
 
-// buildColdIngestersIn opens one ColdIngester per data type enabled in cfg,
-// each under its OWN root from dirs (rather than coldDir/<dataType>). It is the
-// ColdDirs counterpart of buildColdIngesters: same constructors, same
-// rollback-on-constructor-error semantics; it differs only in resolving each
-// type's root from an explicit field instead of a fixed subdirectory of one
-// coldDir.
+// buildColdIngestersIn is the ColdDirs counterpart of buildColdIngesters: same
+// constructors and rollback-on-error semantics, but each ingester's root comes
+// from an explicit dirs field rather than coldDir/<dataType>.
 func buildColdIngestersIn(dirs ColdDirs, chunkID chunk.ID, sink MetricSink, cfg Config) ([]ColdIngester, error) {
 	ctors := []struct {
 		enabled  bool
@@ -234,19 +221,14 @@ func buildColdIngestersIn(dirs ColdDirs, chunkID chunk.ID, sink MetricSink, cfg 
 }
 
 // RunColdChunk ingests EXACTLY ONE chunk's cold artifacts from source into the
-// per-data-type roots named by dirs, in a single streaming pass over the
-// chunk's ledgers. It is the single-chunk, explicit-layout sibling of RunCold:
-// it reuses the same cold ingester constructors, the same ColdService, and the
-// same drain loop (sequence/overrun validation, full-range completeness check
-// before Finalize), differing only in (1) producing one chunk rather than N
-// concurrent chunks and (2) taking explicit per-type output roots so a caller
-// whose layout is not coldDir/<dataType> can still reuse the cold pipeline
-// verbatim.
+// per-data-type roots named by dirs, in a single streaming pass. It is the
+// single-chunk, explicit-layout sibling of RunCold (same ingesters, ColdService,
+// and drain loop with its completeness check before Finalize).
 //
 // The cold ingesters overwrite any prior attempt's files at their canonical
-// paths (see the package doc's artifact model), so RunColdChunk is the
-// re-materialization primitive the streaming freeze protocol drives: a partial
-// file from a crashed attempt is inert scratch the next call overwrites.
+// paths, so RunColdChunk is the re-materialization primitive the streaming
+// freeze protocol drives: a partial file from a crashed attempt is inert scratch
+// the next call overwrites.
 func RunColdChunk(
 	ctx context.Context,
 	logger *supportlog.Entry,

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/driver.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/driver.go
@@ -14,58 +14,33 @@ import (
 	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/ledger"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/hotchunk"
 )
 
-// HotStores holds the long-lived, caller-owned hot stores injected into RunHot.
-// The caller (the daemon) opens and closes these; RunHot only borrows them to
-// build the per-type hot ingesters. A field left nil for an enabled data type is
-// a configuration error caught by RunHot. Every hot store is chunk-bound (each
-// instance accumulates exactly one chunk before being frozen into cold
-// artifacts), so each injected store must already be bound to the chunk being
-// ingested — RunHot rejects a mismatch up front.
+// HotStores holds the long-lived, caller-owned per-chunk hot DB injected into
+// RunHot. The caller (the daemon) opens and closes it; RunHot only borrows it
+// to drive the per-ledger atomic ingest. The DB is chunk-bound (it accumulates
+// exactly one chunk before being frozen into cold artifacts), so the injected
+// DB must already be bound to the chunk being ingested — RunHot rejects a
+// mismatch up front. A nil DB with any data type enabled in cfg is a
+// configuration error caught by RunHot.
 type HotStores struct {
-	Ledgers *ledger.HotStore
-	Txhash  *txhash.HotStore
-	Events  *eventstore.HotStore
+	// HotDB is the per-chunk hot DB. Required when any hot data type is enabled.
+	HotDB *hotchunk.DB
 }
 
-// buildHotIngesters constructs one HotIngester per data type enabled in cfg, in
-// canonical ledgers→txhash→events order, from the injected stores. It errors if
-// an enabled type's store is nil.
-func buildHotIngesters(stores HotStores, sink MetricSink, cfg Config) ([]HotIngester, error) {
-	var ings []HotIngester
-	if cfg.Ledgers {
-		if stores.Ledgers == nil {
-			return nil, errors.New("ingest: Ledgers enabled but HotStores.Ledgers is nil")
-		}
-		ings = append(ings, NewLedgerHotIngester(stores.Ledgers, sink))
-	}
-	if cfg.Txhash {
-		if stores.Txhash == nil {
-			return nil, errors.New("ingest: Txhash enabled but HotStores.Txhash is nil")
-		}
-		ings = append(ings, NewTxhashHotIngester(stores.Txhash, sink))
-	}
-	if cfg.Events {
-		if stores.Events == nil {
-			return nil, errors.New("ingest: Events enabled but HotStores.Events is nil")
-		}
-		ings = append(ings, NewEventsHotIngester(stores.Events, sink))
-	}
-	return ings, nil
+// ingestContributions maps the ingest Config's enabled data types onto the
+// hotchunk.Ingest toggles that select which CFs the single per-ledger batch
+// writes.
+func ingestContributions(cfg Config) hotchunk.Ingest {
+	return hotchunk.Ingest{Ledgers: cfg.Ledgers}
 }
 
 // buildColdIngesters opens one ColdIngester per data type enabled in cfg,
 // each opening its own per-chunk writer under coldDir/<type> (constructors
 // create their own directories and freely overwrite any prior attempt's
-// files — see the package doc's artifact model). The constructor table below
-// is the single definition site of the canonical ledgers→txhash→events order
-// (buildHotIngesters keeps its explicit if-ladder because its three injected
-// store types differ). On any constructor error it closes the ingesters built
-// so far and returns.
+// files — see the package doc's artifact model). On any constructor error it
+// closes the ingesters built so far and returns.
 func buildColdIngesters(coldDir string, chunkID chunk.ID, sink MetricSink, cfg Config) ([]ColdIngester, error) {
 	ctors := []struct {
 		enabled  bool
@@ -73,8 +48,6 @@ func buildColdIngesters(coldDir string, chunkID chunk.ID, sink MetricSink, cfg C
 		open     func(string, chunk.ID, MetricSink) (ColdIngester, error)
 	}{
 		{cfg.Ledgers, dataTypeLedgers, NewLedgerColdIngester},
-		{cfg.Txhash, dataTypeTxhash, NewTxhashColdIngester},
-		{cfg.Events, dataTypeEvents, NewEventsColdIngester},
 	}
 	var ings []ColdIngester
 	for _, c := range ctors {
@@ -123,11 +96,12 @@ func closeColdAll(ings []ColdIngester, err error) error {
 }
 
 // RunHot opens one stream for chunkID from source and feeds each ledger (as a
-// view) to a HotService over the enabled hot ingesters, built from the INJECTED,
-// caller-owned stores in hotStores. Ingest errors abort fast; HotService.Ingest
-// waits for all ingesters before the loop pulls again so the borrowed view is
-// never read past its lifetime. The hot stores are NOT closed here — the caller
-// owns their lifecycle.
+// view) to a HotService backed by the INJECTED, caller-owned shared per-chunk
+// hot DB in hotStores. Each ledger commits as ONE atomic synced WriteBatch
+// across all enabled CFs (decision (a)); Ingest errors abort fast, and
+// HotService.Ingest consumes the borrowed view synchronously before the loop
+// pulls the next ledger. The hot DB is NOT closed here — the caller owns its
+// lifecycle.
 func RunHot(
 	ctx context.Context,
 	logger *supportlog.Entry,
@@ -140,47 +114,25 @@ func RunHot(
 	if verr := cfg.validate(); verr != nil {
 		return verr
 	}
-	// Every hot store is chunk-bound — each instance accumulates exactly one
-	// chunk's data before being frozen into the chunk's cold artifacts — and
-	// records its chunk at open time. An injected store bound to a different
-	// chunk than we're ingesting would silently interleave two chunks' data
-	// (ledgers, txhash) or fail every per-ledger write with an out-of-range
-	// offset (events, whose LedgerOffsets are chunk-relative), so catch the
-	// mismatch up front with a clear message. Nil stores are skipped here:
-	// buildHotIngesters rejects a nil store for an enabled type with a more
-	// specific error.
-	checkBinding := func(name string, got chunk.ID) error {
-		if got != chunkID {
-			return fmt.Errorf("ingest: RunHot chunk %d but injected %s store is bound to chunk %d",
-				uint32(chunkID), name, uint32(got))
-		}
-		return nil
+	anyEnabled := cfg.Ledgers
+	if anyEnabled && hotStores.HotDB == nil {
+		return errors.New("ingest: a hot data type is enabled but HotStores.HotDB is nil")
 	}
-	if cfg.Ledgers && hotStores.Ledgers != nil {
-		if err := checkBinding("Ledgers", hotStores.Ledgers.ChunkID()); err != nil {
-			return err
-		}
-	}
-	if cfg.Txhash && hotStores.Txhash != nil {
-		if err := checkBinding("Txhash", hotStores.Txhash.ChunkID()); err != nil {
-			return err
-		}
-	}
-	if cfg.Events && hotStores.Events != nil {
-		if err := checkBinding("Events", hotStores.Events.ChunkID()); err != nil {
-			return err
-		}
-	}
-	ings, berr := buildHotIngesters(hotStores, sink, cfg)
-	if berr != nil {
-		return berr
+	// The hot DB is chunk-bound — it accumulates exactly one chunk's data
+	// before being frozen into the chunk's cold artifacts — and records its
+	// chunk at open time. An injected DB bound to a different chunk than we're
+	// ingesting would silently interleave two chunks' data, so catch the
+	// mismatch up front with a clear message.
+	if hotStores.HotDB != nil && hotStores.HotDB.ChunkID() != chunkID {
+		return fmt.Errorf("ingest: RunHot chunk %d but injected hot DB is bound to chunk %d",
+			uint32(chunkID), uint32(hotStores.HotDB.ChunkID()))
 	}
 	stream, oerr := source.OpenStream(chunkID)
 	if oerr != nil {
 		return fmt.Errorf("open stream for chunk %d: %w", uint32(chunkID), oerr)
 	}
 	logger.Debugf("RunHot: ingesting chunk %d [%d, %d]", uint32(chunkID), chunkID.FirstLedger(), chunkID.LastLedger())
-	service := NewHotService(ings, sink)
+	service := NewHotService(hotStores.HotDB, ingestContributions(cfg), sink)
 	return drain(ctx, stream, chunkID, service)
 }
 
@@ -233,6 +185,107 @@ func drain(ctx context.Context, stream ledgerbackend.LedgerStream, chunkID chunk
 		return fmt.Errorf("ingest: stream for chunk %d ended at %d, expected through %d", uint32(chunkID), seq-1, last)
 	}
 	return nil
+}
+
+// ColdDirs names the per-data-type output root for one chunk's cold artifacts.
+// Each field is the directory UNDER WHICH the matching cold ingester composes
+// its {bucketID:05d}/ subdirectory — i.e. the same `coldDir` the per-type
+// constructor (NewLedgerColdIngester) takes. A field left "" for a data type
+// enabled in cfg is a configuration error caught by RunColdChunk.
+//
+// RunCold derives this root from a single coldDir by appending the fixed
+// dataType subdirectory (coldDir/ledgers). ColdDirs exists so a caller with a
+// DIFFERENT on-disk layout can place each artifact at its own canonical path
+// while reusing the very same cold ingesters, ColdService, and drain loop.
+type ColdDirs struct {
+	Ledgers string
+}
+
+// buildColdIngestersIn opens one ColdIngester per data type enabled in cfg,
+// each under its OWN root from dirs (rather than coldDir/<dataType>). It is the
+// ColdDirs counterpart of buildColdIngesters: same constructors, same
+// rollback-on-constructor-error semantics; it differs only in resolving each
+// type's root from an explicit field instead of a fixed subdirectory of one
+// coldDir.
+func buildColdIngestersIn(dirs ColdDirs, chunkID chunk.ID, sink MetricSink, cfg Config) ([]ColdIngester, error) {
+	ctors := []struct {
+		enabled  bool
+		dataType string
+		dir      string
+		open     func(string, chunk.ID, MetricSink) (ColdIngester, error)
+	}{
+		{cfg.Ledgers, dataTypeLedgers, dirs.Ledgers, NewLedgerColdIngester},
+	}
+	var ings []ColdIngester
+	for _, c := range ctors {
+		if !c.enabled {
+			continue
+		}
+		if c.dir == "" {
+			return nil, closeColdAll(ings, fmt.Errorf("ingest: %s enabled but ColdDirs.%s is empty", c.dataType, c.dataType))
+		}
+		ing, err := c.open(c.dir, chunkID, sink)
+		if err != nil {
+			return nil, closeColdAll(ings, fmt.Errorf("open %s cold ingester: %w", c.dataType, err))
+		}
+		ings = append(ings, ing)
+	}
+	return ings, nil
+}
+
+// RunColdChunk ingests EXACTLY ONE chunk's cold artifacts from source into the
+// per-data-type roots named by dirs, in a single streaming pass over the
+// chunk's ledgers. It is the single-chunk, explicit-layout sibling of RunCold:
+// it reuses the same cold ingester constructors, the same ColdService, and the
+// same drain loop (sequence/overrun validation, full-range completeness check
+// before Finalize), differing only in (1) producing one chunk rather than N
+// concurrent chunks and (2) taking explicit per-type output roots so a caller
+// whose layout is not coldDir/<dataType> can still reuse the cold pipeline
+// verbatim.
+//
+// The cold ingesters overwrite any prior attempt's files at their canonical
+// paths (see the package doc's artifact model), so RunColdChunk is the
+// re-materialization primitive the streaming freeze protocol drives: a partial
+// file from a crashed attempt is inert scratch the next call overwrites.
+func RunColdChunk(
+	ctx context.Context,
+	logger *supportlog.Entry,
+	source ChunkSource,
+	dirs ColdDirs,
+	chunkID chunk.ID,
+	sink MetricSink,
+	cfg Config,
+) (err error) {
+	if verr := cfg.validate(); verr != nil {
+		return verr
+	}
+	sink = orNop(sink)
+	start := time.Now()
+	if cerr := ctx.Err(); cerr != nil {
+		sink.ColdChunkTotal(time.Since(start))
+		return cerr
+	}
+	stream, oerr := source.OpenStream(chunkID)
+	if oerr != nil {
+		sink.ColdChunkTotal(time.Since(start))
+		return fmt.Errorf("open stream for chunk %d: %w", uint32(chunkID), oerr)
+	}
+	ings, berr := buildColdIngestersIn(dirs, chunkID, sink, cfg)
+	if berr != nil {
+		sink.ColdChunkTotal(time.Since(start))
+		return berr
+	}
+	logger.Debugf("RunColdChunk: ingesting chunk %d [%d, %d]", uint32(chunkID), chunkID.FirstLedger(), chunkID.LastLedger())
+	service := NewColdService(ings, sink)
+	defer func() {
+		if cerr := service.Close(); cerr != nil {
+			err = errors.Join(err, fmt.Errorf("close: %w", cerr))
+		}
+	}()
+	if derr := drain(ctx, stream, chunkID, service); derr != nil {
+		return derr
+	}
+	return service.Finalize(ctx)
 }
 
 // RunCold ingests numChunks consecutive chunks starting at startChunk into the

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/driver.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/driver.go
@@ -275,7 +275,8 @@ func RunColdChunk(
 		sink.ColdChunkTotal(time.Since(start))
 		return berr
 	}
-	logger.Debugf("RunColdChunk: ingesting chunk %d [%d, %d]", uint32(chunkID), chunkID.FirstLedger(), chunkID.LastLedger())
+	logger.Debugf("RunColdChunk: ingesting chunk %d [%d, %d]",
+		uint32(chunkID), chunkID.FirstLedger(), chunkID.LastLedger())
 	service := NewColdService(ings, sink)
 	defer func() {
 		if cerr := service.Close(); cerr != nil {

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/ingest_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/ingest_test.go
@@ -1,7 +1,6 @@
 package ingest
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"iter"
@@ -22,11 +21,9 @@ import (
 	supportlog "github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/go-stellar-sdk/xdr"
 
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/eventstore"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/hotchunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/ledger"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/txhash"
 )
 
 // testPassphrase is a network passphrase literal used only by the test fixtures
@@ -199,53 +196,6 @@ func marshalLCM(t *testing.T, seq uint32) []byte {
 	return raw
 }
 
-// eventTopic is the symbol topic embedded by event-bearing fixtures; the same
-// term key derives from it, so tests can look the event up in the index.
-const eventTopic = "ingest_test"
-
-// marshalLCMWithEvent builds a V2 LCM carrying one transaction with one
-// operation-level contract event (topic=eventTopic). It returns the wire bytes,
-// the transaction hash (for txhash lookups), and the event's term key (for event
-// index lookups).
-func marshalLCMWithEvent(t *testing.T, seq uint32) ([]byte, [32]byte, events.TermKey) {
-	t.Helper()
-	ev := buildContractEvent(eventTopic)
-	meta := xdr.TransactionMeta{
-		V:  4,
-		V4: &xdr.TransactionMetaV4{Operations: []xdr.OperationMetaV2{{Events: []xdr.ContractEvent{ev}}}},
-	}
-	lcm, hash := buildLCMWithTx(t, seq, meta)
-	rawBytes, err := lcm.MarshalBinary()
-	require.NoError(t, err)
-
-	evBytes, err := ev.MarshalBinary()
-	require.NoError(t, err)
-	keys, err := events.TermsForBytes(evBytes)
-	require.NoError(t, err)
-	require.NotEmpty(t, keys)
-	return rawBytes, hash, keys[0]
-}
-
-// buildContractEvent returns a contract ContractEvent with a single symbol
-// topic, mirroring the events-package test fixture.
-func buildContractEvent(topic string) xdr.ContractEvent {
-	var contractID xdr.ContractId
-	contractID[0] = 0xab
-	contractID[1] = 0xcd
-	sym := xdr.ScSymbol(topic)
-	return xdr.ContractEvent{
-		ContractId: &contractID,
-		Type:       xdr.ContractEventTypeContract,
-		Body: xdr.ContractEventBody{
-			V: 0,
-			V0: &xdr.ContractEventV0{
-				Topics: []xdr.ScVal{{Type: xdr.ScValTypeScvSymbol, Sym: &sym}},
-				Data:   xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &sym},
-			},
-		},
-	}
-}
-
 func successResult() xdr.TransactionResult {
 	opResults := []xdr.OperationResult{}
 	return xdr.TransactionResult{
@@ -263,14 +213,6 @@ func buildLCM(t *testing.T, seq uint32, txMetas []xdr.TransactionMeta) xdr.Ledge
 	t.Helper()
 	lcm, _ := buildLCMReturningHashes(t, seq, txMetas)
 	return lcm
-}
-
-// buildLCMWithTx builds a single-transaction V2 LCM and returns the tx hash.
-func buildLCMWithTx(t *testing.T, seq uint32, meta xdr.TransactionMeta) (xdr.LedgerCloseMeta, [32]byte) {
-	t.Helper()
-	lcm, hashes := buildLCMReturningHashes(t, seq, []xdr.TransactionMeta{meta})
-	require.Len(t, hashes, 1)
-	return lcm, hashes[0]
 }
 
 // buildLCMReturningHashes assembles a V2 LedgerCloseMeta with one envelope per tx
@@ -347,21 +289,6 @@ func viewOf(t *testing.T, seq uint32) xdr.LedgerCloseMetaView {
 	return xdr.LedgerCloseMetaView(marshalLCM(t, seq))
 }
 
-// marshalV0LCM builds a minimal V0 (pre-Soroban) LedgerCloseMeta with no
-// transactions and returns its wire bytes. V0 LCMs carry no contract events,
-// so the events ingesters record them as a zero-payload ledger.
-func marshalV0LCM(t *testing.T, seq uint32) []byte {
-	t.Helper()
-	lcm := xdr.LedgerCloseMeta{V: 0, V0: &xdr.LedgerCloseMetaV0{
-		LedgerHeader: xdr.LedgerHeaderHistoryEntry{
-			Header: xdr.LedgerHeader{LedgerSeq: xdr.Uint32(seq)},
-		},
-	}}
-	raw, err := lcm.MarshalBinary()
-	require.NoError(t, err)
-	return raw
-}
-
 // seqStream is a ledgerbackend.LedgerStream that yields LCMs for an explicit
 // list of ledger sequences (in order), regardless of the requested range. It
 // models a backend that hands back a duplicate / out-of-order / wrong-but-
@@ -434,48 +361,6 @@ func TestLedgerHotIngester_Readback(t *testing.T) {
 	require.Equal(t, raw, got)
 }
 
-// TestTxhashHotIngester_Lookup ingests an event/tx-bearing ledger via the hot
-// txhash ingester and looks the hash up.
-func TestTxhashHotIngester_Lookup(t *testing.T) {
-	seq := chunk.ID(0).FirstLedger()
-	raw, hash, _ := marshalLCMWithEvent(t, seq)
-	dir := t.TempDir()
-	logger := testLogger()
-
-	store, err := txhash.NewHotStore(dir, chunk.ID(0), logger)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, store.Close()) }()
-
-	ing := NewTxhashHotIngester(store, nil)
-	require.NoError(t, ing.Ingest(context.Background(), seq, xdr.LedgerCloseMetaView(raw)))
-
-	got, err := store.Get(hash)
-	require.NoError(t, err)
-	require.Equal(t, seq, got)
-}
-
-// TestEventsHotIngester_Query ingests an event-bearing ledger via the hot events
-// ingester and resolves the term.
-func TestEventsHotIngester_Query(t *testing.T) {
-	chunkID := chunk.ID(0)
-	seq := chunkID.FirstLedger()
-	raw, _, term := marshalLCMWithEvent(t, seq)
-	dir := t.TempDir()
-	logger := testLogger()
-
-	store, err := eventstore.OpenHotStore(dir, chunkID, logger)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, store.Close()) }()
-
-	ing := NewEventsHotIngester(store, nil)
-	require.NoError(t, ing.Ingest(context.Background(), seq, xdr.LedgerCloseMetaView(raw)))
-
-	bm, err := store.Lookup(context.Background(), term)
-	require.NoError(t, err)
-	require.NotNil(t, bm)
-	require.Equal(t, uint64(1), bm.GetCardinality())
-}
-
 // TestLedgerColdIngester_Readback ingests one ledger via the cold ledger
 // ingester, finalizes, and reads back through the cold reader.
 func TestLedgerColdIngester_Readback(t *testing.T) {
@@ -499,355 +384,119 @@ func TestLedgerColdIngester_Readback(t *testing.T) {
 	require.Equal(t, raw, got)
 }
 
-// txhashBinPath composes the documented raw-txhash chunk path under root for
-// the tests' fixed chunk 0: {root}/{bucketID:05d}/{chunkID:08d}.bin.
-func txhashBinPath(root string) string {
-	c := chunk.ID(0)
-	return filepath.Join(root, c.BucketID(), txhash.ColdBinName(c))
-}
-
-// TestTxhashColdIngester_Bin ingests two tx-bearing ledgers via the cold txhash
-// ingester, finalizes, and reads the .bin back through the store codec.
-func TestTxhashColdIngester_Bin(t *testing.T) {
-	chunkID := chunk.ID(0)
-	first := chunkID.FirstLedger()
-	coldDir := t.TempDir()
-
-	ing, err := NewTxhashColdIngester(coldDir, chunkID, nil)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ing.Close()) }()
-
-	for _, seq := range []uint32{first, first + 1} {
-		raw, _, _ := marshalLCMWithEvent(t, seq)
-		require.NoError(t, ing.Ingest(context.Background(), seq, xdr.LedgerCloseMetaView(raw)))
-	}
-	require.NoError(t, ing.Finalize(context.Background()))
-
-	entries, err := txhash.ReadColdBin(txhashBinPath(coldDir))
-	require.NoError(t, err)
-	require.Len(t, entries, 2)
-}
-
-// TestEventsColdIngester_Readback ingests two event-bearing ledgers via the cold
-// events ingester, finalizes, and resolves the term through the cold reader.
-func TestEventsColdIngester_Readback(t *testing.T) {
-	chunkID := chunk.ID(0)
-	first := chunkID.FirstLedger()
-	coldDir := t.TempDir()
-
-	ing, err := NewEventsColdIngester(coldDir, chunkID, nil)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ing.Close()) }()
-
-	var term events.TermKey
-	for _, seq := range []uint32{first, first + 1} {
-		raw, _, tk := marshalLCMWithEvent(t, seq)
-		term = tk
-		require.NoError(t, ing.Ingest(context.Background(), seq, xdr.LedgerCloseMetaView(raw)))
-	}
-	require.NoError(t, ing.Finalize(context.Background()))
-
-	bucketDir := filepath.Join(coldDir, chunkID.BucketID())
-	cr, err := eventstore.OpenColdReader(chunkID, bucketDir, eventstore.ColdReaderOptions{})
-	require.NoError(t, err)
-	defer func() { require.NoError(t, cr.Close()) }()
-	cnt, err := cr.EventCount()
-	require.NoError(t, err)
-	require.Equal(t, uint32(2), cnt)
-	bm, err := cr.Lookup(context.Background(), term)
-	require.NoError(t, err)
-	require.NotNil(t, bm)
-	require.Equal(t, uint64(2), bm.GetCardinality())
-}
-
-// ───────────────────────── V0 (pre-Soroban) events handling ─────────────────────────
-
-// TestEventsHotIngester_V0AsEmpty asserts the hot events ingester treats a V0
-// LCM as a zero-event ledger (no error) rather than failing the range, and that
-// the store records the empty ledger (its event count is unchanged).
-func TestEventsHotIngester_V0AsEmpty(t *testing.T) {
-	chunkID := chunk.ID(0)
-	seq := chunkID.FirstLedger()
-	dir := t.TempDir()
-	logger := testLogger()
-
-	store, err := eventstore.OpenHotStore(dir, chunkID, logger)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, store.Close()) }()
-
-	ing := NewEventsHotIngester(store, nil)
-	require.NoError(t, ing.Ingest(context.Background(), seq, xdr.LedgerCloseMetaView(marshalV0LCM(t, seq))),
-		"V0 ledger must ingest as zero events, not error")
-
-	cnt, err := store.EventCount()
-	require.NoError(t, err)
-	require.Equal(t, uint32(0), cnt, "V0 ledger contributes no events")
-}
-
-// TestEventsColdIngester_V0KeepsOffsetsContiguous ingests a V0 ledger followed by
-// an event-bearing V2 ledger and asserts: the V0 ledger does not error, and the
-// LedgerOffsets stay contiguous (both ledgers present, the event-bearing one's
-// single event ID immediately follows the empty V0 ledger).
-func TestEventsColdIngester_V0KeepsOffsetsContiguous(t *testing.T) {
-	chunkID := chunk.ID(0)
-	first := chunkID.FirstLedger()
-	coldDir := t.TempDir()
-
-	ing, err := NewEventsColdIngester(coldDir, chunkID, nil)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ing.Close()) }()
-
-	// Ledger `first`: V0 → zero events, no error.
-	require.NoError(t, ing.Ingest(context.Background(), first, xdr.LedgerCloseMetaView(marshalV0LCM(t, first))))
-	// Ledger `first+1`: one contract event.
-	rawEv, _, term := marshalLCMWithEvent(t, first+1)
-	require.NoError(t, ing.Ingest(context.Background(), first+1, xdr.LedgerCloseMetaView(rawEv)))
-	require.NoError(t, ing.Finalize(context.Background()))
-
-	bucketDir := filepath.Join(coldDir, chunkID.BucketID())
-	cr, err := eventstore.OpenColdReader(chunkID, bucketDir, eventstore.ColdReaderOptions{})
-	require.NoError(t, err)
-	defer func() { require.NoError(t, cr.Close()) }()
-
-	// One event total, from the V2 ledger.
-	cnt, err := cr.EventCount()
-	require.NoError(t, err)
-	require.Equal(t, uint32(1), cnt)
-
-	// Offsets are contiguous: both ledgers recorded, V0 contributes [0,0), the
-	// event-bearing ledger contributes exactly event ID 0.
-	offsets, err := cr.Offsets()
-	require.NoError(t, err)
-	require.Equal(t, 2, offsets.LedgerCount(), "both V0 and V2 ledgers recorded")
-	require.Equal(t, first, offsets.StartLedger())
-	v0Start, v0End, err := offsets.EventIDs(first)
-	require.NoError(t, err)
-	require.Equal(t, uint32(0), v0Start)
-	require.Equal(t, uint32(0), v0End, "V0 ledger has an empty event range")
-	evStart, evEnd, err := offsets.EventIDs(first + 1)
-	require.NoError(t, err)
-	require.Equal(t, uint32(0), evStart, "event ID follows the empty V0 ledger contiguously")
-	require.Equal(t, uint32(1), evEnd)
-
-	// And the event is queryable by its term.
-	bm, err := cr.Lookup(context.Background(), term)
-	require.NoError(t, err)
-	require.NotNil(t, bm)
-	require.Equal(t, uint64(1), bm.GetCardinality())
-}
-
-// TestRunCold_EventlessChunk_FullyReadable drives a full cold chunk of V0
-// (pre-Soroban, eventless) ledgers with Events enabled — the common backfill
-// case for early history. The whole chunk has zero contract events;
-// eventstore.WriteColdIndex publishes a valid EMPTY index for it, so all
-// three cold artifacts exist and the chunk is fully readable: a term-filtered
-// Lookup resolves to "no matches" through the ordinary path instead of a
-// missing-file error.
-func TestRunCold_EventlessChunk_FullyReadable(t *testing.T) {
-	chunkID := chunk.ID(0)
-	coldDir := t.TempDir()
-	logger := testLogger()
-	sink := &testSink{}
-
-	// Every ledger in the chunk is a V0 (pre-Soroban) ledger → zero events.
-	require.NoError(t, RunCold(
-		context.Background(), logger, sourceOf(fullStream(t, chunkID, marshalV0LCM)),
-		coldDir, chunkID, 1, 1, sink, Config{Events: true},
-	))
-
-	bucketDir := filepath.Join(coldDir, dataTypeEvents, chunkID.BucketID())
-
-	// All three cold artifacts exist (events.pack + the empty index pair).
-	for _, name := range []string{
-		eventstore.EventsPackName(chunkID),
-		eventstore.IndexPackName(chunkID),
-		eventstore.IndexHashName(chunkID),
-	} {
-		_, statErr := os.Stat(filepath.Join(bucketDir, name))
-		require.NoError(t, statErr, "eventless chunk must publish %s", name)
-	}
-
-	// The chunk is readable end to end: zero events, and a filtered lookup
-	// misses cleanly rather than erroring on a missing index.
-	cr, err := eventstore.OpenColdReader(chunkID, bucketDir, eventstore.ColdReaderOptions{})
-	require.NoError(t, err)
-	defer func() { require.NoError(t, cr.Close()) }()
-	cnt, err := cr.EventCount()
-	require.NoError(t, err)
-	require.Zero(t, cnt)
-	_, lerr := cr.Lookup(context.Background(), events.ComputeTermKey([]byte("any"), events.FieldContractID))
-	require.ErrorIs(t, lerr, eventstore.ErrTermNotFound)
-
-	// Metrics still fired: one aggregate per-chunk, one (clean) per-ingester.
-	require.Equal(t, 1, sink.coldChunkTotals, "ColdChunkTotal must fire for an eventless chunk")
-	require.Equal(t, 1, sink.coldDataTypes()[dataTypeEvents], "one ColdIngest for events")
-	require.Zero(t, sink.coldErrorTypes()[dataTypeEvents], "eventless chunk is not an error")
-}
-
 // ───────────────────────── HotService tests ─────────────────────────
 
-// TestHotService_AllTypes_FanOut runs HotService with all three hot ingesters
-// over event/tx-bearing ledgers and reads each store back, asserting the
-// aggregate HotLedgerTotal and per-ingester signals fired.
-func TestHotService_AllTypes_FanOut(t *testing.T) {
+// TestHotService_Ledgers_OneAtomicBatch runs HotService over the SHARED multi-CF
+// hot DB (decision (a)) and reads the ledger CF back through the DB's facade,
+// asserting the aggregate HotLedgerTotal and the per-type HotIngest signals
+// fired. Each ledger committed as ONE atomic synced WriteBatch.
+func TestHotService_Ledgers_OneAtomicBatch(t *testing.T) {
 	chunkID := chunk.ID(0)
 	first := chunkID.FirstLedger()
 	logger := testLogger()
-	dir := t.TempDir()
 
-	ls, err := ledger.OpenHotStore(filepath.Join(dir, "ledgers"), chunkID, logger)
+	db, err := hotchunk.Open(t.TempDir(), chunkID, logger)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ls.Close()) }()
-	ts, err := txhash.NewHotStore(filepath.Join(dir, "txhash"), chunkID, logger)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ts.Close()) }()
-	es, err := eventstore.OpenHotStore(filepath.Join(dir, "events"), chunkID, logger)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, es.Close()) }()
+	defer func() { require.NoError(t, db.Close()) }()
 
 	sink := &testSink{}
-	service := NewHotService([]HotIngester{
-		NewLedgerHotIngester(ls, sink),
-		NewTxhashHotIngester(ts, sink),
-		NewEventsHotIngester(es, sink),
-	}, sink)
+	service := NewHotService(db, hotchunk.Ingest{Ledgers: true}, sink)
 
-	rawA, hashA, termA := marshalLCMWithEvent(t, first)
-	rawB, hashB, _ := marshalLCMWithEvent(t, first+1)
+	rawA := marshalLCM(t, first)
+	rawB := marshalLCM(t, first+1)
 	require.NoError(t, service.Ingest(context.Background(), first, xdr.LedgerCloseMetaView(rawA)))
 	require.NoError(t, service.Ingest(context.Background(), first+1, xdr.LedgerCloseMetaView(rawB)))
 
-	// All three stores retained the data.
-	gotRawA, err := ls.GetLedgerRaw(first)
+	// The ledger CF retained the data (read through the shared DB's facade).
+	gotRawA, err := db.Ledgers().GetLedgerRaw(first)
 	require.NoError(t, err)
 	require.Equal(t, rawA, gotRawA)
-	gotA, err := ts.Get(hashA)
+	gotRawB, err := db.Ledgers().GetLedgerRaw(first + 1)
 	require.NoError(t, err)
-	require.Equal(t, first, gotA)
-	gotB, err := ts.Get(hashB)
-	require.NoError(t, err)
-	require.Equal(t, first+1, gotB)
-	bm, err := es.Lookup(context.Background(), termA)
-	require.NoError(t, err)
-	require.Equal(t, uint64(2), bm.GetCardinality())
+	require.Equal(t, rawB, gotRawB)
 
-	// Aggregate + per-ingester signals.
+	// The single watermark advanced to the last committed ledger (decision (a)).
+	maxSeq, ok, err := db.MaxCommittedSeq()
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, first+1, maxSeq)
+
+	// Aggregate + per-type signals.
 	require.Equal(t, 2, sink.hotLedgerTotals, "one HotLedgerTotal per ledger")
 	dt := sink.hotDataTypes()
 	require.Equal(t, 2, dt[dataTypeLedgers])
-	require.Equal(t, 2, dt[dataTypeTxhash])
-	require.Equal(t, 2, dt[dataTypeEvents])
-
-	// Per-stage signals: each ledger fired the hot extract/write stages its
-	// data type defines (ledgers has no extract — it writes the view verbatim).
-	st := sink.stageCounts()
-	require.Equal(t, 2, st[dataTypeLedgers+"/"+tierHot+"/"+stageWrite])
-	require.Equal(t, 2, st[dataTypeTxhash+"/"+tierHot+"/"+stageExtract])
-	require.Equal(t, 2, st[dataTypeTxhash+"/"+tierHot+"/"+stageWrite])
-	require.Equal(t, 2, st[dataTypeEvents+"/"+tierHot+"/"+stageExtract])
-	require.Equal(t, 2, st[dataTypeEvents+"/"+tierHot+"/"+stageWrite])
 }
 
-// TestHotService_EnabledSubset runs HotService with only the ledger ingester and
-// asserts only that type's signals fire.
+// TestHotService_EnabledSubset runs HotService with ledgers enabled and asserts
+// the ledger signal fires for each ingested ledger.
 func TestHotService_EnabledSubset(t *testing.T) {
 	seq := chunk.ID(0).FirstLedger()
 	logger := testLogger()
-	dir := t.TempDir()
 
-	ls, err := ledger.OpenHotStore(dir, chunk.ID(0), logger)
+	db, err := hotchunk.Open(t.TempDir(), chunk.ID(0), logger)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ls.Close()) }()
+	defer func() { require.NoError(t, db.Close()) }()
 
 	sink := &testSink{}
-	service := NewHotService([]HotIngester{NewLedgerHotIngester(ls, sink)}, sink)
+	service := NewHotService(db, hotchunk.Ingest{Ledgers: true}, sink)
 	require.NoError(t, service.Ingest(context.Background(), seq, viewOf(t, seq)))
 
 	require.Equal(t, 1, sink.hotLedgerTotals)
 	dt := sink.hotDataTypes()
 	require.Equal(t, 1, dt[dataTypeLedgers])
-	require.Zero(t, dt[dataTypeTxhash])
-	require.Zero(t, dt[dataTypeEvents])
 }
 
 // ───────────────────────── ColdService tests ─────────────────────────
 
-// TestColdService_Success drives ledger+txhash+events cold ingesters through a
-// ColdService and asserts readback plus the metrics signals.
+// TestColdService_Success drives the ledger cold ingester through a ColdService
+// and asserts readback plus the metrics signals.
 func TestColdService_Success(t *testing.T) {
 	chunkID := chunk.ID(0)
 	first := chunkID.FirstLedger()
 	coldDir := t.TempDir()
 	sink := &testSink{}
 
-	ings, err := buildColdIngesters(coldDir, chunkID, sink, Config{Ledgers: true, Txhash: true, Events: true})
+	ings, err := buildColdIngesters(coldDir, chunkID, sink, Config{Ledgers: true})
 	require.NoError(t, err)
 	service := NewColdService(ings, sink)
 	defer func() { require.NoError(t, service.Close()) }()
 
-	var term events.TermKey
 	for _, seq := range []uint32{first, first + 1} {
-		raw, _, tk := marshalLCMWithEvent(t, seq)
-		term = tk
-		require.NoError(t, service.Ingest(context.Background(), seq, xdr.LedgerCloseMetaView(raw)))
+		require.NoError(t, service.Ingest(context.Background(), seq, viewOf(t, seq)))
 	}
 	require.NoError(t, service.Finalize(context.Background()))
 
-	// Ledger cold readback: tx hashes use random keypairs, so bytes can't be
-	// regenerated for comparison — assert the boundary ledger reads back and
-	// decodes to the right sequence.
+	// Ledger cold readback: the boundary ledger reads back and decodes to the
+	// right sequence.
 	lcr, err := ledger.OpenColdReader(packPath(filepath.Join(coldDir, dataTypeLedgers), chunkID))
 	require.NoError(t, err)
 	defer func() { require.NoError(t, lcr.Close()) }()
 	gotFirst, err := lcr.GetLedgerRaw(first)
 	require.NoError(t, err)
+	require.Equal(t, marshalLCM(t, first), gotFirst)
 	var decoded xdr.LedgerCloseMeta
 	require.NoError(t, decoded.UnmarshalBinary(gotFirst))
 	require.Equal(t, first, decoded.LedgerSequence())
 
-	// Events cold readback.
-	ecr, err := eventstore.OpenColdReader(
-		chunkID, filepath.Join(coldDir, dataTypeEvents, chunkID.BucketID()), eventstore.ColdReaderOptions{})
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ecr.Close()) }()
-	bm, err := ecr.Lookup(context.Background(), term)
-	require.NoError(t, err)
-	require.Equal(t, uint64(2), bm.GetCardinality())
-
-	// Txhash .bin count.
-	binEntries, err := txhash.ReadColdBin(txhashBinPath(filepath.Join(coldDir, dataTypeTxhash)))
-	require.NoError(t, err)
-	require.Len(t, binEntries, 2)
-
-	// Metrics: one ColdChunkTotal, one ColdIngest per data type, no errors.
+	// Metrics: one ColdChunkTotal, one ColdIngest for ledgers, no errors.
 	require.Equal(t, 1, sink.coldChunkTotals)
 	cdt := sink.coldDataTypes()
 	require.Equal(t, 1, cdt[dataTypeLedgers])
-	require.Equal(t, 1, cdt[dataTypeTxhash])
-	require.Equal(t, 1, cdt[dataTypeEvents])
 	require.Empty(t, sink.coldErrorTypes(), "success path records no ingester errors")
 
-	// Per-stage signals: per-ledger cold stages fired once per (non-empty)
-	// ledger, the per-chunk finalize stage once per ingester. The exact map is
-	// asserted so an unexpected stage emission (or a missing one) also fails —
-	// events now emits term_index/write for every ledger, and txhash's extract
-	// spans its whole per-ledger Ingest.
+	// Per-stage signals: per-ledger cold write fired once per ledger, the
+	// per-chunk finalize stage once. The exact map is asserted so an unexpected
+	// stage emission (or a missing one) also fails.
 	require.Equal(t, map[string]int{
 		dataTypeLedgers + "/" + tierCold + "/" + stageWrite:    2,
 		dataTypeLedgers + "/" + tierCold + "/" + stageFinalize: 1,
-		dataTypeTxhash + "/" + tierCold + "/" + stageExtract:   2,
-		dataTypeTxhash + "/" + tierCold + "/" + stageFinalize:  1,
-		dataTypeEvents + "/" + tierCold + "/" + stageExtract:   2,
-		dataTypeEvents + "/" + tierCold + "/" + stageTermIndex: 2,
-		dataTypeEvents + "/" + tierCold + "/" + stageWrite:     2,
-		dataTypeEvents + "/" + tierCold + "/" + stageFinalize:  1,
 	}, sink.stageCounts())
 
 	// No double-emit: the deferred Close (after this body) must not add a second
 	// ColdIngest or ColdChunkTotal, since Finalize already emitted.
 	require.NoError(t, service.Close())
 	require.Equal(t, 1, sink.coldChunkTotals, "Close after Finalize must not re-emit the aggregate")
-	require.Len(t, sink.coldIngests, 3, "Close after Finalize must not re-emit per-ingester signals")
+	require.Len(t, sink.coldIngests, 1, "Close after Finalize must not re-emit per-ingester signals")
 }
 
 // failingCold is a ColdIngester whose Ingest always fails, modeling a mid-chunk
@@ -869,23 +518,21 @@ func (f *failingCold) Close() error                   { f.closed = true; return 
 // failing sibling: ColdService.Ingest returns the sibling's error, Finalize is
 // not called, the deferred Close drops the partial ledger pack, and no finalized
 // artifact remains. It also asserts the cold metrics still fire on this failure
-// path: each real ingester emits exactly one ColdIngest and the service emits one
+// path: the real ingester emits exactly one ColdIngest and the service emits one
 // aggregate ColdChunkTotal — driven from Close, since Finalize never ran.
 func TestColdService_FailurePath_NoArtifact(t *testing.T) {
 	chunkID := chunk.ID(0)
 	coldDir := t.TempDir()
 	sink := &testSink{}
 
-	// Two real cold ingesters (ledger + events) plus a failing sibling, so we can
-	// assert each real ingester emits its per-chunk ColdIngest from Close.
+	// A real cold ledger ingester plus a failing sibling, so we can assert the
+	// real ingester emits its per-chunk ColdIngest from Close.
 	realLedger, err := NewLedgerColdIngester(filepath.Join(coldDir, dataTypeLedgers), chunkID, sink)
 	require.NoError(t, err)
-	realEvents, err := NewEventsColdIngester(filepath.Join(coldDir, dataTypeEvents), chunkID, sink)
-	require.NoError(t, err)
 	failing := &failingCold{}
-	service := NewColdService([]ColdIngester{realLedger, realEvents, failing}, sink)
+	service := NewColdService([]ColdIngester{realLedger, failing}, sink)
 
-	// First ledger: the real ingesters succeed, failing returns an error → the
+	// First ledger: the real ingester succeeds, failing returns an error → the
 	// sequential Ingest aborts the ledger with the sibling's error.
 	err = service.Ingest(context.Background(), chunkID.FirstLedger(), viewOf(t, chunkID.FirstLedger()))
 	require.ErrorIs(t, err, errFailingCold)
@@ -900,10 +547,9 @@ func TestColdService_FailurePath_NoArtifact(t *testing.T) {
 	require.NoError(t, service.Close())
 	require.True(t, failing.closed)
 
-	// Each real ingester emitted exactly one ColdIngest; the aggregate fired once.
+	// The real ingester emitted exactly one ColdIngest; the aggregate fired once.
 	cdt := sink.coldDataTypes()
 	require.Equal(t, 1, cdt[dataTypeLedgers], "ledger cold ingester emits once on failure path")
-	require.Equal(t, 1, cdt[dataTypeEvents], "events cold ingester emits once on failure path")
 	require.Equal(t, 1, sink.coldChunkTotals, "exactly one aggregate ColdChunkTotal")
 
 	// No finalized ledger pack must exist.
@@ -951,12 +597,12 @@ func TestPrometheusSink_Smoke(t *testing.T) {
 	require.NotPanics(t, func() {
 		sink := NewPrometheusSink(reg, "test")
 		sink.HotIngest(dataTypeLedgers, time.Millisecond, 1, nil)
-		sink.HotIngest(dataTypeEvents, time.Millisecond, 3, errFailingCold)
-		sink.ColdIngest(dataTypeTxhash, time.Second, 100, nil)
+		sink.HotIngest(dataTypeLedgers, time.Millisecond, 3, errFailingCold)
+		sink.ColdIngest(dataTypeLedgers, time.Second, 100, nil)
 		sink.HotLedgerTotal(time.Millisecond)
 		sink.ColdChunkTotal(time.Second)
-		sink.IngestStage(dataTypeEvents, tierHot, stageExtract, time.Millisecond, 3)
-		sink.IngestStage(dataTypeEvents, tierCold, stageFinalize, time.Second, 0)
+		sink.IngestStage(dataTypeLedgers, tierHot, stageWrite, time.Millisecond, 1)
+		sink.IngestStage(dataTypeLedgers, tierCold, stageFinalize, time.Second, 0)
 	})
 
 	mfs, err := reg.Gather()
@@ -966,34 +612,27 @@ func TestPrometheusSink_Smoke(t *testing.T) {
 
 // ───────────────────────── hot driver tests ─────────────────────────
 
-// TestRunHot_AllTypes_Readback runs the RunHot driver with injected hot stores
-// over event/tx-bearing ledgers and asserts each hot store reads back. The short
-// stream ends early so RunHot returns the completeness error after both ledgers
-// are fully ingested.
-func TestRunHot_AllTypes_Readback(t *testing.T) {
+// TestRunHot_Ledgers_Readback runs the RunHot driver with the injected SHARED
+// hot DB (decision (a)) and asserts the ledger CF reads back. The short stream
+// ends early so RunHot returns the completeness error after both ledgers are
+// fully ingested.
+func TestRunHot_Ledgers_Readback(t *testing.T) {
 	chunkID := chunk.ID(0)
 	first := chunkID.FirstLedger()
 	logger := testLogger()
-	dir := t.TempDir()
 
-	ls, err := ledger.OpenHotStore(filepath.Join(dir, "ledgers"), chunkID, logger)
+	db, err := hotchunk.Open(t.TempDir(), chunkID, logger)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ls.Close()) }()
-	ts, err := txhash.NewHotStore(filepath.Join(dir, "txhash"), chunkID, logger)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ts.Close()) }()
-	es, err := eventstore.OpenHotStore(filepath.Join(dir, "events"), chunkID, logger)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, es.Close()) }()
+	defer func() { require.NoError(t, db.Close()) }()
 
-	evSeqA, evSeqB := first, first+1
-	rawA, hashA, termA := marshalLCMWithEvent(t, evSeqA)
-	rawB, hashB, _ := marshalLCMWithEvent(t, evSeqB)
+	seqA, seqB := first, first+1
+	rawA := marshalLCM(t, seqA)
+	rawB := marshalLCM(t, seqB)
 	gen := func(tt *testing.T, seq uint32) []byte {
 		switch seq {
-		case evSeqA:
+		case seqA:
 			return rawA
-		case evSeqB:
+		case seqB:
 			return rawB
 		default:
 			return marshalLCM(tt, seq)
@@ -1001,39 +640,30 @@ func TestRunHot_AllTypes_Readback(t *testing.T) {
 	}
 	stream := &fakeStream{t: t, count: 2, gen: gen}
 
-	stores := HotStores{Ledgers: ls, Txhash: ts, Events: es}
-	cfg := Config{Ledgers: true, Txhash: true, Events: true}
+	stores := HotStores{HotDB: db}
+	cfg := Config{Ledgers: true}
 
 	err = RunHot(context.Background(), logger, sourceOf(stream), chunkID, stores, nil, cfg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "ended at")
 
-	gotRawA, err := ls.GetLedgerRaw(evSeqA)
+	gotRawA, err := db.Ledgers().GetLedgerRaw(seqA)
 	require.NoError(t, err)
 	require.Equal(t, rawA, gotRawA)
-
-	gotA, err := ts.Get(hashA)
+	gotRawB, err := db.Ledgers().GetLedgerRaw(seqB)
 	require.NoError(t, err)
-	require.Equal(t, evSeqA, gotA)
-	gotB, err := ts.Get(hashB)
-	require.NoError(t, err)
-	require.Equal(t, evSeqB, gotB)
-
-	bm, err := es.Lookup(context.Background(), termA)
-	require.NoError(t, err)
-	require.NotNil(t, bm)
-	require.Equal(t, uint64(2), bm.GetCardinality(), "both sentinel events share the term")
+	require.Equal(t, rawB, gotRawB)
 }
 
 // TestRunHot_MissingStore asserts RunHot rejects an enabled type with a nil
-// injected store.
+// injected shared hot DB.
 func TestRunHot_MissingStore(t *testing.T) {
 	chunkID := chunk.ID(0)
 	logger := testLogger()
 	err := RunHot(context.Background(), logger, sourceOf(&fakeStream{t: t, count: 1}), chunkID,
 		HotStores{}, nil, Config{Ledgers: true})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "HotStores.Ledgers is nil")
+	require.Contains(t, err.Error(), "HotStores.HotDB is nil")
 }
 
 // TestPackSource_RoundTrip exercises the production PackSource + packStream path
@@ -1197,69 +827,6 @@ func TestRunCold_CustomSource_Extensibility(t *testing.T) {
 	require.Equal(t, marshalLCM(t, first), raw)
 }
 
-// TestRunCold_TxhashCold_Bin runs the cold txhash driver over a chunk whose
-// sentinel ledgers carry one tx each and asserts the .bin entry count.
-func TestRunCold_TxhashCold_Bin(t *testing.T) {
-	chunkID := chunk.ID(0)
-	first := chunkID.FirstLedger()
-	coldDir := t.TempDir()
-	logger := testLogger()
-
-	txSeqs := map[uint32]bool{first: true, first + 1: true}
-	gen := func(tt *testing.T, seq uint32) []byte {
-		if txSeqs[seq] {
-			raw, _, _ := marshalLCMWithEvent(tt, seq)
-			return raw
-		}
-		return marshalLCM(tt, seq)
-	}
-
-	require.NoError(t, RunCold(
-		context.Background(), logger, customSource{t: t, gen: gen}, coldDir, chunkID, 1, 1, nil, Config{Txhash: true},
-	))
-
-	entries, err := txhash.ReadColdBin(txhashBinPath(filepath.Join(coldDir, dataTypeTxhash)))
-	require.NoError(t, err)
-	require.Len(t, entries, len(txSeqs))
-}
-
-// TestRunCold_EventsCold_Readback runs the cold events driver over a chunk whose
-// sentinel ledgers carry one event each and resolves the term post-Finalize.
-func TestRunCold_EventsCold_Readback(t *testing.T) {
-	chunkID := chunk.ID(0)
-	first := chunkID.FirstLedger()
-	coldDir := t.TempDir()
-	logger := testLogger()
-
-	evSeqs := map[uint32]bool{first: true, first + 1: true}
-	var term events.TermKey
-	gen := func(tt *testing.T, seq uint32) []byte {
-		if evSeqs[seq] {
-			raw, _, tk := marshalLCMWithEvent(tt, seq)
-			term = tk
-			return raw
-		}
-		return marshalLCM(tt, seq)
-	}
-
-	require.NoError(t, RunCold(
-		context.Background(), logger, customSource{t: t, gen: gen}, coldDir, chunkID, 1, 1, nil, Config{Events: true},
-	))
-
-	bucketDir := filepath.Join(coldDir, "events", chunkID.BucketID())
-	cr, err := eventstore.OpenColdReader(chunkID, bucketDir, eventstore.ColdReaderOptions{})
-	require.NoError(t, err)
-	defer func() { require.NoError(t, cr.Close()) }()
-
-	cnt, err := cr.EventCount()
-	require.NoError(t, err)
-	require.Equal(t, uint32(len(evSeqs)), cnt)
-	bm, err := cr.Lookup(context.Background(), term)
-	require.NoError(t, err)
-	require.NotNil(t, bm)
-	require.Equal(t, uint64(len(evSeqs)), bm.GetCardinality())
-}
-
 // ───────────────────────── drain seq guard (P0-1) ─────────────────────────
 
 // TestRunCold_OutOfOrderSeq_NoArtifact feeds a stream that yields a ledger out
@@ -1296,37 +863,6 @@ func TestRunCold_OutOfOrderSeq_NoArtifact(t *testing.T) {
 	require.True(t, os.IsNotExist(statErr), "expected no cold artifact at %s, stat err: %v", path, statErr)
 }
 
-// TestDrain_TxhashSeqGuard asserts the guard also fires on the txhash path,
-// where a wrong-but-right-count sequence would otherwise be silently absorbed
-// (each ledger keys on its own LCM seq).
-func TestDrain_TxhashSeqGuard(t *testing.T) {
-	chunkID := chunk.ID(0)
-	first := chunkID.FirstLedger()
-	last := chunkID.LastLedger()
-	coldDir := t.TempDir()
-	logger := testLogger()
-
-	seqs := make([]uint32, 0, last-first+1)
-	for s := first; s <= last; s++ {
-		seqs = append(seqs, s)
-	}
-	require.GreaterOrEqual(t, len(seqs), 2)
-	// Corrupt the SECOND ledger so at least one valid ledger is ingested
-	// before the guard fires.
-	seqs[1] += 100
-
-	err := RunCold(
-		context.Background(), logger, sourceOf(&seqStream{t: t, seqs: seqs}), coldDir, chunkID, 1, 1, nil,
-		Config{Txhash: true},
-	)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "yielded ledger")
-
-	binPath := txhashBinPath(filepath.Join(coldDir, dataTypeTxhash))
-	_, statErr := os.Stat(binPath)
-	require.True(t, os.IsNotExist(statErr), "expected no .bin at %s, stat err: %v", binPath, statErr)
-}
-
 // TestRunCold_DrainStreamError_NoArtifact exercises the drain mid-stream error
 // path: the backend yields valid ledgers, then hands back (nil, err) at a seq in
 // the middle of the chunk. drain must wrap the error with RawLedgers + the seq,
@@ -1356,154 +892,25 @@ func TestRunCold_DrainStreamError_NoArtifact(t *testing.T) {
 	require.True(t, os.IsNotExist(statErr), "expected no cold artifact at %s, stat err: %v", path, statErr)
 }
 
-// The txhash .bin codec itself — atomic publish, create/rename failure
-// cleanup, layout, and the reader round-trip — is owned and tested by
-// pkg/stores/txhash (cold_bin_test.go); these tests only cover the
-// ingester-level behavior on top of it.
-
 // ───────────────────────── HotService failure path (P1-c) ─────────────────────────
 
-// failingHot is a HotIngester whose Ingest always fails. ctxObserved records
-// whether the ingester's context was already canceled when it ran (used to
-// show errgroup sibling cancellation in the multi-ingester path).
-type failingHot struct {
-	mu          sync.Mutex
-	ran         int
-	ctxObserved error
-}
-
-var errFailingHot = errors.New("failingHot: induced ingest failure")
-
-func (f *failingHot) Ingest(ctx context.Context, _ uint32, _ xdr.LedgerCloseMetaView) error {
-	f.mu.Lock()
-	f.ran++
-	f.ctxObserved = ctx.Err()
-	f.mu.Unlock()
-	return errFailingHot
-}
-
-// blockingHot blocks until its context is canceled, then reports the cancel
-// error. Pairs with failingHot in the multi-ingester test to prove the first
-// error cancels the siblings via the errgroup context.
-type blockingHot struct {
-	canceled chan struct{}
-	once     sync.Once
-}
-
-func (b *blockingHot) Ingest(ctx context.Context, _ uint32, _ xdr.LedgerCloseMetaView) error {
-	<-ctx.Done()
-	b.once.Do(func() { close(b.canceled) })
-	return ctx.Err()
-}
-
-// TestHotService_SingleIngesterFailure asserts the len==1 fast path returns the
-// ingester error and still emits exactly one HotLedgerTotal.
-func TestHotService_SingleIngesterFailure(t *testing.T) {
-	sink := &testSink{}
-	fail := &failingHot{}
-	service := NewHotService([]HotIngester{fail}, sink)
-
-	err := service.Ingest(context.Background(), chunk.ID(0).FirstLedger(), viewOf(t, chunk.ID(0).FirstLedger()))
-	require.ErrorIs(t, err, errFailingHot)
-	require.Equal(t, 1, sink.hotLedgerTotals, "HotLedgerTotal fires exactly once even on failure")
-}
-
-// TestHotService_MultiIngesterFailureCancelsSiblings asserts the errgroup path
-// propagates the failing ingester's error, cancels the sibling via the group
-// context, and still emits exactly one HotLedgerTotal.
-func TestHotService_MultiIngesterFailureCancelsSiblings(t *testing.T) {
-	sink := &testSink{}
-	fail := &failingHot{}
-	block := &blockingHot{canceled: make(chan struct{})}
-	service := NewHotService([]HotIngester{fail, block}, sink)
-
-	err := service.Ingest(context.Background(), chunk.ID(0).FirstLedger(), viewOf(t, chunk.ID(0).FirstLedger()))
-	require.ErrorIs(t, err, errFailingHot)
-
-	// The blocking sibling only returns once its context is canceled, so a
-	// non-blocking Ingest return already proves cancellation propagated.
-	select {
-	case <-block.canceled:
-	case <-time.After(2 * time.Second):
-		t.Fatal("sibling ingester was not canceled by the failing ingester")
-	}
-	require.Equal(t, 1, sink.hotLedgerTotals, "HotLedgerTotal fires exactly once even on failure")
-}
-
-// TestHotIngester_Failure_RecordsErrorMetric drives a REAL hot ingester
-// (eventsHot, built via NewEventsHotIngester) with a malformed view so its own
-// Ingest fails through the production hotMetrics emit path — unlike the
-// failingHot/blockingHot stubs, which bypass hotMetrics entirely. Per #765 a
-// failed hot Ingest must record exactly one HotIngest carrying a non-nil error
-// for that data type. Mirrors the cold-side TestColdIngester_Failure_RecordsErrorMetric.
-func TestHotIngester_Failure_RecordsErrorMetric(t *testing.T) {
-	chunkID := chunk.ID(0)
+// TestHotService_IngestFailureStillEmitsTotal asserts a failed shared-DB ingest
+// (here: a closed DB) returns the error and still emits exactly one
+// HotLedgerTotal. Under decision (a) there is no fan-out to cancel — one atomic
+// batch either commits or returns its error — so a single failure path replaces
+// the old errgroup sibling-cancellation behavior.
+func TestHotService_IngestFailureStillEmitsTotal(t *testing.T) {
 	logger := testLogger()
-	dir := t.TempDir()
+	db, err := hotchunk.Open(t.TempDir(), chunk.ID(0), logger)
+	require.NoError(t, err)
+	require.NoError(t, db.Close()) // closed DB makes IngestLedger fail
+
 	sink := &testSink{}
+	service := NewHotService(db, hotchunk.Ingest{Ledgers: true}, sink)
 
-	store, err := eventstore.OpenHotStore(dir, chunkID, logger)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, store.Close()) }()
-
-	ing := NewEventsHotIngester(store, sink)
-
-	// A truncated/garbage view makes the event extraction fail inside the real
-	// Ingest, so the deferred hotMetrics.emit reports the wrapped error.
-	bad := xdr.LedgerCloseMetaView([]byte{0x00, 0x01, 0x02})
-	require.Error(t, ing.Ingest(context.Background(), chunkID.FirstLedger(), bad))
-
-	sink.mu.Lock()
-	defer sink.mu.Unlock()
-	require.Len(t, sink.hotIngests, 1, "exactly one HotIngest recorded")
-	require.Equal(t, dataTypeEvents, sink.hotIngests[0].dataType)
-	require.Error(t, sink.hotIngests[0].err, "the recorded HotIngest carries the ingest error")
-}
-
-// ───────────────────────── cold txhash .bin content (P1-d) ─────────────────────────
-
-// TestTxhashColdIngester_BinContent ingests two tx-bearing ledgers, finalizes,
-// then reads the .bin back through the store codec and asserts the contract
-// the deferred streamhash builder relies on: each key == the fixture tx hash
-// truncated to txhash.ColdKeySize (pinned to streamhash.MinKeySize by the
-// codec), each seq == the ledger it was ingested in, and entries are in
-// non-decreasing key order.
-func TestTxhashColdIngester_BinContent(t *testing.T) {
-	chunkID := chunk.ID(0)
-	first := chunkID.FirstLedger()
-	coldDir := t.TempDir()
-
-	ing, err := NewTxhashColdIngester(coldDir, chunkID, nil)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ing.Close()) }()
-
-	// Capture each fixture hash + the seq it was ingested in.
-	wantSeqByKey := map[[txhash.ColdKeySize]byte]uint32{}
-	for _, seq := range []uint32{first, first + 1} {
-		raw, hash, _ := marshalLCMWithEvent(t, seq)
-		var key [txhash.ColdKeySize]byte
-		copy(key[:], hash[:txhash.ColdKeySize])
-		wantSeqByKey[key] = seq
-		require.NoError(t, ing.Ingest(context.Background(), seq, xdr.LedgerCloseMetaView(raw)))
-	}
-	require.NoError(t, ing.Finalize(context.Background()))
-
-	entries, err := txhash.ReadColdBin(txhashBinPath(coldDir))
-	require.NoError(t, err)
-	require.Len(t, entries, 2)
-
-	var prevKey [txhash.ColdKeySize]byte
-	for i, e := range entries {
-		wantSeq, known := wantSeqByKey[e.Key]
-		require.True(t, known, "entry %d key %x is not one of the ingested fixture hashes", i, e.Key)
-		require.Equal(t, wantSeq, e.Seq, "entry %d seq must equal the ledger it was ingested in", i)
-
-		if i > 0 {
-			require.LessOrEqual(t, bytes.Compare(prevKey[:], e.Key[:]), 0,
-				"entries must be in non-decreasing key order")
-		}
-		prevKey = e.Key
-	}
+	err = service.Ingest(context.Background(), chunk.ID(0).FirstLedger(), viewOf(t, chunk.ID(0).FirstLedger()))
+	require.Error(t, err)
+	require.Equal(t, 1, sink.hotLedgerTotals, "HotLedgerTotal fires exactly once even on failure")
 }
 
 // ───────────────────────── OpenStream failure through the driver (P1-e) ─────────────────────────
@@ -1564,57 +971,37 @@ func TestRunCold_CanceledContext(t *testing.T) {
 func TestRunHot_OpenStreamError(t *testing.T) {
 	chunkID := chunk.ID(0)
 	logger := testLogger()
-	dir := t.TempDir()
 
-	ls, err := ledger.OpenHotStore(dir, chunkID, logger)
+	db, err := hotchunk.Open(t.TempDir(), chunkID, logger)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ls.Close()) }()
+	defer func() { require.NoError(t, db.Close()) }()
 
 	err = RunHot(context.Background(), logger, erroringSource{}, chunkID,
-		HotStores{Ledgers: ls}, nil, Config{Ledgers: true})
+		HotStores{HotDB: db}, nil, Config{Ledgers: true})
 	require.ErrorIs(t, err, errOpenStream)
 	require.Contains(t, err.Error(), "open stream for chunk 0")
 }
 
 // ───────────────────────── RunHot chunkID cross-check (P2-e) ─────────────────────────
 
-// TestRunHot_ChunkIDMismatch asserts RunHot rejects ANY injected hot store
-// bound to a different chunk than the one being ingested, with a clear
-// up-front error (rather than silently interleaving chunks on the ledger and
-// txhash paths, or a later per-ledger out-of-range on the events path). All
-// three hot stores are chunk-bound.
+// TestRunHot_ChunkIDMismatch asserts RunHot rejects an injected shared hot DB
+// bound to a different chunk than the one being ingested, with a clear up-front
+// error (rather than silently interleaving two chunks' data into one DB). The
+// shared DB is chunk-bound (decision (a)).
 func TestRunHot_ChunkIDMismatch(t *testing.T) {
 	ingestChunk := chunk.ID(1)
 	storeChunk := chunk.ID(0)
 	logger := testLogger()
 
-	run := func(t *testing.T, stores HotStores, cfg Config) {
-		t.Helper()
-		err := RunHot(context.Background(), logger, sourceOf(&fakeStream{t: t, count: 1}), ingestChunk,
-			stores, nil, cfg)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "bound to chunk 0")
-		require.Contains(t, err.Error(), "RunHot chunk 1")
-	}
+	db, err := hotchunk.Open(t.TempDir(), storeChunk, logger)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
 
-	t.Run("ledgers", func(t *testing.T) {
-		ls, err := ledger.OpenHotStore(t.TempDir(), storeChunk, logger)
-		require.NoError(t, err)
-		defer func() { require.NoError(t, ls.Close()) }()
-		run(t, HotStores{Ledgers: ls}, Config{Ledgers: true})
-	})
-	t.Run("txhash", func(t *testing.T) {
-		ts, err := txhash.NewHotStore(t.TempDir(), storeChunk, logger)
-		require.NoError(t, err)
-		defer func() { require.NoError(t, ts.Close()) }()
-		run(t, HotStores{Txhash: ts}, Config{Txhash: true})
-	})
-	t.Run("events", func(t *testing.T) {
-		es, err := eventstore.OpenHotStore(t.TempDir(), storeChunk, logger)
-		require.NoError(t, err)
-		defer func() { require.NoError(t, es.Close()) }()
-		run(t, HotStores{Events: es}, Config{Events: true})
-	})
+	err = RunHot(context.Background(), logger, sourceOf(&fakeStream{t: t, count: 1}), ingestChunk,
+		HotStores{HotDB: db}, nil, Config{Ledgers: true})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bound to chunk 0")
+	require.Contains(t, err.Error(), "RunHot chunk 1")
 }
 
 // ───────────────────────── Config validate / guard negatives (P2-g) ─────────────────────────
@@ -1738,79 +1125,19 @@ func countCleanColdIngests(s *testSink) int {
 	return n
 }
 
-// TestBuildColdIngesters_RollbackNoPhantomMetric makes a LATER constructor
-// (txhash) fail by planting a regular file at the txhash per-type directory,
-// so the constructor's own MkdirAll fails. The earlier-built ledger ingester
-// is rolled back via closeColdAll, which must NOT emit a phantom success
-// ColdIngest — the recorded ledger metric (if any) must carry the abort
-// error, never a clean (nil-err, 0-items) success.
-func TestBuildColdIngesters_RollbackNoPhantomMetric(t *testing.T) {
-	chunkID := chunk.ID(0)
-	coldDir := t.TempDir()
-	sink := &testSink{}
-
-	// Plant a regular FILE where the txhash per-type directory must be
-	// created: the ledger ingester builds first, then NewTxhashColdIngester
-	// fails its bucket-dir MkdirAll.
-	require.NoError(t, os.WriteFile(filepath.Join(coldDir, dataTypeTxhash), []byte("not a dir"), 0o644))
-
-	_, err := buildColdIngesters(coldDir, chunkID, sink, Config{Ledgers: true, Txhash: true})
-	require.Error(t, err, "txhash constructor must fail on the planted file")
-
-	// The ledger ingester was built then rolled back. No phantom SUCCESS metric:
-	// any recorded ledger ColdIngest must carry an error.
-	cdt := sink.coldDataTypes()
-	if cdt[dataTypeLedgers] > 0 {
-		require.Equal(t, cdt[dataTypeLedgers], sink.coldErrorTypes()[dataTypeLedgers],
-			"rolled-back ledger ingester must not emit a phantom success ColdIngest")
-	}
-	// And the success-only assertion: there must be zero clean (nil-err) cold
-	// ingest signals recorded.
-	require.Zero(t, countCleanColdIngests(sink), "no clean ColdIngest on the rollback path")
-}
-
-// TestBuildColdIngesters_RollbackLaterFailure_TxhashAborts makes the LAST
-// constructor (events) fail AFTER both the ledger AND txhash ingesters were
-// already built, so closeColdAll rolls back two ingesters. It asserts the txhash
-// ingester (which DOES implement abortMetric) emits an error-carrying — not a
-// clean-success — ColdIngest, complementing the ledger-only abort coverage above.
-func TestBuildColdIngesters_RollbackLaterFailure_TxhashAborts(t *testing.T) {
-	chunkID := chunk.ID(0)
-	coldDir := t.TempDir()
-	sink := &testSink{}
-
-	// Plant a directory at the events.pack path: the ledger and txhash
-	// ingesters build first, then NewEventsColdIngester fails opening the
-	// pack over the directory.
-	packPath := filepath.Join(coldDir, dataTypeEvents, chunkID.BucketID(), eventstore.EventsPackName(chunkID))
-	require.NoError(t, os.MkdirAll(packPath, 0o755))
-
-	_, err := buildColdIngesters(coldDir, chunkID, sink,
-		Config{Ledgers: true, Txhash: true, Events: true})
-	require.Error(t, err, "events constructor must fail on the planted directory")
-
-	// The txhash ingester was built then rolled back: its recorded ColdIngest must
-	// carry the abort error, never a clean success.
-	cdt := sink.coldDataTypes()
-	require.Equal(t, 1, cdt[dataTypeTxhash], "rolled-back txhash ingester emits one ColdIngest")
-	require.Equal(t, 1, sink.coldErrorTypes()[dataTypeTxhash],
-		"the rolled-back txhash ColdIngest must carry the abort error")
-
-	// No phantom clean success on the rollback path for any ingester.
-	require.Zero(t, countCleanColdIngests(sink), "no clean ColdIngest on the rollback path")
-}
-
 // TestRunCold_ConstructorFailure_EmitsAggregate drives a constructor failure
 // through RunCold (not buildColdIngesters directly) and asserts the chunk
 // attempt still produces its single aggregate ColdChunkTotal — the invariant
-// is one aggregate per chunk attempt, including pre-service failures.
+// is one aggregate per chunk attempt, including pre-service failures. The
+// rolled-back ledger ingester must not emit a phantom clean-success ColdIngest.
 func TestRunCold_ConstructorFailure_EmitsAggregate(t *testing.T) {
 	chunkID := chunk.ID(0)
 	coldDir := t.TempDir()
 	logger := testLogger()
 	sink := &testSink{}
 
-	// Plant a regular file where the ledgers per-type subdir must be created.
+	// Plant a regular file where the ledgers per-type subdir must be created so
+	// the ledger cold constructor's MkdirAll fails.
 	require.NoError(t, os.WriteFile(filepath.Join(coldDir, dataTypeLedgers), []byte("not a dir"), 0o644))
 
 	err := RunCold(
@@ -1821,68 +1148,6 @@ func TestRunCold_ConstructorFailure_EmitsAggregate(t *testing.T) {
 	require.Equal(t, 1, sink.coldChunkTotals,
 		"a constructor-failure chunk attempt still emits exactly one ColdChunkTotal")
 	require.Zero(t, countCleanColdIngests(sink), "no clean ColdIngest on the rollback path")
-}
-
-// ───────────────────────── events Finish-then-WriteColdIndex failure ─────────────────────────
-
-// TestEventsCold_FinishThenIndexFails_LeavesInertPack forces WriteColdIndex to
-// fail AFTER writer.Finish has committed events.pack, by planting a directory
-// where the index.hash file must be written (buildMPHF then hits EISDIR).
-// Finalize must surface the error; the index-less events.pack stays on disk —
-// without the orchestrator's completion record it is inert scratch (see the
-// package doc's artifact model), and a retry's overwrite is the cleanup.
-func TestEventsCold_FinishThenIndexFails_LeavesInertPack(t *testing.T) {
-	chunkID := chunk.ID(0)
-	first := chunkID.FirstLedger()
-	coldDir := t.TempDir()
-
-	ing, err := NewEventsColdIngester(coldDir, chunkID, nil)
-	require.NoError(t, err)
-
-	// Ingest one event-bearing ledger so the mirror is non-empty (an empty
-	// build set would take the valid empty-index path instead of buildMPHF).
-	rawEv, _, _ := marshalLCMWithEvent(t, first)
-	require.NoError(t, ing.Ingest(context.Background(), first, xdr.LedgerCloseMetaView(rawEv)))
-
-	// Plant a DIRECTORY where index.hash must be written → buildMPHF fails.
-	bucketDir := filepath.Join(coldDir, chunkID.BucketID())
-	indexHashPath := filepath.Join(bucketDir, eventstore.IndexHashName(chunkID))
-	require.NoError(t, os.Mkdir(indexHashPath, 0o755))
-
-	ferr := ing.Finalize(context.Background())
-	require.Error(t, ferr, "Finalize must fail when WriteColdIndex fails")
-	require.Contains(t, ferr.Error(), "WriteColdIndex")
-
-	// The committed events.pack stays in place as inert scratch (Finish ran,
-	// so the later Close does not drop it either).
-	packPath := filepath.Join(bucketDir, eventstore.EventsPackName(chunkID))
-	_, statErr := os.Stat(packPath)
-	require.NoError(t, statErr, "the index-less events.pack stays on disk after WriteColdIndex failure")
-
-	// Close is still safe/idempotent afterwards and does not remove the pack.
-	require.NoError(t, ing.Close())
-	_, statErr = os.Stat(packPath)
-	require.NoError(t, statErr, "Close after a committed Finish must not drop the pack")
-}
-
-// TestEventsCold_FinalizeAfterFailedIngest_Refuses asserts the failed-Ingest
-// latch: once an Ingest errors (here via a malformed view), Finalize must
-// refuse rather than commit a pack+index whose mirror may be ahead of the
-// offsets commit point.
-func TestEventsCold_FinalizeAfterFailedIngest_Refuses(t *testing.T) {
-	chunkID := chunk.ID(0)
-	coldDir := t.TempDir()
-
-	ing, err := NewEventsColdIngester(coldDir, chunkID, nil)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, ing.Close()) }()
-
-	bad := xdr.LedgerCloseMetaView([]byte{0x00, 0x01, 0x02})
-	require.Error(t, ing.Ingest(context.Background(), chunkID.FirstLedger(), bad))
-
-	ferr := ing.Finalize(context.Background())
-	require.Error(t, ferr)
-	require.Contains(t, ferr.Error(), "Finalize after failed Ingest")
 }
 
 // ───────────────────────── ColdService.Finalize first-error ─────────────────────────

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/service.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/service.go
@@ -22,11 +22,8 @@ func errOrFirst(prev, cur error) error {
 }
 
 // HotService commits one ledger to the per-chunk hot DB as ONE atomic, synced
-// WriteBatch (decision (a)) and emits the per-ledger wall-clock plus per-type
-// volume signals via the sink.
-//
-// A ledger is fully present or fully absent because it commits in a single
-// WriteBatch (hotchunk.DB.IngestLedger).
+// WriteBatch (decision (a)) — so a ledger is fully present or fully absent — and
+// emits the per-ledger wall-clock plus per-type volume signals via the sink.
 type HotService struct {
 	db   *hotchunk.DB
 	cfg  hotchunk.Ingest
@@ -39,12 +36,11 @@ func NewHotService(db *hotchunk.DB, cfg hotchunk.Ingest, sink MetricSink) *HotSe
 	return &HotService{db: db, cfg: cfg, sink: orNop(sink)}
 }
 
-// Ingest commits lcm to the shared hot DB in one atomic synced WriteBatch
-// (decision (a)). seq is the driver-validated sequence of lcm, passed through
-// unchanged. HotLedgerTotal is emitted with the per-ledger wall-clock
-// regardless of success; on success, one HotIngest signal per enabled data type
-// reports that type's item count. A nil DB (no hot tier enabled for this
-// deployment) is a no-op other than the aggregate timing.
+// Ingest commits lcm to the shared hot DB in one atomic synced WriteBatch. seq
+// is the driver-validated sequence, passed through unchanged. HotLedgerTotal is
+// emitted regardless of success; on success, one HotIngest signal per enabled
+// data type reports its item count. A nil DB (no hot tier) is a no-op other than
+// the aggregate timing.
 func (s *HotService) Ingest(_ context.Context, seq uint32, lcm xdr.LedgerCloseMetaView) error {
 	start := time.Now()
 	if s.db == nil {

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/service.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/service.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"time"
 
-	"golang.org/x/sync/errgroup"
-
 	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/hotchunk"
 )
 
 // errOrFirst returns prev if it is non-nil, else cur. Used to retain the FIRST
@@ -21,49 +21,58 @@ func errOrFirst(prev, cur error) error {
 	return cur
 }
 
-// HotService fans one ledger out to a set of HotIngesters concurrently, waiting
-// for all to finish before returning (so the borrowed view is safe to release),
-// and emits the aggregate per-ledger wall-clock via the sink.
+// HotService commits one ledger to the per-chunk hot DB as ONE atomic, synced
+// WriteBatch (decision (a)) and emits the per-ledger wall-clock plus per-type
+// volume signals via the sink.
+//
+// A ledger is fully present or fully absent because it commits in a single
+// WriteBatch (hotchunk.DB.IngestLedger).
 type HotService struct {
-	ingesters []HotIngester
-	sink      MetricSink
+	db   *hotchunk.DB
+	cfg  hotchunk.Ingest
+	sink MetricSink
 }
 
-// NewHotService builds a HotService over the enabled hot ingesters. A nil sink
-// defaults to NopSink.
-func NewHotService(ingesters []HotIngester, sink MetricSink) *HotService {
-	return &HotService{ingesters: ingesters, sink: orNop(sink)}
+// NewHotService builds a HotService that writes the data types enabled in cfg
+// into the shared per-chunk DB. A nil sink defaults to NopSink.
+func NewHotService(db *hotchunk.DB, cfg hotchunk.Ingest, sink MetricSink) *HotService {
+	return &HotService{db: db, cfg: cfg, sink: orNop(sink)}
 }
 
-// Ingest runs every hot ingester on lcm concurrently and waits for all of them.
-// seq is the driver-validated sequence of lcm, passed through unchanged. The
-// first ingester error is returned; the production HotIngester.Ingest
-// implementations do not check ctx.Err(), so the siblings run to completion
-// regardless (g.Wait still returns the first error). The single-ingester config
-// skips the errgroup entirely. HotLedgerTotal is emitted with the fan-out
-// wall-clock regardless of success.
-func (s *HotService) Ingest(ctx context.Context, seq uint32, lcm xdr.LedgerCloseMetaView) error {
+// Ingest commits lcm to the shared hot DB in one atomic synced WriteBatch
+// (decision (a)). seq is the driver-validated sequence of lcm, passed through
+// unchanged. HotLedgerTotal is emitted with the per-ledger wall-clock
+// regardless of success; on success, one HotIngest signal per enabled data type
+// reports that type's item count. A nil DB (no hot tier enabled for this
+// deployment) is a no-op other than the aggregate timing.
+func (s *HotService) Ingest(_ context.Context, seq uint32, lcm xdr.LedgerCloseMetaView) error {
 	start := time.Now()
-	switch len(s.ingesters) {
-	case 0:
-		// No hot ingesters enabled for this tier: nothing to do.
+	if s.db == nil {
 		s.sink.HotLedgerTotal(time.Since(start))
 		return nil
-	case 1:
-		// Single ingester: call directly, skipping the errgroup overhead.
-		err := s.ingesters[0].Ingest(ctx, seq, lcm)
-		s.sink.HotLedgerTotal(time.Since(start))
-		return err
-	default:
-		// Two or more: concurrent fan-out, waiting for all.
-		g, gctx := errgroup.WithContext(ctx)
-		for _, ing := range s.ingesters {
-			g.Go(func() error { return ing.Ingest(gctx, seq, lcm) })
-		}
-		err := g.Wait()
-		s.sink.HotLedgerTotal(time.Since(start))
-		return err
 	}
+	counts, err := s.db.IngestLedger(seq, lcm, s.cfg)
+	s.emit(counts, time.Since(start), err)
+	s.sink.HotLedgerTotal(time.Since(start))
+	return err
+}
+
+// emit reports one HotIngest signal per enabled data type. On error the counts
+// are reported as 0 items with the error attached (matching the per-type "items
+// written" contract: a failed commit wrote nothing durably).
+func (s *HotService) emit(counts hotchunk.LedgerCounts, d time.Duration, err error) {
+	if s.cfg.Ledgers {
+		s.sink.HotIngest(dataTypeLedgers, d, itemsOnSuccess(counts.Ledgers, err), err)
+	}
+}
+
+// itemsOnSuccess returns n on success and 0 on error — a failed atomic batch
+// commits nothing, so no items were written.
+func itemsOnSuccess(n int, err error) int {
+	if err != nil {
+		return 0
+	}
+	return n
 }
 
 // ColdService drives a set of ColdIngesters for one chunk: sequential per-ledger

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/hotchunk/hotchunk.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/hotchunk/hotchunk.go
@@ -42,10 +42,9 @@ func columnFamilies() []string {
 	return []string{ledger.LedgersCF}
 }
 
-// config builds the per-chunk store's rocksdb.Config. It rides on
-// RocksDB's defaults (zero Tuning) — the same choice ledger.OpenHotStore
-// makes for the standalone ledger store: no explicit block cache, bloom
-// filter, or WAL cap. Re-tune only with a workload measurement.
+// config builds the per-chunk store's rocksdb.Config, riding on RocksDB's
+// defaults (zero Tuning) — the same choice ledger.OpenHotStore makes. Re-tune
+// only with a workload measurement.
 func config(path string, logger *supportlog.Entry) rocksdb.Config {
 	return rocksdb.Config{
 		Path:           path,
@@ -107,14 +106,12 @@ type LedgerCounts struct {
 	Ledgers int
 }
 
-// IngestLedger commits ONE ledger to the hot DB as a SINGLE atomic,
-// synced WriteBatch (decision (a)). It queues the ledger row into one
-// rocksdb.BatchWriter and commits once (sync=true via the store's pinned
-// WriteOptions). The single watermark advances atomically.
+// IngestLedger commits ONE ledger as a SINGLE atomic, synced WriteBatch
+// (decision (a)), so the single watermark advances atomically.
 //
-// seq is the driver-validated sequence of lcm. lcm is a borrowed,
-// zero-copy view: the ledger bytes are copied into the batch
-// synchronously, so the view need not outlive this call.
+// seq is the driver-validated sequence of lcm. lcm is a borrowed, zero-copy
+// view: the bytes are copied into the batch synchronously, so it need not
+// outlive this call.
 func (d *DB) IngestLedger(seq uint32, lcm xdr.LedgerCloseMetaView, cfg Ingest) (LedgerCounts, error) {
 	var counts LedgerCounts
 	if d.store.IsClosed() {

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/hotchunk/hotchunk.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/hotchunk/hotchunk.go
@@ -89,7 +89,7 @@ func (d *DB) Close() error { return d.store.Close() }
 // MaxCommittedSeq returns the single authoritative per-chunk watermark:
 // the highest ledger seq durably committed, read from the ledgers CF's
 // last key. ok=false on an empty DB (no ledger committed yet).
-func (d *DB) MaxCommittedSeq() (seq uint32, ok bool, err error) {
+func (d *DB) MaxCommittedSeq() (uint32, bool, error) {
 	return d.ledger.LastSeq()
 }
 

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/hotchunk/hotchunk.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/hotchunk/hotchunk.go
@@ -1,0 +1,141 @@
+// Package hotchunk implements decision (a): the per-chunk hot tier is
+// ONE RocksDB instance holding the ledger column family, and each ledger
+// commits as ONE atomic, synced WriteBatch. There is a SINGLE per-chunk
+// watermark (the max committed ledger seq, authoritative from the
+// ledgers CF's last key), with no per-store frontier markers.
+//
+// The typed ledger facade (ledger.HotStore) is composed over the shared
+// store via its NewWithStore constructor and keeps its existing read API
+// for downstream (#770). Its write path is expressed as Puts queued into
+// the shared batch, which commits once.
+package hotchunk
+
+import (
+	"fmt"
+
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/rocksdb"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/ledger"
+)
+
+// DB is one chunk's hot tier: a single rocksdb.Store plus the typed
+// ledger facade composed over it. It owns the store's lifecycle (Close
+// closes it exactly once); the facade wraps it without owning it.
+//
+// Concurrency: ingestion is single-writer (the daemon's per-chunk
+// ingestion loop). IngestLedger is not safe to call concurrently with
+// itself. Reads via the facade follow its own concurrency contract and
+// are safe alongside the single writer.
+type DB struct {
+	store   *rocksdb.Store
+	chunkID chunk.ID
+
+	ledger *ledger.HotStore
+}
+
+// columnFamilies returns the CF list for the per-chunk DB: the ledger CF.
+func columnFamilies() []string {
+	return []string{ledger.LedgersCF}
+}
+
+// config builds the per-chunk store's rocksdb.Config. It rides on
+// RocksDB's defaults (zero Tuning) — the same choice ledger.OpenHotStore
+// makes for the standalone ledger store: no explicit block cache, bloom
+// filter, or WAL cap. Re-tune only with a workload measurement.
+func config(path string, logger *supportlog.Entry) rocksdb.Config {
+	return rocksdb.Config{
+		Path:           path,
+		ColumnFamilies: columnFamilies(),
+		Logger:         logger,
+	}
+}
+
+// Open opens (or creates) the chunk's hot DB at path and composes the
+// ledger facade over it. path and logger are required.
+func Open(path string, chunkID chunk.ID, logger *supportlog.Entry) (*DB, error) {
+	if path == "" {
+		return nil, stores.ErrInvalidConfig
+	}
+	if logger == nil {
+		return nil, stores.ErrInvalidConfig
+	}
+	store, err := rocksdb.New(config(path, logger))
+	if err != nil {
+		return nil, fmt.Errorf("hotchunk: open chunk %s: %w", chunkID, err)
+	}
+
+	return &DB{
+		store:   store,
+		chunkID: chunkID,
+		ledger:  ledger.NewWithStore(store, chunkID),
+	}, nil
+}
+
+// ChunkID returns the chunk this DB is bound to.
+func (d *DB) ChunkID() chunk.ID { return d.chunkID }
+
+// Ledgers returns the ledger read/write facade over the shared store.
+func (d *DB) Ledgers() *ledger.HotStore { return d.ledger }
+
+// Close releases the shared store exactly once. Idempotent (delegates
+// to rocksdb.Store.Close, which is itself idempotent). Must not be
+// called concurrently with in-flight reads/writes.
+func (d *DB) Close() error { return d.store.Close() }
+
+// MaxCommittedSeq returns the single authoritative per-chunk watermark:
+// the highest ledger seq durably committed, read from the ledgers CF's
+// last key. ok=false on an empty DB (no ledger committed yet).
+func (d *DB) MaxCommittedSeq() (seq uint32, ok bool, err error) {
+	return d.ledger.LastSeq()
+}
+
+// Ingest contributions toggle which data types the single per-ledger
+// batch writes. Mirrors ingest.Config but kept local so hotchunk has no
+// dependency on the ingest package (which depends on the stores).
+type Ingest struct {
+	Ledgers bool
+}
+
+// LedgerCounts reports how many items each data type contributed to one
+// IngestLedger call: 1 ledger (when Ledgers enabled). Lets the caller
+// (HotService) emit per-type volume metrics without re-deriving them.
+type LedgerCounts struct {
+	Ledgers int
+}
+
+// IngestLedger commits ONE ledger to the hot DB as a SINGLE atomic,
+// synced WriteBatch (decision (a)). It queues the ledger row into one
+// rocksdb.BatchWriter and commits once (sync=true via the store's pinned
+// WriteOptions). The single watermark advances atomically.
+//
+// seq is the driver-validated sequence of lcm. lcm is a borrowed,
+// zero-copy view: the ledger bytes are copied into the batch
+// synchronously, so the view need not outlive this call.
+func (d *DB) IngestLedger(seq uint32, lcm xdr.LedgerCloseMetaView, cfg Ingest) (LedgerCounts, error) {
+	var counts LedgerCounts
+	if d.store.IsClosed() {
+		return counts, stores.ErrStoreClosed
+	}
+
+	if cfg.Ledgers {
+		counts.Ledgers = 1
+	}
+
+	cerr := d.store.Batch(func(b *rocksdb.BatchWriter) error {
+		if cfg.Ledgers {
+			if err := d.ledger.AddLedgerToBatch(b, ledger.Entry{Seq: seq, Bytes: []byte(lcm)}); err != nil {
+				return fmt.Errorf("hotchunk: queue ledger seq %d: %w", seq, err)
+			}
+		}
+		return nil
+	})
+	if cerr != nil {
+		return counts, fmt.Errorf("hotchunk: commit ledger %d to chunk %s: %w", seq, d.chunkID, cerr)
+	}
+
+	return counts, nil
+}

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/hotchunk/hotchunk_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/hotchunk/hotchunk_test.go
@@ -1,0 +1,202 @@
+package hotchunk
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/rocksdb"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/ledger"
+)
+
+func silentLogger() *supportlog.Entry {
+	log := supportlog.New()
+	log.SetLevel(logrus.ErrorLevel)
+	return log
+}
+
+func openTestDB(t *testing.T, chunkID chunk.ID) *DB {
+	t.Helper()
+	db, err := Open(t.TempDir(), chunkID, silentLogger())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func allTypes() Ingest { return Ingest{Ledgers: true} }
+
+func TestOpen_ValidatesInputs(t *testing.T) {
+	_, err := Open("", chunk.ID(0), silentLogger())
+	require.ErrorIs(t, err, stores.ErrInvalidConfig)
+
+	_, err = Open(t.TempDir(), chunk.ID(0), nil)
+	require.ErrorIs(t, err, stores.ErrInvalidConfig)
+}
+
+func TestColumnFamilies_IsLedgerCF(t *testing.T) {
+	cfs := columnFamilies()
+	require.Len(t, cfs, 1)
+	require.Equal(t, ledger.LedgersCF, cfs[0])
+}
+
+// TestIngestLedger_LedgerCommittedAndWatermarkAdvances is the core decision-(a)
+// happy path: one IngestLedger call writes the ledger into the hot DB, and the
+// single watermark reaches exactly the committed seq.
+func TestIngestLedger_LedgerCommittedAndWatermarkAdvances(t *testing.T) {
+	chunkID := chunk.ID(0)
+	first := chunkID.FirstLedger()
+	db := openTestDB(t, chunkID)
+
+	// Empty DB: no watermark.
+	_, ok, err := db.MaxCommittedSeq()
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	rawA := zeroTxLCM(t, first)
+	rawB := zeroTxLCM(t, first+1)
+
+	counts, err := db.IngestLedger(first, xdr.LedgerCloseMetaView(rawA), allTypes())
+	require.NoError(t, err)
+	assert.Equal(t, LedgerCounts{Ledgers: 1}, counts)
+
+	counts, err = db.IngestLedger(first+1, xdr.LedgerCloseMetaView(rawB), allTypes())
+	require.NoError(t, err)
+	assert.Equal(t, LedgerCounts{Ledgers: 1}, counts)
+
+	// ledgers CF.
+	gotA, err := db.Ledgers().GetLedgerRaw(first)
+	require.NoError(t, err)
+	assert.Equal(t, rawA, gotA)
+
+	// The single authoritative watermark equals the last committed seq.
+	maxSeq, ok, err := db.MaxCommittedSeq()
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, first+1, maxSeq)
+}
+
+// TestIngestLedger_DurableAcrossReopen confirms a committed ledger survives a
+// close/reopen (sync=true durability), and that a commit into a CLOSED store
+// fails and leaves nothing behind — the single synced WriteBatch is
+// all-or-nothing.
+func TestIngestLedger_DurableAcrossReopen(t *testing.T) {
+	chunkID := chunk.ID(0)
+	first := chunkID.FirstLedger()
+	dir := t.TempDir()
+
+	db, err := Open(dir, chunkID, silentLogger())
+	require.NoError(t, err)
+
+	// Commit one good ledger so there is a known watermark, then close the DB.
+	rawGood := zeroTxLCM(t, first)
+	_, err = db.IngestLedger(first, xdr.LedgerCloseMetaView(rawGood), allTypes())
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	// Reopen and confirm the watermark survived (sync=true durability).
+	db2, err := Open(dir, chunkID, silentLogger())
+	require.NoError(t, err)
+
+	maxSeq, ok, err := db2.MaxCommittedSeq()
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, first, maxSeq, "the committed ledger is durable across reopen")
+
+	// Now close the DB and attempt to ingest the NEXT ledger into the closed
+	// store: the commit fails, and nothing for that ledger persists anywhere.
+	require.NoError(t, db2.Close())
+	rawNext := zeroTxLCM(t, first+1)
+	_, err = db2.IngestLedger(first+1, xdr.LedgerCloseMetaView(rawNext), allTypes())
+	require.Error(t, err)
+
+	// Reopen a third time: the failed ledger left NO trace, and the watermark is
+	// still the last good seq.
+	db3, err := Open(dir, chunkID, silentLogger())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db3.Close() })
+
+	maxSeq, ok, err = db3.MaxCommittedSeq()
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, first, maxSeq, "the failed ledger did not advance the watermark")
+
+	// The good ledger's data is intact; the failed ledger's is wholly absent.
+	_, gerr := db3.Ledgers().GetLedgerRaw(first + 1)
+	require.ErrorIs(t, gerr, stores.ErrNotFound)
+
+	gotGood, err := db3.Ledgers().GetLedgerRaw(first)
+	require.NoError(t, err)
+	assert.Equal(t, rawGood, gotGood)
+}
+
+// TestSharedBatch_DirectRocksAbort is the lower-level atomicity proof: queue a
+// Put into the ledger CF of the store, then return an error from the batch
+// callback — RocksDB applies NONE of it. Pins the property the IngestLedger
+// path relies on (atomicity of one WriteBatch).
+func TestSharedBatch_DirectRocksAbort(t *testing.T) {
+	db := openTestDB(t, chunk.ID(0))
+
+	sentinelErr := assert.AnError
+
+	err := storeOf(db).Batch(func(b *rocksdb.BatchWriter) error {
+		b.Put(ledger.LedgersCF, rocksdb.EncodeUint32(2), []byte("ledger-row"))
+		return sentinelErr // abort: nothing should commit
+	})
+	require.ErrorIs(t, err, sentinelErr)
+
+	// The CF did not receive the aborted write.
+	_, gerr := db.Ledgers().GetLedgerRaw(2)
+	require.ErrorIs(t, gerr, stores.ErrNotFound)
+	_, ok, derr := db.MaxCommittedSeq()
+	require.NoError(t, derr)
+	require.False(t, ok)
+}
+
+// storeOf exposes the store for the direct-batch atomicity test (same package,
+// so no production accessor is needed).
+func storeOf(db *DB) *rocksdb.Store { return db.store }
+
+// TestIngestLedger_ClosedDBFails confirms a closed DB rejects ingest.
+func TestIngestLedger_ClosedDBFails(t *testing.T) {
+	chunkID := chunk.ID(0)
+	db, err := Open(t.TempDir(), chunkID, silentLogger())
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	raw := zeroTxLCM(t, chunkID.FirstLedger())
+	_, err = db.IngestLedger(chunkID.FirstLedger(), xdr.LedgerCloseMetaView(raw), allTypes())
+	require.ErrorIs(t, err, stores.ErrStoreClosed)
+}
+
+// ──────────────────────────── LCM fixtures ────────────────────────────
+
+// zeroTxLCM builds a minimal V2 LCM with no transactions at the given sequence.
+func zeroTxLCM(t *testing.T, seq uint32) []byte {
+	t.Helper()
+	lcm := xdr.LedgerCloseMeta{
+		V: 2,
+		V2: &xdr.LedgerCloseMetaV2{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+				Header: xdr.LedgerHeader{
+					ScpValue:  xdr.StellarValue{CloseTime: xdr.TimePoint(0)},
+					LedgerSeq: xdr.Uint32(seq),
+				},
+			},
+			TxSet: xdr.GeneralizedTransactionSet{
+				V:       1,
+				V1TxSet: &xdr.TransactionSetV1{Phases: []xdr.TransactionPhase{}},
+			},
+			TxProcessing: []xdr.TransactionResultMetaV1{},
+		},
+	}
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	return raw
+}

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/ledger/hot_store.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/ledger/hot_store.go
@@ -17,12 +17,9 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/zstd"
 )
 
-// LedgersCF is the column family the hot ledger data lives in inside
-// the shared per-chunk hot DB (decision (a): one multi-CF RocksDB per
-// chunk). When the HotStore owns a dedicated single-purpose DB (the
-// standalone OpenHotStore path used by per-store tests and the cold
-// freeze readers), the same CF name is registered so the on-disk
-// layout is identical whether the store is shared or standalone.
+// LedgersCF is the column family the hot ledger data lives in (decision (a):
+// one multi-CF RocksDB per chunk). The standalone OpenHotStore path registers
+// the same CF name, so the on-disk layout is identical shared or standalone.
 const LedgersCF = "ledgers"
 
 // Entry — one (sequence, uncompressed ledger bytes) pair. Both
@@ -184,13 +181,11 @@ func (h *HotStore) AddLedgers(entries ...Entry) error {
 	}))
 }
 
-// AddLedgerToBatch compresses one ledger and queues its single Put into
-// b (the LedgersCF) — the building block the hotchunk package uses to
-// fold the ledger write into the one atomic per-ledger WriteBatch
-// shared across all CFs (decision (a)). It does not commit: the caller
-// owns the batch and its single synced Write. Compression happens here
-// (synchronously into a fresh buffer that BatchWriter.Put copies), so
-// the caller's bytes need not outlive this call.
+// AddLedgerToBatch compresses one ledger and queues its single Put into b (the
+// LedgersCF), letting the hotchunk package fold the ledger write into its one
+// atomic per-ledger WriteBatch (decision (a)). It does not commit — the caller
+// owns the batch and its synced Write. Compression copies into a fresh buffer,
+// so the caller's bytes need not outlive this call.
 func (h *HotStore) AddLedgerToBatch(b *rocksdb.BatchWriter, e Entry) error {
 	if h.store.IsClosed() {
 		return stores.ErrStoreClosed

--- a/cmd/stellar-rpc/internal/fullhistory/pkg/stores/ledger/hot_store.go
+++ b/cmd/stellar-rpc/internal/fullhistory/pkg/stores/ledger/hot_store.go
@@ -17,6 +17,14 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/zstd"
 )
 
+// LedgersCF is the column family the hot ledger data lives in inside
+// the shared per-chunk hot DB (decision (a): one multi-CF RocksDB per
+// chunk). When the HotStore owns a dedicated single-purpose DB (the
+// standalone OpenHotStore path used by per-store tests and the cold
+// freeze readers), the same CF name is registered so the on-disk
+// layout is identical whether the store is shared or standalone.
+const LedgersCF = "ledgers"
+
 // Entry — one (sequence, uncompressed ledger bytes) pair. Both
 // hot and cold stores compress on write and decompress on read,
 // so callers always pass and receive raw ledger bytes here.
@@ -48,7 +56,13 @@ type Entry struct {
 type HotStore struct {
 	store   *rocksdb.Store
 	chunkID chunk.ID
-	dec     *zstd.Decompressor
+	// ownsStore is true when this HotStore opened its own dedicated
+	// rocksdb.Store (the standalone OpenHotStore path) and must close
+	// it on Close. It is false when the store is the SHARED per-chunk
+	// multi-CF DB injected by the hotchunk package — that DB is owned
+	// by hotchunk.DB and closed once, not three times.
+	ownsStore bool
+	dec       *zstd.Decompressor
 	// compPool — per-store pool of zstd.Compressors. Each
 	// concurrent AddLedgers borrows one for the duration of its
 	// Encode call; the pool's GC finalizer (set inside
@@ -78,12 +92,25 @@ func OpenHotStore(path string, chunkID chunk.ID, logger *supportlog.Entry) (*Hot
 		return nil, stores.ErrInvalidConfig
 	}
 	store, err := rocksdb.New(rocksdb.Config{
-		Path:   path,
-		Logger: logger,
+		Path:           path,
+		ColumnFamilies: []string{LedgersCF},
+		Logger:         logger,
 	})
 	if err != nil {
 		return nil, err
 	}
+	h := NewWithStore(store, chunkID)
+	h.ownsStore = true
+	return h, nil
+}
+
+// NewWithStore wraps an ALREADY-OPEN rocksdb.Store as a ledger HotStore
+// operating on the LedgersCF column family. The store is NOT owned by
+// the returned HotStore (Close is a no-op on the shared DB) — this is
+// the constructor the hotchunk package uses to compose the three
+// per-type facades over one shared multi-CF DB (decision (a)). The
+// store must have been opened with LedgersCF registered.
+func NewWithStore(store *rocksdb.Store, chunkID chunk.ID) *HotStore {
 	return &HotStore{
 		store:   store,
 		chunkID: chunkID,
@@ -91,13 +118,21 @@ func OpenHotStore(path string, chunkID chunk.ID, logger *supportlog.Entry) (*Hot
 		compPool: sync.Pool{
 			New: func() any { return zstd.NewCompressor() },
 		},
-	}, nil
+	}
 }
 
-// Close releases the underlying RocksDB store. Idempotent —
-// delegates to rocksdb.Store.Close. Must not be called concurrently
-// with in-flight reads/writes on this HotStore.
-func (h *HotStore) Close() error { return h.store.Close() }
+// Close releases the underlying RocksDB store IF this HotStore owns it
+// (the standalone OpenHotStore path). When the store is the shared
+// per-chunk DB injected via NewWithStore, Close is a no-op — the
+// hotchunk.DB owns and closes the shared store exactly once.
+// Idempotent. Must not be called concurrently with in-flight
+// reads/writes on this HotStore.
+func (h *HotStore) Close() error {
+	if !h.ownsStore {
+		return nil
+	}
+	return h.store.Close()
+}
 
 // ChunkID returns the chunk this store is bound to (constructor-supplied;
 // never reads the store).
@@ -127,7 +162,7 @@ func (h *HotStore) AddLedgers(entries ...Entry) error {
 		if err != nil {
 			return err
 		}
-		return translateRocksErr(h.store.Put("", rocksdb.EncodeUint32(e.Seq), compressed))
+		return translateRocksErr(h.store.Put(LedgersCF, rocksdb.EncodeUint32(e.Seq), compressed))
 	}
 	// Multi-entry path: compress each into its own fresh slice so
 	// the batch can hold them all simultaneously (the compressor's
@@ -143,10 +178,31 @@ func (h *HotStore) AddLedgers(entries ...Entry) error {
 	}
 	return translateRocksErr(h.store.Batch(func(b *rocksdb.BatchWriter) error {
 		for i, e := range entries {
-			b.Put("", rocksdb.EncodeUint32(e.Seq), compressed[i])
+			b.Put(LedgersCF, rocksdb.EncodeUint32(e.Seq), compressed[i])
 		}
 		return nil
 	}))
+}
+
+// AddLedgerToBatch compresses one ledger and queues its single Put into
+// b (the LedgersCF) — the building block the hotchunk package uses to
+// fold the ledger write into the one atomic per-ledger WriteBatch
+// shared across all CFs (decision (a)). It does not commit: the caller
+// owns the batch and its single synced Write. Compression happens here
+// (synchronously into a fresh buffer that BatchWriter.Put copies), so
+// the caller's bytes need not outlive this call.
+func (h *HotStore) AddLedgerToBatch(b *rocksdb.BatchWriter, e Entry) error {
+	if h.store.IsClosed() {
+		return stores.ErrStoreClosed
+	}
+	c, _ := h.compPool.Get().(*zstd.Compressor)
+	defer h.compPool.Put(c)
+	compressed, err := c.Encode(nil, e.Bytes)
+	if err != nil {
+		return err
+	}
+	b.Put(LedgersCF, rocksdb.EncodeUint32(e.Seq), compressed)
+	return nil
 }
 
 // GetLedgerRaw decodes the ledger stored under seq into a fresh,
@@ -155,7 +211,7 @@ func (h *HotStore) AddLedgers(entries ...Entry) error {
 // should prefer IterateLedgers, which yields borrows without the
 // per-ledger decode allocation.
 func (h *HotStore) GetLedgerRaw(seq uint32) ([]byte, error) {
-	v, found, err := h.store.Get("", rocksdb.EncodeUint32(seq))
+	v, found, err := h.store.Get(LedgersCF, rocksdb.EncodeUint32(seq))
 	if err != nil {
 		return nil, translateRocksErr(err)
 	}
@@ -184,7 +240,7 @@ func (h *HotStore) edgeSeq(last bool) (uint32, bool, error) {
 	if last {
 		edge = h.store.LastKey
 	}
-	k, ok, err := edge("")
+	k, ok, err := edge(LedgersCF)
 	if err != nil {
 		return 0, false, translateRocksErr(err)
 	}
@@ -213,7 +269,7 @@ func (h *HotStore) IterateLedgers(start, end uint32) iter.Seq2[Entry, error] {
 		// it past the loop body. The read benches consume each ledger in-scope,
 		// so this avoids a per-ledger decode allocation.
 		var scratch []byte
-		for e, err := range h.store.IterateRange("", rocksdb.EncodeUint32(start), rocksdb.EncodeUint32(end)) {
+		for e, err := range h.store.IterateRange(LedgersCF, rocksdb.EncodeUint32(start), rocksdb.EncodeUint32(end)) {
 			if err != nil {
 				yield(Entry{}, translateRocksErr(err))
 				return

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/doc.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/doc.go
@@ -4,9 +4,9 @@
 // (fullhistory/pkg/...). The catalog WRAPS metastore.Store rather than
 // reinventing a RocksDB wrapper.
 //
-// This covers Slice 1 · Layer 1 (foundations): the durable-state substrate
-// only, no daemon goroutines yet. Storage, orchestration, and daemon assembly
-// stack on top in later layers.
+// This covers Slice 1 · Layers 1–2 (foundations + storage): the durable-state
+// substrate and the per-chunk storage primitives, no daemon goroutines yet.
+// Orchestration and daemon assembly stack on top in later layers.
 //
 // # Data model (keys-first)
 //
@@ -22,7 +22,7 @@
 // One cohesive package by design: the crash-safety invariants are verified by
 // fault-injection hooks fired from INSIDE the real methods (hooks.go), so the
 // catalog, protocol, sweeps, and the I/O paths they protect must share a
-// package to keep those hooks package-private. This layer adds:
+// package to keep those hooks package-private. The files group by concern:
 //
 //	Foundation     keys.go, paths.go
 //	                 the catalog key schema, the key↔path bijection, and chunk
@@ -36,10 +36,15 @@
 //	                 over the catalog + storage roots.
 //	Cross-cutting  artifacts.go
 //	                 the ArtifactSet/Kind abstraction the later layers subset.
+//	Storage        process.go, hotsource.go
+//	                 processChunk + backfillSource materialize a chunk's cold
+//	                 artifacts from the cheapest source (ready hot DB → frozen
+//	                 local .pack → bulk backend); hotsource exposes the hot tier
+//	                 as a freeze source.
 //	Test seam      hooks.go
 //	                 test-only crash-injection points fired from inside the real
 //	                 protocol/sweep methods (every field nil in production).
 //
-// Layers 2–4 stack on this foundation (storage → orchestration → daemon
-// assembly); slices 2–3 add the events and tx-hash data types.
+// Layers 3–4 stack on top (orchestration → daemon assembly); slices 2–3 add
+// the events and tx-hash data types.
 package streaming

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/hotsource.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/hotsource.go
@@ -1,0 +1,164 @@
+package streaming
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"os"
+
+	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/ingest"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/hotchunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/ledger"
+)
+
+// rocksHotProbe is the production HotProbe: it opens the chunk's SINGLE shared
+// per-chunk RocksDB hot DB (one multi-CF instance: ledgers + events CFs +
+// txhash CFs) at the path the daemon's hot-storage layout dictates, and answers
+// backfillSource's completeness question over it.
+//
+// Under decision (a) the hot tier is ONE DB whose every CF advances together in
+// one atomic synced WriteBatch per ledger, so "complete" is the single
+// authoritative maxCommittedSeq (the ledgers CF's last key) — no min-of-three,
+// no per-store frontier reconciliation.
+type rocksHotProbe struct {
+	hotRoot func(chunkID chunk.ID) string
+	logger  *supportlog.Entry
+}
+
+// NewRocksHotProbe returns the production HotProbe. hotChunkPath maps a chunk to
+// its hot-DB directory (the daemon passes Layout.HotChunkPath); logger is
+// forwarded to the shared-DB opener.
+//
+// Caller contract: the chunk passed to OpenHotChunk must NOT be the one captive
+// core is actively ingesting — that chunk holds its hot RocksDB open read-write,
+// and a second open of the same path fails on RocksDB's LOCK. The catch-up loop
+// excludes the live chunk by design (the partial resume chunk is finished by
+// ingestion, not by a freeze pass), so the probe only ever opens chunks
+// ingestion has already released.
+func NewRocksHotProbe(hotChunkPath func(chunk.ID) string, logger *supportlog.Entry) HotProbe {
+	return &rocksHotProbe{hotRoot: hotChunkPath, logger: logger}
+}
+
+func (p *rocksHotProbe) OpenHotChunk(chunkID chunk.ID) (HotChunk, bool, error) {
+	dir := p.hotRoot(chunkID)
+	if _, err := os.Stat(dir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, false, nil // dir absent — caller treats as loss under "ready"
+		}
+		return nil, false, fmt.Errorf("stat hot dir %s: %w", dir, err)
+	}
+
+	// One shared multi-CF DB at the chunk's hot dir — the same instance, opened
+	// with the same union of CFs, that the ingestion side writes.
+	db, err := hotchunk.Open(dir, chunkID, p.logger)
+	if err != nil {
+		return nil, false, fmt.Errorf("open hot chunk DB: %w", err)
+	}
+	return &rocksHotChunk{chunkID: chunkID, db: db}, true, nil
+}
+
+// rocksHotChunk is one chunk's opened hot tier — the single shared DB.
+type rocksHotChunk struct {
+	chunkID chunk.ID
+	db      *hotchunk.DB
+}
+
+// MaxCommittedSeq returns the single authoritative watermark (DECISION (a)):
+// the highest ledger seq the shared DB has durably committed, from the ledgers
+// CF's last key. Because every ledger commits as one atomic synced WriteBatch
+// across all CFs, this one value pins every CF's frontier — events and txhash
+// never trail or lead. ok=false on an empty DB.
+func (h *rocksHotChunk) MaxCommittedSeq() (uint32, bool, error) {
+	seq, ok, err := h.db.MaxCommittedSeq()
+	if err != nil {
+		return 0, false, fmt.Errorf("hot DB max committed seq: %w", err)
+	}
+	return seq, ok, nil
+}
+
+// Source streams the chunk's LCMs from the ledgers CF as a ChunkSource the cold
+// pipeline drains.
+func (h *rocksHotChunk) Source() ingest.ChunkSource {
+	return &hotLedgerSource{store: h.db.Ledgers()}
+}
+
+// Close releases the shared hot DB.
+func (h *rocksHotChunk) Close() error {
+	if h.db == nil {
+		return nil
+	}
+	return h.db.Close()
+}
+
+// ---------------------------------------------------------------------------
+// hotLedgerSource — an ingest.ChunkSource backed by a ledger.HotStore, so the
+// merged cold pipeline (RunColdChunk) can freeze a just-closed chunk straight
+// from its hot DB without a refetch.
+// ---------------------------------------------------------------------------
+
+type hotLedgerSource struct {
+	store *ledger.HotStore
+}
+
+// OpenStream returns a stream over the hot store's ledgers for the requested
+// chunk. The store is already chunk-bound; the stream honors the driver's
+// requested [from,to] range via IterateLedgers.
+func (s *hotLedgerSource) OpenStream(chunkID chunk.ID) (ledgerbackend.LedgerStream, error) {
+	if s.store == nil {
+		return nil, errors.New("streaming: hotLedgerSource has no store")
+	}
+	if s.store.ChunkID() != chunkID {
+		return nil, fmt.Errorf("streaming: hotLedgerSource bound to chunk %s, asked for %s",
+			s.store.ChunkID(), chunkID)
+	}
+	return &hotLedgerStream{store: s.store}, nil
+}
+
+type hotLedgerStream struct {
+	store *ledger.HotStore
+}
+
+var _ ledgerbackend.LedgerStream = (*hotLedgerStream)(nil)
+
+// RawLedgers yields each ledger's wire bytes for the requested range from the
+// hot store. The store's IterateLedgers yields BORROWED buffers (valid only to
+// the next step); the cold ingesters copy what they retain (HotIngester
+// contract), and the drain loop consumes each ledger fully before the next
+// yield, so the borrow is safe. ctx cancellation is observed between ledgers,
+// upholding the ChunkSource contract the drain loop relies on.
+func (st *hotLedgerStream) RawLedgers(
+	ctx context.Context, r ledgerbackend.Range, _ ...ledgerbackend.StreamOption,
+) iter.Seq2[[]byte, error] {
+	return func(yield func([]byte, error) bool) {
+		to := r.To()
+		if !r.Bounded() {
+			last, ok, err := st.store.LastSeq()
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			if !ok {
+				return
+			}
+			to = last
+		}
+		for e, ierr := range st.store.IterateLedgers(r.From(), to) {
+			if cerr := ctx.Err(); cerr != nil {
+				yield(nil, cerr)
+				return
+			}
+			if ierr != nil {
+				yield(nil, ierr)
+				return
+			}
+			if !yield(e.Bytes, nil) {
+				return
+			}
+		}
+	}
+}

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/hotsource.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/hotsource.go
@@ -17,29 +17,21 @@ import (
 )
 
 // rocksHotProbe is the production HotProbe: it opens the chunk's SINGLE shared
-// per-chunk RocksDB hot DB (one multi-CF instance: ledgers + events CFs +
-// txhash CFs) at the path the daemon's hot-storage layout dictates, and answers
-// backfillSource's completeness question over it.
-//
-// Under decision (a) the hot tier is ONE DB whose every CF advances together in
-// one atomic synced WriteBatch per ledger, so "complete" is the single
-// authoritative maxCommittedSeq (the ledgers CF's last key) — no min-of-three,
-// no per-store frontier reconciliation.
+// per-chunk RocksDB hot DB at the path the daemon's hot-storage layout dictates
+// and answers backfillSource's completeness question over it (decision (a) —
+// completeness is the single maxCommittedSeq; see pkg/stores/hotchunk).
 type rocksHotProbe struct {
 	hotRoot func(chunkID chunk.ID) string
 	logger  *supportlog.Entry
 }
 
 // NewRocksHotProbe returns the production HotProbe. hotChunkPath maps a chunk to
-// its hot-DB directory (the daemon passes Layout.HotChunkPath); logger is
-// forwarded to the shared-DB opener.
+// its hot-DB directory (the daemon passes Layout.HotChunkPath).
 //
 // Caller contract: the chunk passed to OpenHotChunk must NOT be the one captive
 // core is actively ingesting — that chunk holds its hot RocksDB open read-write,
-// and a second open of the same path fails on RocksDB's LOCK. The catch-up loop
-// excludes the live chunk by design (the partial resume chunk is finished by
-// ingestion, not by a freeze pass), so the probe only ever opens chunks
-// ingestion has already released.
+// so a second open fails on RocksDB's LOCK. The catch-up loop excludes the live
+// chunk by design, so the probe only opens chunks ingestion has already released.
 func NewRocksHotProbe(hotChunkPath func(chunk.ID) string, logger *supportlog.Entry) HotProbe {
 	return &rocksHotProbe{hotRoot: hotChunkPath, logger: logger}
 }
@@ -68,11 +60,9 @@ type rocksHotChunk struct {
 	db      *hotchunk.DB
 }
 
-// MaxCommittedSeq returns the single authoritative watermark (DECISION (a)):
+// MaxCommittedSeq returns the single authoritative watermark (decision (a)):
 // the highest ledger seq the shared DB has durably committed, from the ledgers
-// CF's last key. Because every ledger commits as one atomic synced WriteBatch
-// across all CFs, this one value pins every CF's frontier — events and txhash
-// never trail or lead. ok=false on an empty DB.
+// CF's last key. ok=false on an empty DB.
 func (h *rocksHotChunk) MaxCommittedSeq() (uint32, bool, error) {
 	seq, ok, err := h.db.MaxCommittedSeq()
 	if err != nil {
@@ -95,11 +85,9 @@ func (h *rocksHotChunk) Close() error {
 	return h.db.Close()
 }
 
-// ---------------------------------------------------------------------------
 // hotLedgerSource — an ingest.ChunkSource backed by a ledger.HotStore, so the
-// merged cold pipeline (RunColdChunk) can freeze a just-closed chunk straight
-// from its hot DB without a refetch.
-// ---------------------------------------------------------------------------
+// cold pipeline (RunColdChunk) can freeze a just-closed chunk straight from its
+// hot DB without a refetch.
 
 type hotLedgerSource struct {
 	store *ledger.HotStore
@@ -125,12 +113,11 @@ type hotLedgerStream struct {
 
 var _ ledgerbackend.LedgerStream = (*hotLedgerStream)(nil)
 
-// RawLedgers yields each ledger's wire bytes for the requested range from the
-// hot store. The store's IterateLedgers yields BORROWED buffers (valid only to
-// the next step); the cold ingesters copy what they retain (HotIngester
-// contract), and the drain loop consumes each ledger fully before the next
-// yield, so the borrow is safe. ctx cancellation is observed between ledgers,
-// upholding the ChunkSource contract the drain loop relies on.
+// RawLedgers yields each ledger's wire bytes for the requested range. The store's
+// IterateLedgers yields BORROWED buffers (valid only to the next step); the cold
+// ingesters copy what they retain and the drain loop consumes each ledger before
+// the next yield, so the borrow is safe. ctx cancellation is observed between
+// ledgers.
 func (st *hotLedgerStream) RawLedgers(
 	ctx context.Context, r ledgerbackend.Range, _ ...ledgerbackend.StreamOption,
 ) iter.Seq2[[]byte, error] {

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/process.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/process.go
@@ -178,7 +178,8 @@ func processChunk(ctx context.Context, chunkID chunk.ID, artifacts ArtifactSet, 
 	dirs := ingest.ColdDirs{
 		Ledgers: cat.layout.LedgersRoot(),
 	}
-	if rerr := ingest.RunColdChunk(ctx, cfg.Logger, source, dirs, chunkID, cfg.Sink, artifacts.ingestConfig()); rerr != nil {
+	rerr := ingest.RunColdChunk(ctx, cfg.Logger, source, dirs, chunkID, cfg.Sink, artifacts.ingestConfig())
+	if rerr != nil {
 		return fmt.Errorf("streaming: cold ingest chunk %s %s: %w", chunkID, artifacts, rerr)
 	}
 

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/process.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/process.go
@@ -1,0 +1,364 @@
+package streaming
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/ingest"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
+)
+
+// ErrHotVolumeLost is the case-4 fatal: a hot:chunk key is "ready" but its
+// directory is missing or unopenable. The hot DB is the SOLE copy of a chunk's
+// recently-ingested ledgers, so this is unrecoverable loss — never silently
+// healed. Loss is detected LAZILY, on the open that needs the DB (lastCommitted
+// Ledger's one refinement open of the highest ready chunk before ingestion
+// starts, openHotTierForChunk's "ready" branch, or backfillSource's hot branch),
+// not by an eager all-ready-keys scan. It is returned as a sentinel (not a
+// process exit) so the daemon's top-level loop owns the fatal-and-surface
+// decision and tests can assert it.
+var ErrHotVolumeLost = errors.New("streaming: hot storage lost; run surgical recovery (case 4)")
+
+// ErrBackendCoverageTimeout is the bounded-wait fatal from backfillSource's bulk
+// branch: the configured backend's tip never advanced to cover a
+// genuinely-backend-only chunk within the deadline.
+var ErrBackendCoverageTimeout = errors.New("streaming: backend never covered chunk within deadline")
+
+// HotProbe opens the per-chunk shared hot DB for a chunk and answers the two
+// questions backfillSource's hot branch asks: (1) is the hot tier COMPLETE for
+// this chunk — DECISION (a): the single DB's maxCommittedSeq >= the chunk's
+// last ledger — and (2) if so, hand back a ChunkSource that streams the chunk's
+// LCMs from the ledgers CF so the just-closed chunk freezes without a refetch.
+//
+// It is injected so processChunk/backfillSource stay testable without the live
+// ingestion pipeline: production wires the real shared multi-CF RocksDB; tests
+// pass a fake. Under decision (a) the hot tier is ONE DB whose ledgers, events,
+// and txhash CFs all advance together in one atomic synced WriteBatch per
+// ledger, so completeness is a SINGLE watermark — no min-of-three.
+type HotProbe interface {
+	// OpenHotChunk opens the chunk's shared hot DB read-only-ish (the daemon
+	// owns the writer; this is a borrow for a freeze pass). It returns the
+	// opened handle, or an error the caller treats as case-4 loss when the
+	// catalog key said "ready". A nil error with ok==false means the dir is
+	// absent (also loss when "ready").
+	OpenHotChunk(chunkID chunk.ID) (HotChunk, bool, error)
+}
+
+// HotChunk is one chunk's opened hot tier: the single DB's completeness gate
+// plus an LCM source over the ledgers CF. Close releases the shared DB.
+type HotChunk interface {
+	// MaxCommittedSeq returns the single authoritative watermark — the highest
+	// ledger seq the shared DB has durably committed (every CF advances
+	// together, decision (a)) — and ok=false if the DB is empty (no committed
+	// seq, so the chunk cannot be complete).
+	MaxCommittedSeq() (seq uint32, ok bool, err error)
+	// Source yields the chunk's LCMs from the ledgers CF as a ChunkSource the
+	// cold pipeline (RunColdChunk) can drain.
+	Source() ingest.ChunkSource
+	// Close releases the shared hot DB.
+	Close() error
+}
+
+// BackendWaiter bounds backfillSource's bulk branch: it blocks until the
+// configured backend's tip covers chunkLastLedger, polling on a backoff, and
+// returns ErrBackendCoverageTimeout (wrapped) if the tip never advances within
+// the deadline. A chunk WITH a local copy never reaches here, so this never
+// gates a normal restart whose range is entirely local.
+//
+// It is an interface (not an inline poll) so the bulk source's tip query is
+// injectable: production wraps the configured LedgerBackend's tip; tests pass a
+// fake that is either immediately-covered or never-covered.
+type BackendWaiter interface {
+	WaitForCoverage(ctx context.Context, chunkLastLedger uint32) error
+}
+
+// ProcessConfig is the dependency bundle processChunk/backfillSource read. It is
+// the streaming spine's view of everything a freeze pass needs: the catalog
+// (key state + path layout), the hot probe, the bulk backend source + its
+// coverage waiter, and the metric sink/logger. Construction is the daemon's
+// job; the primitives below never reach around it.
+type ProcessConfig struct {
+	Catalog *Catalog
+	Logger  *supportlog.Entry
+	Sink    ingest.MetricSink
+
+	// HotProbe opens the per-chunk hot tier for the hot branch. Required.
+	HotProbe HotProbe
+
+	// Backend is the configured bulk LedgerBackend as a ChunkSource (BSB by
+	// default — the pack/datastore ChunkSource from ingest). It is the only
+	// source for a chunk with no local copy. May be nil in a frontfill
+	// deployment that never backfills; backfillSource errors loudly if a chunk
+	// actually reaches the bulk branch with no backend configured.
+	Backend ingest.ChunkSource
+
+	// BackendWaiter bounds the bulk branch's wait-for-coverage. Required iff
+	// Backend is set; ignored otherwise.
+	BackendWaiter BackendWaiter
+}
+
+func (cfg ProcessConfig) validate() error {
+	if cfg.Catalog == nil {
+		return errors.New("streaming: ProcessConfig.Catalog is nil")
+	}
+	if cfg.HotProbe == nil {
+		return errors.New("streaming: ProcessConfig.HotProbe is nil")
+	}
+	if cfg.Logger == nil {
+		return errors.New("streaming: ProcessConfig.Logger is nil")
+	}
+	return nil
+}
+
+// processChunk materializes the requested cold artifact kinds (ledgers/.pack, events
+// cold segment, txhash/.bin) for ONE chunk in a single streaming pass over its
+// ledgers, applying the Phase A one-write protocol per kind (rule 1):
+//
+//   - Per-kind idempotency: a kind whose chunk key is already "frozen" is
+//     dropped from the request (it self-skips); a "freezing"/"pruning"/absent
+//     key triggers re-materialization, itself idempotent (the cold ingesters
+//     overwrite at the canonical path).
+//   - Mark-then-write: every remaining kind's key is put "freezing" BEFORE any
+//     I/O, the cold pipeline (RunColdChunk) writes the files at their canonical
+//     paths from the source backfillSource chose, the files + their dirents are
+//     fsynced (barrierNewFile), and only then are the keys flipped to "frozen".
+//
+// The cold ingestion is the merged ingest.RunColdChunk over the same cold
+// ingester set RunCold uses — processChunk does not re-derive any extractor or
+// writer; it only chooses the LCM source (backfillSource) and drives the one
+// write protocol around the freeze.
+func processChunk(ctx context.Context, chunkID chunk.ID, artifacts ArtifactSet, cfg ProcessConfig) error {
+	if err := cfg.validate(); err != nil {
+		return err
+	}
+	cat := cfg.Catalog
+
+	// rule 1 per-kind idempotency: frozen kinds self-skip.
+	for _, kind := range artifacts.Kinds() {
+		state, err := cat.State(chunkID, kind)
+		if err != nil {
+			return fmt.Errorf("streaming: read state chunk %s kind %s: %w", chunkID, kind, err)
+		}
+		if state == StateFrozen {
+			artifacts = artifacts.Remove(kind)
+		}
+	}
+	if artifacts.Empty() {
+		return nil
+	}
+
+	// Choose the LCM source BEFORE marking "freezing": backfillSource may fatal
+	// (case-4 loss) or fall through sources, and we must not leave "freezing"
+	// debris for a chunk we then refuse to produce. The returned closer releases
+	// any opened hot stores once the freeze pass finishes.
+	source, closeSource, err := backfillSource(ctx, chunkID, artifacts, cfg)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = closeSource() }()
+
+	// Mark-then-write: every requested kind "freezing" BEFORE any I/O.
+	if err := cat.MarkChunkFreezing(chunkID, artifacts.Kinds()...); err != nil {
+		return fmt.Errorf("streaming: mark freezing chunk %s %s: %w", chunkID, artifacts, err)
+	}
+
+	// Test-only observation point at the exact mark-then-write instant: every
+	// requested kind is now "freezing" and no file has been written yet. A no-op
+	// in production (hook nil); see crashHooks.afterMarkFreezing.
+	cat.hooks.fireAfterMarkFreezing()
+
+	// One streaming pass through the merged cold pipeline. The cold ingesters
+	// (re)create files at their canonical paths — re-materialization overwrites
+	// any partial from a crashed "freezing" attempt.
+	dirs := ingest.ColdDirs{
+		Ledgers: cat.layout.LedgersRoot(),
+	}
+	if rerr := ingest.RunColdChunk(ctx, cfg.Logger, source, dirs, chunkID, cfg.Sink, artifacts.ingestConfig()); rerr != nil {
+		return fmt.Errorf("streaming: cold ingest chunk %s %s: %w", chunkID, artifacts, rerr)
+	}
+
+	// Durability barrier: fsync each file + its parent dirent (+ grandparent
+	// when this chunk created a new bucket dir) BEFORE flipping to "frozen".
+	// The cold writers fsync file DATA on Finalize, but the one-write protocol
+	// also requires the directory entries be durable before the key flips —
+	// barrierNewFile is the exact two-level barrier (paths.go).
+	newBucket := uint32(chunkID)%chunk.ChunksPerBucket == 0
+	for _, kind := range artifacts.Kinds() {
+		for _, path := range cat.layout.ArtifactPaths(chunkID, kind) {
+			if berr := barrierNewFile(path, newBucket); berr != nil {
+				return fmt.Errorf("streaming: fsync barrier %s: %w", path, berr)
+			}
+		}
+	}
+
+	// Flip every produced kind to "frozen" in one atomic synced batch.
+	if ferr := cat.FlipChunkFrozen(chunkID, artifacts.Kinds()...); ferr != nil {
+		return fmt.Errorf("streaming: flip frozen chunk %s %s: %w", chunkID, artifacts, ferr)
+	}
+	return nil
+}
+
+// backfillSource implements rule 2's source-preference order for one chunk. It
+// returns the chosen ingest.ChunkSource, a closer (releasing any opened hot
+// stores; a no-op for the pack/bulk branches), and an error. The hot branch
+// fatals only on LOSS (a "ready" key whose dir is missing/unopenable — ErrHot
+// VolumeLost, detected lazily on this open); an incomplete-but-present hot DB is
+// STALENESS and falls through to the next source, because re-derivation IS its
+// recovery.
+//
+// Preference order:
+//  1. A ready, COMPLETE hot tier read locally — completeness is DECISION (a):
+//     the single shared DB's maxCommittedSeq >= chunkLastLedger.
+//  2. The frozen local .pack via the ledger cold reader, when ledgers is NOT among
+//     the requested outputs (re-derivation without a download).
+//  3. The configured bulk backend, gated by a bounded WaitForCoverage.
+func backfillSource(
+	ctx context.Context, chunkID chunk.ID, artifacts ArtifactSet, cfg ProcessConfig,
+) (ingest.ChunkSource, func() error, error) {
+	noClose := func() error { return nil }
+	cat := cfg.Catalog
+
+	// (1) Hot branch: only consult it when the chunk is owned by ingestion
+	// (hot key present) AND "ready". A "transient" key (mid creation/deletion or
+	// recovery-demoted) is NOT a read source — it falls through like any other
+	// non-ready state.
+	hotState, err := cat.HotState(chunkID)
+	if err != nil {
+		return nil, noClose, fmt.Errorf("streaming: read hot state chunk %s: %w", chunkID, err)
+	}
+	if hotState == HotReady {
+		src, closer, used, herr := tryHotSource(chunkID, cfg)
+		if herr != nil {
+			return nil, noClose, herr // case-4 loss is fatal
+		}
+		if used {
+			cfg.Logger.Debugf("backfillSource: chunk %s from complete hot tier", chunkID)
+			return src, closer, nil
+		}
+		// Present but incomplete: legitimate staleness — fall through.
+		cfg.Logger.Debugf("backfillSource: chunk %s hot tier present but incomplete; falling through", chunkID)
+	}
+
+	// (2) Frozen local .pack, only when ledgers is not requested (producing ledgers from
+	// the pack we'd write would be circular). The ledger cold reader is the same
+	// reader the merged pack ChunkSource opens.
+	ledgersState, err := cat.State(chunkID, KindLedgers)
+	if err != nil {
+		return nil, noClose, fmt.Errorf("streaming: read ledgers state chunk %s: %w", chunkID, err)
+	}
+	if ledgersState == StateFrozen && !artifacts.Has(KindLedgers) {
+		if _, serr := os.Stat(cat.layout.LedgerPackPath(chunkID)); serr == nil {
+			cfg.Logger.Debugf("backfillSource: chunk %s re-derived from frozen .pack", chunkID)
+			// ingest.NewPackSource composes {coldDir}/{bucket}/{chunk}.pack, which
+			// equals LedgerPackPath when coldDir is the ledgers root.
+			return ingest.NewPackSource(cat.layout.LedgersRoot()), noClose, nil
+		}
+		// A "frozen" ledgers key whose pack is gone violates the key invariant
+		// (frozen ⇒ file exists); surface it rather than silently downloading.
+		return nil, noClose, fmt.Errorf(
+			"streaming: chunk %s ledgers is %q but pack file is missing at %s",
+			chunkID, StateFrozen, cat.layout.LedgerPackPath(chunkID))
+	}
+
+	// (3) Bulk backend — the only source for a chunk with no local copy.
+	if cfg.Backend == nil {
+		return nil, noClose, fmt.Errorf(
+			"streaming: chunk %s has no local copy and no bulk backend is configured", chunkID)
+	}
+	if cfg.BackendWaiter != nil {
+		if werr := cfg.BackendWaiter.WaitForCoverage(ctx, chunkID.LastLedger()); werr != nil {
+			return nil, noClose, werr
+		}
+	}
+	cfg.Logger.Debugf("backfillSource: chunk %s from bulk backend", chunkID)
+	return cfg.Backend, noClose, nil
+}
+
+// tryHotSource handles backfillSource's hot branch under a "ready" key. It
+// returns (source, closer, used, err): used=true with a source when the hot
+// tier is present AND complete (single-watermark gate); used=false (source nil)
+// when present but incomplete (staleness — caller falls through); a non-nil err
+// only for case-4 LOSS (dir missing/unopenable under a "ready" key).
+func tryHotSource(chunkID chunk.ID, cfg ProcessConfig) (ingest.ChunkSource, func() error, bool, error) {
+	hot, ok, err := cfg.HotProbe.OpenHotChunk(chunkID)
+	if err != nil {
+		// "ready" key but the DB cannot be opened — hot-volume loss.
+		return nil, nil, false, fmt.Errorf("%w: chunk %s: %w", ErrHotVolumeLost, chunkID, err)
+	}
+	if !ok {
+		// "ready" key but the dir is absent — hot-volume loss.
+		return nil, nil, false, fmt.Errorf("%w: chunk %s: hot directory absent", ErrHotVolumeLost, chunkID)
+	}
+	closer := hot.Close
+	maxSeq, present, merr := hot.MaxCommittedSeq()
+	if merr != nil {
+		_ = hot.Close()
+		// A read error against an opened DB is loss, not staleness: the
+		// DB opened but cannot answer its own progress.
+		return nil, nil, false, fmt.Errorf("%w: chunk %s: max committed seq: %w", ErrHotVolumeLost, chunkID, merr)
+	}
+	// DECISION (a): complete iff the single DB's maxCommittedSeq reaches the
+	// chunk's last ledger. An empty DB (present==false) cannot be complete.
+	if present && maxSeq >= chunkID.LastLedger() {
+		return hot.Source(), closer, true, nil
+	}
+	_ = hot.Close()
+	return nil, nil, false, nil
+}
+
+// ---------------------------------------------------------------------------
+// pollingBackendWaiter — the default BackendWaiter: poll a tip function on a
+// fixed backoff until it covers chunkLastLedger or the deadline expires.
+// ---------------------------------------------------------------------------
+
+// pollingBackendWaiter polls Tip on Interval until it returns a value >=
+// chunkLastLedger, the ctx is canceled, or Timeout elapses (ErrBackendCoverage
+// Timeout). Tip is the bulk backend's current network/object-store tip ledger.
+type pollingBackendWaiter struct {
+	Tip      func(ctx context.Context) (uint32, error)
+	Interval time.Duration
+	Timeout  time.Duration
+}
+
+// NewPollingBackendWaiter returns a BackendWaiter that polls tip on interval up
+// to timeout. A zero interval/timeout falls back to sane defaults.
+func NewPollingBackendWaiter(
+	tip func(ctx context.Context) (uint32, error), interval, timeout time.Duration,
+) BackendWaiter {
+	if interval <= 0 {
+		interval = time.Second
+	}
+	if timeout <= 0 {
+		timeout = 5 * time.Minute
+	}
+	return &pollingBackendWaiter{Tip: tip, Interval: interval, Timeout: timeout}
+}
+
+func (w *pollingBackendWaiter) WaitForCoverage(ctx context.Context, chunkLastLedger uint32) error {
+	deadline := time.Now().Add(w.Timeout)
+	for {
+		tip, err := w.Tip(ctx)
+		if err != nil {
+			return fmt.Errorf("streaming: backend tip query: %w", err)
+		}
+		if tip >= chunkLastLedger {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("%w: tip %d < needed %d after %s",
+				ErrBackendCoverageTimeout, tip, chunkLastLedger, w.Timeout)
+		}
+		timer := time.NewTimer(w.Interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/process.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/process.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	supportlog "github.com/stellar/go-stellar-sdk/support/log"
@@ -152,6 +153,13 @@ func processChunk(ctx context.Context, chunkID chunk.ID, artifacts ArtifactSet, 
 	// crashHooks.afterMarkFreezing.
 	cat.hooks.fireAfterMarkFreezing()
 
+	// Snapshot which artifact parent dirs are absent BEFORE the write creates
+	// them, so the barrier below fsyncs the grandparent dirent for each dir this
+	// freeze creates. Existence is the real signal: chunkID % ChunksPerBucket == 0
+	// is not a reliable "first chunk in this bucket" — frontfill-at-tip or
+	// out-of-order backfill/recovery can make any chunk the first materialized.
+	createdParents := createdParentDirs(cat.layout, chunkID, artifacts.Kinds())
+
 	// One streaming pass through the cold pipeline; the ingesters (re)create files
 	// at their canonical paths, overwriting any partial from a crashed attempt.
 	dirs := ingest.ColdDirs{
@@ -164,11 +172,11 @@ func processChunk(ctx context.Context, chunkID chunk.ID, artifacts ArtifactSet, 
 
 	// Durability barrier BEFORE flipping "frozen": the cold writers fsync file
 	// DATA on Finalize, but the protocol also needs the dirents durable first.
-	// barrierNewFile fsyncs file + parent (+ grandparent on a new bucket dir).
-	newBucket := uint32(chunkID)%chunk.ChunksPerBucket == 0
+	// barrierNewFile fsyncs file + parent (+ grandparent for a dir this freeze
+	// created, so a freshly created bucket dir's dirent is itself durable).
 	for _, kind := range artifacts.Kinds() {
 		for _, path := range cat.layout.ArtifactPaths(chunkID, kind) {
-			if berr := barrierNewFile(path, newBucket); berr != nil {
+			if berr := barrierNewFile(path, createdParents[filepath.Dir(path)]); berr != nil {
 				return fmt.Errorf("streaming: fsync barrier %s: %w", path, berr)
 			}
 		}
@@ -179,6 +187,26 @@ func processChunk(ctx context.Context, chunkID chunk.ID, artifacts ArtifactSet, 
 		return fmt.Errorf("streaming: flip frozen chunk %s %s: %w", chunkID, artifacts, ferr)
 	}
 	return nil
+}
+
+// createdParentDirs returns the artifact parent directories that do not yet
+// exist — the dirs RunColdChunk's MkdirAll will create on this freeze. Each such
+// dir's grandparent dirent must be fsynced (barrierNewFile's newParent) for the
+// new dir to survive a crash. Existence is the signal because materialization
+// order — not chunkID % ChunksPerBucket — decides which chunk is first in a
+// bucket (frontfill-at-tip and out-of-order backfill/recovery break the
+// arithmetic proxy).
+func createdParentDirs(layout Layout, chunkID chunk.ID, kinds []Kind) map[string]bool {
+	created := map[string]bool{}
+	for _, kind := range kinds {
+		for _, path := range layout.ArtifactPaths(chunkID, kind) {
+			parent := filepath.Dir(path)
+			if _, err := os.Stat(parent); os.IsNotExist(err) {
+				created[parent] = true
+			}
+		}
+	}
+	return created
 }
 
 // backfillSource implements rule 2's source-preference order for one chunk,

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/process.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/process.go
@@ -16,12 +16,9 @@ import (
 // ErrHotVolumeLost is the case-4 fatal: a hot:chunk key is "ready" but its
 // directory is missing or unopenable. The hot DB is the SOLE copy of a chunk's
 // recently-ingested ledgers, so this is unrecoverable loss — never silently
-// healed. Loss is detected LAZILY, on the open that needs the DB (lastCommitted
-// Ledger's one refinement open of the highest ready chunk before ingestion
-// starts, openHotTierForChunk's "ready" branch, or backfillSource's hot branch),
-// not by an eager all-ready-keys scan. It is returned as a sentinel (not a
-// process exit) so the daemon's top-level loop owns the fatal-and-surface
-// decision and tests can assert it.
+// healed. It is detected lazily, on the open that needs the DB (not an eager
+// all-keys scan), and returned as a sentinel (not a process exit) so the
+// daemon's top loop owns the fatal-and-surface decision and tests can assert it.
 var ErrHotVolumeLost = errors.New("streaming: hot storage lost; run surgical recovery (case 4)")
 
 // ErrBackendCoverageTimeout is the bounded-wait fatal from backfillSource's bulk
@@ -29,17 +26,12 @@ var ErrHotVolumeLost = errors.New("streaming: hot storage lost; run surgical rec
 // genuinely-backend-only chunk within the deadline.
 var ErrBackendCoverageTimeout = errors.New("streaming: backend never covered chunk within deadline")
 
-// HotProbe opens the per-chunk shared hot DB for a chunk and answers the two
-// questions backfillSource's hot branch asks: (1) is the hot tier COMPLETE for
-// this chunk — DECISION (a): the single DB's maxCommittedSeq >= the chunk's
-// last ledger — and (2) if so, hand back a ChunkSource that streams the chunk's
-// LCMs from the ledgers CF so the just-closed chunk freezes without a refetch.
-//
-// It is injected so processChunk/backfillSource stay testable without the live
-// ingestion pipeline: production wires the real shared multi-CF RocksDB; tests
-// pass a fake. Under decision (a) the hot tier is ONE DB whose ledgers, events,
-// and txhash CFs all advance together in one atomic synced WriteBatch per
-// ledger, so completeness is a SINGLE watermark — no min-of-three.
+// HotProbe opens the per-chunk shared hot DB and answers backfillSource's two
+// questions: (1) is the hot tier COMPLETE — the single DB's maxCommittedSeq >=
+// the chunk's last ledger (decision (a); see pkg/stores/hotchunk) — and (2) if
+// so, a ChunkSource streaming the chunk's LCMs from the ledgers CF, so a
+// just-closed chunk freezes without a refetch. It is injected so
+// processChunk/backfillSource stay testable without the live ingestion pipeline.
 type HotProbe interface {
 	// OpenHotChunk opens the chunk's shared hot DB read-only-ish (the daemon
 	// owns the writer; this is a borrow for a freeze pass). It returns the
@@ -52,10 +44,9 @@ type HotProbe interface {
 // HotChunk is one chunk's opened hot tier: the single DB's completeness gate
 // plus an LCM source over the ledgers CF. Close releases the shared DB.
 type HotChunk interface {
-	// MaxCommittedSeq returns the single authoritative watermark — the highest
-	// ledger seq the shared DB has durably committed (every CF advances
-	// together, decision (a)) — and ok=false if the DB is empty (no committed
-	// seq, so the chunk cannot be complete).
+	// MaxCommittedSeq returns the single authoritative watermark (decision (a)):
+	// the highest ledger seq the shared DB has durably committed. ok=false if the
+	// DB is empty, so the chunk cannot be complete.
 	MaxCommittedSeq() (seq uint32, ok bool, err error)
 	// Source yields the chunk's LCMs from the ledgers CF as a ChunkSource the
 	// cold pipeline (RunColdChunk) can drain.
@@ -65,23 +56,17 @@ type HotChunk interface {
 }
 
 // BackendWaiter bounds backfillSource's bulk branch: it blocks until the
-// configured backend's tip covers chunkLastLedger, polling on a backoff, and
-// returns ErrBackendCoverageTimeout (wrapped) if the tip never advances within
-// the deadline. A chunk WITH a local copy never reaches here, so this never
-// gates a normal restart whose range is entirely local.
-//
-// It is an interface (not an inline poll) so the bulk source's tip query is
-// injectable: production wraps the configured LedgerBackend's tip; tests pass a
-// fake that is either immediately-covered or never-covered.
+// configured backend's tip covers chunkLastLedger, returning
+// ErrBackendCoverageTimeout if the tip never advances within the deadline. A
+// chunk WITH a local copy never reaches here. It is an interface so the tip
+// query is injectable (production wraps the LedgerBackend; tests pass a fake).
 type BackendWaiter interface {
 	WaitForCoverage(ctx context.Context, chunkLastLedger uint32) error
 }
 
-// ProcessConfig is the dependency bundle processChunk/backfillSource read. It is
-// the streaming spine's view of everything a freeze pass needs: the catalog
-// (key state + path layout), the hot probe, the bulk backend source + its
-// coverage waiter, and the metric sink/logger. Construction is the daemon's
-// job; the primitives below never reach around it.
+// ProcessConfig is the dependency bundle processChunk/backfillSource read:
+// everything a freeze pass needs — the catalog, the hot probe, the bulk backend
+// + its coverage waiter, and the metric sink/logger. The daemon constructs it.
 type ProcessConfig struct {
 	Catalog *Catalog
 	Logger  *supportlog.Entry
@@ -91,10 +76,9 @@ type ProcessConfig struct {
 	HotProbe HotProbe
 
 	// Backend is the configured bulk LedgerBackend as a ChunkSource (BSB by
-	// default — the pack/datastore ChunkSource from ingest). It is the only
-	// source for a chunk with no local copy. May be nil in a frontfill
-	// deployment that never backfills; backfillSource errors loudly if a chunk
-	// actually reaches the bulk branch with no backend configured.
+	// default) — the only source for a chunk with no local copy. May be nil in a
+	// frontfill-only deployment; backfillSource errors loudly if a chunk actually
+	// reaches the bulk branch with no backend.
 	Backend ingest.ChunkSource
 
 	// BackendWaiter bounds the bulk branch's wait-for-coverage. Required iff
@@ -115,23 +99,20 @@ func (cfg ProcessConfig) validate() error {
 	return nil
 }
 
-// processChunk materializes the requested cold artifact kinds (ledgers/.pack, events
-// cold segment, txhash/.bin) for ONE chunk in a single streaming pass over its
-// ledgers, applying the Phase A one-write protocol per kind (rule 1):
+// processChunk materializes the requested cold artifact kinds (ledgers/.pack
+// today; events/txhash later) for ONE chunk in a single streaming pass over its
+// ledgers, applying the one-write protocol per kind (rule 1):
 //
-//   - Per-kind idempotency: a kind whose chunk key is already "frozen" is
-//     dropped from the request (it self-skips); a "freezing"/"pruning"/absent
-//     key triggers re-materialization, itself idempotent (the cold ingesters
-//     overwrite at the canonical path).
-//   - Mark-then-write: every remaining kind's key is put "freezing" BEFORE any
-//     I/O, the cold pipeline (RunColdChunk) writes the files at their canonical
-//     paths from the source backfillSource chose, the files + their dirents are
-//     fsynced (barrierNewFile), and only then are the keys flipped to "frozen".
+//   - Per-kind idempotency: a kind already "frozen" is dropped (self-skip); a
+//     "freezing"/"pruning"/absent key re-materializes (idempotent — the cold
+//     ingesters overwrite at the canonical path).
+//   - Mark-then-write: every remaining kind goes "freezing" BEFORE any I/O, the
+//     cold pipeline (RunColdChunk) writes the files, they + their dirents are
+//     fsynced (barrierNewFile), and only then do the keys flip to "frozen".
 //
-// The cold ingestion is the merged ingest.RunColdChunk over the same cold
-// ingester set RunCold uses — processChunk does not re-derive any extractor or
-// writer; it only chooses the LCM source (backfillSource) and drives the one
-// write protocol around the freeze.
+// Cold ingestion is ingest.RunColdChunk over the same ingester set RunCold uses;
+// processChunk only chooses the LCM source (backfillSource) and drives the
+// protocol around the freeze.
 func processChunk(ctx context.Context, chunkID chunk.ID, artifacts ArtifactSet, cfg ProcessConfig) error {
 	if err := cfg.validate(); err != nil {
 		return err
@@ -152,10 +133,9 @@ func processChunk(ctx context.Context, chunkID chunk.ID, artifacts ArtifactSet, 
 		return nil
 	}
 
-	// Choose the LCM source BEFORE marking "freezing": backfillSource may fatal
-	// (case-4 loss) or fall through sources, and we must not leave "freezing"
-	// debris for a chunk we then refuse to produce. The returned closer releases
-	// any opened hot stores once the freeze pass finishes.
+	// Choose the source BEFORE marking "freezing" — backfillSource may fatal or
+	// fall through, and we must not leave "freezing" debris for a chunk we then
+	// refuse to produce. The closer releases any opened hot store after the pass.
 	source, closeSource, err := backfillSource(ctx, chunkID, artifacts, cfg)
 	if err != nil {
 		return err
@@ -167,14 +147,13 @@ func processChunk(ctx context.Context, chunkID chunk.ID, artifacts ArtifactSet, 
 		return fmt.Errorf("streaming: mark freezing chunk %s %s: %w", chunkID, artifacts, err)
 	}
 
-	// Test-only observation point at the exact mark-then-write instant: every
-	// requested kind is now "freezing" and no file has been written yet. A no-op
-	// in production (hook nil); see crashHooks.afterMarkFreezing.
+	// Test-only observation at the mark-then-write instant: every requested kind
+	// is "freezing" and no file written yet. No-op in production (hook nil); see
+	// crashHooks.afterMarkFreezing.
 	cat.hooks.fireAfterMarkFreezing()
 
-	// One streaming pass through the merged cold pipeline. The cold ingesters
-	// (re)create files at their canonical paths — re-materialization overwrites
-	// any partial from a crashed "freezing" attempt.
+	// One streaming pass through the cold pipeline; the ingesters (re)create files
+	// at their canonical paths, overwriting any partial from a crashed attempt.
 	dirs := ingest.ColdDirs{
 		Ledgers: cat.layout.LedgersRoot(),
 	}
@@ -183,11 +162,9 @@ func processChunk(ctx context.Context, chunkID chunk.ID, artifacts ArtifactSet, 
 		return fmt.Errorf("streaming: cold ingest chunk %s %s: %w", chunkID, artifacts, rerr)
 	}
 
-	// Durability barrier: fsync each file + its parent dirent (+ grandparent
-	// when this chunk created a new bucket dir) BEFORE flipping to "frozen".
-	// The cold writers fsync file DATA on Finalize, but the one-write protocol
-	// also requires the directory entries be durable before the key flips —
-	// barrierNewFile is the exact two-level barrier (paths.go).
+	// Durability barrier BEFORE flipping "frozen": the cold writers fsync file
+	// DATA on Finalize, but the protocol also needs the dirents durable first.
+	// barrierNewFile fsyncs file + parent (+ grandparent on a new bucket dir).
 	newBucket := uint32(chunkID)%chunk.ChunksPerBucket == 0
 	for _, kind := range artifacts.Kinds() {
 		for _, path := range cat.layout.ArtifactPaths(chunkID, kind) {
@@ -204,19 +181,16 @@ func processChunk(ctx context.Context, chunkID chunk.ID, artifacts ArtifactSet, 
 	return nil
 }
 
-// backfillSource implements rule 2's source-preference order for one chunk. It
-// returns the chosen ingest.ChunkSource, a closer (releasing any opened hot
-// stores; a no-op for the pack/bulk branches), and an error. The hot branch
-// fatals only on LOSS (a "ready" key whose dir is missing/unopenable — ErrHot
-// VolumeLost, detected lazily on this open); an incomplete-but-present hot DB is
-// STALENESS and falls through to the next source, because re-derivation IS its
-// recovery.
+// backfillSource implements rule 2's source-preference order for one chunk,
+// returning the chosen source, a closer (no-op for the pack/bulk branches), and
+// an error. The hot branch fatals only on LOSS (a "ready" key whose dir is
+// missing/unopenable — ErrHotVolumeLost, detected lazily here); an incomplete
+// hot DB is STALENESS and falls through, because re-derivation IS its recovery.
 //
 // Preference order:
-//  1. A ready, COMPLETE hot tier read locally — completeness is DECISION (a):
-//     the single shared DB's maxCommittedSeq >= chunkLastLedger.
-//  2. The frozen local .pack via the ledger cold reader, when ledgers is NOT among
-//     the requested outputs (re-derivation without a download).
+//  1. A ready, COMPLETE hot tier (decision (a): maxCommittedSeq >= chunkLastLedger).
+//  2. The frozen local .pack, when ledgers is NOT a requested output (re-derive
+//     without a download).
 //  3. The configured bulk backend, gated by a bounded WaitForCoverage.
 func backfillSource(
 	ctx context.Context, chunkID chunk.ID, artifacts ArtifactSet, cfg ProcessConfig,
@@ -224,10 +198,9 @@ func backfillSource(
 	noClose := func() error { return nil }
 	cat := cfg.Catalog
 
-	// (1) Hot branch: only consult it when the chunk is owned by ingestion
-	// (hot key present) AND "ready". A "transient" key (mid creation/deletion or
-	// recovery-demoted) is NOT a read source — it falls through like any other
-	// non-ready state.
+	// (1) Hot branch: only when the chunk is owned by ingestion and "ready". A
+	// "transient" key (mid creation/deletion or recovery-demoted) is not a read
+	// source — it falls through.
 	hotState, err := cat.HotState(chunkID)
 	if err != nil {
 		return nil, noClose, fmt.Errorf("streaming: read hot state chunk %s: %w", chunkID, err)
@@ -245,9 +218,8 @@ func backfillSource(
 		cfg.Logger.Debugf("backfillSource: chunk %s hot tier present but incomplete; falling through", chunkID)
 	}
 
-	// (2) Frozen local .pack, only when ledgers is not requested (producing ledgers from
-	// the pack we'd write would be circular). The ledger cold reader is the same
-	// reader the merged pack ChunkSource opens.
+	// (2) Frozen local .pack, only when ledgers is not requested (deriving ledgers
+	// from the pack we'd write would be circular).
 	ledgersState, err := cat.State(chunkID, KindLedgers)
 	if err != nil {
 		return nil, noClose, fmt.Errorf("streaming: read ledgers state chunk %s: %w", chunkID, err)
@@ -312,10 +284,8 @@ func tryHotSource(chunkID chunk.ID, cfg ProcessConfig) (ingest.ChunkSource, func
 	return nil, nil, false, nil
 }
 
-// ---------------------------------------------------------------------------
 // pollingBackendWaiter — the default BackendWaiter: poll a tip function on a
-// fixed backoff until it covers chunkLastLedger or the deadline expires.
-// ---------------------------------------------------------------------------
+// fixed interval until it covers chunkLastLedger or the deadline expires.
 
 // pollingBackendWaiter polls Tip on Interval until it returns a value >=
 // chunkLastLedger, the ctx is canceled, or Timeout elapses (ErrBackendCoverage

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/process_bucket_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/process_bucket_test.go
@@ -1,0 +1,42 @@
+package streaming
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
+)
+
+// A freeze must fsync the grandparent dirent for any bucket directory it
+// creates — otherwise a crash can orphan a "frozen" pack whose bucket dirent was
+// never made durable. The "this freeze creates the dir" signal must be real dir
+// existence, NOT chunkID % ChunksPerBucket: under frontfill-at-tip or
+// out-of-order backfill/recovery, the first chunk materialized in a bucket need
+// not be the one whose id is a multiple of ChunksPerBucket.
+func TestCreatedParentDirs_FlagsNewBucketRegardlessOfChunkNumber(t *testing.T) {
+	root := t.TempDir()
+	layout := NewLayout(root)
+
+	// chunk 1500 is in bucket 1 (1500/1000) but 1500 % 1000 == 500 != 0, so the
+	// old arithmetic gate would NOT have fsynced the grandparent — yet 1500 can be
+	// the first chunk materialized in bucket 00001.
+	const midBucket = chunk.ID(1500)
+	require.NotEqual(t, uint32(0), uint32(midBucket)%chunk.ChunksPerBucket,
+		"precondition: 1500 is not a bucket-aligned chunk")
+
+	bucketDir := filepath.Dir(layout.LedgerPackPath(midBucket))
+
+	// Bucket dir absent → the freeze's MkdirAll will create it → must be flagged.
+	created := createdParentDirs(layout, midBucket, AllKinds())
+	require.True(t, created[bucketDir],
+		"absent bucket dir must be flagged new so its grandparent dirent is fsynced")
+
+	// Once the dir exists, a later chunk in the same bucket must NOT re-flag it.
+	require.NoError(t, os.MkdirAll(bucketDir, 0o755))
+	created = createdParentDirs(layout, midBucket, AllKinds())
+	require.False(t, created[bucketDir],
+		"existing bucket dir must not be flagged new")
+}

--- a/cmd/stellar-rpc/internal/fullhistory/streaming/process_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/streaming/process_test.go
@@ -1,0 +1,537 @@
+package streaming
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/ingest"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/hotchunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/pkg/stores/ledger"
+)
+
+// ---------------------------------------------------------------------------
+// LCM fixtures + fake ChunkSource.
+// ---------------------------------------------------------------------------
+
+// zeroTxLCMBytes builds the wire bytes of a minimal valid zero-transaction V2
+// LedgerCloseMeta for seq. Zero-tx keeps the per-ledger work trivial so a full
+// 10,000-ledger chunk pass stays fast in tests.
+func zeroTxLCMBytes(t *testing.T, seq uint32) []byte {
+	t.Helper()
+	lcm := xdr.LedgerCloseMeta{
+		V: 2,
+		V2: &xdr.LedgerCloseMetaV2{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+				Header: xdr.LedgerHeader{
+					ScpValue:  xdr.StellarValue{CloseTime: xdr.TimePoint(0)},
+					LedgerSeq: xdr.Uint32(seq),
+				},
+			},
+			TxSet: xdr.GeneralizedTransactionSet{
+				V:       1,
+				V1TxSet: &xdr.TransactionSetV1{Phases: nil},
+			},
+			TxProcessing: nil,
+		},
+	}
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	return raw
+}
+
+// fullChunkStream is an in-memory ledgerbackend.LedgerStream yielding every
+// ledger in [from, to] from a per-seq LCM generator. It models a backend (or a
+// pack) that has the whole requested range. counter (optional) records the
+// number of OpenStream-driven ledgers pulled so a test can assert a source was
+// (or was not) used.
+type fullChunkStream struct {
+	t   *testing.T
+	gen func(*testing.T, uint32) []byte
+}
+
+var _ ledgerbackend.LedgerStream = (*fullChunkStream)(nil)
+
+func (s *fullChunkStream) RawLedgers(
+	_ context.Context, r ledgerbackend.Range, _ ...ledgerbackend.StreamOption,
+) iter.Seq2[[]byte, error] {
+	return func(yield func([]byte, error) bool) {
+		for seq := r.From(); seq <= r.To(); seq++ {
+			if !yield(s.gen(s.t, seq), nil) {
+				return
+			}
+		}
+	}
+}
+
+// countingChunkSource wraps a stream factory and counts OpenStream calls, so a
+// test can assert which preference branch backfillSource picked.
+type countingChunkSource struct {
+	opens atomic.Int32
+	make  func(chunk.ID) (ledgerbackend.LedgerStream, error)
+}
+
+func (c *countingChunkSource) OpenStream(id chunk.ID) (ledgerbackend.LedgerStream, error) {
+	c.opens.Add(1)
+	return c.make(id)
+}
+
+func zeroTxBackend(t *testing.T) *countingChunkSource {
+	return &countingChunkSource{
+		make: func(chunk.ID) (ledgerbackend.LedgerStream, error) {
+			return &fullChunkStream{t: t, gen: zeroTxLCMBytes}, nil
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// fake HotProbe / HotChunk.
+// ---------------------------------------------------------------------------
+
+type fakeHotChunk struct {
+	maxSeq   uint32
+	present  bool
+	maxErr   error
+	source   ingest.ChunkSource
+	closedTo *atomic.Int32
+}
+
+func (h *fakeHotChunk) MaxCommittedSeq() (uint32, bool, error) {
+	return h.maxSeq, h.present, h.maxErr
+}
+func (h *fakeHotChunk) Source() ingest.ChunkSource { return h.source }
+func (h *fakeHotChunk) Close() error {
+	if h.closedTo != nil {
+		h.closedTo.Add(1)
+	}
+	return nil
+}
+
+type fakeHotProbe struct {
+	chunk    *fakeHotChunk
+	ok       bool
+	openErr  error
+	openedTo *atomic.Int32
+}
+
+func (p *fakeHotProbe) OpenHotChunk(chunk.ID) (HotChunk, bool, error) {
+	if p.openedTo != nil {
+		p.openedTo.Add(1)
+	}
+	if p.openErr != nil {
+		return nil, false, p.openErr
+	}
+	if !p.ok {
+		return nil, false, nil
+	}
+	return p.chunk, true, nil
+}
+
+// ---------------------------------------------------------------------------
+// fake BackendWaiter.
+// ---------------------------------------------------------------------------
+
+type fakeWaiter struct {
+	err    error
+	called atomic.Int32
+}
+
+func (w *fakeWaiter) WaitForCoverage(context.Context, uint32) error {
+	w.called.Add(1)
+	return w.err
+}
+
+// ---------------------------------------------------------------------------
+// process config helper.
+// ---------------------------------------------------------------------------
+
+func testProcessConfig(t *testing.T, cat *Catalog) ProcessConfig {
+	t.Helper()
+	return ProcessConfig{
+		Catalog:  cat,
+		Logger:   silentLogger(),
+		Sink:     ingest.NopSink{},
+		HotProbe: &fakeHotProbe{}, // not "ready" by default; tests override
+	}
+}
+
+// ---------------------------------------------------------------------------
+// processChunk — produces the ledger artifact and flips the key to frozen.
+// ---------------------------------------------------------------------------
+
+func TestProcessChunk_ProducesAllArtifactsAndFreezes(t *testing.T) {
+	cat, root := testCatalog(t)
+	cfg := testProcessConfig(t, cat)
+	backend := zeroTxBackend(t)
+	cfg.Backend = backend
+	cfg.BackendWaiter = &fakeWaiter{}
+
+	chunkID := chunk.ID(0)
+	require.NoError(t, processChunk(context.Background(), chunkID, AllArtifacts(), cfg))
+
+	// The ledgers catalog key flipped to frozen (verified via Phase A Catalog).
+	for _, kind := range AllKinds() {
+		state, err := cat.State(chunkID, kind)
+		require.NoError(t, err)
+		require.Equal(t, StateFrozen, state, "kind %s should be frozen", kind)
+	}
+
+	// The ledger artifact exists on disk at its canonical Layout path.
+	require.FileExists(t, cat.layout.LedgerPackPath(chunkID))
+
+	// The pack is a valid cold ledger pack covering the whole chunk.
+	cr, err := ledger.OpenColdReader(cat.layout.LedgerPackPath(chunkID))
+	require.NoError(t, err)
+	defer func() { _ = cr.Close() }()
+	last, err := cr.LastSeq()
+	require.NoError(t, err)
+	require.Equal(t, chunkID.LastLedger(), last)
+	_ = root
+}
+
+// ---------------------------------------------------------------------------
+// Idempotency: a frozen kind self-skips.
+// ---------------------------------------------------------------------------
+
+func TestProcessChunk_IdempotentSkipWhenFrozen(t *testing.T) {
+	cat, _ := testCatalog(t)
+	cfg := testProcessConfig(t, cat)
+	backend := zeroTxBackend(t)
+	cfg.Backend = backend
+	cfg.BackendWaiter = &fakeWaiter{}
+
+	chunkID := chunk.ID(0)
+	require.NoError(t, processChunk(context.Background(), chunkID, AllArtifacts(), cfg))
+	opensAfterFirst := backend.opens.Load()
+	require.Equal(t, int32(1), opensAfterFirst, "first pass opens the backend once")
+
+	// Second pass: every kind is frozen, so processChunk returns without opening
+	// any source.
+	require.NoError(t, processChunk(context.Background(), chunkID, AllArtifacts(), cfg))
+	require.Equal(t, opensAfterFirst, backend.opens.Load(),
+		"a fully-frozen chunk must not re-open the source")
+}
+
+// ---------------------------------------------------------------------------
+// Crash recovery: a "freezing" key (partial crash) is re-materialized.
+// ---------------------------------------------------------------------------
+
+func TestProcessChunk_RematerializesAfterFreezingCrash(t *testing.T) {
+	cat, _ := testCatalog(t)
+	cfg := testProcessConfig(t, cat)
+	cfg.Backend = zeroTxBackend(t)
+	cfg.BackendWaiter = &fakeWaiter{}
+
+	chunkID := chunk.ID(0)
+
+	// Simulate a crash mid-freeze: the keys are "freezing" and a stale/partial
+	// pack file exists at the canonical path.
+	require.NoError(t, cat.MarkChunkFreezing(chunkID, AllKinds()...))
+	require.NoError(t, os.MkdirAll(filepath.Dir(cat.layout.LedgerPackPath(chunkID)), 0o755))
+	require.NoError(t, os.WriteFile(cat.layout.LedgerPackPath(chunkID), []byte("PARTIAL-GARBAGE"), 0o644))
+
+	// Re-run: a "freezing" key triggers re-materialization (rule 1), overwriting
+	// the partial at the canonical path.
+	require.NoError(t, processChunk(context.Background(), chunkID, AllArtifacts(), cfg))
+
+	for _, kind := range AllKinds() {
+		state, err := cat.State(chunkID, kind)
+		require.NoError(t, err)
+		require.Equal(t, StateFrozen, state)
+	}
+	// The partial garbage was overwritten with a real pack.
+	cr, err := ledger.OpenColdReader(cat.layout.LedgerPackPath(chunkID))
+	require.NoError(t, err)
+	defer func() { _ = cr.Close() }()
+	last, err := cr.LastSeq()
+	require.NoError(t, err)
+	require.Equal(t, chunkID.LastLedger(), last)
+}
+
+// ---------------------------------------------------------------------------
+// Mark-then-write ORDERING: the core one-write-protocol invariant. At the
+// instant after MarkChunkFreezing and before any file I/O, every requested kind
+// must read "freezing" and no artifact file may exist yet. The afterMarkFreezing
+// crash hook (hooks.go) observes that exact instant from INSIDE processChunk, so
+// dropping the mark (keys would be absent) or reordering the write ahead of it
+// (a file would exist) is caught — neither could ship green.
+// ---------------------------------------------------------------------------
+
+func TestProcessChunk_MarksFreezingBeforeWrite(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		artifacts ArtifactSet
+	}{
+		{"all kinds", AllArtifacts()},
+		{"ledgers only", NewArtifactSet(KindLedgers)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cat, _ := testCatalog(t)
+			cfg := testProcessConfig(t, cat)
+			cfg.Backend = zeroTxBackend(t)
+			cfg.BackendWaiter = &fakeWaiter{}
+
+			chunkID := chunk.ID(0)
+			requested := tc.artifacts.Kinds()
+
+			var fired bool
+			cat.hooks.afterMarkFreezing = func() {
+				fired = true
+				// (1) Every requested kind reads "freezing" at the mark instant.
+				// Dropping MarkChunkFreezing would leave these absent (empty State).
+				for _, kind := range requested {
+					state, err := cat.State(chunkID, kind)
+					require.NoError(t, err)
+					require.Equal(t, StateFreezing, state,
+						"kind %s must be 'freezing' before any I/O", kind)
+				}
+				// (2) No artifact file exists yet. Reordering the write ahead of the
+				// mark (or writing without marking) would leave a file present here.
+				for _, kind := range requested {
+					for _, p := range cat.layout.ArtifactPaths(chunkID, kind) {
+						require.NoFileExists(t, p,
+							"no %s artifact file may exist at the mark instant", kind)
+					}
+				}
+			}
+
+			require.NoError(t, processChunk(context.Background(), chunkID, tc.artifacts, cfg))
+			require.True(t, fired, "afterMarkFreezing hook must have fired inside processChunk")
+
+			// And the freeze still completes: every requested kind ends "frozen".
+			for _, kind := range requested {
+				state, err := cat.State(chunkID, kind)
+				require.NoError(t, err)
+				require.Equal(t, StateFrozen, state)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// backfillSource preference order.
+// ---------------------------------------------------------------------------
+
+func TestBackfillSource_PrefersCompleteHotTier(t *testing.T) {
+	cat, _ := testCatalog(t)
+	cfg := testProcessConfig(t, cat)
+
+	chunkID := chunk.ID(0)
+	// Mark the hot key "ready" and wire a complete hot tier (max committed seq
+	// reaches the chunk's last ledger).
+	require.NoError(t, cat.FlipHotReady(chunkID))
+	hotBackend := zeroTxBackend(t)
+	var closed atomic.Int32
+	cfg.HotProbe = &fakeHotProbe{
+		ok: true,
+		chunk: &fakeHotChunk{
+			maxSeq:   chunkID.LastLedger(),
+			present:  true,
+			source:   hotBackend,
+			closedTo: &closed,
+		},
+	}
+	// A bulk backend is configured but must NOT be used.
+	bulk := zeroTxBackend(t)
+	cfg.Backend = bulk
+	cfg.BackendWaiter = &fakeWaiter{}
+
+	src, closeSrc, err := backfillSource(context.Background(), chunkID, AllArtifacts(), cfg)
+	require.NoError(t, err)
+	require.Same(t, ingest.ChunkSource(hotBackend), src)
+	require.NoError(t, closeSrc())
+	require.Equal(t, int32(1), closed.Load(), "the closer releases the opened hot tier")
+	require.Equal(t, int32(0), bulk.opens.Load(), "the bulk backend was not consulted")
+}
+
+func TestBackfillSource_WatermarkGate_IncompleteFallsThrough(t *testing.T) {
+	cat, _ := testCatalog(t)
+	cfg := testProcessConfig(t, cat)
+
+	chunkID := chunk.ID(0)
+	require.NoError(t, cat.FlipHotReady(chunkID))
+	var closed atomic.Int32
+	// maxSeq is ONE BELOW the chunk's last ledger — i.e. the single DB's
+	// watermark has not reached completeness even though it is present. Under
+	// decision (a) every CF advances together, so a watermark short of the last
+	// ledger means the chunk is genuinely unfinished. It is staleness, not loss:
+	// fall through.
+	cfg.HotProbe = &fakeHotProbe{
+		ok: true,
+		chunk: &fakeHotChunk{
+			maxSeq:   chunkID.LastLedger() - 1,
+			present:  true,
+			closedTo: &closed,
+		},
+	}
+	bulk := zeroTxBackend(t)
+	cfg.Backend = bulk
+	cfg.BackendWaiter = &fakeWaiter{}
+
+	src, closeSrc, err := backfillSource(context.Background(), chunkID, AllArtifacts(), cfg)
+	require.NoError(t, err)
+	require.Same(t, ingest.ChunkSource(bulk), src, "incomplete hot tier falls through to bulk")
+	require.NoError(t, closeSrc())
+	require.GreaterOrEqual(t, closed.Load(), int32(1), "the incomplete hot tier was closed on fall-through")
+}
+
+func TestBackfillSource_LossIsFatal(t *testing.T) {
+	cat, _ := testCatalog(t)
+	cfg := testProcessConfig(t, cat)
+
+	chunkID := chunk.ID(0)
+	require.NoError(t, cat.FlipHotReady(chunkID))
+	// "ready" key but the probe reports the dir absent (ok=false) — case-4 loss.
+	cfg.HotProbe = &fakeHotProbe{ok: false}
+	cfg.Backend = zeroTxBackend(t)
+	cfg.BackendWaiter = &fakeWaiter{}
+
+	_, _, err := backfillSource(context.Background(), chunkID, AllArtifacts(), cfg)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrHotVolumeLost)
+}
+
+func TestBackfillSource_LossOnOpenError(t *testing.T) {
+	cat, _ := testCatalog(t)
+	cfg := testProcessConfig(t, cat)
+
+	chunkID := chunk.ID(0)
+	require.NoError(t, cat.FlipHotReady(chunkID))
+	cfg.HotProbe = &fakeHotProbe{openErr: errors.New("cannot open hot dir")}
+	cfg.Backend = zeroTxBackend(t)
+	cfg.BackendWaiter = &fakeWaiter{}
+
+	_, _, err := backfillSource(context.Background(), chunkID, AllArtifacts(), cfg)
+	require.ErrorIs(t, err, ErrHotVolumeLost)
+}
+
+func TestBackfillSource_DoesNotUsePackWhenLFSRequested(t *testing.T) {
+	cat, _ := testCatalog(t)
+	cfg := testProcessConfig(t, cat)
+
+	chunkID := chunk.ID(0)
+	require.NoError(t, cat.MarkChunkFreezing(chunkID, KindLedgers))
+	require.NoError(t, os.MkdirAll(filepath.Dir(cat.layout.LedgerPackPath(chunkID)), 0o755))
+	writeRealPack(t, cat, chunkID)
+	require.NoError(t, cat.FlipChunkFrozen(chunkID, KindLedgers))
+
+	bulk := zeroTxBackend(t)
+	cfg.Backend = bulk
+	cfg.BackendWaiter = &fakeWaiter{}
+
+	// ledgers IS requested — the pack branch is skipped (circular), so it goes to bulk.
+	src, closeSrc, err := backfillSource(context.Background(), chunkID, AllArtifacts(), cfg)
+	require.NoError(t, err)
+	require.NoError(t, closeSrc())
+	require.Same(t, ingest.ChunkSource(bulk), src)
+}
+
+func TestBackfillSource_BulkWaitTimeoutFatal(t *testing.T) {
+	cat, _ := testCatalog(t)
+	cfg := testProcessConfig(t, cat)
+
+	chunkID := chunk.ID(0)
+	cfg.Backend = zeroTxBackend(t)
+	cfg.BackendWaiter = &fakeWaiter{err: ErrBackendCoverageTimeout}
+
+	_, _, err := backfillSource(context.Background(), chunkID, AllArtifacts(), cfg)
+	require.ErrorIs(t, err, ErrBackendCoverageTimeout)
+}
+
+func TestBackfillSource_NoBackendConfigured(t *testing.T) {
+	cat, _ := testCatalog(t)
+	cfg := testProcessConfig(t, cat)
+	cfg.Backend = nil
+
+	_, _, err := backfillSource(context.Background(), chunk.ID(0), AllArtifacts(), cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no bulk backend")
+}
+
+// writeRealPack writes a valid cold ledger pack for chunkID at its canonical
+// Layout path by driving the merged cold ledger ingester over a zero-tx stream.
+func writeRealPack(t *testing.T, cat *Catalog, chunkID chunk.ID) {
+	t.Helper()
+	src := &countingChunkSource{
+		make: func(chunk.ID) (ledgerbackend.LedgerStream, error) {
+			return &fullChunkStream{t: t, gen: zeroTxLCMBytes}, nil
+		},
+	}
+	dirs := ingest.ColdDirs{Ledgers: cat.layout.LedgersRoot()}
+	require.NoError(t, ingest.RunColdChunk(
+		context.Background(), silentLogger(), src, dirs, chunkID,
+		ingest.NopSink{}, ingest.Config{Ledgers: true}))
+	require.FileExists(t, cat.layout.LedgerPackPath(chunkID))
+}
+
+// ---------------------------------------------------------------------------
+// Real hot probe: single-watermark completeness over the shared multi-CF
+// RocksDB hot DB (decision (a)).
+// ---------------------------------------------------------------------------
+
+func TestRocksHotProbe_SingleWatermark_CompleteVsStale(t *testing.T) {
+	hotRoot := t.TempDir()
+	chunkID := chunk.ID(0)
+	chunkDir := filepath.Join(hotRoot, chunkID.String())
+
+	// Ingest a SHORT prefix of the chunk into the shared hot DB (one atomic
+	// batch per ledger across all CFs), so the single watermark is well below
+	// the chunk's last ledger (stale).
+	stalePrefix := chunkID.FirstLedger() + 4
+	ingestHotPrefix(t, chunkDir, chunkID, stalePrefix)
+
+	probe := NewRocksHotProbe(func(c chunk.ID) string {
+		return filepath.Join(hotRoot, c.String())
+	}, silentLogger())
+
+	hot, ok, err := probe.OpenHotChunk(chunkID)
+	require.NoError(t, err)
+	require.True(t, ok)
+	defer func() { _ = hot.Close() }()
+
+	maxSeq, present, err := hot.MaxCommittedSeq()
+	require.NoError(t, err)
+	require.True(t, present)
+	require.Equal(t, stalePrefix, maxSeq, "the single watermark equals the last committed ledger")
+	require.Less(t, maxSeq, chunkID.LastLedger(), "a stale prefix is not complete")
+}
+
+func TestRocksHotProbe_AbsentDirIsNotOpened(t *testing.T) {
+	hotRoot := t.TempDir()
+	probe := NewRocksHotProbe(func(c chunk.ID) string {
+		return filepath.Join(hotRoot, c.String())
+	}, silentLogger())
+	_, ok, err := probe.OpenHotChunk(chunk.ID(7))
+	require.NoError(t, err)
+	require.False(t, ok, "an absent hot dir reports ok=false (loss when key is ready)")
+}
+
+// ingestHotPrefix writes ledgers [chunk.First, throughSeq] into the chunk's
+// SHARED multi-CF hot DB via hotchunk.IngestLedger — one atomic synced
+// WriteBatch per ledger across all CFs (decision (a)) — then closes it so the
+// probe can reopen it.
+func ingestHotPrefix(t *testing.T, chunkDir string, chunkID chunk.ID, throughSeq uint32) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(chunkDir, 0o755))
+
+	db, err := hotchunk.Open(chunkDir, chunkID, silentLogger())
+	require.NoError(t, err)
+
+	cfg := hotchunk.Ingest{Ledgers: true}
+	for seq := chunkID.FirstLedger(); seq <= throughSeq; seq++ {
+		lcm := xdr.LedgerCloseMetaView(zeroTxLCMBytes(t, seq))
+		_, err := db.IngestLedger(seq, lcm, cfg)
+		require.NoError(t, err)
+	}
+	require.NoError(t, db.Close())
+}


### PR DESCRIPTION
**Slice 1, Layer 2 of 4 — Storage primitives.** Stacked on Layer 1 (foundations). Diff is storage-only.

Producing and freezing a chunk:
- the **per-chunk hot RocksDB** lifecycle (`pkg/stores/hotchunk`, ledger CF) — one atomic synced `WriteBatch` per ledger;
- **`processChunk`** + `backfillSource` (materialize a chunk's cold `.pack` via the one-write protocol; source preference hot→local→backend);
- the ledger cold-artifact ingest wiring (`ingest/driver`,`service`).

Compiles + `-short`-green on top of Layer 1.
