### PR TITLE
docs(full-history): query routing design (#770)

### DIFF
--- a/design-docs/query-routing-design.md
+++ b/design-docs/query-routing-design.md
@@ -370,7 +370,7 @@ func (v *View) resolve(c chunk.ID, k Kind) (Store, error) {
 
 The resolution order is deterministic. When both hot and cold copies are available, routing selects the cold artifact.
 
-If a chunk has no serving home, routing returns `ErrUnavailable`. This can occur during startup recovery when a required artifact has not yet reached a serving state.
+If a chunk has no serving home, routing returns `ErrUnavailable`.
 
 ### Chunk traversal
 
@@ -396,10 +396,10 @@ tx-hash   ───────────── window .idx ──────
 
 Example request:
 
-- `startLedger = 65,439,500`
-- `limit = 1,000`
+- `startLedger = 65,439,995`
+- `limit = 10`
 
-The request spans chunks 6543 and 6544. Chunk 6543 resolves to the cold ledger store and returns the rest of that chunk. Chunk 6544 resolves to the live hot store and returns ledgers up to the remaining limit. The response is the concatenation of both streams.
+The request spans chunks 6543 and 6544. Chunk 6543 resolves to the cold ledger store and returns the last five ledgers of that chunk. Chunk 6544 resolves to the live hot store and returns the remaining five. The response is the concatenation of both streams.
 
 ### `getTransactions`
 

--- a/design-docs/query-routing-design.md
+++ b/design-docs/query-routing-design.md
@@ -8,7 +8,7 @@ Every query is admitted against a single immutable snapshot of the **serving map
 
 A small in-memory **registry** owns the serving map. When a storage operation changes what is servable, such as freezing a chunk, replacing a transaction hash index, discarding a hot database, or advancing the retention floor, the registry creates a new View, applies the change, and atomically publishes it. Queries already in flight continue using the View they admitted with, while newly admitted queries observe the updated View.
 
-Deletion safety is time-based rather than reader-tracked. Every request runs under a fixed deadline. Once a resource is removed from the current View, no newly admitted query can reach it. Any query that can still reach it must have admitted an older View and must finish before its deadline. The lifecycle therefore delays physical destruction until a grace period longer than the maximum request lifetime has elapsed.
+Deletion is deferred rather than reader-tracked. Every request runs under a fixed deadline. Once a resource is removed from the current View, no newly admitted query can reach it, and physical destruction waits out a grace period longer than the maximum request lifetime, so queries holding an older View can finish against it ([The reaper](#the-reaper)).
 
 The following terms are used throughout this document.
 
@@ -54,11 +54,11 @@ These races occur while ingestion, freezing, index replacement, discard, and pru
 The design uses four mechanisms:
 
 1. Every query resolves against one immutable View of the serving map, so routing decisions never mix storage states (H1).
-2. The registry publishes a new View whenever the serving map changes.
-3. The reaper destroys retired resources only after they have been unreachable for a grace period longer than the maximum request lifetime, so nothing a request can reach is destroyed while it runs (H2, H4).
+2. The registry publishes a new View whenever the serving map changes, for example when a freeze adds cold artifacts or prune advances the retention floor.
+3. The reaper destroys retired resources only after they have been unreachable for a grace period longer than the maximum request lifetime, and every close of a shared handle drains in-flight operations, so nothing a request can reach is destroyed while it runs (H2, H4).
 4. The registry maintains the `latest` watermark so queries never observe partially ingested ledgers (H3).
 
-Together, these mechanisms let ingestion, lifecycle operations, and queries proceed concurrently without requiring readers to coordinate with writers. Queries perform two atomic loads during admission, then use ordinary immutable data for the rest of the request. They do not acquire locks or participate in reference counting.
+Together, these mechanisms let ingestion, lifecycle operations, and queries proceed concurrently without requiring readers to coordinate with writers. Queries perform two atomic loads at admission and never register with the registry, hold reference counts, or block on writers.
 
 ```mermaid
 flowchart TB
@@ -72,25 +72,20 @@ flowchart TB
     CAT[("Catalog")] -.->|"startup rebuild"| V
 
     subgraph REG["registry"]
-        V["current View<br/>floor · hot · cold · indexes"]
+        V["current View<br/>floor · hot · cold · index coverage"]
         W["latest watermark"]
         HOT["hot DB handles"]
-        IDX["window .idx readers"]
-        CACHE["cold reader caches"]
         REAP["reaper"]
     end
 
     Q["Query"] -->|"load latest"| W
     Q -->|"load View"| V
+    Q -.->|"opens per request"| FILES["cold files: .pack, events, .idx"]
 
     V -->|"references"| HOT
-    V -->|"references"| IDX
-    V -.->|"opens on demand"| CACHE
 
-    REAP -->|"retire / close after T"| HOT
-    REAP -->|"retire / close after T"| IDX
-    REAP -->|"evict / close after T"| CACHE
-    REAP -->|"unlink / remove after T"| FS["retired files and dirs"]
+    REAP -->|"close after T"| HOT
+    REAP -->|"unlink after T"| FILES
 ```
 
 ---
@@ -105,7 +100,7 @@ Each View records:
 - the retention floor used by queries admitted with that View,
 - the hot stores,
 - the cold artifacts available for each chunk, and
-- the transaction hash indexes for each window.
+- the transaction hash index coverage for each window.
 
 The registry is rebuilt from the catalog during startup before the server begins accepting requests.
 
@@ -130,11 +125,10 @@ type ColdChunk struct {
 }
 
 type IndexCoverage struct {
-    Window WindowID
+    Window geometry.TxHashIndexID
     Lo, Hi chunk.ID // the frozen .idx's actual coverage, not the window bounds:
                     // Hi trails the tip while the window is current, and Lo is
                     // the retention floor at build time
-    Idx    *txhash.ColdReader
 }
 ```
 
@@ -143,8 +137,8 @@ type IndexCoverage struct {
 Each field exists for a specific reason.
 
 - **`hot` stores shared handles.** Each hot chunk has one registry-owned `hotchunk.DB` instance used by ingestion and queries.
-- **`cold` holds flags, not open readers.** A `ColdChunk` entry only says the chunk's artifact is frozen and servable. The reader object itself is opened on demand through the reader caches ([Open-handle management](#open-handle-management)): with thousands of cold chunks, holding every reader open would cost gigabytes, unlike the handful of hot databases and window indexes the View references directly.
-- **`indexes` stores transaction hash readers.** Each in-retention window has one current `.idx` reader.
+- **`cold` holds flags, not open readers.** A `ColdChunk` entry only says the chunk's artifact is frozen and servable. The reader itself is opened per request ([Open-handle management](#open-handle-management)): with thousands of cold chunks, holding every reader open would cost gigabytes, unlike the handful of hot databases the View references directly.
+- **`indexes` stores coverage metadata, not readers.** Each in-retention window has one current coverage entry; the `.idx` file itself is opened per request ([Open-handle management](#open-handle-management)).
 - **`latest` is stored outside the View.** The serving map changes only at chunk boundaries and lifecycle transitions, while `latest` advances every ledger. Keeping it separate avoids copying the View every few seconds.
 
 ### Admission
@@ -201,7 +195,7 @@ Its rule is:
 
 > A resource that was reachable from a published View may be destroyed only after it has been unreachable for at least grace period **T**.
 
-A resource becomes **unreachable** when it has been removed from the current View and can no longer be returned by reader caches. A resource is **destroyed** when it is permanently closed or removed.
+A resource becomes **unreachable** when it has been removed from the current View. A resource is **destroyed** when it is permanently closed or removed.
 
 ```go
 type Reaper struct {
@@ -216,16 +210,23 @@ Every read handler runs under an enforced request deadline **D**. The grace peri
 T = maximum request timeout + safety margin
 ```
 
-This is enough because every query keeps exactly one admitted View for its entire lifetime. Once a resource is unpublished, no newly admitted query can reach it. Any query that can still reach it must have admitted an older View, and therefore must finish before its deadline **D**. Since **T > D**, the resource is not destroyed until all such queries should have completed.
+The grace period preserves availability. A query that admitted a View before a resource was unpublished may still be routed to that resource for the rest of its lifetime. Since **T > D**, the resource remains open and servable until every such query has passed its deadline, so lifecycle transitions do not fail requests already in flight.
 
-The same rule covers hot databases, transaction hash index readers, and cached cold readers.
+The grace period alone is not sufficient for memory safety, because the deadline bounds the response, not the handler goroutine. On timeout, the request duration limiter cancels the request context and returns an error to the client without waiting for the handler. A handler blocked in a call that cannot observe cancellation, such as a RocksDB read stalled on a slow disk, keeps running past **D** and can still hold a reference after **T**.
+
+Memory safety therefore comes from ownership and drain barriers, not from time:
+
+- **Hot databases**: the only shared handles. `rocksdb.Store` holds a read lock across every C call; `Close` flips a closed flag, then takes the write lock, so it waits for in-flight operations to drain and every later operation fails cleanly with a closed error.
+- **Cold readers and window indexes**: opened and closed by the request that uses them ([Open-handle management](#open-handle-management)). No other component ever closes them, so a close cannot race a read.
+
+A straggler that outlives **T** is harmless: `Close` waits out its in-flight operation, and any later operation fails with a closed error. For retired files, unlink does not disturb descriptors already open: a straggler keeps reading the unlinked file, and the space is reclaimed when it exits.
 
 Deletion follows this sequence:
 
 1. Remove the resource from the serving map.
 2. Record the catalog demotion, such as `"pruning"` or `"transient"`.
 3. Schedule the resource with the reaper.
-4. After **T**, close handles, unlink files, remove directories, and remove the catalog entry.
+4. After **T**: close retired hot databases, unlink retired files, remove directories, and remove the catalog entry.
 
 Only physical destruction is delayed. Catalog demotions still occur during the lifecycle run.
 
@@ -260,9 +261,9 @@ Every write-side transition that changes what is servable gets a registry hook. 
 | `openHotDBForChunk` flips `hot:chunk:{c}` to `"ready"` | Publish `hot[c] = stores` using the shared instance. | Publish after the catalog key flips to `"ready"` and before the chunk's first ledger commits, so the watermark can never enter a chunk the current View does not serve.                                       |
 | Per-ledger ingest cycle: atomic `batch.Commit(sync)` plus in-memory applies | `latest.Store(seq)` | Final step of the cycle, after every serving structure contains the ledger.                                                                                                                                   |
 | `processChunk` flips artifact keys to `"frozen"` | Publish `cold[c].{kind} = true` for each frozen kind. | Publish after the commit. During startup backfill this hook has no effect; the startup scan (last row) covers those chunks.                                                                                   |
-| Transaction index rebuild (`buildTxhashIndex`): a single atomic catalog write freezes the new coverage and demotes its predecessor to `"pruning"` | Replace the window's `IndexCoverage` entry with the new coverage and its reader. Hand the predecessor's reader to the reaper. | Publish after the atomic write. The predecessor's file deletion, previously `buildThenSweep`'s immediate unlink, now waits out the grace period, because queries holding older Views may still be reading it. |
-| `discardHotDBForChunk` | Remove `hot[c]` from the View and hand the hot database to the reaper. | Unpublish before catalog demotion and every destructive step.                                                                                                                                                 |
-| Retention prune | Publish the run's new floor, which also drops below-floor `cold`, `hot`, and `indexes` entries. | Gate, unpublish, demote, then destroy. The floor update removes below-floor resources before every demotion.                                                                                                  |
+| Transaction index rebuild (`buildTxhashIndex`): a single atomic catalog write freezes the new coverage and demotes its predecessor to `"pruning"` | Replace the window's `IndexCoverage` entry with the new coverage. Schedule the predecessor's `.idx` unlink with the reaper. | Publish after the atomic write. The predecessor's file deletion, previously `buildThenSweep`'s immediate unlink, now waits out the grace period, because queries holding older Views may still open and read it. Coverage file names encode their `Lo-Hi` range, so an older View's entry opens its own generation of the index, never the replacement. |
+| Hot database discard (`DiscardHotChunk`) | Remove `hot[c]` from the View and hand the hot database to the reaper. | Unpublish before catalog demotion and every destructive step.                                                                                                                                                 |
+| Retention prune | Publish the run's new floor, which also drops below-floor `cold`, `hot`, and `indexes` entries. | Gate, unpublish, demote, then schedule destruction with the reaper. The floor update removes below-floor resources before every demotion.                                                                                                  |
 | Startup `serveReads()` | Build the initial View from the catalog scan: `"ready"` hot keys, `"frozen"` chunk keys, frozen coverages, and the calculated floor. | Complete before the lifecycle goroutine starts, so no freeze can land between the scan and the hooks becoming live.                                                                                           |
 
 Four ordering notes matter:
@@ -281,41 +282,34 @@ Together, these hooks maintain the read-side coverage property: at every publica
 
 ## Open-handle management
 
-The registry manages three kinds of serving resources. Each uses a different lifetime policy based on its access pattern and resource cost.
+The registry manages two kinds of serving resources, with opposite lifetime policies.
 
 | Resource | Policy |
 | --- | --- |
-| Hot databases | Always open |
-| Window transaction indexes (`txhash.ColdReader`) | Always open |
-| Per-chunk cold readers (`ledger.ColdReader`, `eventstore.ColdReader`) | Open on demand through per-kind LRU caches |
+| Hot databases | Always open, shared by ingestion and queries |
+| Cold files (chunk packfiles, events indexes, window `.idx`) | Opened and closed by each request |
+
+Handles are cheap to create and expensive to share: an open or mmap costs microseconds, while a shared handle needs close coordination with every reader. The policies follow.
 
 ### Hot databases
 
-Hot databases remain open from `openHotDBForChunk` until the reaper destroys them after discard.
+Hot databases remain open from `openHotDBForChunk` until the reaper destroys them after discard. Each hot chunk has a single shared RocksDB instance owned by the registry; ingestion and queries use the same handle concurrently, and its close drains in-flight operations ([The reaper](#the-reaper)).
 
-Each hot chunk has a single shared RocksDB instance owned by the registry. Ingestion and queries use the same handle concurrently. RocksDB supports concurrent reads and writes on a single database instance.
+### Cold readers and window indexes
 
-### Transaction hash indexes
+Every cold resource is opened by the request that needs it and closed when the request finishes with it. Only the owner closes a reader, so a close never races a read, and retirement needs no reader tracking ([The reaper](#the-reaper)).
 
-Each in-retention window keeps one `txhash.ColdReader` open.
+The MVP does no caching here. Each open re-reads and re-parses what it needs.
 
-These readers maintain only the state needed to service lookups efficiently. Keeping them open also simplifies index replacement because older Views continue using the superseded reader until the reaper closes it after the grace period.
+### Deferred: caching parsed state
 
-### Cold readers
+An open re-reads and re-parses the reader's metadata: the events reader loads its MPHF and each packfile loads its offsets index. For a frequently hit chunk the reads are served from the OS page cache, but the parsing and allocation repeat on every open.
 
-Cold readers are opened on demand.
+If this shows up in profiles, add a bounded cache of the parsed state, keyed by chunk. Only data with no close method goes in it; handles never do. Evicting data is harmless, so the cache needs nothing from the reaper or the serving map, and it can be added later without changing this design.
 
-Full history contains thousands of chunks and continues to grow. Keeping readers open for every cold artifact would consume substantial memory while providing little benefit for infrequently accessed data. Instead, the registry records only whether an artifact is available, and reader objects are managed through bounded per-kind LRU caches.
+### Platform assumption
 
-Ledger and event readers use separate caches because their resource costs differ significantly. Separate caches also prevent heavy event traffic from evicting ledger readers needed by other query paths.
-
-### Interaction with the reaper
-
-Reader caches follow the same lifetime rules as every other serving resource.
-
-When a chunk is removed from the serving map, its cached readers are also retired. The reaper delays closing those readers until the grace period has elapsed, ensuring that no admitted query can still be using them.
-
-Removing cached readers when a chunk is unpublished also guarantees deterministic cleanup. Otherwise, a lightly used reader could remain in the cache indefinitely and keep an unlinked file open until it was eventually evicted.
+Per-request opens with deferred unlink rely on POSIX unlink semantics: an unlinked file stays readable through existing descriptors and mappings, and its name is immediately reusable. Linux and macOS provide this. Windows does not provide this reliably: memory-mapped files cannot be deleted while mapped, so the reaper's unlink would need retry semantics there.
 
 ---
 
@@ -359,7 +353,7 @@ Routing resolves each chunk independently.
 ```go
 func (v *View) resolve(c chunk.ID, k Kind) (Store, error) {
     if v.cold[c].has(k) {
-        return coldReaders(c, k)
+        return openColdReaders(c, k)
     }
     if hs, ok := v.hot[c]; ok {
         return hs.store(k)
@@ -421,7 +415,7 @@ Instead, the router probes the transaction indexes in two stages:
 The router supplies `TxReader` with:
 
 - the hot transaction indexes,
-- the window transaction indexes, and
+- the window index coverages, whose `.idx` files the lookup opens as it probes, and
 - a ledger source backed by `resolve(chunk, Ledgers)`.
 
 This preserves the existing lookup semantics while allowing `TxReader` to operate across both hot and cold storage.
@@ -467,7 +461,7 @@ The streaming workflow assumes the ingestion worker owns the hot RocksDB instanc
 
 This proposal transfers ownership to the registry. Each hot database is opened once, registered in the current View, and shared by both ingestion and queries until the reaper destroys it after discard.
 
-This change allows queries to access hot databases without opening additional RocksDB instances. It also changes the freeze source: freezing previously reopened the cleanly closed chunk read-only, and instead reads through the same shared handle, supplied via the backfill `HotProbe` seam.
+This change allows queries to access hot databases without opening additional RocksDB instances. It also changes the freeze source: today the backfill's `resolveHotSource` reopens the cleanly closed chunk read-only; under this proposal it is supplied the registry's shared handle instead.
 
 ### View updates
 
@@ -505,7 +499,6 @@ The catalog protocol is unchanged except for the delayed physical destruction of
 - **Datastore fallback below the floor.** The v1 `getLedgers` handler can fall back to the remote object store for pre-retention ledgers. v2 must either preserve that behavior as an explicit exception to R2 or remove it at cutover. This decision belongs to #772.
 - **Serving floor precision.** This design currently uses a chunk-aligned floor, so `oldestLedger` advances in 10,000-ledger steps. A ledger-precise floor would better match v1’s sliding window, but adds another floor concept.
 - **`getTransaction` probe parallelism.** The proposal uses sequential newest-first probing. If window count or tail latency becomes a problem, parallel probing can be added inside the lookup path without changing the routing model.
-- **Cache sizing.** Ledger and event reader cache capacities are implementation-time tuning parameters.
 
 ---
 
@@ -513,15 +506,25 @@ The catalog protocol is unchanged except for the delayed physical destruction of
 
 ### Explicit reader tracking
 
-Track active readers directly, either by reference-counting Views/resources or by holding a reader lock while a query runs.
+Track active readers directly, either by reference-counting Views and resources or by holding a reader lock while a query runs.
 
-This was not chosen because it adds work to every query: each request must acquire and release some reader state. This proposal avoids that by using the request deadline as the bound on reader lifetime. Queries only load `latest` and the current View at admission.
+The design already tracks readers at the operation level: the hot database wrapper holds a read lock for the duration of each call, which is what makes its close a drain barrier. This alternative is per-request tracking: a count held for the request's whole lifetime, letting the reaper destroy a resource the moment its count reaches zero instead of waiting out the grace period.
+
+This was not chosen because exact reclamation timing is not needed, and per-request counts handle the failure case worse. A request stuck past its deadline holds its count indefinitely and keeps the resource alive, while under the grace period the same straggler receives a closed error and terminates. A missed release also pins the resource forever, a bug class a dropped View pointer cannot have.
+
+Per-request tracking becomes necessary if a request type without an enforced deadline is ever added, such as a streaming subscription. The grace period's availability argument depends on **D** existing.
 
 ### Filesystem unlink semantics alone
 
-Rely on the filesystem to keep already-open files readable after they are unlinked.
+Rely on the filesystem to keep already-open files readable after they are unlinked, and unlink immediately at retirement with no grace period.
 
-This was not chosen because it only applies to already-open cold files. It does not protect RocksDB handles, cache misses that open a file after unlink, or other resource types that must be closed explicitly. This proposal uses the grace period uniformly for hot databases, cold readers, and index readers.
+The design adopts the first half: a request that opened a cold file before it was unlinked keeps reading it ([Open-handle management](#open-handle-management)). Immediate unlink was not chosen because it only protects files that are already open. A query holding an older View may open a chunk for the first time after prune has removed it, and would fail mid-request. Deferring the unlink by the grace period covers those late opens. Hot databases are unaffected either way: a RocksDB handle is not kept alive by unlink semantics, and its lifetime is governed by the drain barrier and the reaper.
+
+### Catalog snapshots instead of the View
+
+Take a RocksDB snapshot of the catalog at each admission instead of publishing an immutable View.
+
+A snapshot covers only metadata. It cannot share the hot database's single handle or keep files alive, so the registry, reaper, and watermark all remain. What it adds: per-request snapshot acquire and release across the CGO boundary, routing lookups as CGO reads instead of map lookups, and the serving rules evaluated in every reader instead of once at publish, all to re-derive state that changes only a few times a day. The View is the same repeatable read, built once per transition and loaded with one atomic pointer read.
 
 ---
 

--- a/design-docs/query-routing-design.md
+++ b/design-docs/query-routing-design.md
@@ -18,7 +18,8 @@ The following terms are used throughout this document.
 - **Admission snapshot**: A RocksDB snapshot of the catalog taken when a query is admitted and released when it completes. A repeatable read of routing metadata.
 - **Handle set**: The router's map of open hot database handles, published atomically. A query loads it once at admission.
 - **Hot / cold**: Hot data is served from a live RocksDB database, one per hot chunk. Cold data is served from sealed files written once during freezing.
-- **Retention floor**: The oldest ledger served, derived at admission from `latest` and the retention configuration. A request whose leading edge is below its admitted floor is not served (R2).
+- **Index coverage**: The chunk range `[Lo, Hi]` a window's `.idx` actually covers, recorded in its catalog key and encoded in its file name. `Hi` trails the tip while the window is current, and `Lo` is the retention floor at build time.
+- **Retention floor**: The oldest ledger served, derived at admission from the snapshot and the retention configuration. A request whose leading edge is below its admitted floor is not served (R2).
 - **`latest`**: The newest fully ingested ledger visible to queries.
 
 ---
@@ -127,8 +128,9 @@ func (r *Router) Admit() (*Admission, error) {
     if err != nil {
         return nil, err
     }
-    // The frontier is the last complete chunk, the same anchor prune uses.
-    floor := r.retention.FloorAt(geometry.LastCompleteChunkAt(latest))
+    // The frontier is the highest ready hot chunk in the snapshot minus
+    // one: the same last-complete-chunk anchor the lifecycle run uses.
+    floor := r.retention.FloorAt(hotFrontier(r.catalog, snap))
     return &Admission{latest: latest, floor: floor, handles: handles, snap: snap, catalog: r.catalog}, nil
 }
 
@@ -141,7 +143,7 @@ The order is important, for the same reason as in the streaming workflow's write
 
 The snapshot is loaded last, so the metadata is the newest of the three. Any skew between the handle set and the snapshot then resolves safely: if the snapshot shows a chunk demoted from hot after the handle set was loaded, it also shows the chunk's cold artifacts frozen, because coverage is published before discard, and routing prefers cold. A query never needs a handle for a chunk its snapshot no longer serves hot. Skew in the other direction, a hot chunk the handle set does not yet contain, cannot be reached at all: its first ledger commits only after the handle is published, so the admitted `latest` never points into it.
 
-The floor is derived from the admitted `latest` and the retention configuration, so it is consistent with the admitted range by construction. Prune uses the same derivation at its own frontier; since `latest` is monotonic, an admitted floor is never behind a completed prune's floor, so queries are never routed below pruned data.
+The floor is derived from the snapshot: the frontier is the highest ready hot chunk minus one, the same anchor the lifecycle run uses. Floor and index coverage therefore come from the same read and cannot disagree.
 
 After admission, the query validates and clamps its requested range against `[floor, latest]`. Requests whose leading edge falls below the floor are rejected with an error carrying the available range. Requests extending beyond `latest` are truncated.
 
@@ -199,10 +201,10 @@ The grace period alone is not sufficient for memory safety, because the deadline
 
 Memory safety therefore comes from ownership and drain barriers, not from time:
 
-- **Hot databases**: the only shared handles. `rocksdb.Store` holds a read lock across every C call; `Close` flips a closed flag, then takes the write lock, so it waits for in-flight operations to drain and every later operation fails cleanly with a closed error.
+- **Hot databases**: the only shared handles. `rocksdb.Store` holds a read lock across every C call, and no close path frees the database while an operation is in flight. The blocking `Close` waits for in-flight operations to drain. The deletion path closes through `CloseIfIdle`, a non-blocking variant this design adds ([Changes to the streaming workflow](#changes-to-the-streaming-workflow)): it sets the closed flag, closes only if nothing is in flight, and otherwise reports failure so the run can alarm and skip. Either way, every operation after the flag is set fails cleanly with a closed error. By deletion time the grace period has outlasted every deadline, so `CloseIfIdle` normally succeeds immediately; failure means a read stuck past its deadline, exactly the case the alarm is for.
 - **Cold readers and window indexes**: opened and closed by the request that uses them ([Open-handle management](#open-handle-management)). No other component ever closes them, so a close cannot race a read.
 
-A straggler that outlives **T** is harmless: `Close` waits out its in-flight operation, and any later operation fails with a closed error. For retired files, unlink does not disturb descriptors already open: a straggler keeps reading the unlinked file, and the space is reclaimed when it exits.
+A straggler that outlives **T** is harmless: the deletion path declines to close under it and retries in a later run, and every operation the straggler issues after the closed flag is set fails with a closed error. For retired files, unlink does not disturb descriptors already open: a straggler keeps reading the unlinked file, and the space is reclaimed when it exits.
 
 Deletion follows this sequence:
 
@@ -368,7 +370,9 @@ A transaction hash does not identify the chunk containing the transaction, so ro
 Instead, the router probes the transaction indexes in two stages:
 
 1. Probe the hot transaction indexes. A match is definitive.
-2. Probe each window transaction index. A match identifies a candidate ledger, which is fetched and verified against the full transaction hash. Candidates below the admitted floor are skipped. This enforces R2 for by-hash lookups, which have no range to clamp, and makes it safe for a window index to keep naming ledgers that prune has already removed.
+2. Probe each window transaction index. A match identifies a candidate ledger, which is fetched and verified against the full transaction hash.
+
+A candidate is served only if `floor <= ledger <= latest`, both from admission. The floor gate enforces R2 and makes it safe for a window index to keep naming pruned ledgers. The `latest` gate enforces H3: without it, a probe could return a transaction from a ledger above the admitted `latest`, since the hot store keeps advancing after admission.
 
 The router supplies `TxReader` with:
 
@@ -423,7 +427,7 @@ This change allows queries to access hot databases without opening additional Ro
 
 ### Catalog snapshot support
 
-The rocksdb wrapper gains snapshot support: acquire and release, and snapshot-pinned reads and iteration, under the same lifecycle-lock discipline as its other operations. The catalog store uses them for admission.
+The rocksdb wrapper gains snapshot support: acquire and release (`NewSnapshot`, `ReleaseSnapshot`) and snapshot-pinned reads and iteration (`GetSnap`), under the same lifecycle-lock discipline as its other operations. The catalog store uses them for admission.
 
 ### `latest` watermark
 
@@ -435,7 +439,7 @@ Advancing the watermark is the final step of per-ledger ingestion. Queries admit
 
 The streaming workflow destroys retired resources immediately after catalog demotion.
 
-This proposal defers destruction to the end of the run, after a grace period from demotion. The catalog protocol is unchanged except for that delay.
+This proposal defers destruction to the end of the run, after a grace period from demotion. The catalog protocol is unchanged except for that delay. The rocksdb wrapper gains a non-blocking `CloseIfIdle` for this path: it closes only when no operation is in flight and reports failure rather than waiting.
 
 ---
 

--- a/design-docs/query-routing-design.md
+++ b/design-docs/query-routing-design.md
@@ -4,21 +4,21 @@
 
 This document is the read-side counterpart to the [streaming workflow](./full-history-streaming-workflow.md). It describes how queries determine, for each chunk in their requested range, whether data is served from a hot database or sealed cold files. It also explains how that routing remains correct while ingestion and lifecycle workers concurrently add, replace, and remove stores.
 
-Every query is admitted against a single immutable snapshot of the **serving map**, called a **View**. The serving map records which store serves each chunk, which transaction hash index serves each window, and the retention floor. At admission, the query loads the current `latest` watermark and one current View. It then uses that admitted state for its entire lifetime.
+Every query is admitted against a consistent snapshot of serving state. At admission, the query loads the current `latest` watermark, the current set of open hot database handles, and a RocksDB snapshot of the **catalog**. It uses that admitted state for its entire lifetime and releases the snapshot when the request completes. The snapshot gives the query a repeatable read of the routing metadata: which chunks are frozen, which hot databases are ready, and which index generation covers each window. There is no second copy of that metadata to maintain: queries read the same catalog the lifecycle writes, pinned at admission time.
 
-A small in-memory **registry** owns the serving map. When a storage operation changes what is servable, such as freezing a chunk, replacing a transaction hash index, discarding a hot database, or advancing the retention floor, the registry creates a new View, applies the change, and atomically publishes it. Queries already in flight continue using the View they admitted with, while newly admitted queries observe the updated View.
+A small in-memory **router** owns only what cannot live in the catalog: the `latest` watermark and the shared hot database handles. It changes only when a hot database opens or is discarded.
 
-Deletion is deferred rather than reader-tracked. Every request runs under a fixed deadline. Once a resource is removed from the current View, no newly admitted query can reach it, and physical destruction waits out a grace period longer than the maximum request lifetime, so queries holding an older View can finish against it ([The reaper](#the-reaper)).
+Deletion is deferred rather than reader-tracked. Every request runs under a fixed deadline. Once a resource is demoted in the catalog, no newly admitted query is routed to it, and physical destruction waits out a grace period longer than the maximum request lifetime, so queries admitted earlier can finish against it ([Deferred deletion](#deferred-deletion)).
 
 The following terms are used throughout this document.
 
 - **Chunk**: 10,000 consecutive ledgers, the unit of storage.
 - **Window**: 1,000 chunks, or 10 million ledgers. Each window has one transaction hash `.idx` file.
-- **Serving map**: The in-memory map of chunks and windows to the stores that serve them, plus the retention floor.
-- **View**: An immutable snapshot of the serving map admitted by a query.
+- **Catalog**: The durable RocksDB record of each store and its lifecycle state, and the single source of truth for routing metadata.
+- **Admission snapshot**: A RocksDB snapshot of the catalog taken when a query is admitted and released when it completes. A repeatable read of routing metadata.
+- **Handle set**: The router's map of open hot database handles, published atomically. A query loads it once at admission.
 - **Hot / cold**: Hot data is served from a live RocksDB database, one per hot chunk. Cold data is served from sealed files written once during freezing.
-- **Catalog**: The durable RocksDB record of each store and its lifecycle state.
-- **Retention floor**: The oldest ledger served by a View. A request whose leading edge is below its admitted View's floor is not served (R2).
+- **Retention floor**: The oldest ledger served, derived at admission from `latest` and the retention configuration. A request whose leading edge is below its admitted floor is not served (R2).
 - **`latest`**: The newest fully ingested ledger visible to queries.
 
 ---
@@ -31,19 +31,19 @@ Three kinds of workers access storage concurrently:
 - **One lifecycle worker** performs housekeeping. It freezes completed chunks into cold files, rebuilds the window's transaction hash index at each boundary, discards hot databases once cold files fully cover their data, and removes data that has fallen outside the retention window.
 - **Many query workers**, one for each incoming JSON-RPC request.
 
-Every query must observe a consistent serving map throughout its lifetime. It must not combine routing decisions from different storage states, and it must not be directed to a resource that can be destroyed before the request finishes. Without coordination, several races become possible.
+Every query must observe a consistent serving state throughout its lifetime. It must not combine routing decisions from different storage states, and it must not be directed to a resource that can be destroyed before the request finishes. Without coordination, several races become possible.
 
 |        | Problem | Example |
 | ------ | ------- | ------- |
-| **H1** | A query plans its reads while the serving map changes. | A range query resolves chunk X to its hot database just as the discard scan removes that database because cold files now cover it. |
+| **H1** | A query plans its reads while serving state changes. | A range query resolves chunk X to its hot database just as the discard scan removes that database because cold files now cover it. |
 | **H2** | A resource is destroyed while a read is in progress. | An index rebuild replaces a superseded `.idx`, and the sweep closes and unlinks it while a `getTransaction` request is still reading it. |
 | **H3** | A query reads the newest ledger while it is still being ingested. | A `getLedgers` request at the tip must either return ledger *n* completely or not at all. It must never advertise a `latestLedger` that it cannot actually serve. |
 | **H4** | The retention floor advances during a query. | A prune removes the oldest chunk in a range after the query has already been admitted. |
 
 The streaming design already establishes two read-path requirements:
 
-- **R1. Only finished data is newly visible.** A newly published View must not introduce a chunk or index while it is in the catalog state `"freezing"`, `"pruning"`, or `"transient"`.
-- **R2. Data below the admitted retention floor is not served.** Even if data still exists on disk, a request whose leading edge is below the floor recorded in its admitted View is not served: point lookups return not found, and range requests are rejected with an error that reports the available range.
+- **R1. Only finished data is served.** A query must not serve a chunk or index whose catalog state is `"freezing"`, `"pruning"`, or `"transient"`.
+- **R2. Data below the admitted retention floor is not served.** Even if data still exists on disk, a request whose leading edge is below its admitted floor is not served: point lookups return not found, and range requests are rejected with an error that reports the available range.
 
 These races occur while ingestion, freezing, index replacement, discard, and pruning all proceed concurrently. Throughout every transition, the entire active retention window must remain continuously servable, with no gaps between hot and cold storage. This is the read-side view of [INV-1](./full-history-streaming-workflow.md#invariants) from the streaming workflow.
 
@@ -53,164 +53,147 @@ These races occur while ingestion, freezing, index replacement, discard, and pru
 
 The design uses four mechanisms:
 
-1. Every query resolves against one immutable View of the serving map, so routing decisions never mix storage states (H1).
-2. The registry publishes a new View whenever the serving map changes, for example when a freeze adds cold artifacts or prune advances the retention floor.
-3. The reaper destroys retired resources only after they have been unreachable for a grace period longer than the maximum request lifetime, and every close of a shared handle drains in-flight operations, so nothing a request can reach is destroyed while it runs (H2, H4).
-4. The registry maintains the `latest` watermark so queries never observe partially ingested ledgers (H3).
+1. Every query reads routing metadata through one catalog snapshot taken at admission, so routing decisions never mix storage states (H1).
+2. The router publishes the shared hot database handles; every cold file is opened by the request that reads it.
+3. The lifecycle destroys retired resources only after a grace period longer than the maximum request lifetime, and every close of a shared handle drains in-flight operations, so nothing a request can reach is destroyed while it runs (H2, H4).
+4. The router maintains the `latest` watermark so queries never observe partially ingested ledgers (H3).
 
-Together, these mechanisms let ingestion, lifecycle operations, and queries proceed concurrently without requiring readers to coordinate with writers. Queries perform two atomic loads at admission and never register with the registry, hold reference counts, or block on writers.
+Together, these mechanisms let ingestion, lifecycle operations, and queries proceed concurrently without requiring readers to coordinate with writers. Admission is three loads; the request's only bookkeeping obligation is releasing its snapshot when it completes.
 
 ```mermaid
 flowchart TB
-    I["Ingestion"] --> CAT
-    L["Lifecycle"] --> CAT
-
-    I -->|"publish hot chunk"| V
+    I["Ingestion"] -->|"write ledgers"| CAT
+    L["Lifecycle"] -->|"freeze / swap / prune: demote, then delete after T"| CAT
     I -->|"advance latest"| W
-    L -->|"publish freeze / index swap / floor / unpublish"| V
-    L -->|"retire resources"| REAP
-    CAT[("Catalog")] -.->|"startup rebuild"| V
+    I -->|"publish hot handle"| H
+    L -->|"discard hot handle"| H
 
-    subgraph REG["registry"]
-        V["current View<br/>floor · hot · cold · index coverage"]
+    subgraph REG["router"]
         W["latest watermark"]
-        HOT["hot DB handles"]
-        REAP["reaper"]
+        H["hot DB handles"]
     end
 
-    Q["Query"] -->|"load latest"| W
-    Q -->|"load View"| V
+    CAT[("Catalog")]
+
+    Q["Query"] -->|"1: load latest"| W
+    Q -->|"2: load handles"| H
+    Q -->|"3: snapshot"| CAT
     Q -.->|"opens per request"| FILES["cold files: .pack, events, .idx"]
-
-    V -->|"references"| HOT
-
-    REAP -->|"close after T"| HOT
-    REAP -->|"unlink after T"| FILES
 ```
 
 ---
 
-## Registry and View
+## Admission
 
-The catalog remains the durable record of every store and its lifecycle state. The registry is a disposable in-memory projection of the catalog.
-
-A query loads one View when it is admitted and uses that same View for its entire lifetime. Later View updates affect only newly admitted queries.
-
-Each View records:
-- the retention floor used by queries admitted with that View,
-- the hot stores,
-- the cold artifacts available for each chunk, and
-- the transaction hash index coverage for each window.
-
-The registry is rebuilt from the catalog during startup before the server begins accepting requests.
+The catalog is the durable record of every store and its lifecycle state, and queries route directly from it. The router holds the two things the catalog cannot: the `latest` watermark, which advances every ledger, and the open hot database handles, which are live objects.
 
 ```go
-type Registry struct {
-    mu      sync.Mutex
-    current atomic.Pointer[View]
-    latest  atomic.Uint32
-    reaper  *Reaper
+type Router struct {
+    catalog   *rocksdb.Store
+    retention geometry.Retention
+    latest    atomic.Uint32
+    handles   atomic.Pointer[HandleSet]
+    mu        sync.Mutex // serializes handle-set updates
 }
 
-type View struct {
+type HandleSet struct {
+    hot map[chunk.ID]*hotchunk.DB
+}
+
+type Admission struct {
+    latest  uint32
     floor   chunk.ID
-    hot     map[chunk.ID]*hotchunk.DB
-    cold    map[chunk.ID]ColdChunk
-    indexes []IndexCoverage
-}
-
-type ColdChunk struct {
-    Ledgers bool
-    Events  bool
-}
-
-type IndexCoverage struct {
-    Window geometry.TxHashIndexID
-    Lo, Hi chunk.ID // the frozen .idx's actual coverage, not the window bounds:
-                    // Hi trails the tip while the window is current, and Lo is
-                    // the retention floor at build time
+    handles *HandleSet
+    snap    *rocksdb.Snapshot
+    catalog *rocksdb.Store
 }
 ```
 
 ### Design rationale
 
-Each field exists for a specific reason.
+- **`latest` lives in the router.** The catalog records durability; `latest` records completeness, which includes the in-memory events apply that happens after the commit. Only the ingest loop can announce it, and it advances every few seconds, far too often for catalog reads to be the lookup path.
+- **`handles` lives in the router.** The live chunk's hot database has exactly one usable handle, owned by ingestion; RocksDB is single-writer, so a query cannot open its own. An in-memory map is the only way to share it. The handle set is copy-on-write: updates clone the map under `mu` and publish it atomically, and it changes only at hot open and hot discard.
+- **Everything else has no in-memory copy.** Frozen flags, hot states, index coverage, and the data needed to derive the floor are read from the catalog through the admission snapshot.
 
-- **`hot` stores shared handles.** Each hot chunk has one registry-owned `hotchunk.DB` instance used by ingestion and queries.
-- **`cold` holds flags, not open readers.** A `ColdChunk` entry only says the chunk's artifact is frozen and servable. The reader itself is opened per request ([Open-handle management](#open-handle-management)): with thousands of cold chunks, holding every reader open would cost gigabytes, unlike the handful of hot databases the View references directly.
-- **`indexes` stores coverage metadata, not readers.** Each in-retention window has one current coverage entry; the `.idx` file itself is opened per request ([Open-handle management](#open-handle-management)).
-- **`latest` is stored outside the View.** The serving map changes only at chunk boundaries and lifecycle transitions, while `latest` advances every ledger. Keeping it separate avoids copying the View every few seconds.
+### Admitting a query
 
-### Admission
-
-Every query performs two atomic loads during admission.
+Every query performs three loads at admission, in this order:
 
 ```go
-latest := registry.latest.Load()
-view := registry.current.Load()
+func (r *Router) Admit() (*Admission, error) {
+    latest := r.latest.Load()
+    handles := r.handles.Load()
+    snap, err := r.catalog.NewSnapshot()
+    if err != nil {
+        return nil, err
+    }
+    // The frontier is the last complete chunk, the same anchor prune uses.
+    floor := r.retention.FloorAt(geometry.LastCompleteChunkAt(latest))
+    return &Admission{latest: latest, floor: floor, handles: handles, snap: snap, catalog: r.catalog}, nil
+}
 
-floorLedger := view.floor.FirstLedger()
+func (a *Admission) Release() { a.catalog.ReleaseSnapshot(a.snap) }
 ```
 
-The order is important. The query reads `latest` before loading the View. A ledger less than or equal to the admitted `latest` is queryable only if it is not below the floor recorded in the subsequently loaded View. The write-side publication order guarantees that every ledger in that admitted range has a serving home in the loaded View.
+The order is important, for the same reason as in the streaming workflow's write ordering.
 
-Reversing the order would break that guarantee. A chunk boundary could occur between the two loads, allowing `latest` to point into a newly opened chunk that is not present in the older View. The response could then advertise a `latestLedger` that it cannot serve.
+`latest` is loaded first. The write side publishes a chunk's serving state (catalog key and handle) before the chunk's first ledger commits, and advances `latest` last. A query's admitted range therefore only covers chunks whose serving state predates its `latest`, which predates its other two loads. Loading `latest` after the snapshot would allow a chunk boundary between them: `latest` could point into a newly opened chunk the older snapshot does not show.
 
-After admission, the query validates and clamps its requested range against `[floorLedger, latest]`. Requests whose leading edge falls below `floorLedger` are rejected with an error carrying the available range. Requests extending beyond `latest` are truncated.
+The snapshot is loaded last, so the metadata is the newest of the three. Any skew between the handle set and the snapshot then resolves safely: if the snapshot shows a chunk demoted from hot after the handle set was loaded, it also shows the chunk's cold artifacts frozen, because coverage is published before discard, and routing prefers cold. A query never needs a handle for a chunk its snapshot no longer serves hot. Skew in the other direction, a hot chunk the handle set does not yet contain, cannot be reached at all: its first ledger commits only after the handle is published, so the admitted `latest` never points into it.
 
-No further synchronization is required. The View is immutable, so the query simply keeps its pointer for the lifetime of the request.
+The floor is derived from the admitted `latest` and the retention configuration, so it is consistent with the admitted range by construction. Prune uses the same derivation at its own frontier; since `latest` is monotonic, an admitted floor is never behind a completed prune's floor, so queries are never routed below pruned data.
 
-### Publishing View updates
+After admission, the query validates and clamps its requested range against `[floor, latest]`. Requests whose leading edge falls below the floor are rejected with an error carrying the available range. Requests extending beyond `latest` are truncated.
 
-Every change to the serving map follows the same pattern.
+Every request must release its snapshot when it completes, including on error paths. A leaked snapshot pins catalog compaction until process exit; snapshot age is worth a metric.
+
+### Resolution
+
+Routing resolves each chunk independently, reading its state through the admission snapshot. All query methods share this one function, so the serving rules (R1, cold-wins) have a single implementation site.
 
 ```go
-func (r *Registry) publish(mutate func(*View) (removed []Resource)) {
-    r.mu.Lock()
-
-    next := r.current.Load().clone()
-    removed := mutate(next)
-
-    r.current.Store(next)
-
-    r.mu.Unlock()
-
-    r.reaper.Schedule(removed)
+func (a *Admission) resolve(c chunk.ID, k Kind) (Store, error) {
+    st, ok, _ := a.catalog.GetSnap(a.snap, geometry.ChunkKey(c, k))
+    if ok && st == geometry.StateFrozen {
+        return openColdReaders(c, k)
+    }
+    hst, ok, _ := a.catalog.GetSnap(a.snap, geometry.HotChunkKey(c))
+    if ok && hst == geometry.HotReady {
+        if db, ok := a.handles.hot[c]; ok {
+            return db.Store(k), nil
+        }
+    }
+    return nil, ErrUnavailable
 }
 ```
 
-The registry serializes View updates with a mutex. Each update clones the current View, applies the requested changes, atomically publishes the new View, and schedules any removed resources with the reaper.
+The resolution order is deterministic. When both hot and cold copies exist, routing selects the cold artifact. States other than `"frozen"` and `"ready"` are never served, which is R1: a freezing, pruning, or transient resource is invisible to routing regardless of what is on disk.
 
-Additions are published only after the corresponding catalog state is durable and serving-ready. Removals follow the ordering rules in [View update points](#view-update-points).
+If a chunk has no serving home, routing returns `ErrUnavailable`.
 
-View updates occur only when the serving map changes, such as chunk boundaries or lifecycle transitions. Even with full history, cloning the View copies only a few hundred kilobytes of pointers, which is negligible compared to the roughly fourteen-hour interval between chunk boundaries.
+For `getTransaction`, the window index coverage is read the same way: the lookup iterates the coverage keys through the snapshot, and opens each generation-named `.idx` file it probes.
 
 ---
 
-## The reaper
+## Deferred deletion
 
-The reaper safely destroys resources that have been removed from the serving map.
+Destruction of retired resources is delayed and executed by the lifecycle itself. There is no separate reaper thread.
 
-Its rule is:
+The rule is:
 
-> A resource that was reachable from a published View may be destroyed only after it has been unreachable for at least grace period **T**.
+> A resource that was servable may be destroyed only after it has been demoted for at least grace period **T**.
 
-A resource becomes **unreachable** when it has been removed from the current View. A resource is **destroyed** when it is permanently closed or removed.
-
-```go
-type Reaper struct {
-    graceT time.Duration // derived from the request timeout
-    queue  []retired     // {destroy func(), notBefore time.Time}
-}
-```
-
-Every read handler runs under an enforced request deadline **D**. The grace period is derived from that deadline:
+Every read handler runs under an enforced request deadline **D**, and the grace period is derived from it:
 
 ```text
 T = maximum request timeout + safety margin
 ```
 
-The grace period preserves availability. A query that admitted a View before a resource was unpublished may still be routed to that resource for the rest of its lifetime. Since **T > D**, the resource remains open and servable until every such query has passed its deadline, so lifecycle transitions do not fail requests already in flight.
+As a run's stages demote resources in the catalog, they append each demoted item to a list local to the run. When the stages finish and the list is non-empty, the run waits out the grace period once, then deletes each item: closing discarded hot databases, unlinking superseded index generations and pruned chunk files, and removing their catalog entries. An item that cannot be deleted, such as a hot database whose close is blocked by a read stuck on a slow disk, is alarmed and skipped; the next run's scans re-discover its demoted key and retry.
+
+The catalog demotions are the durable work list: after a crash, startup re-discovers pending deletions and runs the same sweep before serving, which is safe because no query survives the process. Because deletion happens inside the run, a finished run means everything it demoted is gone or alarmed: an idle daemon is a settled catalog.
+
+The grace period preserves availability. A query admitted before a resource was demoted may still be routed to it for the rest of its lifetime. Since **T > D**, the resource remains open and servable until every such query has passed its deadline, so lifecycle transitions do not fail requests already in flight.
 
 The grace period alone is not sufficient for memory safety, because the deadline bounds the response, not the handler goroutine. On timeout, the request duration limiter cancels the request context and returns an error to the client without waiting for the handler. A handler blocked in a call that cannot observe cancellation, such as a RocksDB read stalled on a slow disk, keeps running past **D** and can still hold a reference after **T**.
 
@@ -223,66 +206,58 @@ A straggler that outlives **T** is harmless: `Close` waits out its in-flight ope
 
 Deletion follows this sequence:
 
-1. Remove the resource from the serving map.
-2. Record the catalog demotion, such as `"pruning"` or `"transient"`.
-3. Schedule the resource with the reaper.
-4. After **T**: close retired hot databases, unlink retired files, remove directories, and remove the catalog entry.
-
-Only physical destruction is delayed. Catalog demotions still occur during the lifecycle run.
+1. A lifecycle run demotes the resource in the catalog (`"pruning"` or `"transient"`) and, for a hot database, removes its handle from the handle set.
+2. Newly admitted queries no longer route to it: their snapshots see the demotion.
+3. At the end of the run, after the grace period, the run closes handles, unlinks files, removes directories, and removes the catalog entries. Stuck items are alarmed, skipped, and retried by the next run's scans.
 
 ```mermaid
 sequenceDiagram
-    participant L as Lifecycle
-    participant V as View
+    participant L as Lifecycle run
     participant C as Catalog
-    participant P as Reaper
+    participant H as Handle set
     participant FS as Disk
 
-    L->>V: Remove from serving map
-    Note over V: New queries cannot reach the resource
-    L->>C: Record "pruning" or "transient"
-    L->>P: Schedule destruction after T
-    P->>FS: Close, unlink, remove
-    P->>C: Remove catalog entry
+    L->>H: Remove hot handle (discard only)
+    L->>C: Demote to "pruning" or "transient"
+    Note over C: New admissions no longer route here
+    Note over L: Stages finish, wait grace period T
+    L->>FS: Close, unlink, remove (bounded retries)
+    L->>C: Remove catalog entry
 ```
 
-The reaper has no persistent state. If the process exits before scheduled deletion completes, startup reconstructs pending deletion work from the catalog and runs it immediately. No new grace period is needed because demoted stores never enter the rebuilt View, so no query can reference them.
-
-The tradeoff is delayed cleanup. Retired hot databases, superseded indexes, and pruned chunk files may remain on disk until **T** expires. Because **T** is measured in minutes while lifecycle operations occur hours apart, the extra disk usage is expected to be small.
+The tradeoff is a longer run: the grace period is waited once at the end, minutes against runs that happen hours apart. In exchange, retired resources are reclaimed within the run that demoted them, and a deletion blocked by a straggler cannot stall the run beyond its bounded retries: it is alarmed, skipped, and retried by the next run.
 
 ---
 
-## View update points
+## Write-side transitions
 
-Every write-side transition that changes what is servable gets a registry hook. Additions are published after the catalog commit that makes the resource serving-ready, which is how R1 is kept: a transitional resource never enters a newly published View. Removals are unpublished before destructive work and, except for the index swap, before catalog demotion.
+Most lifecycle transitions need no serving-side action at all: they commit to the catalog, and newly admitted queries observe the commit through their snapshots. Only the hot database handles require explicit publication.
 
-| Write-side transition | Registry hook | Ordering rule                                                                                                                                                                                                 |
-| --- | --- |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `openHotDBForChunk` flips `hot:chunk:{c}` to `"ready"` | Publish `hot[c] = stores` using the shared instance. | Publish after the catalog key flips to `"ready"` and before the chunk's first ledger commits, so the watermark can never enter a chunk the current View does not serve.                                       |
-| Per-ledger ingest cycle: atomic `batch.Commit(sync)` plus in-memory applies | `latest.Store(seq)` | Final step of the cycle, after every serving structure contains the ledger.                                                                                                                                   |
-| `processChunk` flips artifact keys to `"frozen"` | Publish `cold[c].{kind} = true` for each frozen kind. | Publish after the commit. During startup backfill this hook has no effect; the startup scan (last row) covers those chunks.                                                                                   |
-| Transaction index rebuild (`buildTxhashIndex`): a single atomic catalog write freezes the new coverage and demotes its predecessor to `"pruning"` | Replace the window's `IndexCoverage` entry with the new coverage. Schedule the predecessor's `.idx` unlink with the reaper. | Publish after the atomic write. The predecessor's file deletion, previously `buildThenSweep`'s immediate unlink, now waits out the grace period, because queries holding older Views may still open and read it. Coverage file names encode their `Lo-Hi` range, so an older View's entry opens its own generation of the index, never the replacement. |
-| Hot database discard (`DiscardHotChunk`) | Remove `hot[c]` from the View and hand the hot database to the reaper. | Unpublish before catalog demotion and every destructive step.                                                                                                                                                 |
-| Retention prune | Publish the run's new floor, which also drops below-floor `cold`, `hot`, and `indexes` entries. | Gate, unpublish, demote, then schedule destruction with the reaper. The floor update removes below-floor resources before every demotion.                                                                                                  |
-| Startup `serveReads()` | Build the initial View from the catalog scan: `"ready"` hot keys, `"frozen"` chunk keys, frozen coverages, and the calculated floor. | Complete before the lifecycle goroutine starts, so no freeze can land between the scan and the hooks becoming live.                                                                                           |
+| Write-side transition | Serving-side action | Ordering rule |
+| --- | --- | --- |
+| `openHotDBForChunk` flips `hot:chunk:{c}` to `"ready"` | Publish the handle into the handle set. | After the catalog flip and before the chunk's first ledger commits, so the watermark can never enter a chunk whose serving state is unpublished. |
+| Per-ledger ingest cycle: atomic `batch.Commit(sync)` plus in-memory applies | `latest.Store(seq)` | Final step of the cycle, after every serving structure contains the ledger. |
+| `processChunk` flips artifact keys to `"frozen"` | None. New admissions see the frozen keys. | Commit before any hot discard is evaluated (freeze adds before discard removes). |
+| Transaction index rebuild (`buildTxhashIndex`): a single atomic catalog write freezes the new coverage and demotes its predecessor to `"pruning"` | None. New admissions see the new coverage. The predecessor's file is deleted at the end of the run, after the grace period. | Coverage file names encode their `Lo-Hi` range, so an admission that read the old coverage opens its own generation of the index, never the replacement. |
+| Hot database discard (`DiscardHotChunk`) | Remove the handle from the handle set. | Remove the handle and demote only after cold coverage is committed; destruction happens at the end of the run, after the grace period. |
+| Retention prune | None. Demotions only; the floor is derived at admission, not published. | Gate on the derived floor, demote, and destroy at the end of the run. |
+| Startup `serveReads()` | Build the handle set from `"ready"` hot keys; run the deferred-deletion sweep for leftover demotions. | Complete before the lifecycle goroutine starts and before queries are admitted. |
 
-Four ordering notes matter:
+Three ordering notes matter:
 
 - **`latest` advances last.** The watermark moves only after every serving structure contains the ledger. The RocksDB commit alone is not enough because the hot events store also applies in-memory indexes after commit. Advancing `latest` too early could let a query observe ledger N while its events are not yet searchable. Serving structures may run ahead of `latest`, but they must never lag it.
 
-- **Coverage is published before discard.** The index-swap hook runs synchronously during `buildTxhashIndex`, and the discard scan runs later in the same lifecycle run. By the time discard is evaluated, the replacement coverage is already present in both the catalog and the View. After a crash, startup rebuilds the View from the catalog before serving.
+- **Coverage is committed before discard.** The index swap happens during `buildTxhashIndex`, and the discard scan runs later in the same lifecycle run. By the time discard is evaluated, the replacement coverage is already in the catalog, so any snapshot that no longer shows a chunk hot shows it covered cold.
 
-- **Freeze adds before discard removes.** Freezing a chunk adds cold artifacts to the View while the hot store remains available. During the overlap, routing chooses one serving home deterministically. Discard removes the hot store only after cold coverage exists.
+- **Freeze adds before discard removes.** Freezing a chunk commits cold artifacts while the hot store remains available. During the overlap, routing chooses cold deterministically. Discard removes the hot handle only after cold coverage exists.
 
-- **Index replacement is the only demotion-before-removal case.** The old index is marked `"pruning"` in the same catalog write that freezes the replacement. The View is updated immediately afterward. This short interval is safe because readers use their admitted View, not catalog state, and physical destruction still waits for the grace period.
-
-Together, these hooks maintain the read-side coverage property: at every publication, every chunk in `[floor, lastCompleteChunk]` has a cold flag or a hot handle for each data type, and the live chunk has its hot handle before its first ledger commits. Freeze adds before discard removes; the index swap replaces within one publish; prune removes only below the floor it publishes first.
+Together, these keep the read-side coverage property: at every catalog commit, every chunk in `[floor, lastCompleteChunk]` has a frozen artifact or a ready hot database for each data type, and the live chunk is ready before its first ledger commits.
 
 ---
 
 ## Open-handle management
 
-The registry manages two kinds of serving resources, with opposite lifetime policies.
+The router manages two kinds of serving resources, with opposite lifetime policies.
 
 | Resource | Policy |
 | --- | --- |
@@ -293,11 +268,11 @@ Handles are cheap to create and expensive to share: an open or mmap costs micros
 
 ### Hot databases
 
-Hot databases remain open from `openHotDBForChunk` until the reaper destroys them after discard. Each hot chunk has a single shared RocksDB instance owned by the registry; ingestion and queries use the same handle concurrently, and its close drains in-flight operations ([The reaper](#the-reaper)).
+Hot databases remain open from `openHotDBForChunk` until a lifecycle run destroys them after discard. Each hot chunk has a single shared RocksDB instance owned by the router; ingestion and queries use the same handle concurrently, and its close drains in-flight operations ([Deferred deletion](#deferred-deletion)).
 
 ### Cold readers and window indexes
 
-Every cold resource is opened by the request that needs it and closed when the request finishes with it. Only the owner closes a reader, so a close never races a read, and retirement needs no reader tracking ([The reaper](#the-reaper)).
+Every cold resource is opened by the request that needs it and closed when the request finishes with it. Only the owner closes a reader, so a close never races a read, and retirement needs no reader tracking ([Deferred deletion](#deferred-deletion)).
 
 The MVP does no caching here. Each open re-reads and re-parses what it needs.
 
@@ -305,11 +280,11 @@ The MVP does no caching here. Each open re-reads and re-parses what it needs.
 
 An open re-reads and re-parses the reader's metadata: the events reader loads its MPHF and each packfile loads its offsets index. For a frequently hit chunk the reads are served from the OS page cache, but the parsing and allocation repeat on every open.
 
-If this shows up in profiles, add a bounded cache of the parsed state, keyed by chunk. Only data with no close method goes in it; handles never do. Evicting data is harmless, so the cache needs nothing from the reaper or the serving map, and it can be added later without changing this design.
+If this shows up in profiles, add a bounded cache of the parsed state, keyed by chunk. Only data with no close method goes in it; handles never do. Evicting data is harmless, so the cache needs nothing from the deletion path or the catalog, and it can be added later without changing this design.
 
 ### Platform assumption
 
-Per-request opens with deferred unlink rely on POSIX unlink semantics: an unlinked file stays readable through existing descriptors and mappings, and its name is immediately reusable. Linux and macOS provide this. Windows does not provide this reliably: memory-mapped files cannot be deleted while mapped, so the reaper's unlink would need retry semantics there.
+Per-request opens with deferred unlink rely on POSIX unlink semantics: an unlinked file stays readable through existing descriptors and mappings, and its name is immediately reusable. Linux and macOS provide this. Windows does not provide this reliably: memory-mapped files cannot be deleted while mapped, so the deferred deletes would need retry semantics there.
 
 ---
 
@@ -321,16 +296,17 @@ All query handlers follow the same routing model. They differ only in how they c
 
 Every query follows the same sequence:
 
-1. Admit the request by loading `latest` and the current View.
+1. Admit the request: load `latest` and the handle set, take the catalog snapshot, derive the floor.
 2. Validate and clamp the requested ledger range.
-3. Resolve each chunk to its serving store.
+3. Resolve each chunk to its serving store through the snapshot.
 4. Execute the query against the resolved stores.
+5. Release the snapshot.
 
 The admission protocol is described in [Admission](#admission).
 
 ### Bounds
 
-Every request validates its leading edge and clamps its trailing edge against the admitted range `[floorLedger, latest]`.
+Every request validates its leading edge and clamps its trailing edge against the admitted range `[floor, latest]`.
 
 The leading edge determines where results begin. A range request whose leading edge falls below the admitted retention floor is rejected with an error that carries the available range, matching v1's out-of-range behavior. Silently clamping would drop the first results the caller asked for.
 
@@ -346,25 +322,7 @@ Pagination cursors obey five rules:
 - `latest` is re-read at each page's admission, so an ascending scan that catches up to the tip finds more ledgers under the same cursor later.
 - A page that exhausts its scan window without matches still advances the cursor, so rare filters make progress.
 
-### Chunk resolution
-
-Routing resolves each chunk independently.
-
-```go
-func (v *View) resolve(c chunk.ID, k Kind) (Store, error) {
-    if v.cold[c].has(k) {
-        return openColdReaders(c, k)
-    }
-    if hs, ok := v.hot[c]; ok {
-        return hs.store(k)
-    }
-    return nil, ErrUnavailable
-}
-```
-
-The resolution order is deterministic. When both hot and cold copies are available, routing selects the cold artifact.
-
-If a chunk has no serving home, routing returns `ErrUnavailable`.
+Each page performs its own admission and releases its own snapshot.
 
 ### Chunk traversal
 
@@ -415,7 +373,7 @@ Instead, the router probes the transaction indexes in two stages:
 The router supplies `TxReader` with:
 
 - the hot transaction indexes,
-- the window index coverages, whose `.idx` files the lookup opens as it probes, and
+- the window index coverages, read from the admission snapshot, whose `.idx` files the lookup opens as it probes, and
 - a ledger source backed by `resolve(chunk, Ledgers)`.
 
 This preserves the existing lookup semantics while allowing `TxReader` to operate across both hot and cold storage.
@@ -459,24 +417,13 @@ This proposal introduces a small number of changes to the streaming workflow. Th
 
 The streaming workflow assumes the ingestion worker owns the hot RocksDB instances.
 
-This proposal transfers ownership to the registry. Each hot database is opened once, registered in the current View, and shared by both ingestion and queries until the reaper destroys it after discard.
+This proposal transfers ownership to the router. Each hot database is opened once, published in the handle set, and shared by both ingestion and queries until a lifecycle run destroys it after discard.
 
-This change allows queries to access hot databases without opening additional RocksDB instances. It also changes the freeze source: today the backfill's `resolveHotSource` reopens the cleanly closed chunk read-only; under this proposal it is supplied the registry's shared handle instead.
+This change allows queries to access hot databases without opening additional RocksDB instances. It also changes the freeze source: today the backfill's `resolveHotSource` reopens the cleanly closed chunk read-only; under this proposal it is supplied the router's shared handle instead.
 
-### View updates
+### Catalog snapshot support
 
-The registry publishes a new View at each storage transition that changes the serving map.
-
-The update points are:
-
-- opening a new hot database,
-- publishing frozen chunk artifacts,
-- replacing a transaction hash index,
-- advancing the retention floor,
-- removing a hot database during discard, and
-- building the initial View from a catalog scan during startup `serveReads()`, before queries are admitted and before the lifecycle goroutine starts.
-
-These updates occur in the order described in [View update points](#view-update-points).
+The rocksdb wrapper gains snapshot support: acquire and release, and snapshot-pinned reads and iteration, under the same lifecycle-lock discipline as its other operations. The catalog store uses them for admission.
 
 ### `latest` watermark
 
@@ -488,29 +435,34 @@ Advancing the watermark is the final step of per-ledger ingestion. Queries admit
 
 The streaming workflow destroys retired resources immediately after catalog demotion.
 
-This proposal instead schedules those resources with the reaper. Physical destruction occurs after the grace period has elapsed.
-
-The catalog protocol is unchanged except for the delayed physical destruction of retired resources.
+This proposal defers destruction to the end of the run, after a grace period from demotion. The catalog protocol is unchanged except for that delay.
 
 ---
 
 ## Open questions
 
 - **Datastore fallback below the floor.** The v1 `getLedgers` handler can fall back to the remote object store for pre-retention ledgers. v2 must either preserve that behavior as an explicit exception to R2 or remove it at cutover. This decision belongs to #772.
-- **Serving floor precision.** This design currently uses a chunk-aligned floor, so `oldestLedger` advances in 10,000-ledger steps. A ledger-precise floor would better match v1’s sliding window, but adds another floor concept.
+- **Serving floor precision.** The floor derived at admission is chunk-aligned, so `oldestLedger` advances in 10,000-ledger steps. A ledger-precise floor would better match v1's sliding window, but adds another floor concept.
 - **`getTransaction` probe parallelism.** The proposal uses sequential newest-first probing. If window count or tail latency becomes a problem, parallel probing can be added inside the lookup path without changing the routing model.
+- **Snapshot hygiene.** A leaked admission snapshot pins catalog compaction until process exit. Whether release discipline needs a backstop (a snapshot age metric, or a watchdog) is an implementation-time decision.
 
 ---
 
 ## Alternatives considered
 
+### Immutable in-memory View
+
+Publish a derived, immutable View of the routing metadata on every lifecycle transition; queries load one pointer at admission instead of taking a catalog snapshot.
+
+Not chosen because it maintains a second copy of the routing metadata, kept in sync with the catalog through per-transition publish hooks. Worth revisiting only if per-request snapshot costs ever become measurable: snapshot acquire and release contend under high concurrency, and a straggler's held snapshot pins catalog compaction, which stays harmless only while the catalog's write rate is low.
+
 ### Explicit reader tracking
 
-Track active readers directly, either by reference-counting Views and resources or by holding a reader lock while a query runs.
+Track active readers directly, either by reference-counting resources or by holding a reader lock while a query runs.
 
-The design already tracks readers at the operation level: the hot database wrapper holds a read lock for the duration of each call, which is what makes its close a drain barrier. This alternative is per-request tracking: a count held for the request's whole lifetime, letting the reaper destroy a resource the moment its count reaches zero instead of waiting out the grace period.
+The design already tracks readers at the operation level: the hot database wrapper holds a read lock for the duration of each call, which is what makes its close a drain barrier. This alternative is per-request tracking: a count held for the request's whole lifetime, letting destruction happen the moment the count reaches zero instead of waiting out the grace period.
 
-This was not chosen because exact reclamation timing is not needed, and per-request counts handle the failure case worse. A request stuck past its deadline holds its count indefinitely and keeps the resource alive, while under the grace period the same straggler receives a closed error and terminates. A missed release also pins the resource forever, a bug class a dropped View pointer cannot have.
+This was not chosen because exact reclamation timing is not needed, and per-request counts handle the failure case worse. A request stuck past its deadline holds its count indefinitely and keeps the resource alive, while under the grace period the same straggler receives a closed error and terminates.
 
 Per-request tracking becomes necessary if a request type without an enforced deadline is ever added, such as a streaming subscription. The grace period's availability argument depends on **D** existing.
 
@@ -518,13 +470,7 @@ Per-request tracking becomes necessary if a request type without an enforced dea
 
 Rely on the filesystem to keep already-open files readable after they are unlinked, and unlink immediately at retirement with no grace period.
 
-The design adopts the first half: a request that opened a cold file before it was unlinked keeps reading it ([Open-handle management](#open-handle-management)). Immediate unlink was not chosen because it only protects files that are already open. A query holding an older View may open a chunk for the first time after prune has removed it, and would fail mid-request. Deferring the unlink by the grace period covers those late opens. Hot databases are unaffected either way: a RocksDB handle is not kept alive by unlink semantics, and its lifetime is governed by the drain barrier and the reaper.
-
-### Catalog snapshots instead of the View
-
-Take a RocksDB snapshot of the catalog at each admission instead of publishing an immutable View.
-
-A snapshot covers only metadata. It cannot share the hot database's single handle or keep files alive, so the registry, reaper, and watermark all remain. What it adds: per-request snapshot acquire and release across the CGO boundary, routing lookups as CGO reads instead of map lookups, and the serving rules evaluated in every reader instead of once at publish, all to re-derive state that changes only a few times a day. The View is the same repeatable read, built once per transition and loaded with one atomic pointer read.
+The design adopts the first half: a request that opened a cold file before it was unlinked keeps reading it ([Open-handle management](#open-handle-management)). Immediate unlink was not chosen because it only protects files that are already open. A query admitted earlier may open a chunk for the first time after prune has demoted it, and would fail mid-request. Deferring the unlink by the grace period covers those late opens. Hot databases are unaffected either way: a RocksDB handle is not kept alive by unlink semantics, and its lifetime is governed by the drain barrier.
 
 ---
 

--- a/design-docs/query-routing-design.md
+++ b/design-docs/query-routing-design.md
@@ -1,0 +1,532 @@
+# Query Routing Design
+
+## Overview
+
+This document is the read-side counterpart to the [streaming workflow](./full-history-streaming-workflow.md). It describes how queries determine, for each chunk in their requested range, whether data is served from a hot database or sealed cold files. It also explains how that routing remains correct while ingestion and lifecycle workers concurrently add, replace, and remove stores.
+
+Every query is admitted against a single immutable snapshot of the **serving map**, called a **View**. The serving map records which store serves each chunk, which transaction hash index serves each window, and the retention floor. At admission, the query loads the current `latest` watermark and one current View. It then uses that admitted state for its entire lifetime.
+
+A small in-memory **registry** owns the serving map. When a storage operation changes what is servable, such as freezing a chunk, replacing a transaction hash index, discarding a hot database, or advancing the retention floor, the registry creates a new View, applies the change, and atomically publishes it. Queries already in flight continue using the View they admitted with, while newly admitted queries observe the updated View.
+
+Deletion safety is time-based rather than reader-tracked. Every request runs under a fixed deadline. Once a resource is removed from the current View, no newly admitted query can reach it. Any query that can still reach it must have admitted an older View and must finish before its deadline. The lifecycle therefore delays physical destruction until a grace period longer than the maximum request lifetime has elapsed.
+
+The following terms are used throughout this document.
+
+- **Chunk**: 10,000 consecutive ledgers, the unit of storage.
+- **Window**: 1,000 chunks, or 10 million ledgers. Each window has one transaction hash `.idx` file.
+- **Serving map**: The in-memory map of chunks and windows to the stores that serve them, plus the retention floor.
+- **View**: An immutable snapshot of the serving map admitted by a query.
+- **Hot / cold**: Hot data is served from a live RocksDB database, one per hot chunk. Cold data is served from sealed files written once during freezing.
+- **Catalog**: The durable RocksDB record of each store and its lifecycle state.
+- **Retention floor**: The oldest ledger served by a View. A request whose leading edge is below its admitted View's floor is not served (R2).
+- **`latest`**: The newest fully ingested ledger visible to queries.
+
+---
+
+## The problem
+
+Three kinds of workers access storage concurrently:
+
+- **One ingestion worker** appends each new ledger to the live hot database as the network produces it. Approximately every 5 seconds it commits one atomic write batch. At each chunk boundary, it stops writing to the completed hot chunk and opens the next hot database.
+- **One lifecycle worker** performs housekeeping. It freezes completed chunks into cold files, rebuilds the window's transaction hash index at each boundary, discards hot databases once cold files fully cover their data, and removes data that has fallen outside the retention window.
+- **Many query workers**, one for each incoming JSON-RPC request.
+
+Every query must observe a consistent serving map throughout its lifetime. It must not combine routing decisions from different storage states, and it must not be directed to a resource that can be destroyed before the request finishes. Without coordination, several races become possible.
+
+|        | Problem | Example |
+| ------ | ------- | ------- |
+| **H1** | A query plans its reads while the serving map changes. | A range query resolves chunk X to its hot database just as the discard scan removes that database because cold files now cover it. |
+| **H2** | A resource is destroyed while a read is in progress. | An index rebuild replaces a superseded `.idx`, and the sweep closes and unlinks it while a `getTransaction` request is still reading it. |
+| **H3** | A query reads the newest ledger while it is still being ingested. | A `getLedgers` request at the tip must either return ledger *n* completely or not at all. It must never advertise a `latestLedger` that it cannot actually serve. |
+| **H4** | The retention floor advances during a query. | A prune removes the oldest chunk in a range after the query has already been admitted. |
+
+The streaming design already establishes two read-path requirements:
+
+- **R1. Only finished data is newly visible.** A newly published View must not introduce a chunk or index while it is in the catalog state `"freezing"`, `"pruning"`, or `"transient"`.
+- **R2. Data below the admitted retention floor is not served.** Even if data still exists on disk, a request whose leading edge is below the floor recorded in its admitted View is not served: point lookups return not found, and range requests are rejected with an error that reports the available range.
+
+These races occur while ingestion, freezing, index replacement, discard, and pruning all proceed concurrently. Throughout every transition, the entire active retention window must remain continuously servable, with no gaps between hot and cold storage. This is the read-side view of [INV-1](./full-history-streaming-workflow.md#invariants) from the streaming workflow.
+
+---
+
+## Design summary
+
+The design uses four mechanisms:
+
+1. Every query resolves against one immutable View of the serving map, so routing decisions never mix storage states (H1).
+2. The registry publishes a new View whenever the serving map changes.
+3. The reaper destroys retired resources only after they have been unreachable for a grace period longer than the maximum request lifetime, so nothing a request can reach is destroyed while it runs (H2, H4).
+4. The registry maintains the `latest` watermark so queries never observe partially ingested ledgers (H3).
+
+Together, these mechanisms let ingestion, lifecycle operations, and queries proceed concurrently without requiring readers to coordinate with writers. Queries perform two atomic loads during admission, then use ordinary immutable data for the rest of the request. They do not acquire locks or participate in reference counting.
+
+```mermaid
+flowchart TB
+    I["Ingestion"] --> CAT
+    L["Lifecycle"] --> CAT
+
+    I -->|"publish hot chunk"| V
+    I -->|"advance latest"| W
+    L -->|"publish freeze / index swap / floor / unpublish"| V
+    L -->|"retire resources"| REAP
+    CAT[("Catalog")] -.->|"startup rebuild"| V
+
+    subgraph REG["registry"]
+        V["current View<br/>floor · hot · cold · indexes"]
+        W["latest watermark"]
+        HOT["hot DB handles"]
+        IDX["window .idx readers"]
+        CACHE["cold reader caches"]
+        REAP["reaper"]
+    end
+
+    Q["Query"] -->|"load latest"| W
+    Q -->|"load View"| V
+
+    V -->|"references"| HOT
+    V -->|"references"| IDX
+    V -.->|"opens on demand"| CACHE
+
+    REAP -->|"retire / close after T"| HOT
+    REAP -->|"retire / close after T"| IDX
+    REAP -->|"evict / close after T"| CACHE
+    REAP -->|"unlink / remove after T"| FS["retired files and dirs"]
+```
+
+---
+
+## Registry and View
+
+The catalog remains the durable record of every store and its lifecycle state. The registry is a disposable in-memory projection of the catalog.
+
+A query loads one View when it is admitted and uses that same View for its entire lifetime. Later View updates affect only newly admitted queries.
+
+Each View records:
+- the retention floor used by queries admitted with that View,
+- the hot stores,
+- the cold artifacts available for each chunk, and
+- the transaction hash indexes for each window.
+
+The registry is rebuilt from the catalog during startup before the server begins accepting requests.
+
+```go
+type Registry struct {
+    mu      sync.Mutex
+    current atomic.Pointer[View]
+    latest  atomic.Uint32
+    reaper  *Reaper
+}
+
+type View struct {
+    floor   chunk.ID
+    hot     map[chunk.ID]*hotchunk.DB
+    cold    map[chunk.ID]ColdChunk
+    indexes []IndexCoverage
+}
+
+type ColdChunk struct {
+    Ledgers bool
+    Events  bool
+}
+
+type IndexCoverage struct {
+    Window WindowID
+    Lo, Hi chunk.ID // the frozen .idx's actual coverage, not the window bounds:
+                    // Hi trails the tip while the window is current, and Lo is
+                    // the retention floor at build time
+    Idx    *txhash.ColdReader
+}
+```
+
+### Design rationale
+
+Each field exists for a specific reason.
+
+- **`hot` stores shared handles.** Each hot chunk has one registry-owned `hotchunk.DB` instance used by ingestion and queries.
+- **`cold` holds flags, not open readers.** A `ColdChunk` entry only says the chunk's artifact is frozen and servable. The reader object itself is opened on demand through the reader caches ([Open-handle management](#open-handle-management)): with thousands of cold chunks, holding every reader open would cost gigabytes, unlike the handful of hot databases and window indexes the View references directly.
+- **`indexes` stores transaction hash readers.** Each in-retention window has one current `.idx` reader.
+- **`latest` is stored outside the View.** The serving map changes only at chunk boundaries and lifecycle transitions, while `latest` advances every ledger. Keeping it separate avoids copying the View every few seconds.
+
+### Admission
+
+Every query performs two atomic loads during admission.
+
+```go
+latest := registry.latest.Load()
+view := registry.current.Load()
+
+floorLedger := view.floor.FirstLedger()
+```
+
+The order is important. The query reads `latest` before loading the View. A ledger less than or equal to the admitted `latest` is queryable only if it is not below the floor recorded in the subsequently loaded View. The write-side publication order guarantees that every ledger in that admitted range has a serving home in the loaded View.
+
+Reversing the order would break that guarantee. A chunk boundary could occur between the two loads, allowing `latest` to point into a newly opened chunk that is not present in the older View. The response could then advertise a `latestLedger` that it cannot serve.
+
+After admission, the query validates and clamps its requested range against `[floorLedger, latest]`. Requests whose leading edge falls below `floorLedger` are rejected with an error carrying the available range. Requests extending beyond `latest` are truncated.
+
+No further synchronization is required. The View is immutable, so the query simply keeps its pointer for the lifetime of the request.
+
+### Publishing View updates
+
+Every change to the serving map follows the same pattern.
+
+```go
+func (r *Registry) publish(mutate func(*View) (removed []Resource)) {
+    r.mu.Lock()
+
+    next := r.current.Load().clone()
+    removed := mutate(next)
+
+    r.current.Store(next)
+
+    r.mu.Unlock()
+
+    r.reaper.Schedule(removed)
+}
+```
+
+The registry serializes View updates with a mutex. Each update clones the current View, applies the requested changes, atomically publishes the new View, and schedules any removed resources with the reaper.
+
+Additions are published only after the corresponding catalog state is durable and serving-ready. Removals follow the ordering rules in [View update points](#view-update-points).
+
+View updates occur only when the serving map changes, such as chunk boundaries or lifecycle transitions. Even with full history, cloning the View copies only a few hundred kilobytes of pointers, which is negligible compared to the roughly fourteen-hour interval between chunk boundaries.
+
+---
+
+## The reaper
+
+The reaper safely destroys resources that have been removed from the serving map.
+
+Its rule is:
+
+> A resource that was reachable from a published View may be destroyed only after it has been unreachable for at least grace period **T**.
+
+A resource becomes **unreachable** when it has been removed from the current View and can no longer be returned by reader caches. A resource is **destroyed** when it is permanently closed or removed.
+
+```go
+type Reaper struct {
+    graceT time.Duration // derived from the request timeout
+    queue  []retired     // {destroy func(), notBefore time.Time}
+}
+```
+
+Every read handler runs under an enforced request deadline **D**. The grace period is derived from that deadline:
+
+```text
+T = maximum request timeout + safety margin
+```
+
+This is enough because every query keeps exactly one admitted View for its entire lifetime. Once a resource is unpublished, no newly admitted query can reach it. Any query that can still reach it must have admitted an older View, and therefore must finish before its deadline **D**. Since **T > D**, the resource is not destroyed until all such queries should have completed.
+
+The same rule covers hot databases, transaction hash index readers, and cached cold readers.
+
+Deletion follows this sequence:
+
+1. Remove the resource from the serving map.
+2. Record the catalog demotion, such as `"pruning"` or `"transient"`.
+3. Schedule the resource with the reaper.
+4. After **T**, close handles, unlink files, remove directories, and remove the catalog entry.
+
+Only physical destruction is delayed. Catalog demotions still occur during the lifecycle run.
+
+```mermaid
+sequenceDiagram
+    participant L as Lifecycle
+    participant V as View
+    participant C as Catalog
+    participant P as Reaper
+    participant FS as Disk
+
+    L->>V: Remove from serving map
+    Note over V: New queries cannot reach the resource
+    L->>C: Record "pruning" or "transient"
+    L->>P: Schedule destruction after T
+    P->>FS: Close, unlink, remove
+    P->>C: Remove catalog entry
+```
+
+The reaper has no persistent state. If the process exits before scheduled deletion completes, startup reconstructs pending deletion work from the catalog and runs it immediately. No new grace period is needed because demoted stores never enter the rebuilt View, so no query can reference them.
+
+The tradeoff is delayed cleanup. Retired hot databases, superseded indexes, and pruned chunk files may remain on disk until **T** expires. Because **T** is measured in minutes while lifecycle operations occur hours apart, the extra disk usage is expected to be small.
+
+---
+
+## View update points
+
+Every write-side transition that changes what is servable gets a registry hook. Additions are published after the catalog commit that makes the resource serving-ready, which is how R1 is kept: a transitional resource never enters a newly published View. Removals are unpublished before destructive work and, except for the index swap, before catalog demotion.
+
+| Write-side transition | Registry hook | Ordering rule                                                                                                                                                                                                 |
+| --- | --- |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `openHotDBForChunk` flips `hot:chunk:{c}` to `"ready"` | Publish `hot[c] = stores` using the shared instance. | Publish after the catalog key flips to `"ready"` and before the chunk's first ledger commits, so the watermark can never enter a chunk the current View does not serve.                                       |
+| Per-ledger ingest cycle: atomic `batch.Commit(sync)` plus in-memory applies | `latest.Store(seq)` | Final step of the cycle, after every serving structure contains the ledger.                                                                                                                                   |
+| `processChunk` flips artifact keys to `"frozen"` | Publish `cold[c].{kind} = true` for each frozen kind. | Publish after the commit. During startup backfill this hook has no effect; the startup scan (last row) covers those chunks.                                                                                   |
+| Transaction index rebuild (`buildTxhashIndex`): a single atomic catalog write freezes the new coverage and demotes its predecessor to `"pruning"` | Replace the window's `IndexCoverage` entry with the new coverage and its reader. Hand the predecessor's reader to the reaper. | Publish after the atomic write. The predecessor's file deletion, previously `buildThenSweep`'s immediate unlink, now waits out the grace period, because queries holding older Views may still be reading it. |
+| `discardHotDBForChunk` | Remove `hot[c]` from the View and hand the hot database to the reaper. | Unpublish before catalog demotion and every destructive step.                                                                                                                                                 |
+| Retention prune | Publish the run's new floor, which also drops below-floor `cold`, `hot`, and `indexes` entries. | Gate, unpublish, demote, then destroy. The floor update removes below-floor resources before every demotion.                                                                                                  |
+| Startup `serveReads()` | Build the initial View from the catalog scan: `"ready"` hot keys, `"frozen"` chunk keys, frozen coverages, and the calculated floor. | Complete before the lifecycle goroutine starts, so no freeze can land between the scan and the hooks becoming live.                                                                                           |
+
+Four ordering notes matter:
+
+- **`latest` advances last.** The watermark moves only after every serving structure contains the ledger. The RocksDB commit alone is not enough because the hot events store also applies in-memory indexes after commit. Advancing `latest` too early could let a query observe ledger N while its events are not yet searchable. Serving structures may run ahead of `latest`, but they must never lag it.
+
+- **Coverage is published before discard.** The index-swap hook runs synchronously during `buildTxhashIndex`, and the discard scan runs later in the same lifecycle run. By the time discard is evaluated, the replacement coverage is already present in both the catalog and the View. After a crash, startup rebuilds the View from the catalog before serving.
+
+- **Freeze adds before discard removes.** Freezing a chunk adds cold artifacts to the View while the hot store remains available. During the overlap, routing chooses one serving home deterministically. Discard removes the hot store only after cold coverage exists.
+
+- **Index replacement is the only demotion-before-removal case.** The old index is marked `"pruning"` in the same catalog write that freezes the replacement. The View is updated immediately afterward. This short interval is safe because readers use their admitted View, not catalog state, and physical destruction still waits for the grace period.
+
+Together, these hooks maintain the read-side coverage property: at every publication, every chunk in `[floor, lastCompleteChunk]` has a cold flag or a hot handle for each data type, and the live chunk has its hot handle before its first ledger commits. Freeze adds before discard removes; the index swap replaces within one publish; prune removes only below the floor it publishes first.
+
+---
+
+## Open-handle management
+
+The registry manages three kinds of serving resources. Each uses a different lifetime policy based on its access pattern and resource cost.
+
+| Resource | Policy |
+| --- | --- |
+| Hot databases | Always open |
+| Window transaction indexes (`txhash.ColdReader`) | Always open |
+| Per-chunk cold readers (`ledger.ColdReader`, `eventstore.ColdReader`) | Open on demand through per-kind LRU caches |
+
+### Hot databases
+
+Hot databases remain open from `openHotDBForChunk` until the reaper destroys them after discard.
+
+Each hot chunk has a single shared RocksDB instance owned by the registry. Ingestion and queries use the same handle concurrently. RocksDB supports concurrent reads and writes on a single database instance.
+
+### Transaction hash indexes
+
+Each in-retention window keeps one `txhash.ColdReader` open.
+
+These readers maintain only the state needed to service lookups efficiently. Keeping them open also simplifies index replacement because older Views continue using the superseded reader until the reaper closes it after the grace period.
+
+### Cold readers
+
+Cold readers are opened on demand.
+
+Full history contains thousands of chunks and continues to grow. Keeping readers open for every cold artifact would consume substantial memory while providing little benefit for infrequently accessed data. Instead, the registry records only whether an artifact is available, and reader objects are managed through bounded per-kind LRU caches.
+
+Ledger and event readers use separate caches because their resource costs differ significantly. Separate caches also prevent heavy event traffic from evicting ledger readers needed by other query paths.
+
+### Interaction with the reaper
+
+Reader caches follow the same lifetime rules as every other serving resource.
+
+When a chunk is removed from the serving map, its cached readers are also retired. The reaper delays closing those readers until the grace period has elapsed, ensuring that no admitted query can still be using them.
+
+Removing cached readers when a chunk is unpublished also guarantees deterministic cleanup. Otherwise, a lightly used reader could remain in the cache indefinitely and keep an unlinked file open until it was eventually evicted.
+
+---
+
+## Query routing
+
+All query handlers follow the same routing model. They differ only in how they consume the resolved stores.
+
+### Common routing
+
+Every query follows the same sequence:
+
+1. Admit the request by loading `latest` and the current View.
+2. Validate and clamp the requested ledger range.
+3. Resolve each chunk to its serving store.
+4. Execute the query against the resolved stores.
+
+The admission protocol is described in [Admission](#admission).
+
+### Bounds
+
+Every request validates its leading edge and clamps its trailing edge against the admitted range `[floorLedger, latest]`.
+
+The leading edge determines where results begin. A range request whose leading edge falls below the admitted retention floor is rejected with an error that carries the available range, matching v1's out-of-range behavior. Silently clamping would drop the first results the caller asked for.
+
+The trailing edge determines where the scan ends. Requests extending beyond `latest` are truncated, and descending scans terminate at the retention floor.
+
+### Cursors
+
+Pagination cursors obey five rules:
+
+- A cursor encodes ledger coordinates (ledger, transaction, operation, event), never a store, tier, or internal event ID, so stores can change between pages without invalidating it.
+- Resume is exclusive in the scan direction: strictly after the cursor position ascending, strictly before it descending, so a retried page never duplicates results.
+- The request's bounds and filters travel in the cursor; the floor does not. Each page gates against its own admitted floor, and a cursor whose position has aged below it is rejected with the available range.
+- `latest` is re-read at each page's admission, so an ascending scan that catches up to the tip finds more ledgers under the same cursor later.
+- A page that exhausts its scan window without matches still advances the cursor, so rare filters make progress.
+
+### Chunk resolution
+
+Routing resolves each chunk independently.
+
+```go
+func (v *View) resolve(c chunk.ID, k Kind) (Store, error) {
+    if v.cold[c].has(k) {
+        return coldReaders(c, k)
+    }
+    if hs, ok := v.hot[c]; ok {
+        return hs.store(k)
+    }
+    return nil, ErrUnavailable
+}
+```
+
+The resolution order is deterministic. When both hot and cold copies are available, routing selects the cold artifact.
+
+If a chunk has no serving home, routing returns `ErrUnavailable`. This can occur during startup recovery when a required artifact has not yet reached a serving state.
+
+### Chunk traversal
+
+Each chunk belongs to exactly one serving store for a given query path. Multi-chunk requests therefore concatenate results rather than merge them.
+
+Ascending requests visit chunks in ascending order. Descending requests reverse the traversal.
+
+The following diagram illustrates the running example used throughout this section.
+
+```text
+          ◄──────────────────── retention window ────────────────────►
+          floor                              last complete       live
+chunks:   5100 ─────── fully cold ───── 6542 │      6543      │ 6544
+                                             │ (both tiers)   │
+ledgers   ─────────── {chunk}.pack ──────────┤ .pack ◄ wins   │ hot CF
+events    ────── events/index packs ─────────┤ packs ◄ wins   │ hot CFs
+tx-hash   ───────────── window .idx ─────────┤ hot CF until covered
+```
+
+### `getLedgers`
+
+`getLedgers` streams ledgers in ascending ledger order. For each overlapping chunk, the router resolves the ledger store and streams the requested range. Results are concatenated until the requested limit is reached.
+
+Example request:
+
+- `startLedger = 65,439,500`
+- `limit = 1,000`
+
+The request spans chunks 6543 and 6544. Chunk 6543 resolves to the cold ledger store and returns the rest of that chunk. Chunk 6544 resolves to the live hot store and returns ledgers up to the remaining limit. The response is the concatenation of both streams.
+
+### `getTransactions`
+
+`getTransactions` builds on `getLedgers`.
+
+The router streams ledgers using the same traversal described above. Each ledger is decoded and its transactions are emitted in application order.
+
+The cursor identifies a transaction within a ledger. The first ledger resumes after the cursor position, while subsequent ledgers begin with their first transaction.
+
+### `getTransaction`
+
+A transaction hash does not identify the chunk containing the transaction, so routing cannot resolve it directly.
+
+Instead, the router probes the transaction indexes in two stages:
+
+1. Probe the hot transaction indexes. A match is definitive.
+2. Probe each window transaction index. A match identifies a candidate ledger, which is fetched and verified against the full transaction hash. Candidates below the admitted floor are skipped. This enforces R2 for by-hash lookups, which have no range to clamp, and makes it safe for a window index to keep naming ledgers that prune has already removed.
+
+The router supplies `TxReader` with:
+
+- the hot transaction indexes,
+- the window transaction indexes, and
+- a ledger source backed by `resolve(chunk, Ledgers)`.
+
+This preserves the existing lookup semantics while allowing `TxReader` to operate across both hot and cold storage.
+
+### `getEvents`
+
+`getEvents` searches rather than fetches data.
+
+Each page establishes a scan window, resolves the overlapping chunks, and invokes the existing event query engine for each reader.
+
+The event query engine operates on the common `eventstore.Reader` interface, so routing is identical for hot and cold readers.
+
+Pages terminate when either:
+
+- the requested number of events has been returned, or
+- the scan window has been exhausted.
+
+The cursor records the query position, while `scannedLedger` records how far the search progressed.
+
+Example: the following shows the first page of a descending query beginning at the current `latest` ledger.
+
+```text
+ page 1
+
+ [65,433,211 .................................. 65,443,210]
+                                           ◄── scan direction
+
+ chunk 6544 (hot)
+ chunk 6543 (cold)
+```
+
+The router resolves the live chunk first, followed by the cold chunk. Results are returned in descending ledger order until the page is full or the scan window has been exhausted.
+
+---
+
+## Changes to the streaming workflow
+
+This proposal introduces a small number of changes to the streaming workflow. The overall storage lifecycle is unchanged.
+
+### Hot database ownership
+
+The streaming workflow assumes the ingestion worker owns the hot RocksDB instances.
+
+This proposal transfers ownership to the registry. Each hot database is opened once, registered in the current View, and shared by both ingestion and queries until the reaper destroys it after discard.
+
+This change allows queries to access hot databases without opening additional RocksDB instances. It also changes the freeze source: freezing previously reopened the cleanly closed chunk read-only, and instead reads through the same shared handle, supplied via the backfill `HotProbe` seam.
+
+### View updates
+
+The registry publishes a new View at each storage transition that changes the serving map.
+
+The update points are:
+
+- opening a new hot database,
+- publishing frozen chunk artifacts,
+- replacing a transaction hash index,
+- advancing the retention floor,
+- removing a hot database during discard, and
+- building the initial View from a catalog scan during startup `serveReads()`, before queries are admitted and before the lifecycle goroutine starts.
+
+These updates occur in the order described in [View update points](#view-update-points).
+
+### `latest` watermark
+
+The write path advances `latest` only after a ledger has become fully queryable.
+
+Advancing the watermark is the final step of per-ledger ingestion. Queries admitted afterward may observe the new ledger.
+
+### Deferred destruction
+
+The streaming workflow destroys retired resources immediately after catalog demotion.
+
+This proposal instead schedules those resources with the reaper. Physical destruction occurs after the grace period has elapsed.
+
+The catalog protocol is unchanged except for the delayed physical destruction of retired resources.
+
+---
+
+## Open questions
+
+- **Datastore fallback below the floor.** The v1 `getLedgers` handler can fall back to the remote object store for pre-retention ledgers. v2 must either preserve that behavior as an explicit exception to R2 or remove it at cutover. This decision belongs to #772.
+- **Serving floor precision.** This design currently uses a chunk-aligned floor, so `oldestLedger` advances in 10,000-ledger steps. A ledger-precise floor would better match v1’s sliding window, but adds another floor concept.
+- **`getTransaction` probe parallelism.** The proposal uses sequential newest-first probing. If window count or tail latency becomes a problem, parallel probing can be added inside the lookup path without changing the routing model.
+- **Cache sizing.** Ledger and event reader cache capacities are implementation-time tuning parameters.
+
+---
+
+## Alternatives considered
+
+### Explicit reader tracking
+
+Track active readers directly, either by reference-counting Views/resources or by holding a reader lock while a query runs.
+
+This was not chosen because it adds work to every query: each request must acquire and release some reader state. This proposal avoids that by using the request deadline as the bound on reader lifetime. Queries only load `latest` and the current View at admission.
+
+### Filesystem unlink semantics alone
+
+Rely on the filesystem to keep already-open files readable after they are unlinked.
+
+This was not chosen because it only applies to already-open cold files. It does not protect RocksDB handles, cache misses that open a file after unlink, or other resource types that must be closed explicitly. This proposal uses the grace period uniformly for hot databases, cold readers, and index readers.
+
+---
+
+## Related documents
+
+- [full-history-streaming-workflow.md](./full-history-streaming-workflow.md): the write side this design reads from: geometry, the catalog and one write protocol, the lifecycle run, the reader contract, and INV-1 through INV-4.
+- [gettransaction-full-history-design.md](./gettransaction-full-history-design.md): the tx-hash tiers, `.idx` coverage semantics, and the cold-lookup verify chain that `getTransaction` routing drives.
+- [getevents-full-history-design.md](./getevents-full-history-design.md): the per-chunk events engines and their measured latencies.


### PR DESCRIPTION
## What this delivers

The query-serving design for #770: `design-docs/query-routing-design.md`, the read-side counterpart to the streaming workflow. It covers how each query resolves the chunks of its range to the store serving them (hot database or sealed cold files), and how routing stays correct while ingestion and the lifecycle concurrently add, replace, and delete those stores.

The design in brief:

- **One catalog snapshot per query.** Every request admits by loading the `latest` watermark, the hot handle set, and a RocksDB snapshot of the catalog, then routes from that state for its whole lifetime. Routing metadata has no second copy: queries read the same catalog the lifecycle writes, pinned at admission (H1).
- **Deferred deletion, barrier-backed safety.** Every request runs under an enforced deadline; the lifecycle run demotes resources in the catalog, waits out a grace period T derived from that deadline at the end of the run, and deletes with bounded retries, so queries admitted earlier finish first. Memory safety comes from close discipline rather than timing: the hot database wrapper drains in-flight operations on close, and every cold file (packfiles, events indexes, window `.idx`) is opened and closed by the request using it — no reader tracking, no reference counts (H2, H4).
- **The `latest` watermark advances last.** It moves only after the per-ledger commit and every in-memory serving apply, so a query never observes a partially ingested ledger or advertises a `latestLedger` it cannot serve (H3).
- **Per-method routing** for getLedgers, getTransactions, getTransaction, and getEvents over the existing store packages, with the bounds rule (validate the leading edge, clamp the trailing edge) and cursor requirements.

It asks the streaming workflow for a small set of changes, listed in "Changes to the streaming workflow": router ownership of the hot `hotchunk.DB` handles (the boundary no longer closes the completed chunk; freeze reads through the shared handle supplied to the backfill's `resolveHotSource`), catalog snapshot support in the rocksdb wrapper, and destruction deferred to the end of the lifecycle run. The catalog protocol and storage formats are unchanged.

Open questions flagged for review: serving-floor precision (chunk-aligned vs ledger-precise), the pre-retention datastore fallback (#772), getTransaction probe parallelism, and snapshot release hygiene.

## Notes for review

- Docs only; no code changes. Easiest to review as rendered markdown.
- Per #770, this is the design-review gate: implementation issues get carved from the doc once it is approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)