### PR TITLE
fullhistory: delete dead pre-wired surface + stale contract docs (closes #841)

### DIFF
--- a/cmd/stellar-rpc/internal/db/event.go
+++ b/cmd/stellar-rpc/internal/db/event.go
@@ -160,8 +160,8 @@ func (eventHandler *eventHandler) InsertEvents(lcm xdr.LedgerCloseMeta) error {
 			// events.StageSentinels — the single definition shared with the
 			// full-history view path — so the two backends cannot drift.
 			// Only the per-stage event counters are selected here (the
-			// full-history path stores no per-event index; it is positional
-			// there).
+			// full-history path stores EventIdx explicitly too, per the
+			// byte-stable-ID decision).
 			var txIdx, opIdx uint32
 			txIdx, opIdx, err = events.StageSentinels(event.Stage, tx.Index)
 			if err != nil {

--- a/cmd/stellar-rpc/internal/events/benchmark_test.go
+++ b/cmd/stellar-rpc/internal/events/benchmark_test.go
@@ -22,7 +22,7 @@ func BenchmarkEventIndex_10M(b *testing.B) {
 		buildSec := time.Since(start).Seconds()
 
 		b.ReportMetric(buildSec, "build_sec")
-		b.ReportMetric(float64(idx.Len()), "terms")
+		b.ReportMetric(float64(len(idx.terms)), "terms")
 
 		runtime.GC()
 		var mem runtime.MemStats
@@ -42,7 +42,7 @@ func buildIndex10M() *ConcurrentBitmaps {
 		numTopicVals = 3_000_000
 	)
 
-	idx := NewConcurrentBitmaps()
+	idx := NewConcurrentBitmapsFromBitmaps(NewBitmaps())
 	rng := rand.New(rand.NewSource(42))
 
 	contractKeys := make([]TermKey, numContracts)

--- a/cmd/stellar-rpc/internal/events/bitmaps.go
+++ b/cmd/stellar-rpc/internal/events/bitmaps.go
@@ -5,8 +5,8 @@ import (
 )
 
 // Bitmaps is the in-memory event index for single-threaded
-// build-then-freeze paths (cold backfill ingest, WriteColdIndex
-// snapshots produced by ConcurrentBitmaps.Snapshot).
+// build-then-freeze paths (cold backfill ingest feeding
+// WriteColdIndex).
 //
 // As a named map type, it supports the natural map operations
 // (`for term, bm := range b`, `len(b)`, `b[term]`) directly — no
@@ -17,8 +17,7 @@ import (
 // NOT safe for concurrent access. The caller guarantees serial
 // access (build then hand off, or a single goroutine throughout).
 // For the concurrent-reader-vs-single-writer case (live HotStore
-// ingest) use ConcurrentBitmaps and convert to Bitmaps via
-// ConcurrentBitmaps.Snapshot before serialization.
+// ingest) use ConcurrentBitmaps.
 type Bitmaps map[TermKey]*roaring.Bitmap
 
 // NewBitmaps returns an empty Bitmaps. Equivalent to make(Bitmaps).
@@ -31,8 +30,8 @@ func NewBitmaps() Bitmaps {
 // the same (key, eventID) pair are silently skipped.
 //
 // The eventIDs slice may be in any order; AddMany handles
-// insertion. For monotonically-ordered batches (the IngestLedgerEvents
-// pattern), AddMany takes its fast path.
+// insertion. For monotonically-ordered batches (the cold backfill
+// ingest pattern), AddMany takes its fast path.
 func (b Bitmaps) AddTo(key TermKey, eventIDs ...uint32) {
 	bm, ok := b[key]
 	if !ok {

--- a/cmd/stellar-rpc/internal/events/concurrent_bitmaps.go
+++ b/cmd/stellar-rpc/internal/events/concurrent_bitmaps.go
@@ -56,26 +56,9 @@ type termState struct {
 //
 //   - Get / LookupKeys: many-reader. No Clone, just atomic.Load.
 //     Safe to call concurrently with AddTo.
-//
-//   - Snapshot: single-caller, called only AFTER ingest has stopped
-//     on the chunk (the freeze path's natural lifecycle). Snapshot
-//     does Clone every dense bitmap to hand uniquely-owned bitmaps
-//     to WriteColdIndex; the same side-effect-on-source applies, so
-//     concurrent Snapshot calls or Snapshot concurrent with AddTo
-//     would race. The orchestrator stops ingest before freezing.
-//
-// To freeze the index to disk, call Snapshot to get a uniquely-owned
-// Bitmaps the caller can mutate (e.g., RunOptimize before
-// MarshalBinary).
 type ConcurrentBitmaps struct {
 	rwmu  sync.RWMutex
 	terms map[TermKey]*atomic.Pointer[termState]
-}
-
-// NewConcurrentBitmaps returns an empty ConcurrentBitmaps ready for
-// single-writer + many-reader use.
-func NewConcurrentBitmaps() *ConcurrentBitmaps {
-	return &ConcurrentBitmaps{terms: make(map[TermKey]*atomic.Pointer[termState])}
 }
 
 // NewConcurrentBitmapsFromBitmaps takes ownership of a single-threaded
@@ -124,7 +107,8 @@ func NewConcurrentBitmapsFromBitmaps(b Bitmaps) *ConcurrentBitmaps {
 // ≥2-input qualifier on FastAnd/FastOr: with a single input the
 // roaring library has historically taken a Clone-the-input
 // shortcut, so callers MUST avoid passing a singleton slice to
-// those aggregators (see query.go:248 for the borrow guard).
+// those aggregators (eventstore's Query guards its single-input
+// cases before calling FastAnd/FastOr).
 //
 // Callers may hold the pointer arbitrarily long. A subsequent Get
 // on the same key may return either this same pointer (no AddTo
@@ -141,15 +125,11 @@ func (s *ConcurrentBitmaps) Get(key TermKey) (*roaring.Bitmap, error) {
 	if p == nil {
 		return nil, nil //nolint:nilnil // not-found is signaled by nil bitmap, no error
 	}
+	// The pointer is always Stored with a non-nil termState holding a
+	// non-nil bm or non-empty ids before it is published to the map.
 	st := p.Load()
-	if st == nil {
-		return nil, nil //nolint:nilnil
-	}
 	if st.bm != nil {
 		return st.bm, nil
-	}
-	if len(st.ids) == 0 {
-		return nil, nil //nolint:nilnil
 	}
 	bm := roaring.New()
 	bm.AddMany(st.ids)
@@ -157,9 +137,9 @@ func (s *ConcurrentBitmaps) Get(key TermKey) (*roaring.Bitmap, error) {
 }
 
 // AddTo records each eventID under key. Idempotent: callers
-// (IngestLedgerEvents, warmup) feed events in chunk-relative
-// event-ID order, so any duplicate is a retry of the already-added
-// sorted prefix and is skipped. The same (key, eventID) pair has
+// (HotStore.applyLedger via the post-commit hook, warmup) feed
+// events in chunk-relative event-ID order, so any duplicate is a
+// retry of the already-added sorted prefix and is skipped. The same (key, eventID) pair has
 // the same effect added once or many times.
 //
 // Single-writer contract: AddTo must not run concurrently with
@@ -248,65 +228,4 @@ func newTermState(eventIDs []uint32) *termState {
 		ids = append(ids, id)
 	}
 	return &termState{ids: ids}
-}
-
-// Len returns the number of distinct terms currently indexed.
-func (s *ConcurrentBitmaps) Len() int {
-	s.rwmu.RLock()
-	defer s.rwmu.RUnlock()
-	return len(s.terms)
-}
-
-// Snapshot materializes the index into a Bitmaps that the caller
-// uniquely owns. Each per-term bitmap is a fresh Clone (for
-// dense-mode entries) or a freshly-built bitmap from the sparse-mode
-// id list. The returned Bitmaps' container-data ownership story
-// depends on the source bitmap's CopyOnWrite state:
-//
-//   - Dense terms (created with SetCopyOnWrite=true, see AddTo):
-//     Clone shares container pointers with the source. The
-//     resulting Bitmaps is "Clone-safe": any mutator that REPLACES
-//     a container slot (RunOptimize, AddRange spanning new high-16
-//     blocks) writes into the clone's own keys/containers slice
-//     without touching the source. Any mutator that WRITES THROUGH
-//     a container pointer (Add, AddMany on shared containers)
-//     would alias back to the live mirror — which is why the only
-//     downstream consumer of Snapshot (WriteColdIndex's
-//     RunOptimize + MarshalBinary at cold_index.go:127-128) is
-//     limited to container-replacement mutators.
-//   - Sparse terms: a fresh empty bitmap is built from te.ids, so
-//     the result is fully independent of the source.
-//
-// Single-caller contract: Snapshot must not be called concurrently
-// with itself OR with AddTo on the same ConcurrentBitmaps. The Clone
-// it performs mutates the source bitmap's needCopyOnWrite slice as
-// a side effect of roaring's clone implementation; concurrent
-// Clones on the same source bitmap would race on that slice. In
-// production the orchestrator only calls Snapshot at freeze time,
-// after ingest has stopped on the chunk.
-//
-// Cost: one (O(1) shallow) Clone per dense term + one materialize
-// per sparse term. The RWMutex is held in read mode for the entire
-// iteration, blocking only new-key inserts.
-func (s *ConcurrentBitmaps) Snapshot() Bitmaps {
-	s.rwmu.RLock()
-	defer s.rwmu.RUnlock()
-	snap := make(Bitmaps, len(s.terms))
-	for k, p := range s.terms {
-		st := p.Load()
-		if st == nil {
-			continue
-		}
-		if st.bm != nil {
-			snap[k] = st.bm.Clone()
-			continue
-		}
-		if len(st.ids) == 0 {
-			continue
-		}
-		bm := roaring.New()
-		bm.AddMany(st.ids)
-		snap[k] = bm
-	}
-	return snap
 }

--- a/cmd/stellar-rpc/internal/events/concurrent_bitmaps_test.go
+++ b/cmd/stellar-rpc/internal/events/concurrent_bitmaps_test.go
@@ -164,10 +164,7 @@ func TestConcurrentBitmaps_GetReturnsImmutableSnapshot(t *testing.T) {
 // TestConcurrentBitmaps_ConcurrentGetIsSafe runs many concurrent
 // Get callers against the same store. Get is lock-free past the
 // brief map-lookup RLock and returns an immutable snapshot, so
-// concurrent reads should not race. Snapshot is intentionally NOT
-// exercised here — its contract is single-caller (called only at
-// freeze time after ingest stops), so multi-goroutine Snapshot
-// would be out-of-contract. Run under -race.
+// concurrent reads should not race. Run under -race.
 func TestConcurrentBitmaps_ConcurrentGetIsSafe(t *testing.T) {
 	s := newTestConcurrentBitmaps()
 	const nTerms = 200

--- a/cmd/stellar-rpc/internal/events/concurrent_bitmaps_test.go
+++ b/cmd/stellar-rpc/internal/events/concurrent_bitmaps_test.go
@@ -8,8 +8,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// newTestConcurrentBitmaps builds an empty ConcurrentBitmaps via the
+// only remaining constructor (production always converts from a
+// warmup/backfill-built Bitmaps).
+func newTestConcurrentBitmaps() *ConcurrentBitmaps {
+	return NewConcurrentBitmapsFromBitmaps(NewBitmaps())
+}
+
 func TestConcurrentBitmaps_AddToAndGet(t *testing.T) {
-	s := NewConcurrentBitmaps()
+	s := newTestConcurrentBitmaps()
 	key := ComputeTermKey([]byte("transfer"), FieldTopic0)
 
 	s.AddTo(key, 0)
@@ -26,7 +33,7 @@ func TestConcurrentBitmaps_AddToAndGet(t *testing.T) {
 }
 
 func TestConcurrentBitmaps_GetMissing(t *testing.T) {
-	s := NewConcurrentBitmaps()
+	s := newTestConcurrentBitmaps()
 	key := ComputeTermKey([]byte("missing"), FieldTopic0)
 	bm, err := s.Get(key)
 	require.NoError(t, err)
@@ -34,7 +41,7 @@ func TestConcurrentBitmaps_GetMissing(t *testing.T) {
 }
 
 func TestConcurrentBitmaps_ListMode(t *testing.T) {
-	s := NewConcurrentBitmaps()
+	s := newTestConcurrentBitmaps()
 	key := ComputeTermKey([]byte("sparse"), FieldTopic0)
 
 	for i := range uint32(promotionThreshold - 1) {
@@ -58,7 +65,7 @@ func TestConcurrentBitmaps_ListMode(t *testing.T) {
 }
 
 func TestConcurrentBitmaps_Promotion(t *testing.T) {
-	s := NewConcurrentBitmaps()
+	s := newTestConcurrentBitmaps()
 	key := ComputeTermKey([]byte("dense"), FieldTopic0)
 
 	for i := range uint32(promotionThreshold) {
@@ -74,7 +81,7 @@ func TestConcurrentBitmaps_Promotion(t *testing.T) {
 }
 
 func TestConcurrentBitmaps_AddAfterPromotion(t *testing.T) {
-	s := NewConcurrentBitmaps()
+	s := newTestConcurrentBitmaps()
 	key := ComputeTermKey([]byte("dense"), FieldTopic0)
 
 	for i := range uint32(promotionThreshold) {
@@ -90,77 +97,8 @@ func TestConcurrentBitmaps_AddAfterPromotion(t *testing.T) {
 	assert.True(t, bm.Contains(2000))
 }
 
-func TestConcurrentBitmaps_Len(t *testing.T) {
-	s := NewConcurrentBitmaps()
-	assert.Equal(t, 0, s.Len())
-
-	keyA := ComputeTermKey([]byte("a"), FieldTopic0)
-	keyB := ComputeTermKey([]byte("b"), FieldTopic1)
-
-	s.AddTo(keyA, 0)
-	assert.Equal(t, 1, s.Len())
-
-	s.AddTo(keyA, 1) // same term
-	assert.Equal(t, 1, s.Len())
-
-	s.AddTo(keyB, 2)
-	assert.Equal(t, 2, s.Len())
-}
-
-// TestConcurrentBitmaps_SnapshotIsUniquelyOwned pins that Snapshot
-// returns a Bitmaps whose bitmaps are independent of the source
-// ConcurrentBitmaps. Mutating a snapshot bitmap must not affect a
-// subsequent Snapshot of the same source.
-func TestConcurrentBitmaps_SnapshotIsUniquelyOwned(t *testing.T) {
-	s := NewConcurrentBitmaps()
-	key := ComputeTermKey([]byte("dense"), FieldTopic0)
-	for i := range uint32(promotionThreshold) {
-		s.AddTo(key, i)
-	}
-
-	snap1 := s.Snapshot()
-	bm1 := snap1[key]
-	require.NotNil(t, bm1)
-	bm1.Add(999_999)
-
-	snap2 := s.Snapshot()
-	bm2 := snap2[key]
-	require.NotNil(t, bm2)
-	assert.False(t, bm2.Contains(999_999),
-		"mutating a snapshot bitmap must not bleed into the source ConcurrentBitmaps")
-
-	// And the original index is still clean.
-	live, err := s.Get(key)
-	require.NoError(t, err)
-	assert.False(t, live.Contains(999_999),
-		"snapshot mutation must not affect the live ConcurrentBitmaps")
-}
-
-func TestConcurrentBitmaps_SnapshotIncludesSparseAndDense(t *testing.T) {
-	s := NewConcurrentBitmaps()
-
-	sparseKey := ComputeTermKey([]byte("sparse"), FieldTopic0)
-	denseKey := ComputeTermKey([]byte("dense"), FieldTopic0)
-
-	// Sparse: stays in list mode.
-	s.AddTo(sparseKey, 0)
-	s.AddTo(sparseKey, 1)
-
-	// Dense: promoted to bitmap mode.
-	for i := range uint32(promotionThreshold + 10) {
-		s.AddTo(denseKey, 100+i)
-	}
-
-	snap := s.Snapshot()
-	assert.Len(t, snap, 2)
-	require.NotNil(t, snap[sparseKey])
-	require.NotNil(t, snap[denseKey])
-	assert.Equal(t, uint64(2), snap[sparseKey].GetCardinality())
-	assert.Equal(t, uint64(promotionThreshold+10), snap[denseKey].GetCardinality())
-}
-
 func TestConcurrentBitmaps_BatchAddTo(t *testing.T) {
-	s := NewConcurrentBitmaps()
+	s := newTestConcurrentBitmaps()
 	key := ComputeTermKey([]byte("batch"), FieldTopic0)
 
 	s.AddTo(key, 0, 1, 2, 3, 4)
@@ -174,7 +112,7 @@ func TestConcurrentBitmaps_BatchAddTo(t *testing.T) {
 }
 
 func TestConcurrentBitmaps_BatchAddToPromotion(t *testing.T) {
-	s := NewConcurrentBitmaps()
+	s := newTestConcurrentBitmaps()
 	key := ComputeTermKey([]byte("batch-promote"), FieldTopic0)
 
 	// Single batch call that crosses threshold.
@@ -198,7 +136,7 @@ func TestConcurrentBitmaps_BatchAddToPromotion(t *testing.T) {
 // pointer. This is the key invariant readers can rely on across the
 // borrow.
 func TestConcurrentBitmaps_GetReturnsImmutableSnapshot(t *testing.T) {
-	s := NewConcurrentBitmaps()
+	s := newTestConcurrentBitmaps()
 	key := ComputeTermKey([]byte("borrow"), FieldTopic0)
 
 	// Promote to bitmap mode.
@@ -231,7 +169,7 @@ func TestConcurrentBitmaps_GetReturnsImmutableSnapshot(t *testing.T) {
 // freeze time after ingest stops), so multi-goroutine Snapshot
 // would be out-of-contract. Run under -race.
 func TestConcurrentBitmaps_ConcurrentGetIsSafe(t *testing.T) {
-	s := NewConcurrentBitmaps()
+	s := newTestConcurrentBitmaps()
 	const nTerms = 200
 	keys := make([]TermKey, nTerms)
 	for i := range nTerms {
@@ -278,7 +216,7 @@ func TestConcurrentBitmaps_ConcurrentGetIsSafe(t *testing.T) {
 // the writer publishes new snapshots; no clones or locks span the
 // borrow. Under -race no data races should be reported.
 func TestConcurrentBitmaps_ConcurrentReadWrite(t *testing.T) {
-	s := NewConcurrentBitmaps()
+	s := newTestConcurrentBitmaps()
 
 	const numTerms = 100
 	const numEvents = 10_000
@@ -301,14 +239,12 @@ func TestConcurrentBitmaps_ConcurrentReadWrite(t *testing.T) {
 		wg.Go(func() {
 			for i := range numEvents {
 				_, _ = s.Get(keys[i%numTerms])
-				_ = s.Len()
 			}
 		})
 	}
 
 	wg.Wait()
 
-	assert.Equal(t, numTerms, s.Len())
 	for _, key := range keys {
 		bm, err := s.Get(key)
 		require.NoError(t, err)
@@ -329,7 +265,7 @@ func TestConcurrentBitmaps_ConcurrentReadWrite(t *testing.T) {
 // promotion boundary should never produce a nil bitmap and
 // should never trip the race detector.
 func TestConcurrentBitmaps_GetDuringPromotionNeverReturnsNil(t *testing.T) {
-	s := NewConcurrentBitmaps()
+	s := newTestConcurrentBitmaps()
 	const numKeys = 200
 
 	keys := make([]TermKey, numKeys)
@@ -383,46 +319,6 @@ func TestConcurrentBitmaps_GetDuringPromotionNeverReturnsNil(t *testing.T) {
 	wg.Wait()
 }
 
-// TestConcurrentBitmaps_SnapshotPostPromotionIncludesAllTerms
-// drives AddTo to push every term across the sparse→dense
-// promotion boundary, then takes a single Snapshot and verifies
-// every populated term appears with the right cardinality.
-//
-// Snapshot's contract is single-caller, called only after ingest
-// has stopped on the chunk — so concurrent AddTo + Snapshot is
-// out-of-contract. This sequential test pins the post-promotion
-// snapshot correctness without violating that contract.
-func TestConcurrentBitmaps_SnapshotPostPromotionIncludesAllTerms(t *testing.T) {
-	s := NewConcurrentBitmaps()
-	const numKeys = 200
-
-	keys := make([]TermKey, numKeys)
-	for i := range numKeys {
-		keys[i] = ComputeTermKey([]byte{byte(i / 256), byte(i % 256)}, FieldTopic0)
-	}
-
-	// Seed each term with promotionThreshold-1 ids: sparse mode.
-	for _, k := range keys {
-		ids := make([]uint32, promotionThreshold-1)
-		for j := range ids {
-			ids[j] = uint32(j)
-		}
-		s.AddTo(k, ids...)
-	}
-
-	// Push every term over the promotion threshold.
-	for i, k := range keys {
-		s.AddTo(k, uint32(promotionThreshold-1+i))
-	}
-
-	snap := s.Snapshot()
-	for _, k := range keys {
-		require.NotNil(t, snap[k], "Snapshot dropped a populated term")
-		assert.Equal(t, uint64(promotionThreshold), snap[k].GetCardinality(),
-			"Snapshot bitmap missing events for a promoted term")
-	}
-}
-
 // TestConcurrentBitmaps_AddToIsIdempotent pins the dedup contract:
 // AddTo can be called multiple times with the same eventID for the
 // same key and the result is the same as adding it once. Covers
@@ -430,7 +326,7 @@ func TestConcurrentBitmaps_SnapshotPostPromotionIncludesAllTerms(t *testing.T) {
 // set semantics).
 func TestConcurrentBitmaps_AddToIsIdempotent(t *testing.T) {
 	t.Run("list mode", func(t *testing.T) {
-		s := NewConcurrentBitmaps()
+		s := newTestConcurrentBitmaps()
 		key := ComputeTermKey([]byte("sparse"), FieldTopic0)
 
 		// Add a few in order.
@@ -457,7 +353,7 @@ func TestConcurrentBitmaps_AddToIsIdempotent(t *testing.T) {
 	})
 
 	t.Run("bitmap mode", func(t *testing.T) {
-		s := NewConcurrentBitmaps()
+		s := newTestConcurrentBitmaps()
 		key := ComputeTermKey([]byte("dense"), FieldTopic0)
 
 		// Force bitmap mode by exceeding the threshold.
@@ -487,7 +383,7 @@ func TestConcurrentBitmaps_AddToIsIdempotent(t *testing.T) {
 // (+40% hot-ingest wall, observed empirically).
 func TestConcurrentBitmaps_DenseAddToSetsCopyOnWrite(t *testing.T) {
 	t.Run("via promotion in AddTo", func(t *testing.T) {
-		s := NewConcurrentBitmaps()
+		s := newTestConcurrentBitmaps()
 		key := ComputeTermKey([]byte("promote"), FieldTopic0)
 		for i := range uint32(promotionThreshold) {
 			s.AddTo(key, i)
@@ -499,7 +395,7 @@ func TestConcurrentBitmaps_DenseAddToSetsCopyOnWrite(t *testing.T) {
 	})
 
 	t.Run("via newTermState over-threshold initial batch", func(t *testing.T) {
-		s := NewConcurrentBitmaps()
+		s := newTestConcurrentBitmaps()
 		key := ComputeTermKey([]byte("initial"), FieldTopic0)
 		ids := make([]uint32, promotionThreshold+10)
 		for i := range ids {
@@ -513,7 +409,7 @@ func TestConcurrentBitmaps_DenseAddToSetsCopyOnWrite(t *testing.T) {
 	})
 
 	t.Run("subsequent AddTo preserves CopyOnWrite via Clone", func(t *testing.T) {
-		s := NewConcurrentBitmaps()
+		s := newTestConcurrentBitmaps()
 		key := ComputeTermKey([]byte("evolve"), FieldTopic0)
 		for i := range uint32(promotionThreshold) {
 			s.AddTo(key, i)

--- a/cmd/stellar-rpc/internal/events/concurrent_ledgeroffsets.go
+++ b/cmd/stellar-rpc/internal/events/concurrent_ledgeroffsets.go
@@ -1,17 +1,16 @@
 package events
 
 import (
-	"fmt"
 	"sync/atomic"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
 )
 
 // ConcurrentLedgerOffsets tracks cumulative event counts per ledger
-// for live ingest paths: a single writer (IngestLedgerEvents) and
-// many concurrent readers (queries calling EventIDs / TotalEvents /
-// etc.). Lock-free reads via a fixed-capacity backing array plus an
-// atomic counter publishing the valid prefix.
+// for live ingest paths: a single writer (HotStore.applyLedger via
+// the post-commit hook) and many concurrent readers (queries calling
+// View / TotalEvents / etc.). Lock-free reads via a fixed-capacity
+// backing array plus an atomic counter publishing the valid prefix.
 //
 // Memory: 40KB up-front per instance (LedgersPerChunk × uint32).
 // Same as the slice the locked version pre-allocates, just shaped
@@ -22,12 +21,9 @@ import (
 //   - Append (writer): writes backing[n] then atomic.Store(len, n+1).
 //     The Store happens-before any reader's Load that observes the
 //     new value (Go memory model), so the prior write is visible.
-//   - Read methods (EventIDs, TotalEvents, etc.): atomic.Load(len),
+//   - Read methods (View, TotalEvents, etc.): atomic.Load(len),
 //     then read backing[:n]. Disjoint memory from the writer's
 //     next write at backing[n].
-//   - Snapshot copies backing[:n] into a fresh slice and returns a
-//     uniquely-owned LedgerOffsets for serialization (ColdWriter.Finish,
-//     query handoff to the build-then-read shape).
 //
 // Single-writer contract: Append must be called from a single
 // goroutine. Concurrent Appends would race on the len counter and
@@ -67,26 +63,6 @@ func (m *ConcurrentLedgerOffsets) Append(eventCount uint32) {
 	m.count.Store(n + 1)
 }
 
-// EventIDs returns the half-open event ID range [start, end) for the
-// given ledger.
-func (m *ConcurrentLedgerOffsets) EventIDs(ledger uint32) (uint32, uint32, error) {
-	n := m.count.Load()
-	if n == 0 {
-		return 0, 0, fmt.Errorf("ledger %d not found: no ledgers recorded", ledger)
-	}
-	endLedger := m.startLedger + n
-	if ledger < m.startLedger || ledger >= endLedger {
-		return 0, 0, fmt.Errorf("ledger %d is outside bounds [%d, %d)",
-			ledger, m.startLedger, endLedger)
-	}
-	rel := ledger - m.startLedger
-	var start uint32
-	if rel > 0 {
-		start = m.backing[rel-1]
-	}
-	return start, m.backing[rel], nil
-}
-
 // LedgerCount returns the number of ledgers recorded.
 func (m *ConcurrentLedgerOffsets) LedgerCount() int {
 	return int(m.count.Load())
@@ -114,8 +90,8 @@ func (m *ConcurrentLedgerOffsets) EndLedger() uint32 {
 // View returns a *LedgerOffsets sharing the live backing array,
 // capped to the count visible at call time. Used by HotStore on
 // the query hot path: each Query allocates one View (~24 bytes:
-// slice header + startLedger) instead of a 40KB Snapshot copy of
-// the full backing array.
+// slice header + startLedger) instead of a 40KB deep copy of the
+// full backing array.
 //
 // Safety: the slice's cap is set equal to its len, so any caller
 // that calls Append on the returned LedgerOffsets allocates a
@@ -133,22 +109,6 @@ func (m *ConcurrentLedgerOffsets) View() *LedgerOffsets {
 	n := m.count.Load()
 	return &LedgerOffsets{
 		offsets:     m.backing[:n:n],
-		startLedger: m.startLedger,
-	}
-}
-
-// Snapshot returns a uniquely-owned LedgerOffsets containing a
-// deep copy of the current state. Use this when the caller needs
-// independence from the live backing array — e.g., serializing to
-// disk via ColdWriter.Finish, or any path that retains the
-// pointer across mutation of the source. For the read hot path
-// where the caller only needs a few scalar reads, prefer View.
-func (m *ConcurrentLedgerOffsets) Snapshot() *LedgerOffsets {
-	n := m.count.Load()
-	offsets := make([]uint32, n)
-	copy(offsets, m.backing[:n])
-	return &LedgerOffsets{
-		offsets:     offsets,
 		startLedger: m.startLedger,
 	}
 }

--- a/cmd/stellar-rpc/internal/events/index.go
+++ b/cmd/stellar-rpc/internal/events/index.go
@@ -50,54 +50,6 @@ func ComputeTermKey(value []byte, field Field) TermKey {
 	return key
 }
 
-// TermsFor returns the 16-byte hashed term keys (contractID + topics
-// 0..MaxTopicCount-1) applicable to ev. Topics beyond MaxTopicCount
-// are not indexed because the getEvents filter API can't match them
-// anyway (see topicField).
-//
-// Callers pair each returned key with the event's chunk-relative
-// event ID at the call site — TermsFor itself doesn't track event
-// IDs because they're a property of the writer's scheduling
-// (start_id + i), not of the event's contents.
-//
-// Used by callers that already hold a decoded ContractEvent:
-//   - Cold backfill (cold-events-ingest) — derives terms per
-//     payload while populating an in-memory events.Bitmaps for
-//     later WriteColdIndex.
-//
-// The hot ingest path holds only raw event bytes and derives terms via
-// TermsForBytes instead. The live-chunk freeze path calls neither — it
-// converts the hot mirror to a Bitmaps via ConcurrentBitmaps.Snapshot and
-// hands that to WriteColdIndex.
-//
-// A MarshalBinary failure on a topic surfaces as an error rather
-// than a silent skip. Stellar-core has already validated the XDR
-// when it closed the ledger, so a failure here signals corruption
-// somewhere in the pipeline — the right response is to reject the
-// ledger commit (leaving on-disk state untouched), not to
-// under-index events and continue.
-func TermsFor(ev xdr.ContractEvent) ([]TermKey, error) {
-	var keys []TermKey
-	if ev.ContractId != nil {
-		keys = append(keys, ComputeTermKey(ev.ContractId[:], FieldContractID))
-	}
-	v0, ok := ev.Body.GetV0()
-	if !ok {
-		return keys, nil
-	}
-	for i, topic := range v0.Topics {
-		if i >= protocol.MaxTopicCount {
-			break
-		}
-		raw, err := topic.MarshalBinary()
-		if err != nil {
-			return nil, fmt.Errorf("events: marshal topic %d: %w", i, err)
-		}
-		keys = append(keys, ComputeTermKey(raw, topicField(i)))
-	}
-	return keys, nil
-}
-
 // TermsForBytes returns the term keys (contract ID + topics
 // 0..MaxTopicCount-1) for a marshaled ContractEvent, navigating the raw
 // XDR via xdr.ContractEventView instead of a full UnmarshalBinary.

--- a/cmd/stellar-rpc/internal/events/ledgeroffsets.go
+++ b/cmd/stellar-rpc/internal/events/ledgeroffsets.go
@@ -8,15 +8,14 @@ import (
 
 // LedgerOffsets tracks cumulative event counts per ledger within a
 // chunk for build-then-read paths (cold backfill, DecodeLedgerOffsets
-// on the cold-reader side, ConcurrentLedgerOffsets.Snapshot for the
-// freeze handoff). Single-threaded by contract: callers either build
-// it in one goroutine and hand it off to many readers via a
-// sync-providing handoff (sync.OnceValues, struct-field-after-init,
-// etc.), or use it from one goroutine throughout.
+// on the cold-reader side). Single-threaded by contract: callers
+// either build it in one goroutine and hand it off to many readers
+// via a sync-providing handoff (sync.OnceValues,
+// struct-field-after-init, etc.), or use it from one goroutine
+// throughout.
 //
-// For live ingest paths (HotStore) use ConcurrentLedgerOffsets and
-// call Snapshot to convert when handing off to the cold reader's
-// build-then-read shape.
+// For live ingest paths (HotStore) use ConcurrentLedgerOffsets;
+// queries borrow a read-only view of it via View.
 //
 // offsets[i] holds the cumulative event count through relative ledger i.
 // Ledger i's events span IDs [offsets[i-1], offsets[i]).

--- a/cmd/stellar-rpc/internal/events/ledgeroffsets_test.go
+++ b/cmd/stellar-rpc/internal/events/ledgeroffsets_test.go
@@ -152,37 +152,17 @@ func TestConcurrentLedgerOffsets_Basic(t *testing.T) {
 	assert.Equal(t, uint32(100), m.StartLedger())
 	assert.Equal(t, uint32(104), m.EndLedger())
 
-	start, end, err := m.EventIDs(102)
+	// Per-ledger ranges resolve through a View (the query path's shape).
+	start, end, err := m.View().EventIDs(102)
 	require.NoError(t, err)
 	assert.Equal(t, uint32(1042), start)
 	assert.Equal(t, uint32(2029), end)
 
 	// The empty ledger (101) is a zero-width range.
-	s, e, err := m.EventIDs(101)
+	s, e, err := m.View().EventIDs(101)
 	require.NoError(t, err)
 	assert.Equal(t, uint32(1042), s)
 	assert.Equal(t, uint32(1042), e, "empty ledger is zero-width")
-}
-
-// TestConcurrentLedgerOffsets_Snapshot pins that Snapshot returns a
-// uniquely-owned LedgerOffsets containing the visible state at call
-// time. Subsequent appends to the source don't affect the snapshot.
-func TestConcurrentLedgerOffsets_Snapshot(t *testing.T) {
-	m := NewConcurrentLedgerOffsets(0)
-	m.Append(10)
-	m.Append(20)
-
-	snap := m.Snapshot()
-	assert.Equal(t, 2, snap.LedgerCount())
-	assert.Equal(t, uint32(30), snap.TotalEvents())
-
-	// Append after snapshot.
-	m.Append(5)
-
-	// Source advanced; snapshot unchanged.
-	assert.Equal(t, 3, m.LedgerCount())
-	assert.Equal(t, 2, snap.LedgerCount())
-	assert.Equal(t, uint32(30), snap.TotalEvents())
 }
 
 // TestConcurrentLedgerOffsets_AppendPastCapacity pins the contract that
@@ -220,7 +200,7 @@ func TestConcurrentLedgerOffsets_ConcurrentReadWrite(t *testing.T) {
 	for range numReaders {
 		wg.Go(func() {
 			for i := range uint32(numLedgers) {
-				_, _, _ = m.EventIDs(i)
+				_, _, _ = m.View().EventIDs(i)
 				_ = m.LedgerCount()
 				_ = m.TotalEvents()
 			}

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/process_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/process_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/ingest"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/ledger"
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash"
 )
 
 // ---------------------------------------------------------------------------
@@ -132,8 +131,7 @@ func TestProcessChunk_ProducesAllArtifactsAndFreezes(t *testing.T) {
 
 	// The .bin is readable as a sorted run (rule 5) — exercises the merged
 	// txhash cold writer's output via its reader.
-	entries, err := txhash.ReadColdBin(layout.TxHashBinPath(chunkID))
-	require.NoError(t, err)
+	entries := fhtest.ReadColdBin(t, layout.TxHashBinPath(chunkID))
 	require.Empty(t, entries, "zero-tx chunk yields an empty sorted .bin")
 
 	// The pack is a valid cold ledger pack covering the whole chunk.

--- a/cmd/stellar-rpc/internal/fullhistory/config_validate.go
+++ b/cmd/stellar-rpc/internal/fullhistory/config_validate.go
@@ -14,8 +14,7 @@ import (
 
 // validateConfig is the config gate run before the daemon's run loop: (1) form-validate,
 // (2) on restart confirm earliest_ledger unchanged, (3) on first start resolve and
-// pin it. Returns the resolved earliest ledger for StartConfig; plain error returns
-// (the daemon loop owns fatal-and-surface).
+// pin it. Plain error returns (the daemon loop owns fatal-and-surface).
 func validateConfig(
 	ctx context.Context,
 	cfg config.Config,
@@ -23,9 +22,9 @@ func validateConfig(
 	tip NetworkTipBackend,
 	tipBackoff time.Duration,
 	tipMaxAttempts int,
-) (uint32, error) {
+) error {
 	if cat == nil {
-		return 0, errors.New("validateConfig requires a non-nil Catalog")
+		return errors.New("validateConfig requires a non-nil Catalog")
 	}
 
 	workers := deref(cfg.Backfill.Workers)
@@ -33,44 +32,41 @@ func validateConfig(
 
 	// --- 1. Form validation. ---
 	if workers < 1 {
-		return 0, fmt.Errorf("workers must be >= 1 (got %d) — a zero pool deadlocks executePlan", workers)
+		return fmt.Errorf("workers must be >= 1 (got %d) — a zero pool deadlocks executePlan", workers)
 	}
 	if maxRetries < 0 {
-		return 0, fmt.Errorf("max_retries must be >= 0 (got %d) — 0 means run once, no retry", maxRetries)
+		return fmt.Errorf("max_retries must be >= 0 (got %d) — 0 means run once, no retry", maxRetries)
 	}
 	// logging.format silently means text unless it is exactly "json", so reject any
 	// other value rather than let a typo drop the operator to text logging. Empty is
 	// the unset sentinel WithDefaults resolves to text, so it is not a typo.
 	if f := cfg.Logging.Format; f != "" && f != config.DefaultLogFormat && f != config.LogFormatJSON {
-		return 0, fmt.Errorf("logging.format must be %q or %q; got %q", config.DefaultLogFormat, config.LogFormatJSON, f)
+		return fmt.Errorf("logging.format must be %q or %q; got %q", config.DefaultLogFormat, config.LogFormatJSON, f)
 	}
 	// Form-validate here so the numeric case avoids chunk.IDFromLedger's sub-genesis panic below.
 	if err := validateEarliestForm(cfg.Retention.EarliestLedger); err != nil {
-		return 0, err
+		return err
 	}
 
 	earliestStored, earliestPinned, err := cat.EarliestLedger()
 	if err != nil {
-		return 0, fmt.Errorf("read earliest_ledger pin: %w", err)
+		return fmt.Errorf("read earliest_ledger pin: %w", err)
 	}
 
 	if earliestPinned {
 		// --- 2. Restart: confirm earliest_ledger unchanged. ---
-		if err := confirmEarliestUnchanged(cfg.Retention.EarliestLedger, earliestStored); err != nil {
-			return 0, err
-		}
-		return earliestStored, nil
+		return confirmEarliestUnchanged(cfg.Retention.EarliestLedger, earliestStored)
 	}
 
 	// --- 3. First start: resolve, then pin earliest_ledger. ---
 	earliest, err := resolveEarliestFirstStart(ctx, cfg.Retention.EarliestLedger, tip, tipBackoff, tipMaxAttempts)
 	if err != nil {
-		return 0, err
+		return err
 	}
 	if err := cat.PinEarliestLedger(earliest); err != nil {
-		return 0, fmt.Errorf("pin earliest ledger (earliest=%d): %w", earliest, err)
+		return fmt.Errorf("pin earliest ledger (earliest=%d): %w", earliest, err)
 	}
-	return earliest, nil
+	return nil
 }
 
 // confirmEarliestUnchanged enforces earliest_ledger's restart immutability: genesis or

--- a/cmd/stellar-rpc/internal/fullhistory/config_validate_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/config_validate_test.go
@@ -35,9 +35,16 @@ func downTip() *fakeTipBackend {
 	return &fakeTipBackend{err: errors.New("backend unreachable"), errFirst: 99}
 }
 
+// callValidate runs validateConfig and, on success, returns the earliest_ledger
+// value it pinned (read back from the catalog, since validateConfig no longer
+// returns it). On failure the earliest is meaningless, so it returns 0.
 func callValidate(t *testing.T, cfg config.Config, cat *catalog.Catalog, tip NetworkTipBackend) (uint32, error) {
 	t.Helper()
-	return validateConfig(context.Background(), cfg, cat, tip, time.Millisecond, 3)
+	if err := validateConfig(context.Background(), cfg, cat, tip, time.Millisecond, 3); err != nil {
+		return 0, err
+	}
+	el, _, err := cat.EarliestLedger()
+	return el, err
 }
 
 // requireEarliestPin asserts the earliest_ledger pin reads back as wantEarliest;

--- a/cmd/stellar-rpc/internal/fullhistory/daemon.go
+++ b/cmd/stellar-rpc/internal/fullhistory/daemon.go
@@ -134,10 +134,8 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 		serveReads = func(context.Context) error { return nil }
 	}
 
-	tipBackoff, tipMaxAttempts := defaultTipBackoff, defaultTipMaxAttempts
-
 	// --- validateConfig: pin/confirm the layout, resolve the earliest floor. ---
-	if _, err := validateConfig(ctx, cfg, cat, networkTip, tipBackoff, tipMaxAttempts); err != nil {
+	if err := validateConfig(ctx, cfg, cat, networkTip, defaultTipBackoff, defaultTipMaxAttempts); err != nil {
 		return err
 	}
 
@@ -161,7 +159,7 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 
 	// --- Assemble the StartConfig and run the supervised run loop. ---
 	start := startConfig(
-		cfg, cat, logger, backend, networkTip, core, serveReads, metrics, sink, tipBackoff, tipMaxAttempts)
+		cfg, cat, logger, backend, networkTip, core, serveReads, metrics, sink)
 
 	backoff := opts.RestartBackoff
 	if backoff <= 0 {
@@ -176,7 +174,7 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 func startConfig(
 	cfg config.Config, cat *catalog.Catalog, logger *supportlog.Entry,
 	backend backfill.Backend, networkTip NetworkTipBackend, core CoreOpener, serveReads func(context.Context) error,
-	metrics observability.Metrics, sink ingest.MetricSink, tipBackoff time.Duration, tipMaxAttempts int,
+	metrics observability.Metrics, sink ingest.MetricSink,
 ) StartConfig {
 	exec := backfill.ExecConfig{
 		Catalog:    cat,
@@ -189,14 +187,14 @@ func startConfig(
 			Sink:    sink,
 		},
 	}
+	// TipBackoff / TipMaxAttempts are left zero here on purpose:
+	// StartConfig.withDefaults fills them at Start.
 	return StartConfig{
 		Exec:            exec,
 		RetentionChunks: deref(cfg.Retention.RetentionChunks),
 		NetworkTip:      networkTip,
 		Core:            core,
 		ServeReads:      serveReads,
-		TipBackoff:      tipBackoff,
-		TipMaxAttempts:  tipMaxAttempts,
 	}
 }
 

--- a/cmd/stellar-rpc/internal/fullhistory/fhtest/fhtest.go
+++ b/cmd/stellar-rpc/internal/fullhistory/fhtest/fhtest.go
@@ -5,11 +5,16 @@
 package fhtest
 
 import (
+	"encoding/binary"
+	"io"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash"
 )
 
 // ZeroTxLCMBytes returns the marshaled bytes of a minimal, zero-transaction
@@ -36,4 +41,43 @@ func ZeroTxLCMBytes(t *testing.T, seq uint32) []byte {
 	raw, err := lcm.MarshalBinary()
 	require.NoError(t, err)
 	return raw
+}
+
+// ReadColdBin reads back a cold txhash .bin file written by
+// txhash.WriteColdBin, verifying the header count against the file size.
+// Test-side mirror of the on-disk contract (production consumes .bin files
+// via the index builder's streaming scan, never a full read-back).
+func ReadColdBin(t *testing.T, path string) []txhash.ColdEntry {
+	t.Helper()
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	const headerSize = 8
+	entrySize := txhash.ColdKeySize + 4
+
+	var header [headerSize]byte
+	_, err = io.ReadFull(f, header[:])
+	require.NoError(t, err)
+	count := binary.LittleEndian.Uint64(header[:])
+
+	info, err := f.Stat()
+	require.NoError(t, err)
+	// Divide the trusted size rather than multiplying the untrusted
+	// count (mirrors production's overflow-safe coldBinCount check).
+	body := info.Size() - headerSize
+	require.GreaterOrEqual(t, body, int64(0), "cold .bin shorter than its header")
+	require.Zero(t, body%int64(entrySize), "cold .bin body is not whole entries")
+	require.EqualValues(t, count, body/int64(entrySize),
+		"cold .bin size must match its declared entry count")
+
+	entries := make([]txhash.ColdEntry, count)
+	buf := make([]byte, entrySize)
+	for i := range entries {
+		_, err = io.ReadFull(f, buf)
+		require.NoError(t, err)
+		copy(entries[i].Key[:], buf[:txhash.ColdKeySize])
+		entries[i].Seq = binary.LittleEndian.Uint32(buf[txhash.ColdKeySize:])
+	}
+	return entries
 }

--- a/cmd/stellar-rpc/internal/fullhistory/geometry/txhash_index.go
+++ b/cmd/stellar-rpc/internal/fullhistory/geometry/txhash_index.go
@@ -55,9 +55,6 @@ func NewTxHashIndexLayout(chunksPerIndex uint32) (TxHashIndexLayout, error) {
 	return TxHashIndexLayout{cpi: chunksPerIndex}, nil
 }
 
-// ChunksPerIndex returns the configured cpi.
-func (l TxHashIndexLayout) ChunksPerIndex() uint32 { return l.cpi }
-
 // TxHashIndexID returns the index containing chunk c: c / cpi.
 func (l TxHashIndexLayout) TxHashIndexID(c chunk.ID) TxHashIndexID {
 	return TxHashIndexID(uint32(c) / l.cpi)

--- a/cmd/stellar-rpc/internal/fullhistory/geometry/txhash_index_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/geometry/txhash_index_test.go
@@ -22,7 +22,7 @@ func TestNewTxHashIndexLayout_Validation(t *testing.T) {
 
 	w, err := NewTxHashIndexLayout(MaxChunksPerTxhashIndex)
 	require.NoError(t, err)
-	require.Equal(t, MaxChunksPerTxhashIndex, w.ChunksPerIndex())
+	require.Equal(t, MaxChunksPerTxhashIndex, w.cpi)
 }
 
 // The pinnable cpi ceiling must never exceed what the cold tx-hash index format
@@ -60,7 +60,7 @@ func TestTxHashIndexArithmetic(t *testing.T) {
 			require.Equal(t, tc.wantTxHashIndex, w.TxHashIndexID(tc.chunkID))
 			require.Equal(t, tc.wantFirst, w.FirstChunk(tc.wantTxHashIndex))
 			require.Equal(t, tc.wantHi, w.LastChunk(tc.wantTxHashIndex))
-			require.Equal(t, uint32(1000), w.ChunksPerIndex())
+			require.Equal(t, uint32(1000), w.cpi)
 		})
 	}
 }

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/events.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/events.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os"
 	"time"
 
 	"github.com/stellar/go-stellar-sdk/xdr"
@@ -52,6 +53,9 @@ type eventsCold struct {
 // Layout's single derivation — and returns a ColdIngester that owns it. The
 // writer uses its zero-value options; driver-level tuning is a follow-up (issue #836).
 func NewEventsColdIngester(bucketDir string, chunkID chunk.ID, sink MetricSink) (ColdIngester, error) {
+	if err := os.MkdirAll(bucketDir, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir %s: %w", bucketDir, err)
+	}
 	w, err := eventstore.NewColdWriter(chunkID, bucketDir, eventstore.ColdWriterOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("eventstore.NewColdWriter: %w", err)

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/ingest_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/ingest_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/events"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/fhtest"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk"
@@ -481,8 +482,7 @@ func TestTxhashColdIngester_Bin(t *testing.T) {
 	}
 	require.NoError(t, ing.Finalize(context.Background()))
 
-	entries, err := txhash.ReadColdBin(txhashBinPath(coldDir))
-	require.NoError(t, err)
+	entries := fhtest.ReadColdBin(t, txhashBinPath(coldDir))
 	require.Len(t, entries, 2)
 }
 
@@ -512,10 +512,10 @@ func TestEventsColdIngester_Readback(t *testing.T) {
 	cnt, err := cr.EventCount()
 	require.NoError(t, err)
 	require.Equal(t, uint32(2), cnt)
-	bm, err := cr.Lookup(context.Background(), term)
+	bms, err := cr.LookupKeys(context.Background(), []events.TermKey{term})
 	require.NoError(t, err)
-	require.NotNil(t, bm)
-	require.Equal(t, uint64(2), bm.GetCardinality())
+	require.NotNil(t, bms[0])
+	require.Equal(t, uint64(2), bms[0].GetCardinality())
 }
 
 // ───────────────────────── V0 (pre-Soroban) events handling ─────────────────────────
@@ -566,10 +566,10 @@ func TestEventsColdIngester_V0KeepsOffsetsContiguous(t *testing.T) {
 	require.Equal(t, uint32(1), evEnd)
 
 	// And the event is queryable by its term.
-	bm, err := cr.Lookup(context.Background(), term)
+	bms, err := cr.LookupKeys(context.Background(), []events.TermKey{term})
 	require.NoError(t, err)
-	require.NotNil(t, bm)
-	require.Equal(t, uint64(1), bm.GetCardinality())
+	require.NotNil(t, bms[0])
+	require.Equal(t, uint64(1), bms[0].GetCardinality())
 }
 
 // TestWriteColdChunk_EventlessChunk_FullyReadable drives a full cold chunk of V0
@@ -611,8 +611,10 @@ func TestWriteColdChunk_EventlessChunk_FullyReadable(t *testing.T) {
 	cnt, err := cr.EventCount()
 	require.NoError(t, err)
 	require.Zero(t, cnt)
-	_, lerr := cr.Lookup(context.Background(), events.ComputeTermKey([]byte("any"), events.FieldContractID))
-	require.ErrorIs(t, lerr, eventstore.ErrTermNotFound)
+	anyKey := events.ComputeTermKey([]byte("any"), events.FieldContractID)
+	bms, lerr := cr.LookupKeys(context.Background(), []events.TermKey{anyKey})
+	require.NoError(t, lerr)
+	require.Nil(t, bms[0], "a term with no matching events misses cleanly (nil bitmap)")
 
 	// Metrics still fired: one aggregate per-chunk, one (clean) per-ingester.
 	require.Equal(t, 1, sink.coldChunkTotals, "ColdChunkTotal must fire for an eventless chunk")
@@ -661,13 +663,12 @@ func TestColdService_Success(t *testing.T) {
 		chunkID, filepath.Join(coldDir, dataTypeEvents, chunkID.BucketID()), eventstore.ColdReaderOptions{})
 	require.NoError(t, err)
 	defer func() { require.NoError(t, ecr.Close()) }()
-	bm, err := ecr.Lookup(context.Background(), term)
+	bms, err := ecr.LookupKeys(context.Background(), []events.TermKey{term})
 	require.NoError(t, err)
-	require.Equal(t, uint64(2), bm.GetCardinality())
+	require.Equal(t, uint64(2), bms[0].GetCardinality())
 
 	// Txhash .bin count.
-	binEntries, err := txhash.ReadColdBin(txhashBinPath(filepath.Join(coldDir, dataTypeTxhash)))
-	require.NoError(t, err)
+	binEntries := fhtest.ReadColdBin(t, txhashBinPath(filepath.Join(coldDir, dataTypeTxhash)))
 	require.Len(t, binEntries, 2)
 
 	// Metrics: one ColdChunkTotal, one ColdIngest per data type, no errors.
@@ -894,8 +895,7 @@ func TestWriteColdChunk_TxhashCold_Bin(t *testing.T) {
 		coldDirsAt(coldDir, chunkID), nil, Config{Txhash: true},
 	))
 
-	entries, err := txhash.ReadColdBin(txhashBinPath(filepath.Join(coldDir, dataTypeTxhash)))
-	require.NoError(t, err)
+	entries := fhtest.ReadColdBin(t, txhashBinPath(filepath.Join(coldDir, dataTypeTxhash)))
 	require.Len(t, entries, len(txSeqs))
 }
 
@@ -931,10 +931,10 @@ func TestWriteColdChunk_EventsCold_Readback(t *testing.T) {
 	cnt, err := cr.EventCount()
 	require.NoError(t, err)
 	require.Equal(t, uint32(len(evSeqs)), cnt)
-	bm, err := cr.Lookup(context.Background(), term)
+	bms, err := cr.LookupKeys(context.Background(), []events.TermKey{term})
 	require.NoError(t, err)
-	require.NotNil(t, bm)
-	require.Equal(t, uint64(len(evSeqs)), bm.GetCardinality())
+	require.NotNil(t, bms[0])
+	require.Equal(t, uint64(len(evSeqs)), bms[0].GetCardinality())
 }
 
 // ───────────────────────── drain stream errors ─────────────────────────
@@ -1133,8 +1133,7 @@ func TestTxhashColdIngester_BinContent(t *testing.T) {
 	}
 	require.NoError(t, ing.Finalize(context.Background()))
 
-	entries, err := txhash.ReadColdBin(txhashBinPath(coldDir))
-	require.NoError(t, err)
+	entries := fhtest.ReadColdBin(t, txhashBinPath(coldDir))
 	require.Len(t, entries, 2)
 
 	var prevKey [txhash.ColdKeySize]byte

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/ledgers.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/ledgers.go
@@ -19,10 +19,9 @@ import (
 // packfile per chunk). Finalize calls Commit (trailer + fsync). Close cleans up
 // the partial file when Finalize never ran (idempotent — no-op after Commit).
 type ledgerCold struct {
-	path     string
-	writer   *ledger.ColdWriter
-	metrics  coldMetrics
-	appended bool
+	path    string
+	writer  *ledger.ColdWriter
+	metrics coldMetrics
 }
 
 // NewLedgerColdIngester opens a per-chunk cold ledger writer at packPath — the
@@ -47,20 +46,12 @@ func (c *ledgerCold) Ingest(_ context.Context, seq uint32, lcm xdr.LedgerCloseMe
 		return fmt.Errorf("AppendLedger(seq=%d): %w", seq, err)
 	}
 	c.metrics.sink.IngestStage(dataTypeLedgers, stageWrite, time.Since(start), 1)
-	c.appended = true
 	c.metrics.observe(time.Since(start), 1, nil)
 	return nil
 }
 
 func (c *ledgerCold) Finalize(_ context.Context) error {
 	start := time.Now()
-	// ColdWriter.Commit errors on a zero-append pack. If the per-ledger loop
-	// bailed out before any AppendLedger succeeded, skip Commit so the failure
-	// surface is clean (Close in deferred cleanup removes the partial pack).
-	if !c.appended {
-		c.metrics.emit(time.Since(start), nil)
-		return nil
-	}
 	if err := c.writer.Commit(); err != nil {
 		err = fmt.Errorf("ledger ColdWriter.Commit: %w", err)
 		c.metrics.emit(time.Since(start), err)

--- a/cmd/stellar-rpc/internal/fullhistory/storage/rocksdb/tuning.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/rocksdb/tuning.go
@@ -18,10 +18,12 @@ type CFOptions struct {
 	Compression grocksdb.CompressionType
 
 	// BlockSize overrides the per-CF SST block size in bytes. Zero
-	// means "leave RocksDB's BBTO default (16 KiB)". Small-value CFs
-	// (sparse-key indexes, dense-key offset maps) benefit from
-	// smaller blocks because random Get only needs the block holding
-	// the target key; larger blocks waste I/O per cache miss.
+	// means "leave RocksDB's BBTO default (4 KiB)" — so an explicit
+	// 4-KiB value pins the default rather than changing it.
+	// Small-value CFs (sparse-key indexes, dense-key offset maps)
+	// benefit from smaller blocks because random Get only needs the
+	// block holding the target key; larger blocks waste I/O per
+	// cache miss.
 	BlockSize int
 }
 

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/cold_index.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/cold_index.go
@@ -51,7 +51,7 @@ import (
 // catastrophically.
 //
 // Both cold backfill and the live-chunk freeze build a Bitmaps single-threaded by
-// re-deriving terms from raw LCMs (per-event events.TermsFor + Bitmaps.AddTo) and
+// re-deriving terms from raw LCMs (per-event events.TermsForBytes + Bitmaps.AddTo) and
 // hand it directly here.
 //
 // index.hash is the MPHF serialized via buildMPHF.

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/cold_index.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/cold_index.go
@@ -34,9 +34,9 @@ import (
 // A zero-term bitmaps (an eventless chunk, e.g. a pre-Soroban
 // backfill range) produces the EMPTY index: a zero-length index.hash
 // plus a zero-record index.pack. The cold reader resolves every
-// lookup against it to ErrTermNotFound through the ordinary path, so
-// neither readers nor orchestrators need a pack-without-index special
-// case.
+// LookupKeys entry against it to a nil-bitmap miss through the
+// ordinary path, so neither readers nor orchestrators need a
+// pack-without-index special case.
 //
 // bitmaps is the complete term index for the Chunk, uniquely owned by
 // the caller (no concurrent reader holds a pointer to any of its
@@ -94,9 +94,9 @@ func WriteColdIndex(ctx context.Context, chunkID chunk.ID, bitmaps events.Bitmap
 	// build an MPHF over zero keys, so write the empty index instead —
 	// a zero-length index.hash (the sentinel openMPHF recognizes) plus
 	// a zero-record index.pack. Readers then need no missing-file
-	// special case: every Lookup resolves to ErrTermNotFound through
-	// the ordinary path, and all three cold artifacts always exist for
-	// a finalized chunk.
+	// special case: every LookupKeys entry resolves to a nil-bitmap
+	// miss through the ordinary path, and all three cold artifacts
+	// always exist for a finalized chunk.
 	if n == 0 {
 		return writeEmptyColdIndex(indexPackPath, indexHashPath)
 	}

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/cold_reader.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/cold_reader.go
@@ -6,16 +6,18 @@ package eventstore
 // events.LedgerOffsets app-data block, and serves the events.Reader
 // interface against them.
 //
-// Lifecycle: each ColdReader owns two lazy packfile.Reader
-// instances plus an in-memory parsed MPHF index. Open kicks off the
-// MPHF read in a background goroutine; the packfile.Readers are
-// truly lazy and only touch disk on the first call that needs them.
-// Close drains the MPHF goroutine and releases the packfile handles.
-// Multiple ColdReaders can be open against the same chunk directory
-// concurrently — packfile.Reader is safe for concurrent reads and
-// the MPHF is read-only after load.
+// Lifecycle: each ColdReader owns two packfile.Reader instances
+// plus an in-memory parsed MPHF index. Open returns immediately,
+// but all three I/O units start right away in background
+// goroutines: packfile.Open opens each file (holding its fd) and
+// reads its trailer in the background, and the MPHF read kicks off
+// alongside them. Decoded metadata is awaited on the first call
+// that needs it. Close drains the MPHF goroutine and releases the
+// packfile handles. Multiple ColdReaders can be open against the
+// same chunk directory concurrently — packfile.Reader is safe for
+// concurrent reads and the MPHF is read-only after load.
 //
-// Concurrency contract: read methods (Lookup, LookupKeys,
+// Concurrency contract: read methods (LookupKeys,
 // FetchEvents, All) are safe to call concurrently with each other
 // on the same ColdReader. They are NOT safe to call concurrently
 // with Close — the caller is responsible for draining all in-flight
@@ -27,8 +29,8 @@ package eventstore
 //
 // Close semantics by method:
 //
-//   - Lookup, LookupKeys, FetchEvents, All, EventCount, Offsets:
-//     return / yield ErrClosed after Close.
+//   - LookupKeys, FetchEvents, All, EventCount, Offsets:
+//     return / yield stores.ErrStoreClosed after Close.
 //   - ChunkID: is the constructor-supplied chunk ID; never reads
 //     from disk and is unaffected by Close. Callers can use it for
 //     logging, metrics, or error context after closing the reader.
@@ -53,31 +55,32 @@ import (
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/packfile"
 )
 
 // ColdReader is the read side of a frozen Chunk. Implements
 // events.Reader.
 //
-// Open shape: OpenColdReader does no I/O beyond options validation.
-// packfile.Open is lazy; events.pack metadata (TotalItems + AppData
-// + offsets decode + chunkID cross-check) is loaded on first
-// metadata access via a sync.OnceValues-cached loader. The MPHF
-// kicks off in a background goroutine at Open and is awaited on
-// first Lookup / LookupKeys call via a second sync.OnceValues.
-// This makes opening N chunks for a query non-blocking — each
-// reader returns immediately and the three I/O units fan out
-// concurrently across all opened readers.
+// Open shape: OpenColdReader does no synchronous I/O beyond options
+// validation. packfile.Open starts each file's open + trailer read
+// in a background goroutine immediately; events.pack metadata
+// (TotalItems + AppData + offsets decode + chunkID cross-check) is
+// decoded on first metadata access via a sync.OnceValues-cached
+// loader. The MPHF kicks off in a background goroutine at Open and
+// is awaited on the first LookupKeys call via a second
+// sync.OnceValues. This makes opening N chunks for a query
+// non-blocking — each reader returns immediately and the three I/O
+// units fan out concurrently across all opened readers.
 type ColdReader struct {
 	chunkID chunk.ID
 
-	events *packfile.Reader // lazy — first read drives the actual open
-	index  *packfile.Reader // lazy — first ReadItem drives the actual open
+	events *packfile.Reader // opened in the background by packfile.Open; reads await it
+	index  *packfile.Reader // opened in the background by packfile.Open; reads await it
 
-	// waitMeta returns the events.pack metadata (count + offsets)
-	// loaded on first call from the events.pack trailer + AppData.
-	// Cached via sync.OnceValues; the underlying packfile.Reader
-	// is itself lazy, so the trailer/AppData reads only happen here.
+	// waitMeta returns the events.pack metadata (count + offsets),
+	// decoded on first call from the events.pack trailer + AppData.
+	// Cached via sync.OnceValues.
 	waitMeta func() (coldMeta, error)
 
 	// waitMPHF returns the MPHF loaded by a background goroutine
@@ -111,12 +114,14 @@ type ColdReaderOptions struct {
 }
 
 // OpenColdReader prepares a ColdReader for chunkID inside bucketDir.
-// It does no I/O — packfile.Open is lazy, the events.pack metadata
-// loader is sync.OnceValues-deferred, and the MPHF loader runs in
-// a background goroutine awaited via sync.OnceValues on first
-// Lookup. Validation errors that depend on file contents (chunkID
-// cross-check, format, AppData layout, MPHF parse) surface from
-// the first method that needs the data, not from Open itself.
+// It does no synchronous I/O — packfile.Open starts each file's open
+// in a background goroutine (holding its fd once open), the
+// events.pack metadata decode is sync.OnceValues-deferred, and the
+// MPHF loader runs in a background goroutine awaited via
+// sync.OnceValues on first LookupKeys. Validation errors that depend
+// on file contents (chunkID cross-check, format, AppData layout,
+// MPHF parse) surface from the first method that needs the data, not
+// from Open itself.
 //
 // bucketDir is the orchestrator-supplied bucket directory
 // ({events_root}/{bucketID:05d}/); this reader does not compose it.
@@ -192,9 +197,9 @@ func OpenColdReader(chunkID chunk.ID, bucketDir string, opts ColdReaderOptions) 
 // the MPHF background goroutine before tearing down so an
 // in-flight load doesn't write to a half-closed handle.
 //
-// Must not be called concurrently with Lookup, LookupKeys,
-// FetchEvents, or All on the same ColdReader. See the type-level
-// concurrency contract for the rationale.
+// Must not be called concurrently with LookupKeys, FetchEvents, or
+// All on the same ColdReader. See the type-level concurrency
+// contract for the rationale.
 func (c *ColdReader) Close() error {
 	if c.closed.Swap(true) {
 		return nil
@@ -225,10 +230,10 @@ func (c *ColdReader) ChunkID() chunk.ID { return c.chunkID }
 // EventCount is the total number of events in this Chunk. The
 // underlying value is read from events.pack's trailer on first
 // metadata access (lazy); subsequent calls return the cached
-// value. Returns (0, ErrClosed) after Close.
+// value. Returns (0, stores.ErrStoreClosed) after Close.
 func (c *ColdReader) EventCount() (uint32, error) {
 	if c.closed.Load() {
-		return 0, ErrClosed
+		return 0, stores.ErrStoreClosed
 	}
 	m, err := c.waitMeta()
 	if err != nil {
@@ -242,68 +247,18 @@ func (c *ColdReader) EventCount() (uint32, error) {
 // uses this to stitch a multi-ledger query range into
 // chunk-relative event-id ranges (see Reader.Offsets).
 //
-// Returns (nil, ErrClosed) after Close. Callers must treat the
+// Returns (nil, stores.ErrStoreClosed) after Close. Callers must treat the
 // returned value as read-only — mutations would corrupt every
 // other reader holding the same cached snapshot.
 func (c *ColdReader) Offsets() (*events.LedgerOffsets, error) {
 	if c.closed.Load() {
-		return nil, ErrClosed
+		return nil, stores.ErrStoreClosed
 	}
 	m, err := c.waitMeta()
 	if err != nil {
 		return nil, err
 	}
 	return m.offsets, nil
-}
-
-// Lookup returns the bitmap of event IDs matching key. Returns
-// (nil, ErrTermNotFound) when:
-//
-//   - streamhash's routing-stage check proves key was not in the
-//     build set (fast no-match), OR
-//   - MPHF returns a slot but the index.pack 4-byte fingerprint at
-//     that slot doesn't match key[:4] (residual collision).
-//
-// The returned bitmap is freshly unmarshalled — callers can mutate
-// it freely. ctx is observed before and after the MPHF wait (the
-// wait itself isn't ctx-cancellable; the second check catches a
-// cancel that landed while waiting on the background load).
-func (c *ColdReader) Lookup(ctx context.Context, key events.TermKey) (*roaring.Bitmap, error) {
-	if c.closed.Load() {
-		return nil, ErrClosed
-	}
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-
-	mphf, err := c.waitMPHF()
-	if err != nil {
-		return nil, err
-	}
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-	slot, err := mphf.Lookup(key)
-	if err != nil {
-		if errors.Is(err, ErrKeyNotFound) {
-			return nil, ErrTermNotFound
-		}
-		return nil, fmt.Errorf("events: MPHF lookup for chunk %s: %w", c.chunkID, err)
-	}
-
-	var bm *roaring.Bitmap
-	err = c.index.ReadItem(int(slot), func(record []byte) error {
-		var err error
-		bm, err = verifyAndDeserializeBitmap(record, key, slot)
-		return err
-	})
-	if err != nil {
-		return nil, fmt.Errorf("events: read index.pack slot %d for chunk %s: %w", slot, c.chunkID, err)
-	}
-	if bm == nil {
-		return nil, ErrTermNotFound
-	}
-	return bm, nil
 }
 
 // verifyAndDeserializeBitmap checks the index.pack record's leading
@@ -348,7 +303,7 @@ func verifyAndDeserializeBitmap(record []byte, key events.TermKey, slot uint32) 
 //     match. Misses (fingerprint mismatch) leave result[i] = nil.
 func (c *ColdReader) LookupKeys(ctx context.Context, keys []events.TermKey) ([]*roaring.Bitmap, error) {
 	if c.closed.Load() {
-		return nil, ErrClosed
+		return nil, stores.ErrStoreClosed
 	}
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -434,7 +389,7 @@ func (c *ColdReader) LookupKeys(ctx context.Context, keys []events.TermKey) ([]*
 // idx is unique.
 func (c *ColdReader) FetchEvents(ctx context.Context, eventIDs []uint32) ([]events.Payload, error) {
 	if c.closed.Load() {
-		return nil, ErrClosed
+		return nil, stores.ErrStoreClosed
 	}
 	if len(eventIDs) == 0 {
 		return nil, nil
@@ -488,7 +443,7 @@ func (c *ColdReader) FetchEvents(ctx context.Context, eventIDs []uint32) ([]even
 func (c *ColdReader) FetchRange(ctx context.Context, start, count uint32) iter.Seq2[events.Payload, error] {
 	return func(yield func(events.Payload, error) bool) {
 		if c.closed.Load() {
-			yield(events.Payload{}, ErrClosed)
+			yield(events.Payload{}, stores.ErrStoreClosed)
 			return
 		}
 		if err := ctx.Err(); err != nil {
@@ -537,13 +492,13 @@ func (c *ColdReader) FetchRange(ctx context.Context, start, count uint32) iter.S
 // All streams every event in this Chunk in chunk-relative eventID
 // order. Thin wrapper over FetchRange; its yielded Payloads are
 // likewise borrowed (valid only for the step). The up-front closed
-// check short-circuits to ErrClosed without spinning up the cached
+// check short-circuits to stores.ErrStoreClosed without spinning up the cached
 // waitMeta + descending into FetchRange (which would also detect
 // the closed state, just one indirection later).
 func (c *ColdReader) All(ctx context.Context) iter.Seq2[events.Payload, error] {
 	return func(yield func(events.Payload, error) bool) {
 		if c.closed.Load() {
-			yield(events.Payload{}, ErrClosed)
+			yield(events.Payload{}, stores.ErrStoreClosed)
 			return
 		}
 		m, err := c.waitMeta()

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/cold_reader_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/cold_reader_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores"
 )
 
 // buildColdFixture writes a complete cold artifact set (events.pack
@@ -19,7 +20,7 @@ import (
 //   - writing every payload to events.pack in order,
 //   - feeding the same payload's indexed (contractID + topic0)
 //     fields into a fresh events.Bitmaps (matching what the freezer
-//     would do via events.TermsFor + idx.Add),
+//     would do via events.TermsForBytes + idx.Add),
 //   - finalizing with WriteColdIndex.
 //
 // Layout:
@@ -80,7 +81,7 @@ func buildColdFixture(t *testing.T, chunkID chunk.ID, eventsPerLedger, ledgersPe
 	return dir, payloads
 }
 
-// contractTermKey computes the events.TermKey ColdReader.Lookup expects for
+// contractTermKey computes the events.TermKey ColdReader.LookupKeys expects for
 // the contractID indexed field of p.
 func contractTermKey(p events.Payload) events.TermKey {
 	return events.ComputeTermKey(eventOf(p).ContractId[:], events.FieldContractID)
@@ -119,8 +120,7 @@ func TestColdReader_LookupKnownTerm(t *testing.T) {
 
 	// Every payload's contractID is the same; lookup that term and
 	// expect a bitmap containing every event's ID.
-	bm, err := cr.Lookup(context.Background(), contractTermKey(payloads[0]))
-	require.NoError(t, err)
+	bm := lookupOne(t, cr, contractTermKey(payloads[0]))
 	require.NotNil(t, bm)
 	assert.Equal(t, uint64(len(payloads)), bm.GetCardinality())
 	for i := range payloads {
@@ -130,15 +130,14 @@ func TestColdReader_LookupKnownTerm(t *testing.T) {
 	// Each payload has a unique topic0 (the symbol); each topic
 	// looks up to exactly one event id.
 	for i, p := range payloads {
-		bm, err := cr.Lookup(context.Background(), topic0TermKey(t, p))
-		require.NoError(t, err, "topic0 lookup for payload %d", i)
-		require.NotNil(t, bm)
+		bm := lookupOne(t, cr, topic0TermKey(t, p))
+		require.NotNil(t, bm, "topic0 lookup for payload %d", i)
 		assert.Equal(t, uint64(1), bm.GetCardinality())
 		assert.True(t, bm.Contains(uint32(i)))
 	}
 }
 
-func TestColdReader_LookupUnseenTermReturnsSentinel(t *testing.T) {
+func TestColdReader_LookupUnseenTermReturnsNil(t *testing.T) {
 	const chunkID = chunk.ID(0)
 	dir, _ := buildColdFixture(t, chunkID, 32, 1)
 
@@ -148,26 +147,23 @@ func TestColdReader_LookupUnseenTermReturnsSentinel(t *testing.T) {
 
 	// Drive a batch of synthetic unseen keys. Both miss paths
 	// (streamhash fast-no-match AND fingerprint mismatch) must
-	// surface ErrTermNotFound. We don't care which path each key
-	// takes — only that the union of outcomes is exclusively the
-	// sentinel.
+	// surface a clean miss: a nil bitmap and no error. We don't care
+	// which path each key takes — only that every outcome is nil.
 	for i := range 100 {
 		key := events.ComputeTermKey(
 			fmt.Appendf(nil, "never-added-%d", i),
 			events.FieldTopic1,
 		)
-		bm, err := cr.Lookup(context.Background(), key)
-		assert.Nil(t, bm, "unseen key %d returned a bitmap", i)
-		assert.ErrorIs(t, err, ErrTermNotFound, "unseen key %d", i)
+		assert.Nil(t, lookupOne(t, cr, key), "unseen key %d returned a bitmap", i)
 	}
 }
 
-func TestColdReader_LookupReturnsFreshBitmap(t *testing.T) {
-	// Two Lookups for the same term return independent bitmaps —
-	// mutating one must not affect the other. The interface
-	// contract requires implementations to clone (or freshly
-	// construct); ColdReader unmarshals fresh on every call so
-	// this is trivially satisfied. The test pins the behavior.
+func TestColdReader_LookupKeysReturnsFreshBitmaps(t *testing.T) {
+	// Two LookupKeys calls for the same term return independent
+	// bitmaps — mutating one must not affect the other. The interface
+	// contract says cold-side results are freshly unmarshaled and
+	// logically owned by the caller; this pins that a mutation cannot
+	// bleed into a later lookup.
 	const chunkID = chunk.ID(0)
 	dir, payloads := buildColdFixture(t, chunkID, 8, 1)
 
@@ -176,14 +172,14 @@ func TestColdReader_LookupReturnsFreshBitmap(t *testing.T) {
 	t.Cleanup(func() { _ = cr.Close() })
 
 	key := contractTermKey(payloads[0])
-	first, err := cr.Lookup(context.Background(), key)
-	require.NoError(t, err)
+	first := lookupOne(t, cr, key)
+	require.NotNil(t, first)
 	first.Add(999_999)
 
-	second, err := cr.Lookup(context.Background(), key)
-	require.NoError(t, err)
+	second := lookupOne(t, cr, key)
+	require.NotNil(t, second)
 	assert.False(t, second.Contains(999_999),
-		"a Lookup result mutation must not bleed into the next Lookup")
+		"a LookupKeys result mutation must not bleed into the next lookup")
 }
 
 func TestColdReader_FetchEventsRoundTrip(t *testing.T) {
@@ -277,12 +273,9 @@ func TestColdReader_EventlessChunk(t *testing.T) {
 	require.NoError(t, err)
 	assert.Zero(t, cnt)
 
-	// Term-filtered paths miss through the ordinary path instead of
-	// surfacing a filesystem error.
+	// Term-filtered paths miss cleanly (nil bitmap, no error) instead
+	// of surfacing a filesystem error.
 	someTerm := events.ComputeTermKey([]byte("any"), events.FieldContractID)
-	_, lerr := cr.Lookup(context.Background(), someTerm)
-	require.ErrorIs(t, lerr, ErrTermNotFound)
-
 	bms, err := cr.LookupKeys(context.Background(), []events.TermKey{someTerm})
 	require.NoError(t, err)
 	require.Len(t, bms, 1)
@@ -318,10 +311,9 @@ func TestColdReader_EmptyIndexOverNonEmptyPackErrors(t *testing.T) {
 	require.NoError(t, err, "Open is lazy — the mismatch surfaces at first Lookup")
 	t.Cleanup(func() { _ = cr.Close() })
 
-	_, lerr := cr.Lookup(context.Background(), contractTermKey(payloads[0]))
+	// The mismatch must surface as an error, not a clean miss (nil, no error).
+	_, lerr := cr.LookupKeys(context.Background(), []events.TermKey{contractTermKey(payloads[0])})
 	require.Error(t, lerr)
-	require.NotErrorIs(t, lerr, ErrTermNotFound,
-		"the mismatch must be an error, not a silent no-match")
 	assert.Contains(t, lerr.Error(), "empty-index sentinel")
 }
 
@@ -355,9 +347,9 @@ func TestColdReader_OpenMissingIndexHash(t *testing.T) {
 	require.NoError(t, err, "Open is lazy — files missing should not error at construction")
 	t.Cleanup(func() { _ = cr.Close() })
 
-	// First Lookup awaits the background MPHF load → missing-file error.
-	_, err = cr.Lookup(context.Background(), events.TermKey{})
-	assert.Error(t, err, "missing index.hash must surface from the first Lookup")
+	// First LookupKeys awaits the background MPHF load → missing-file error.
+	_, err = cr.LookupKeys(context.Background(), []events.TermKey{{}})
+	assert.Error(t, err, "missing index.hash must surface from the first LookupKeys")
 }
 
 func TestColdReader_CloseIsIdempotent(t *testing.T) {
@@ -376,20 +368,20 @@ func TestColdReader_PostCloseMethodsError(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, cr.Close())
 
-	_, err = cr.Lookup(context.Background(), contractTermKey(payloads[0]))
-	require.ErrorIs(t, err, ErrClosed)
+	_, err = cr.LookupKeys(context.Background(), []events.TermKey{contractTermKey(payloads[0])})
+	require.ErrorIs(t, err, stores.ErrStoreClosed)
 
 	_, err = cr.FetchEvents(context.Background(), []uint32{0})
-	require.ErrorIs(t, err, ErrClosed)
+	require.ErrorIs(t, err, stores.ErrStoreClosed)
 
-	assert.ErrorIs(t, firstIterError(cr.All(context.Background())), ErrClosed)
+	assert.ErrorIs(t, firstIterError(cr.All(context.Background())), stores.ErrStoreClosed)
 }
 
 // TestColdReader_MetadataErrorsAfterClose pins the post-Close
 // contract for the fallible metadata accessors: EventCount and
-// Offsets return ErrClosed after Close. ChunkID is infallible
-// (it's a constructor parameter, not loaded from the file) so it
-// keeps returning the cached value.
+// Offsets return stores.ErrStoreClosed after Close. ChunkID is
+// infallible (it's a constructor parameter, not loaded from the
+// file) so it keeps returning the cached value.
 func TestColdReader_MetadataErrorsAfterClose(t *testing.T) {
 	const chunkID = chunk.ID(0)
 	dir, _ := buildColdFixture(t, chunkID, 5, 3)
@@ -402,10 +394,10 @@ func TestColdReader_MetadataErrorsAfterClose(t *testing.T) {
 		"ChunkID must keep returning the constructor-supplied value after Close")
 
 	_, err = cr.EventCount()
-	require.ErrorIs(t, err, ErrClosed)
+	require.ErrorIs(t, err, stores.ErrStoreClosed)
 
 	_, err = cr.Offsets()
-	require.ErrorIs(t, err, ErrClosed)
+	require.ErrorIs(t, err, stores.ErrStoreClosed)
 }
 
 func TestColdReader_SatisfiesReaderInterface(t *testing.T) {
@@ -438,16 +430,14 @@ func TestColdReader_MPHFSurvivesIndexHashDeletion(t *testing.T) {
 	// Force the background MPHF load to complete before we delete
 	// the file (otherwise the goroutine's os.ReadFile races our
 	// os.Remove).
-	_, err = cr.Lookup(context.Background(), topic0TermKey(t, payloads[0]))
-	require.NoError(t, err)
+	_ = lookupOne(t, cr, topic0TermKey(t, payloads[0]))
 
 	require.NoError(t, os.Remove(filepath.Join(dir, IndexHashName(chunkID))))
 
 	// Lookup must still find every term — the MPHF lives in memory.
 	for i, p := range payloads {
-		bm, err := cr.Lookup(context.Background(), topic0TermKey(t, p))
-		require.NoError(t, err, "lookup after index.hash deletion (payload %d)", i)
-		require.NotNil(t, bm)
+		bm := lookupOne(t, cr, topic0TermKey(t, p))
+		require.NotNil(t, bm, "lookup after index.hash deletion (payload %d)", i)
 		assert.True(t, bm.Contains(uint32(i)))
 	}
 }
@@ -471,8 +461,7 @@ func TestColdReader_OpenWithConcurrency(t *testing.T) {
 	assert.Equal(t, uint32(len(payloads)), count)
 
 	// Lookup path uses index.pack — exercise it.
-	bm, err := cr.Lookup(context.Background(), contractTermKey(payloads[0]))
-	require.NoError(t, err)
+	bm := lookupOne(t, cr, contractTermKey(payloads[0]))
 	assert.Equal(t, uint64(len(payloads)), bm.GetCardinality())
 
 	// FetchEvents path uses events.pack — exercise it with a
@@ -541,8 +530,8 @@ func TestColdReader_FetchEventsHonorsContext(t *testing.T) {
 
 // TestColdReader_LookupKeys exercises the batched LookupKeys API
 // against a fixture with a mix of hit/miss keys. result[i] must
-// align positionally with keys[i]; misses surface as nil rather
-// than ErrTermNotFound.
+// align positionally with keys[i]; misses surface as a nil bitmap
+// rather than an error.
 func TestColdReader_LookupKeys(t *testing.T) {
 	const chunkID = chunk.ID(0)
 	dir, payloads := buildColdFixture(t, chunkID, 4, 1)
@@ -651,7 +640,7 @@ func TestColdReader_FetchRangePostCloseYieldsErrClosed(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, cr.Close())
 
-	require.ErrorIs(t, firstIterError(cr.FetchRange(context.Background(), 0, 1)), ErrClosed)
+	require.ErrorIs(t, firstIterError(cr.FetchRange(context.Background(), 0, 1)), stores.ErrStoreClosed)
 }
 
 func TestColdReader_AllMatchesFetchRange(t *testing.T) {

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/cold_writer.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/cold_writer.go
@@ -16,19 +16,12 @@ package eventstore
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/packfile"
 )
-
-// ErrWriterClosed is returned by Append and Finish after the
-// ColdWriter has been closed — either by a successful Finish call
-// or by Close. Re-exported from packfile so callers stay within the
-// eventstore facade for errors.Is checks.
-var ErrWriterClosed = packfile.ErrWriterClosed
 
 // ──────────────────────────────────────────────────────────────────
 // ColdWriter — streams a Chunk's events.Payload sequence into events.pack.
@@ -60,8 +53,6 @@ var ErrWriterClosed = packfile.ErrWriterClosed
 // own internal worker pool for compression, but the writer's
 // public API is single-producer.
 type ColdWriter struct {
-	chunkID chunk.ID
-	dir     string
 	pw      *packfile.Writer
 	scratch []byte // reused Marshal buffer for Append; avoids a per-event alloc
 }
@@ -88,7 +79,8 @@ type ColdWriterOptions struct {
 }
 
 // NewColdWriter creates the events.pack for chunkID inside bucketDir.
-// bucketDir is created if it doesn't exist; the filename is
+// bucketDir must already exist — like the sibling stores, directory
+// creation belongs to the ingest layer. The filename is
 // {chunkID:08d}-events.pack per the backfill design doc. The returned
 // ColdWriter must be closed via either Finish (on success) or Close
 // (on abort) — leaving a ColdWriter open leaks the underlying
@@ -99,9 +91,6 @@ type ColdWriterOptions struct {
 // defaults (serial, no writeback) — fine for tests and per-ledger
 // live writes; batch workloads should opt in.
 func NewColdWriter(chunkID chunk.ID, bucketDir string, opts ColdWriterOptions) (*ColdWriter, error) {
-	if err := os.MkdirAll(bucketDir, 0o755); err != nil {
-		return nil, fmt.Errorf("events: mkdir %s: %w", bucketDir, err)
-	}
 	path := filepath.Join(bucketDir, EventsPackName(chunkID))
 	pw, err := packfile.Create(path, packfile.WriterOptions{
 		Format:           eventsPackFormat,
@@ -114,22 +103,15 @@ func NewColdWriter(chunkID chunk.ID, bucketDir string, opts ColdWriterOptions) (
 	if err != nil {
 		return nil, fmt.Errorf("events: create events.pack at %s: %w", path, err)
 	}
-	return &ColdWriter{chunkID: chunkID, dir: bucketDir, pw: pw}, nil
+	return &ColdWriter{pw: pw}, nil
 }
-
-// ChunkID returns the chunk this ColdWriter serves.
-func (w *ColdWriter) ChunkID() chunk.ID { return w.chunkID }
-
-// Dir returns the bucket directory the cold artifacts live in.
-func (w *ColdWriter) Dir() string { return w.dir }
 
 // Append marshals p into the canonical wire format and writes it to
 // events.pack. Callers must drive Appends in chunk-relative eventID
 // order — packfile records this as item position 0, 1, 2, ... and
 // the cold reader reads them back the same way.
 //
-// Returns ErrWriterClosed (== packfile.ErrWriterClosed) if called
-// after Finish or Close.
+// Returns packfile.ErrWriterClosed if called after Finish or Close.
 func (w *ColdWriter) Append(p events.Payload) error {
 	// Marshal into a reusable scratch buffer. AppendItem copies the bytes
 	// into the packfile's record buffer synchronously, so the scratch is
@@ -147,7 +129,7 @@ func (w *ColdWriter) Append(p events.Payload) error {
 // safe to fence with an atomic durability flag.
 //
 // Finish must not be called more than once. A second call (or a
-// call after Close) returns ErrWriterClosed.
+// call after Close) returns packfile.ErrWriterClosed.
 func (w *ColdWriter) Finish(offsets *events.LedgerOffsets) error {
 	appData, err := encodeLedgerOffsets(offsets)
 	if err != nil {

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/cold_writer_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/cold_writer_test.go
@@ -151,10 +151,10 @@ func TestWriter_AppendAfterFinishErrors(t *testing.T) {
 	require.NoError(t, w.Finish(offsets))
 
 	err = w.Append(makeColdPayload(2, 1, "x"))
-	require.ErrorIs(t, err, ErrWriterClosed, "Append after Finish must return ErrWriterClosed")
+	require.ErrorIs(t, err, packfile.ErrWriterClosed, "Append after Finish must return packfile.ErrWriterClosed")
 
 	err = w.Finish(offsets)
-	require.ErrorIs(t, err, ErrWriterClosed, "double Finish must return ErrWriterClosed")
+	require.ErrorIs(t, err, packfile.ErrWriterClosed, "double Finish must return packfile.ErrWriterClosed")
 }
 
 func TestWriter_FailedFinishCleansUpViaClose(t *testing.T) {

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/hot_store.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/hot_store.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/rocksdb"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores"
 )
 
 // Column-family names used inside one chunk's hot RocksDB DB. The
@@ -92,12 +93,12 @@ var ErrLedgerOutOfOrder = errors.New("events: ledger out of order")
 // Concurrency:
 //
 //   - Writes (IngestLedgerToBatch) are single-writer (one goroutine per chunk).
-//   - Reads (Lookup, FetchEvents, All) take NO HotStore-level lock — they guard
+//   - Reads (LookupKeys, FetchEvents, All) take NO HotStore-level lock — they guard
 //     via chunkStore.IsClosed() and rely on the mirror's internal locks and
 //     RocksDB's thread-safety.
 //   - Metadata split after the caller-owned store is closed: ChunkID is
 //     infallible (cached, usable post-close); EventCount and
-//     Offsets return ErrClosed after close (Reader-interface contract).
+//     Offsets return stores.ErrStoreClosed after close (Reader-interface contract).
 type HotStore struct {
 	chunkStore *rocksdb.Store
 	chunkID    chunk.ID
@@ -134,12 +135,12 @@ func (h *HotStore) ChunkID() chunk.ID { return h.chunkID }
 
 // EventCount is the total number of events committed to this Chunk
 // so far. Equal to the next event-id IngestLedgerToBatch would assign.
-// Returns (0, ErrClosed) after the caller-owned store is closed. The Reader interface signature
+// Returns (0, stores.ErrStoreClosed) after the caller-owned store is closed. The Reader interface signature
 // is fallible to accommodate ColdReader's lazy metadata load; on the
-// hot side the value is always live and the error is only ErrClosed.
+// hot side the value is always live and the error is only stores.ErrStoreClosed.
 func (h *HotStore) EventCount() (uint32, error) {
 	if h.chunkStore.IsClosed() {
-		return 0, ErrClosed
+		return 0, stores.ErrStoreClosed
 	}
 	return h.offsets.TotalEvents(), nil
 }
@@ -160,40 +161,12 @@ func (h *HotStore) EventCount() (uint32, error) {
 // with the live backing array. Calling Append on the view would
 // silently fork it from the live data; the contract is read-only.
 //
-// Returns (nil, ErrClosed) after the caller-owned store is closed.
+// Returns (nil, stores.ErrStoreClosed) after the caller-owned store is closed.
 func (h *HotStore) Offsets() (*events.LedgerOffsets, error) {
 	if h.chunkStore.IsClosed() {
-		return nil, ErrClosed
+		return nil, stores.ErrStoreClosed
 	}
 	return h.offsets.View(), nil
-}
-
-// Lookup returns the bitmap of event IDs in this Chunk that match
-// the given term. The returned bitmap is an immutable snapshot of
-// the live mirror — writers publish new pointers via atomic.Store
-// (see ConcurrentBitmaps), so the caller never observes a mutating
-// bitmap. Callers MUST NOT mutate it themselves. See Reader.Lookup
-// and ConcurrentBitmaps.Get for the full contract. Returns
-// (nil, ErrTermNotFound) when the term has no matching events.
-// Returns (nil, ErrClosed) after the caller-owned store is closed.
-//
-// ctx is checked as a fast guard but the hot path does no blocking
-// I/O — the bitmap comes from the in-memory mirror.
-func (h *HotStore) Lookup(ctx context.Context, key events.TermKey) (*roaring.Bitmap, error) {
-	if h.chunkStore.IsClosed() {
-		return nil, ErrClosed
-	}
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-	bm, err := h.mirror.Get(key)
-	if err != nil {
-		return nil, err
-	}
-	if bm == nil {
-		return nil, ErrTermNotFound
-	}
-	return bm, nil
 }
 
 // LookupKeys returns bitmaps for each key, aligned positionally with
@@ -207,7 +180,7 @@ func (h *HotStore) Lookup(ctx context.Context, key events.TermKey) (*roaring.Bit
 // uniformly.
 func (h *HotStore) LookupKeys(ctx context.Context, keys []events.TermKey) ([]*roaring.Bitmap, error) {
 	if h.chunkStore.IsClosed() {
-		return nil, ErrClosed
+		return nil, stores.ErrStoreClosed
 	}
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -241,14 +214,14 @@ func (h *HotStore) LookupKeys(ctx context.Context, keys []events.TermKey) ([]*ro
 // cancellable mid-flight.
 //
 // A missing row is an error: eventIDs only reach this path through
-// Lookup, which only returns IDs the mirror knows about — implying
-// RocksDB also has them. A miss indicates corruption or a
+// LookupKeys, which only returns IDs the mirror knows about —
+// implying RocksDB also has them. A miss indicates corruption or a
 // writer/reader mismatch, not a normal not-found case.
 //
-// After the caller-owned store is closed, returns ErrClosed.
+// After the caller-owned store is closed, returns stores.ErrStoreClosed.
 func (h *HotStore) FetchEvents(ctx context.Context, eventIDs []uint32) ([]events.Payload, error) {
 	if h.chunkStore.IsClosed() {
-		return nil, ErrClosed
+		return nil, stores.ErrStoreClosed
 	}
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -301,7 +274,7 @@ func (h *HotStore) FetchEvents(ctx context.Context, eventIDs []uint32) ([]events
 // Yielded Payloads are borrowed: ContractEventBytes aliases the iteration
 // buffer and is valid only until the next step — clone to retain.
 //
-// After the caller-owned store is closed, yields (zero Payload, ErrClosed) and stops.
+// After the caller-owned store is closed, yields (zero Payload, stores.ErrStoreClosed) and stops.
 // ctx is checked at entry and between iterator steps —
 // rocksdb.Store.IterateRange does not itself accept a ctx, so a
 // very slow Next() can block past a cancellation until the next
@@ -317,7 +290,7 @@ func (h *HotStore) FetchEvents(ctx context.Context, eventIDs []uint32) ([]events
 func (h *HotStore) FetchRange(ctx context.Context, start, count uint32) iter.Seq2[events.Payload, error] {
 	return func(yield func(events.Payload, error) bool) {
 		if h.chunkStore.IsClosed() {
-			yield(events.Payload{}, ErrClosed)
+			yield(events.Payload{}, stores.ErrStoreClosed)
 			return
 		}
 		if err := ctx.Err(); err != nil {
@@ -379,7 +352,7 @@ func (h *HotStore) FetchRange(ctx context.Context, start, count uint32) iter.Seq
 // concurrent ingest between r.All(ctx) returning the Seq2 and the
 // consumer's first range step is included in the snapshot.
 //
-// After the caller-owned store is closed, yields (zero Payload, ErrClosed) and stops.
+// After the caller-owned store is closed, yields (zero Payload, stores.ErrStoreClosed) and stops.
 func (h *HotStore) All(ctx context.Context) iter.Seq2[events.Payload, error] {
 	return func(yield func(events.Payload, error) bool) {
 		// FetchRange stops iterating after yielding an error; we

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/hot_store_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/hot_store_test.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"iter"
 	"path/filepath"
 	"sync"
 	"testing"
 
+	"github.com/RoaringBitmap/roaring/v2"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,6 +21,7 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/rocksdb"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores"
 )
 
 // silentLogger returns a logger whose output is buffered into an
@@ -105,7 +106,7 @@ func makePayload(symbol string) (events.Payload, []events.TermKey) {
 	if err != nil {
 		panic(err) // hardcoded test fixture; an error here is a test bug
 	}
-	keys, err := events.TermsFor(ev)
+	keys, err := events.TermsForBytes(evBytes)
 	if err != nil {
 		panic(err)
 	}
@@ -174,8 +175,7 @@ func TestHotStore_IngestLedgerWritesAllCFs(t *testing.T) {
 	assert.Equal(t, uint32(1), binary.BigEndian.Uint32(offVal))
 
 	// In-memory mirror sees the term.
-	bm, err := h.store.Lookup(context.Background(), keys[0])
-	require.NoError(t, err)
+	bm := lookupOne(t, h.store, keys[0])
 	require.NotNil(t, bm)
 	assert.True(t, bm.Contains(0))
 
@@ -215,12 +215,12 @@ func TestHotStore_EmptyLedgerStillWritesOffsetsAndState(t *testing.T) {
 }
 
 func TestHotStore_LookupReturnsImmutableSnapshot(t *testing.T) {
-	// Pins the dense-mode contract: HotStore.Lookup returns an
-	// immutable snapshot of the live mirror. Writers (IngestLedgerEvents)
+	// Pins the dense-mode contract: HotStore.LookupKeys returns
+	// immutable snapshots of the live mirror. Writers (IngestLedgerEvents)
 	// publish new snapshots via atomic.Pointer COW; the pointer
-	// previously returned by Lookup is never mutated. A subsequent
+	// previously returned by LookupKeys is never mutated. A subsequent
 	// IngestLedgerEvents must NOT affect a previously-returned
-	// bitmap pointer — Lookup callers can safely retain the pointer
+	// bitmap pointer — callers can safely retain the pointer
 	// across writes.
 	const chunkID = chunk.ID(0)
 	h := openHotStoreForTest(t, chunkID)
@@ -232,8 +232,7 @@ func TestHotStore_LookupReturnsImmutableSnapshot(t *testing.T) {
 		require.NoError(t, ingestLedgerEvents(h.store, 2+i, []events.Payload{p}))
 	}
 
-	first, err := h.store.Lookup(context.Background(), keys[0])
-	require.NoError(t, err)
+	first := lookupOne(t, h.store, keys[0])
 	cardBefore := first.GetCardinality()
 
 	// New ingest publishes a new snapshot. The old pointer must
@@ -241,12 +240,11 @@ func TestHotStore_LookupReturnsImmutableSnapshot(t *testing.T) {
 	require.NoError(t, ingestLedgerEvents(h.store, 72, []events.Payload{p}))
 
 	assert.Equal(t, cardBefore, first.GetCardinality(),
-		"prior Lookup result must be an immutable snapshot — later IngestLedgerEvents must not mutate it")
+		"prior LookupKeys result must be an immutable snapshot — later IngestLedgerEvents must not mutate it")
 
-	second, err := h.store.Lookup(context.Background(), keys[0])
-	require.NoError(t, err)
+	second := lookupOne(t, h.store, keys[0])
 	assert.Equal(t, cardBefore+1, second.GetCardinality(),
-		"subsequent Lookup must observe the new snapshot")
+		"subsequent LookupKeys must observe the new snapshot")
 }
 
 func TestHotStore_FetchEventsRoundTrip(t *testing.T) {
@@ -386,12 +384,12 @@ func TestHotStore_CloseRejectsWrites(t *testing.T) {
 	h := openHotStoreForTest(t, 0)
 	require.NoError(t, h.raw.Close())
 	err := ingestLedgerEvents(h.store, 2, nil)
-	assert.ErrorIs(t, err, ErrClosed)
+	assert.ErrorIs(t, err, stores.ErrStoreClosed)
 }
 
 // TestHotStore_PostCloseReadsError pins the contract that read methods
-// fail loudly after Close. Pre-fix: Lookup only touched the in-memory
-// mirror and returned the cached bitmap silently, even after Close had
+// fail loudly after Close. Pre-fix: LookupKeys only touched the in-memory
+// mirror and returned the cached bitmaps silently, even after Close had
 // released chunkStore — the only "this store is gone" signal callers
 // got was when they tried to FetchEvents and hit a closed RocksDB.
 func TestHotStore_PostCloseReadsError(t *testing.T) {
@@ -402,25 +400,25 @@ func TestHotStore_PostCloseReadsError(t *testing.T) {
 	require.NoError(t, ingestLedgerEvents(h.store, chunkID.FirstLedger(), []events.Payload{p}))
 	require.NoError(t, h.raw.Close())
 
-	// Lookup must error rather than silently returning the cached bitmap.
-	bm, err := h.store.Lookup(context.Background(), keys[0])
-	assert.Nil(t, bm)
-	require.ErrorIs(t, err, ErrClosed)
+	// LookupKeys must error rather than silently returning cached bitmaps.
+	bms, err := h.store.LookupKeys(context.Background(), []events.TermKey{keys[0]})
+	assert.Nil(t, bms)
+	require.ErrorIs(t, err, stores.ErrStoreClosed)
 
-	// FetchEvents returns ErrClosed.
+	// FetchEvents returns ErrStoreClosed.
 	_, err = h.store.FetchEvents(context.Background(), []uint32{0})
-	require.ErrorIs(t, err, ErrClosed)
+	require.ErrorIs(t, err, stores.ErrStoreClosed)
 
-	// All iterator yields ErrClosed on first step.
-	require.ErrorIs(t, firstIterError(h.store.All(context.Background())), ErrClosed)
+	// All iterator yields ErrStoreClosed on first step.
+	require.ErrorIs(t, firstIterError(h.store.All(context.Background())), stores.ErrStoreClosed)
 
 	// Post-Close: ChunkID still works (constructor param);
-	// EventCount and Offsets return ErrClosed.
+	// EventCount and Offsets return ErrStoreClosed.
 	assert.Equal(t, chunkID, h.store.ChunkID())
 	_, err = h.store.EventCount()
-	require.ErrorIs(t, err, ErrClosed)
+	require.ErrorIs(t, err, stores.ErrStoreClosed)
 	_, err = h.store.Offsets()
-	require.ErrorIs(t, err, ErrClosed)
+	require.ErrorIs(t, err, stores.ErrStoreClosed)
 }
 
 // TestHotStore_IngestLedgerEvents_DuplicateLedgerErrors pins the sequencing
@@ -459,10 +457,8 @@ func TestHotStore_IngestLedgerEvents_DuplicateLedgerErrors(t *testing.T) {
 	// (hardcoded 0xab), so we check topic0 (index 1), which is symbol-specific.
 	_, secondKeys := makePayload("b")
 	require.GreaterOrEqual(t, len(secondKeys), 2, "test fixture expected to have a topic0 term")
-	bm, lookupErr := h.store.Lookup(context.Background(), secondKeys[1])
-	require.ErrorIs(t, lookupErr, ErrTermNotFound,
+	assert.Nil(t, lookupOne(t, h.store, secondKeys[1]),
 		"the rejected payload's topic0 term must not appear in the mirror")
-	assert.Nil(t, bm)
 }
 
 // TestHotStore_IngestLedgerEvents_RejectsLedgerGap pins the contract
@@ -565,9 +561,9 @@ func TestHotStore_ConcurrentIngestAndLookup(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for range N {
-			// ErrTermNotFound is expected during the race window
-			// where the writer goroutine hasn't ingested yet.
-			if _, err := h.store.Lookup(context.Background(), keys[0]); err != nil && !errors.Is(err, ErrTermNotFound) {
+			// A miss during the race window (writer hasn't ingested
+			// yet) is a nil bitmap, not an error — any error is a bug.
+			if _, err := h.store.LookupKeys(context.Background(), keys[:1]); err != nil {
 				t.Errorf("lookup: %v", err)
 				return
 			}
@@ -599,10 +595,10 @@ func fetchRangePayloads(t *testing.T, r Reader, start, count uint32) ([]events.P
 
 // firstIterError returns the first non-nil error yielded by seq,
 // or nil if the sequence finishes without one. Used by tests that
-// pin "after Close, this iterator yields ErrClosed and stops" —
-// the iterator returns immediately after the error yield, so the
-// helper doesn't walk a long sequence in practice. Shared with
-// cold_reader_test.go.
+// pin "after Close, this iterator yields stores.ErrStoreClosed and
+// stops" — the iterator returns immediately after the error yield,
+// so the helper doesn't walk a long sequence in practice. Shared
+// with cold_reader_test.go.
 func firstIterError(seq iter.Seq2[events.Payload, error]) error {
 	for _, err := range seq {
 		if err != nil {
@@ -610,6 +606,19 @@ func firstIterError(seq iter.Seq2[events.Payload, error]) error {
 		}
 	}
 	return nil
+}
+
+// lookupOne resolves a single term through the batched LookupKeys API
+// and returns its bitmap (nil on a clean miss). Shared by the
+// hot/cold/query tests that assert on one term at a time. It requires
+// LookupKeys to succeed, so closed/corrupt-path tests must call
+// LookupKeys directly and assert on the error.
+func lookupOne(t *testing.T, r Reader, key events.TermKey) *roaring.Bitmap {
+	t.Helper()
+	bms, err := r.LookupKeys(context.Background(), []events.TermKey{key})
+	require.NoError(t, err)
+	require.Len(t, bms, 1)
+	return bms[0]
 }
 
 func TestHotStore_FetchRangeMidRange(t *testing.T) {
@@ -657,7 +666,7 @@ func TestHotStore_FetchRangePostCloseYieldsErrClosed(t *testing.T) {
 	h := openHotStoreForTest(t, chunkID)
 	require.NoError(t, h.raw.Close())
 
-	require.ErrorIs(t, firstIterError(h.store.FetchRange(context.Background(), 0, 1)), ErrClosed)
+	require.ErrorIs(t, firstIterError(h.store.FetchRange(context.Background(), 0, 1)), stores.ErrStoreClosed)
 }
 
 func TestHotStore_AllMatchesFetchRange(t *testing.T) {
@@ -709,7 +718,7 @@ func mustOffsets(t *testing.T, r Reader) *events.LedgerOffsets {
 // write shape, reduced to a test seeding call.
 func ingestLedgerEvents(h *HotStore, ledgerSeq uint32, payloads []events.Payload) error {
 	if h.chunkStore.IsClosed() {
-		return ErrClosed
+		return stores.ErrStoreClosed
 	}
 	var apply func()
 	if err := h.chunkStore.Batch(func(b *rocksdb.BatchWriter) error {

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/hot_warmup_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/hot_warmup_test.go
@@ -33,7 +33,11 @@ func TestWarmup_FreshChunkProducesEmptyMirrorsViaNewWithStore(t *testing.T) {
 func TestWarmup_RebuildsMirrorFromIngestedRows(t *testing.T) {
 	// Ingest into one HotStore, close, reopen; the reopened store's
 	// mirror must hold the same terms (warmup replayed them from
-	// events_index).
+	// events_index). One-directional by design: every seeded term
+	// must survive with the right cardinality, but a phantom extra
+	// term in the reopened mirror would pass unnoticed —
+	// ConcurrentBitmaps deliberately has no term enumeration to
+	// check the other direction with.
 	const chunkID = chunk.ID(0)
 	dir := t.TempDir()
 

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/hot_warmup_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/hot_warmup_test.go
@@ -1,7 +1,6 @@
 package eventstore
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,10 +20,11 @@ func TestWarmup_FreshChunkProducesEmptyMirrorsViaNewWithStore(t *testing.T) {
 	const chunkID = chunk.ID(0)
 	h := openHotStoreForTest(t, chunkID)
 
-	// The mirror is open (ingest can still happen); use Len to
-	// inspect it. ConcurrentBitmaps.Len is RLock-protected and
-	// returns the live count.
-	assert.Equal(t, 0, h.store.mirror.Len())
+	// A fresh mirror is empty: probing any term is a clean miss
+	// (nil bitmap, no error).
+	bm, err := h.store.mirror.Get(events.ComputeTermKey([]byte("any"), events.FieldContractID))
+	require.NoError(t, err)
+	assert.Nil(t, bm)
 	assert.Zero(t, h.store.offsets.LedgerCount())
 	assert.Equal(t, uint32(0), h.store.offsets.TotalEvents())
 	assert.Equal(t, chunkID.FirstLedger(), h.store.offsets.StartLedger())
@@ -42,11 +42,21 @@ func TestWarmup_RebuildsMirrorFromIngestedRows(t *testing.T) {
 	p2, _ := makePayload("beta")
 	require.NoError(t, ingestLedgerEvents(hot1, 2, []events.Payload{p1, p2}))
 
-	// Snapshot the mirror state before close. Snapshot returns a
-	// uniquely-owned Bitmaps the test can iterate freely.
+	// Derive the terms each seeded payload contributes (the same
+	// events.TermsForBytes the ingest path indexed by), then snapshot
+	// their pre-close cardinalities straight from the live mirror.
+	var seededKeys []events.TermKey
+	for _, p := range []events.Payload{p1, p2} {
+		keys, err := events.TermsForBytes(p.ContractEventBytes)
+		require.NoError(t, err)
+		seededKeys = append(seededKeys, keys...)
+	}
 	expected := make(map[events.TermKey]uint64)
-	for term, bm := range hot1.mirror.Snapshot() {
-		expected[term] = bm.GetCardinality()
+	for _, k := range seededKeys {
+		bm, err := hot1.mirror.Get(k)
+		require.NoError(t, err)
+		require.NotNil(t, bm, "seeded term missing from the pre-close mirror")
+		expected[k] = bm.GetCardinality()
 	}
 	require.NoError(t, raw1.Close())
 
@@ -54,8 +64,11 @@ func TestWarmup_RebuildsMirrorFromIngestedRows(t *testing.T) {
 	hot2, _ := openHotStoreForTestAt(t, dir, chunkID)
 
 	got := make(map[events.TermKey]uint64)
-	for term, bm := range hot2.mirror.Snapshot() {
-		got[term] = bm.GetCardinality()
+	for k := range expected {
+		bm, err := hot2.mirror.Get(k)
+		require.NoError(t, err)
+		require.NotNil(t, bm, "seeded term missing from the reopened mirror")
+		got[k] = bm.GetCardinality()
 	}
 	assert.Equal(t, expected, got)
 }
@@ -74,8 +87,7 @@ func TestWarmup_RestoresEventIDsForRepeatedTerm(t *testing.T) {
 	hot2, _ := openHotStoreForTestAt(t, dir, chunkID)
 
 	contractTermKey := events.ComputeTermKey(eventOf(p1).ContractId[:], events.FieldContractID)
-	bm, err := hot2.Lookup(context.Background(), contractTermKey)
-	require.NoError(t, err)
+	bm := lookupOne(t, hot2, contractTermKey)
 	require.NotNil(t, bm)
 	assert.Equal(t, uint64(3), bm.GetCardinality())
 	for id := range uint32(3) {

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/query.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/query.go
@@ -44,7 +44,7 @@ import (
 // event. nil or empty slices are wildcards.
 //
 // Topics[i] constrains topic position i. Positions beyond
-// protocol.MaxTopicCount are not indexed (see events.TermsFor).
+// protocol.MaxTopicCount are not indexed (see events.TermsForBytes).
 type Filter struct {
 	ContractID []byte
 	Topics     [protocol.MaxTopicCount][]byte

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/query_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/query_test.go
@@ -259,8 +259,7 @@ func TestQuery_DoesNotMutateMirrorBitmaps(t *testing.T) {
 	fx := newQueryFixture(t)
 	// Snapshot the mirror's bitmap for topic0=alpha before any query.
 	key := events.ComputeTermKey(fx.t0aRaw, events.FieldTopic0)
-	before, err := fx.store.Lookup(context.Background(), key)
-	require.NoError(t, err)
+	before := lookupOne(t, fx.store, key)
 	beforeCard := before.GetCardinality()
 
 	// Run several queries that all touch the topic0=alpha term.
@@ -272,8 +271,7 @@ func TestQuery_DoesNotMutateMirrorBitmaps(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	after, err := fx.store.Lookup(context.Background(), key)
-	require.NoError(t, err)
+	after := lookupOne(t, fx.store, key)
 	assert.Equal(t, beforeCard, after.GetCardinality(),
 		"Query must not mutate the mirror's bitmaps")
 }
@@ -536,8 +534,7 @@ func TestQuery_PostFilterRejectsTermHashCollision(t *testing.T) {
 	// topic1=gamma). Inject id=4 (evt-a-b — topic0=beta only,
 	// no topic1) into the same bitmap to simulate a collision.
 	gammaKey := events.ComputeTermKey(fx.t0cRaw, events.FieldTopic1)
-	before, err := fx.store.Lookup(context.Background(), gammaKey)
-	require.NoError(t, err)
+	before := lookupOne(t, fx.store, gammaKey)
 	require.True(t, before.Contains(1), "fixture sanity: id=1 indexes topic1=gamma")
 	require.False(t, before.Contains(4), "fixture sanity: id=4 not yet in topic1=gamma bitmap")
 
@@ -546,8 +543,7 @@ func TestQuery_PostFilterRejectsTermHashCollision(t *testing.T) {
 	// in this test, so the single-writer contract is satisfied.
 	fx.store.index().AddTo(gammaKey, 4)
 
-	after, err := fx.store.Lookup(context.Background(), gammaKey)
-	require.NoError(t, err)
+	after := lookupOne(t, fx.store, gammaKey)
 	require.True(t, after.Contains(4), "fixture sanity: collision id=4 is now in the bitmap")
 
 	// Query with the colliding term: only id=1 should survive the
@@ -578,12 +574,10 @@ func TestQuery_MixedSuccessFilterList(t *testing.T) {
 	missingTopic := xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &missingSym}
 	missingRaw, err := missingTopic.MarshalBinary()
 	require.NoError(t, err)
-	// Sanity check: this term really isn't in the index. The
-	// LookupKeys path (which Query uses) signals miss with a nil
-	// slot; the single-key Lookup surfaces ErrTermNotFound.
+	// Sanity check: this term really isn't in the index. LookupKeys
+	// (which Query uses) signals the miss with a nil slot.
 	missingKey := events.ComputeTermKey(missingRaw, events.FieldTopic0)
-	_, err = fx.store.Lookup(context.Background(), missingKey)
-	require.ErrorIs(t, err, ErrTermNotFound,
+	require.Nil(t, lookupOne(t, fx.store, missingKey),
 		"fixture sanity: 'nonexistent' must not be indexed")
 
 	got, err := Query(context.Background(), fx.store, []Filter{

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/reader.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/reader.go
@@ -12,23 +12,11 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
 )
 
-// ErrTermNotFound is the canonical "this term has no matching events
-// in this Chunk" sentinel returned by all Reader implementations.
-// Callers use errors.Is(err, ErrTermNotFound) to distinguish a clean
-// no-match from real errors (closed store, decode failure, etc.).
-//
-// HotStore returns this when the in-memory mirror has no entry for
-// the key. ColdReader returns this when streamhash fast-no-matches
-// the key OR when the index.pack fingerprint mismatches the key
-// (a residual MPHF collision).
-var ErrTermNotFound = errors.New("events: term not found in chunk")
-
-// ErrClosed is the canonical "this reader/store has been closed"
-// sentinel for the package. Returned by HotStore and ColdReader
-// read methods (Lookup, LookupKeys, FetchEvents, All, EventCount,
-// Offsets) after Close. ChunkID is the one exception — it returns
+// Closed-store lifecycle: HotStore and ColdReader read methods
+// (LookupKeys, FetchEvents, All, EventCount, Offsets) return
+// stores.ErrStoreClosed after Close, per the storage/stores
+// translation contract. ChunkID is the one exception — it returns
 // its constructor-supplied value unchanged after Close.
-var ErrClosed = errors.New("events: store is closed")
 
 // ErrUnsortedEventIDs is returned by FetchEvents when the supplied
 // eventIDs slice violates the sorted-ascending-no-duplicates
@@ -71,7 +59,7 @@ type Reader interface {
 
 	// EventCount is the total number of events in this Chunk.
 	// Equal to the last events.LedgerOffsets cumulative count.
-	// Returns (0, ErrClosed) after Close. On ColdReader, the value
+	// Returns (0, stores.ErrStoreClosed) after Close. On ColdReader, the value
 	// is read lazily from events.pack's trailer on first call.
 	EventCount() (uint32, error)
 
@@ -82,59 +70,46 @@ type Reader interface {
 	// ranges before fetching events.
 	//
 	// Implementations:
-	//   - HotStore allocates a fresh Snapshot from the live
-	//     ConcurrentLedgerOffsets per call. A concurrent
-	//     IngestLedgerToBatch may extend the underlying state after
-	//     Offsets returns, but the returned snapshot reflects what
-	//     was visible at call time. Callers (Query) take the
-	//     snapshot once at entry and pass it through their helpers.
+	//   - HotStore returns a View sharing the live
+	//     ConcurrentLedgerOffsets backing array, capped to the count
+	//     visible at call time. A concurrent ingest may extend the
+	//     underlying state after Offsets returns, but the returned
+	//     view reflects what was visible at call time. Callers
+	//     (Query) take the view once at entry and pass it through
+	//     their helpers.
 	//   - ColdReader returns the lazily-decoded LedgerOffsets cached
 	//     on the reader; the same pointer is returned to every
 	//     caller. Both paths must treat the returned value as
 	//     read-only — mutation would corrupt either the live mirror
-	//     (hot, indirectly via the snapshot's backing slice) or
-	//     every other reader holding the cached pointer (cold).
+	//     (hot, indirectly via the view's backing slice) or every
+	//     other reader holding the cached pointer (cold).
 	//
-	// Returns (nil, ErrClosed) after Close.
+	// Returns (nil, stores.ErrStoreClosed) after Close.
 	Offsets() (*events.LedgerOffsets, error)
-
-	// Lookup returns the bitmap of event IDs in this Chunk that
-	// match the given term.
-	//
-	// Bitmap ownership: callers MUST treat the returned bitmap as
-	// read-only. The hot path returns an immutable snapshot of the
-	// live mirror — ConcurrentBitmaps stores bitmap pointers via
-	// atomic.Pointer COW, so the returned pointer will never be
-	// mutated by anyone. The cold path returns a freshly-unmarshaled
-	// bitmap that's logically owned by the caller. Either way callers
-	// must not mutate; eventstore.Query is the only consumer today
-	// and never mutates, and downstream roaring.FastAnd/FastOr never
-	// mutate inputs.
-	//
-	// Returns (nil, ErrTermNotFound) when the term has no matching
-	// events. Other errors signal corruption or internal failure.
-	//
-	// ctx cancels in-flight I/O on the cold path (MPHF load,
-	// index.pack ReadAt); hot side checks ctx as a fast guard before
-	// touching the in-memory mirror.
-	Lookup(ctx context.Context, key events.TermKey) (*roaring.Bitmap, error)
 
 	// LookupKeys returns bitmaps for each key, aligned positionally
 	// with the input slice (result[i] corresponds to keys[i]).
 	// result[i] is nil if keys[i] has no matching events in this
-	// chunk — the function does not return ErrTermNotFound for
-	// individual misses.
+	// chunk — a per-key miss is not an error.
 	//
-	// Equivalent to calling Lookup for each key (and treating
-	// ErrTermNotFound as a nil result), but ColdReader coalesces
-	// the underlying packfile reads into a single ReadItems pass,
-	// fanning out across the worker count configured via
-	// ColdReaderOptions.Concurrency. HotStore returns borrowed
-	// mirror references with no per-key Clone (see Lookup).
+	// ColdReader coalesces the underlying packfile reads into a
+	// single ReadItems pass, fanning out across the worker count
+	// configured via ColdReaderOptions.Concurrency. HotStore returns
+	// borrowed mirror references with no per-key Clone.
 	//
-	// Bitmap ownership: same as Lookup — caller must not mutate.
+	// Bitmap ownership: callers MUST treat returned bitmaps as
+	// read-only. The hot path returns immutable snapshots of the
+	// live mirror — ConcurrentBitmaps stores bitmap pointers via
+	// atomic.Pointer COW, so a returned pointer will never be
+	// mutated by anyone. The cold path returns freshly-unmarshaled
+	// bitmaps logically owned by the caller. Either way callers
+	// must not mutate; eventstore.Query is the only consumer today
+	// and never mutates, and downstream roaring.FastAnd/FastOr never
+	// mutate inputs.
 	//
-	// ctx cancels in-flight I/O on the cold path.
+	// ctx cancels in-flight I/O on the cold path (MPHF load,
+	// index.pack ReadAt); hot side checks ctx as a fast guard before
+	// touching the in-memory mirror.
 	LookupKeys(ctx context.Context, keys []events.TermKey) ([]*roaring.Bitmap, error)
 
 	// FetchEvents decodes events for the supplied chunk-relative
@@ -151,7 +126,7 @@ type Reader interface {
 	// scattered-read batches, the hot path checks between Gets.
 	//
 	// A missing row is an error: eventIDs only reach this path
-	// through Lookup, so a miss signals corruption or a
+	// through LookupKeys, so a miss signals corruption or a
 	// writer/reader mismatch, not a normal not-found case.
 	FetchEvents(ctx context.Context, eventIDs []uint32) ([]events.Payload, error)
 
@@ -168,7 +143,7 @@ type Reader interface {
 	// and may be sparse.
 	//
 	// ctx cancels in-flight I/O on both paths. Yielding
-	// (events.Payload{}, ErrClosed) and stopping is the after-Close
+	// (events.Payload{}, stores.ErrStoreClosed) and stopping is the after-Close
 	// behavior, mirroring All.
 	//
 	// Out-of-range arguments (start >= EventCount, or start+count >
@@ -177,9 +152,9 @@ type Reader interface {
 	FetchRange(ctx context.Context, start, count uint32) iter.Seq2[events.Payload, error]
 
 	// All streams every event in this Chunk in chunk-relative
-	// eventID order. The freeze loop uses this to dump a hot Chunk
-	// into a Writer without intermediate buffering. Equivalent to
-	// FetchRange(ctx, 0, EventCount).
+	// eventID order without intermediate buffering. Equivalent to
+	// FetchRange(ctx, 0, EventCount). (The freeze path does NOT use
+	// this — it re-derives cold artifacts from raw LCMs.)
 	// Each events.Payload carries its LedgerSequence, so consumers can
 	// track ledger boundaries without separate signaling.
 	All(ctx context.Context) iter.Seq2[events.Payload, error]

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk/hotchunk_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk/hotchunk_test.go
@@ -114,10 +114,10 @@ func TestIngestLedger_AllCFsAdvanceTogether(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, first+1, seqB)
 	// events CFs.
-	bm, err := db.Events().Lookup(context.Background(), termA)
+	bms, err := db.Events().LookupKeys(context.Background(), []events.TermKey{termA})
 	require.NoError(t, err)
-	require.NotNil(t, bm)
-	assert.Equal(t, uint64(2), bm.GetCardinality(), "both ledgers share the event term")
+	require.NotNil(t, bms[0])
+	assert.Equal(t, uint64(2), bms[0].GetCardinality(), "both ledgers share the event term")
 	assert.Equal(t, uint32(2), eventCount(t, db.Events()))
 
 	// The single authoritative committed frontier equals the last committed seq.
@@ -153,9 +153,10 @@ func TestIngestLedger_RejectedLedgerPersistsNothingAcrossAnyCF(t *testing.T) {
 	// txhash CFs — the hash is absent.
 	_, gerr = db.Txhash().Get(hash)
 	require.ErrorIs(t, gerr, stores.ErrNotFound)
-	// events CFs — no term indexed, no event committed.
-	_, lerr := db.Events().Lookup(context.Background(), term)
-	require.ErrorIs(t, lerr, eventstore.ErrTermNotFound)
+	// events CFs — no term indexed, no event committed (clean miss = nil bitmap).
+	bms, lerr := db.Events().LookupKeys(context.Background(), []events.TermKey{term})
+	require.NoError(t, lerr)
+	require.Nil(t, bms[0])
 	assert.Equal(t, uint32(0), eventCount(t, db.Events()))
 
 	// The single committed frontier is still empty — nothing committed.
@@ -333,10 +334,10 @@ func TestIngestLedger_WritesEveryHotType(t *testing.T) {
 	seq, err := db.Txhash().Get(hash)
 	require.NoError(t, err)
 	assert.Equal(t, first, seq)
-	bm, err := db.Events().Lookup(context.Background(), term)
+	bms, err := db.Events().LookupKeys(context.Background(), []events.TermKey{term})
 	require.NoError(t, err)
-	require.NotNil(t, bm)
-	assert.Equal(t, uint64(1), bm.GetCardinality())
+	require.NotNil(t, bms[0])
+	assert.Equal(t, uint64(1), bms[0].GetCardinality())
 }
 
 // TestIngestLedger_EventlessTxStillIndexesHash pins the post-merge txhash

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/ledger/cold_reader.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/ledger/cold_reader.go
@@ -35,7 +35,7 @@ var coldPackDecoder = zstd.NewDecompressor()
 // returns no error. packfile.Open begins the open in a background
 // goroutine immediately; the trailer + AppData are read and validated
 // on the first method call, via a sync.OnceValues-cached loadHeader,
-// where a failed open also surfaces. Read methods (FirstSeq, LastSeq,
+// where a failed open also surfaces. Read methods (LastSeq,
 // GetLedgerRaw, IterateLedgers) are safe for concurrent use; Close
 // is NOT — callers must ensure all in-flight reads have returned
 // before invoking it, matching the underlying packfile.Reader.Close
@@ -102,8 +102,7 @@ func (c *ColdReader) loadHeader() (coldHeader, error) {
 	return coldHeader{firstSeq: first, lastSeq: first + tr.TotalItems - 1}, nil
 }
 
-func (c *ColdReader) FirstSeq() (uint32, error) { h, err := c.init(); return h.firstSeq, err }
-func (c *ColdReader) LastSeq() (uint32, error)  { h, err := c.init(); return h.lastSeq, err }
+func (c *ColdReader) LastSeq() (uint32, error) { h, err := c.init(); return h.lastSeq, err }
 
 // GetLedgerRaw reads the raw LedgerCloseMeta bytes for seq into a fresh,
 // caller-owned buffer. Sequential bulk readers should prefer IterateLedgers,
@@ -133,11 +132,11 @@ func (c *ColdReader) GetLedgerRaw(seq uint32) ([]byte, error) {
 
 // IterateLedgers walks (seq, raw bytes) pairs in [start, end] inclusive,
 // ascending. The requested range must be fully contained within the
-// store's coverage [FirstSeq, LastSeq]; any out-of-range portion — or
+// store's coverage [firstSeq, lastSeq]; any out-of-range portion — or
 // an invalid start > end — is reported as stores.ErrOutOfRange on the
 // first yield (no entries are produced). Callers that span chunk
-// boundaries should clip explicitly against FirstSeq/LastSeq before
-// calling.
+// boundaries should clip explicitly against the store's coverage
+// (the chunk's ledger window, or LastSeq) before calling.
 func (c *ColdReader) IterateLedgers(start, end uint32) iter.Seq2[Entry, error] {
 	return func(yield func(Entry, error) bool) {
 		h, err := c.init()

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/ledger/cold_reader_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/ledger/cold_reader_test.go
@@ -39,9 +39,6 @@ func TestColdReader_RoundTripVariousSizes(t *testing.T) {
 			path, raws := writeFixturePack(t, firstSeq, n)
 			c := newTestColdReader(t, path)
 
-			first, err := c.FirstSeq()
-			require.NoError(t, err)
-			assert.Equal(t, firstSeq, first)
 			last, err := c.LastSeq()
 			require.NoError(t, err)
 			assert.Equal(t, firstSeq+uint32(n)-1, last)
@@ -171,7 +168,7 @@ func TestColdReader_LazyOpen(t *testing.T) {
 	require.NoError(t, err, "OpenColdReader must not do I/O")
 	t.Cleanup(func() { _ = c.Close() })
 
-	_, err = c.FirstSeq()
+	_, err = c.LastSeq()
 	require.Error(t, err)
 }
 
@@ -189,7 +186,7 @@ func TestColdReader_RejectsWrongAppDataSize(t *testing.T) {
 	c, err := OpenColdReader(path)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = c.Close() })
-	_, err = c.FirstSeq()
+	_, err = c.LastSeq()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "AppData")
 }
@@ -207,7 +204,7 @@ func TestColdReader_RejectsWrongFormat(t *testing.T) {
 	c, err := OpenColdReader(path)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = c.Close() })
-	_, err = c.FirstSeq()
+	_, err = c.LastSeq()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "format")
 }
@@ -242,7 +239,7 @@ func TestColdReader_LastSeqOverflowRejected(t *testing.T) {
 	c, err := OpenColdReader(path)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = c.Close() })
-	_, err = c.FirstSeq()
+	_, err = c.LastSeq()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "overflows")
 }

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/ledger/cold_writer_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/ledger/cold_writer_test.go
@@ -59,9 +59,9 @@ func TestColdWriter_AppendRejectsGapAndKeepsCounter(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = c.Close() })
 
-	first, err := c.FirstSeq()
+	got, err := c.GetLedgerRaw(100)
 	require.NoError(t, err)
-	assert.Equal(t, uint32(100), first)
+	assert.Equal(t, []byte("a"), got)
 	last, err := c.LastSeq()
 	require.NoError(t, err)
 	assert.Equal(t, uint32(101), last)
@@ -139,9 +139,6 @@ func TestNewColdWriter_TruncatesPreexistingFile(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = c.Close() })
 
-	first, err := c.FirstSeq()
-	require.NoError(t, err)
-	assert.Equal(t, uint32(999), first)
 	last, err := c.LastSeq()
 	require.NoError(t, err)
 	assert.Equal(t, uint32(999), last)

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/cold_bin.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/cold_bin.go
@@ -2,10 +2,11 @@ package txhash
 
 // cold_bin.go owns the on-disk format of the RAW cold txhash chunk: the
 // sorted per-chunk `<chunkID:08d>.bin` file the cold ingester publishes and
-// the deferred streamhash index builder consumes. Keeping the writer, the
-// reader, and the filename helper next to each other in this package gives
-// the format a single owner — producer (ingest) and consumer (index build)
-// import a compile-time-linked codec instead of byte-matching a convention.
+// the deferred streamhash index builder consumes. Keeping the writer and
+// the filename helper next to the index builder's pre-scan in this package
+// gives the format a single owner — producer (ingest) and consumer (index
+// build) import a compile-time-linked codec instead of byte-matching a
+// convention.
 //
 // File layout:
 //
@@ -13,14 +14,16 @@ package txhash
 //	entry   ColdKeySize B  txhash[:ColdKeySize]
 //	        uint32 LE      absolute ledger seq
 //
-// Entries are lex-sorted by key (non-decreasing; duplicate truncated keys
-// are possible and preserved).
+// Entries are lex-sorted by key. Duplicate truncated keys are written
+// verbatim, but the downstream streamhash build fails on them — with
+// 16-byte truncated hashes a collision is astronomically unlikely, and
+// if one ever occurs the index build rejects it loudly rather than
+// serving an ambiguous key.
 
 import (
 	"bufio"
 	"encoding/binary"
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/stellar/streamhash"
@@ -62,8 +65,8 @@ func ColdBinName(chunkID chunk.ID) string {
 // orchestrator's completion record — written only after WriteColdBin returns —
 // is the sole authority on whether the artifact exists, so a partial file
 // from a failed or crashed attempt is inert scratch the retry overwrites
-// (and ReadColdBin's header-vs-size check rejects loudly if one is ever
-// opened).
+// (and scanBinHeader's header-vs-size check rejects loudly if one is
+// ever opened).
 //
 // entries must already be sorted (lex by Key, non-decreasing); this function
 // writes them verbatim.
@@ -119,8 +122,7 @@ func WriteColdBin(path string, entries []ColdEntry) error {
 // the untrusted count, so a corrupt header can't overflow the arithmetic
 // (coldBinEntrySize·2^62 ≡ 0 mod 2^64 would slip a wildly wrong count past a
 // naive `size == header + count*entry` check and hand it to the index builder
-// as an allocation). Both the raw reader (ReadColdBin) and the index builder's
-// pre-scan (scanBinHeader) gate on it.
+// as an allocation). The index builder's pre-scan (scanBinHeader) gates on it.
 func coldBinCount(path string, size int64, count uint64) (uint64, error) {
 	body := size - coldBinHeaderSize
 	if body < 0 || body%coldBinEntrySize != 0 {
@@ -132,41 +134,4 @@ func coldBinCount(path string, size int64, count uint64) (uint64, error) {
 			path, count, size, want)
 	}
 	return count, nil
-}
-
-// ReadColdBin reads back a .bin file written by WriteColdBin, verifying the
-// header count against the file size. The index-build step iterates these
-// entries; tests use it to assert the writer's on-disk contract.
-func ReadColdBin(path string) ([]ColdEntry, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("txhash: open %s: %w", path, err)
-	}
-	defer func() { _ = f.Close() }()
-
-	br := bufio.NewReaderSize(f, 1<<20)
-	var header [coldBinHeaderSize]byte
-	if _, err := io.ReadFull(br, header[:]); err != nil {
-		return nil, fmt.Errorf("txhash: read header of %s: %w", path, err)
-	}
-	count := binary.LittleEndian.Uint64(header[:])
-
-	info, err := f.Stat()
-	if err != nil {
-		return nil, fmt.Errorf("txhash: stat %s: %w", path, err)
-	}
-	if _, err := coldBinCount(path, info.Size(), count); err != nil {
-		return nil, err
-	}
-
-	entries := make([]ColdEntry, count)
-	var entryBuf [coldBinEntrySize]byte
-	for i := range entries {
-		if _, err := io.ReadFull(br, entryBuf[:]); err != nil {
-			return nil, fmt.Errorf("txhash: read entry %d of %s: %w", i, path, err)
-		}
-		copy(entries[i].Key[:], entryBuf[:ColdKeySize])
-		entries[i].Seq = binary.LittleEndian.Uint32(entryBuf[ColdKeySize:])
-	}
-	return entries, nil
 }

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/cold_bin_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/cold_bin_test.go
@@ -1,7 +1,10 @@
 package txhash
 
 import (
+	"bufio"
 	"encoding/binary"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,6 +14,45 @@ import (
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
 )
+
+// readColdBin reads back a cold .bin file, validating its header count against
+// the file size via the shared coldBinCount. It is the test-side mirror of the
+// .bin codec: production consumes .bin files through the index builder's
+// streaming pre-scan, never a full read-back, so this read path lives only in
+// the tests that pin the writer's output.
+func readColdBin(path string) ([]ColdEntry, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("txhash: open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	br := bufio.NewReaderSize(f, 1<<20)
+	var header [coldBinHeaderSize]byte
+	if _, err := io.ReadFull(br, header[:]); err != nil {
+		return nil, fmt.Errorf("txhash: read header of %s: %w", path, err)
+	}
+	count := binary.LittleEndian.Uint64(header[:])
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("txhash: stat %s: %w", path, err)
+	}
+	if _, err := coldBinCount(path, info.Size(), count); err != nil {
+		return nil, err
+	}
+
+	entries := make([]ColdEntry, count)
+	var entryBuf [coldBinEntrySize]byte
+	for i := range entries {
+		if _, err := io.ReadFull(br, entryBuf[:]); err != nil {
+			return nil, fmt.Errorf("txhash: read entry %d of %s: %w", i, path, err)
+		}
+		copy(entries[i].Key[:], entryBuf[:ColdKeySize])
+		entries[i].Seq = binary.LittleEndian.Uint32(entryBuf[ColdKeySize:])
+	}
+	return entries, nil
+}
 
 // TestColdBin_RoundTrip writes entries and reads them back through the
 // matching reader, pinning the writer/reader codec to each other.
@@ -24,7 +66,7 @@ func TestColdBin_RoundTrip(t *testing.T) {
 	}
 	require.NoError(t, WriteColdBin(path, entries))
 
-	got, err := ReadColdBin(path)
+	got, err := readColdBin(path)
 	require.NoError(t, err)
 	assert.Equal(t, entries, got)
 }
@@ -81,7 +123,7 @@ func TestColdBin_OverwritesPriorAttempt(t *testing.T) {
 	entries := []ColdEntry{{Key: [ColdKeySize]byte{0x03}, Seq: 21}}
 	require.NoError(t, WriteColdBin(path, entries))
 
-	got, err := ReadColdBin(path)
+	got, err := readColdBin(path)
 	require.NoError(t, err)
 	assert.Equal(t, entries, got)
 }
@@ -99,6 +141,6 @@ func TestColdBin_ReadRejectsTruncated(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(path, data[:len(data)-4], 0o644)) // tear the tail off
 
-	_, err = ReadColdBin(path)
+	_, err = readColdBin(path)
 	require.Error(t, err)
 }

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/cold_format.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/cold_format.go
@@ -13,8 +13,6 @@ import (
 	"fmt"
 
 	"github.com/stellar/streamhash"
-
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
 )
 
 // DefaultChunksPerIndex is the default number of chunks per cold txhash index.
@@ -38,21 +36,6 @@ const coldMetadataSize = 8
 // ErrInvalidMetadata is returned when a cold index's metadata is not a valid
 // [MinLedger, MaxLedger] blob.
 var ErrInvalidMetadata = errors.New("txhash: cold index user metadata malformed")
-
-// IndexBaseChunk returns the first chunk ID of the group of chunksPerIndex
-// chunks that contains c. Panics if chunksPerIndex is 0.
-func IndexBaseChunk(c chunk.ID, chunksPerIndex uint32) chunk.ID {
-	if chunksPerIndex == 0 {
-		panic("txhash: IndexBaseChunk called with chunksPerIndex 0")
-	}
-	return chunk.ID(uint32(c) / chunksPerIndex * chunksPerIndex)
-}
-
-// IndexFileName returns the filename for the cold txhash index whose group
-// begins at baseChunk.
-func IndexFileName(baseChunk chunk.ID) string {
-	return baseChunk.String() + "-txhash.idx"
-}
 
 // EncodeLedgerRange packs [minLedger, maxLedger] into the metadata blob.
 func EncodeLedgerRange(minLedger, maxLedger uint32) []byte {

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/cold_format_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/cold_format_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stellar/streamhash"
 
-	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores"
 )
 
@@ -34,35 +33,6 @@ func TestParseLedgerRange_WrongSizeErrors(t *testing.T) {
 func TestParseLedgerRange_MaxBelowMinErrors(t *testing.T) {
 	_, _, err := ParseLedgerRange(EncodeLedgerRange(100, 99))
 	assert.ErrorIs(t, err, ErrInvalidMetadata)
-}
-
-func TestIndexBaseChunk(t *testing.T) {
-	const cpi = 1000
-	cases := []struct {
-		in   chunk.ID
-		want chunk.ID
-	}{
-		{0, 0},
-		{1, 0},
-		{999, 0},
-		{1000, 1000},
-		{1500, 1000},
-		{2000, 2000},
-	}
-	for _, tc := range cases {
-		assert.Equalf(t, tc.want, IndexBaseChunk(tc.in, cpi),
-			"IndexBaseChunk(%d, %d)", tc.in, cpi)
-	}
-}
-
-func TestIndexBaseChunk_ZeroPanics(t *testing.T) {
-	assert.Panics(t, func() { IndexBaseChunk(5, 0) },
-		"a zero group size must panic loudly, not divide-by-zero")
-}
-
-func TestIndexFileName(t *testing.T) {
-	assert.Equal(t, "00000000-txhash.idx", IndexFileName(0))
-	assert.Equal(t, "00001000-txhash.idx", IndexFileName(1000))
 }
 
 func TestColdReader_UnseenKeyReturnsNotFound(t *testing.T) {

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/cold_index.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/cold_index.go
@@ -135,7 +135,7 @@ func scanAndValidate(inputs []string) (uint64, error) {
 
 // scanBinHeader opens path, reads its declared entry count, and verifies its
 // byte size matches that count via coldBinCount (the shared, overflow-safe
-// header check ReadColdBin also uses).
+// header check).
 func scanBinHeader(path string) (uint64, error) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/cold_index_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/cold_index_test.go
@@ -62,6 +62,11 @@ const (
 	fixtureSpreadChunks = 6
 )
 
+// indexFileName names a scratch cold-index file for baseChunk. The on-disk
+// layout is geometry.Layout.TxHashIndexFilePath; tests only need a stable name
+// in their own TempDir, so this reuses chunk.ID's zero-padded String().
+func indexFileName(baseChunk chunk.ID) string { return baseChunk.String() + "-txhash.idx" }
+
 // fixtureMinLedger is the MinLedger anchor for the fixture index group.
 func fixtureMinLedger() uint32 { return fixtureBaseChunk.FirstLedger() }
 
@@ -151,7 +156,7 @@ func buildColdFixture(t *testing.T, n int) (string, []fixtureEntry) {
 	inputs := writeFixtureBins(t, dir, entries)
 	require.Greater(t, len(inputs), 1, "fixture should span multiple .bin files to exercise the merge")
 
-	idxPath := filepath.Join(dir, IndexFileName(fixtureBaseChunk))
+	idxPath := filepath.Join(dir, indexFileName(fixtureBaseChunk))
 	require.NoError(t, BuildColdIndex(context.Background(), inputs, idxPath, fixtureMinLedger(), fixtureMaxLedger()))
 	return idxPath, entries
 }
@@ -203,7 +208,7 @@ func TestBuildColdIndex_LargeFilesSpanMultipleBuffers(t *testing.T) {
 	require.Greater(t, maxSize, int64(mergeFileBufBytes),
 		"fixture must produce a file larger than the read buffer to exercise refills")
 
-	idxPath := filepath.Join(dir, IndexFileName(fixtureBaseChunk))
+	idxPath := filepath.Join(dir, indexFileName(fixtureBaseChunk))
 	require.NoError(t, BuildColdIndex(context.Background(), inputs, idxPath, fixtureMinLedger(), fixtureMaxLedger()))
 
 	r, err := OpenColdReader(idxPath)
@@ -217,7 +222,7 @@ func TestBuildColdIndex_LargeFilesSpanMultipleBuffers(t *testing.T) {
 }
 
 func TestBuildColdIndex_NoInputs(t *testing.T) {
-	idxPath := filepath.Join(t.TempDir(), IndexFileName(0))
+	idxPath := filepath.Join(t.TempDir(), indexFileName(0))
 	err := BuildColdIndex(context.Background(), nil, idxPath, 2, 2)
 	require.ErrorIs(t, err, ErrEmptyBuildSet)
 	assert.NoFileExists(t, idxPath)
@@ -226,7 +231,7 @@ func TestBuildColdIndex_NoInputs(t *testing.T) {
 func TestBuildColdIndex_MaxBelowMinErrors(t *testing.T) {
 	dir := t.TempDir()
 	inputs := writeFixtureBins(t, dir, makeFixtureEntries(8))
-	idxPath := filepath.Join(dir, IndexFileName(fixtureBaseChunk))
+	idxPath := filepath.Join(dir, indexFileName(fixtureBaseChunk))
 	err := BuildColdIndex(context.Background(), inputs, idxPath, 100, 99)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "maxLedger")
@@ -245,7 +250,7 @@ func TestBuildColdIndex_AllEmptyInputs(t *testing.T) {
 		writeBinFile(t, p, nil)
 		inputs = append(inputs, p)
 	}
-	idxPath := filepath.Join(dir, IndexFileName(fixtureBaseChunk))
+	idxPath := filepath.Join(dir, indexFileName(fixtureBaseChunk))
 	err := BuildColdIndex(context.Background(), inputs, idxPath, fixtureMinLedger(), fixtureMaxLedger())
 	require.ErrorIs(t, err, ErrEmptyBuildSet)
 	assert.NoFileExists(t, idxPath)
@@ -253,7 +258,7 @@ func TestBuildColdIndex_AllEmptyInputs(t *testing.T) {
 
 func TestBuildColdIndex_MissingInputErrors(t *testing.T) {
 	dir := t.TempDir()
-	idxPath := filepath.Join(dir, IndexFileName(fixtureBaseChunk))
+	idxPath := filepath.Join(dir, indexFileName(fixtureBaseChunk))
 	err := BuildColdIndex(context.Background(),
 		[]string{filepath.Join(dir, "00000005.bin")}, idxPath, fixtureMinLedger(), fixtureMaxLedger())
 	require.Error(t, err)
@@ -275,7 +280,7 @@ func TestBuildColdIndex_SeqOutsideCoverageErrors(t *testing.T) {
 			dir := t.TempDir()
 			p := filepath.Join(dir, "00000004.bin")
 			writeBinFile(t, p, []fixtureEntry{{hash: randHash(testRNG(1)), seq: tc.seq}})
-			idxPath := filepath.Join(dir, IndexFileName(fixtureBaseChunk))
+			idxPath := filepath.Join(dir, indexFileName(fixtureBaseChunk))
 			err := BuildColdIndex(context.Background(), []string{p}, idxPath, fixtureMinLedger(), fixtureMaxLedger())
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "outside index coverage")
@@ -294,7 +299,7 @@ func TestBuildColdIndex_CoverageSpanExceedsBudgetErrors(t *testing.T) {
 	p := filepath.Join(dir, "99999999.bin")
 	writeBinFile(t, p, entries)
 
-	idxPath := filepath.Join(dir, IndexFileName(0))
+	idxPath := filepath.Join(dir, indexFileName(0))
 	err := BuildColdIndex(context.Background(), []string{p}, idxPath, minLedger, overflowSeq)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "payload budget")
@@ -308,7 +313,7 @@ func TestBuildColdIndex_CallerOptsCannotOverrideFormat(t *testing.T) {
 	dir := t.TempDir()
 	entries := makeFixtureEntries(64)
 	inputs := writeFixtureBins(t, dir, entries)
-	idxPath := filepath.Join(dir, IndexFileName(fixtureBaseChunk))
+	idxPath := filepath.Join(dir, indexFileName(fixtureBaseChunk))
 	err := BuildColdIndex(context.Background(), inputs, idxPath,
 		fixtureMinLedger(), fixtureMaxLedger(), streamhash.WithMetadata(EncodeLedgerRange(7, 7)))
 	require.NoError(t, err)
@@ -340,7 +345,7 @@ func TestBuildColdIndex_TruncatedFileErrors(t *testing.T) {
 	p := filepath.Join(dir, "00000005.bin")
 	require.NoError(t, os.WriteFile(p, buf.Bytes(), 0o600))
 
-	idxPath := filepath.Join(dir, IndexFileName(fixtureBaseChunk))
+	idxPath := filepath.Join(dir, indexFileName(fixtureBaseChunk))
 	err := BuildColdIndex(context.Background(), []string{p}, idxPath, fixtureMinLedger(), fixtureMaxLedger())
 	require.Error(t, err)
 	assert.NoFileExists(t, idxPath)
@@ -359,7 +364,7 @@ func TestBuildColdIndex_HeaderUndercountErrors(t *testing.T) {
 	p := filepath.Join(dir, "00000005.bin")
 	require.NoError(t, os.WriteFile(p, buf.Bytes(), 0o600))
 
-	idxPath := filepath.Join(dir, IndexFileName(fixtureBaseChunk))
+	idxPath := filepath.Join(dir, indexFileName(fixtureBaseChunk))
 	err := BuildColdIndex(context.Background(), []string{p}, idxPath, fixtureMinLedger(), fixtureMaxLedger())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "header claims")
@@ -381,7 +386,7 @@ func TestBuildColdIndex_HeaderOverflowRejected(t *testing.T) {
 	p := filepath.Join(dir, "00000005.bin")
 	require.NoError(t, os.WriteFile(p, buf.Bytes(), 0o600))
 
-	idxPath := filepath.Join(dir, IndexFileName(fixtureBaseChunk))
+	idxPath := filepath.Join(dir, indexFileName(fixtureBaseChunk))
 	err := BuildColdIndex(context.Background(), []string{p}, idxPath, fixtureMinLedger(), fixtureMaxLedger())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "header claims")

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/cold_reader.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/cold_reader.go
@@ -14,10 +14,6 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores"
 )
 
-// ErrClosed is returned by Get after Close. Package-local: this store
-// reads an mmap directly, with no Layer-1 wrapper to source a closed error.
-var ErrClosed = errors.New("txhash: store is closed")
-
 // ColdReader serves point lookups against one cold txhash index file.
 //
 // Concurrent Gets are safe (the index is read-only). Get is NOT safe
@@ -31,8 +27,9 @@ type ColdReader struct {
 	closed    atomic.Bool
 }
 
-// OpenColdReader opens the mmap-backed cold txhash index at path (compose it
-// via IndexFileName), validating its payload width and metadata.
+// OpenColdReader opens the mmap-backed cold txhash index at path (the
+// on-disk layout composes it via geometry.Layout.TxHashIndexFilePath),
+// validating its payload width and metadata.
 func OpenColdReader(path string) (*ColdReader, error) {
 	idx, err := streamhash.OpenPayload(path)
 	if err != nil {
@@ -54,11 +51,11 @@ func OpenColdReader(path string) (*ColdReader, error) {
 
 // Get returns the ledgerSeq the hash was committed in, stores.ErrNotFound
 // if it wasn't in the build set (residual fingerprint false positives are
-// caught downstream), or ErrClosed after Close. streamhash keys on the first
+// caught downstream), or stores.ErrStoreClosed after Close. streamhash keys on the first
 // 16 bytes, so the full 32-byte hash and hash[:16] are equivalent.
 func (r *ColdReader) Get(hash [32]byte) (uint32, error) {
 	if r.closed.Load() {
-		return 0, ErrClosed
+		return 0, stores.ErrStoreClosed
 	}
 	_, payload, err := r.idx.QueryPayload(hash[:])
 	if err != nil {

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/cold_reader_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/cold_reader_test.go
@@ -66,7 +66,7 @@ func TestColdReader_GetAfterCloseReturnsClosed(t *testing.T) {
 	require.NoError(t, r.Close())
 
 	_, err = r.Get(entries[0].hash)
-	assert.ErrorIs(t, err, ErrClosed)
+	assert.ErrorIs(t, err, stores.ErrStoreClosed)
 }
 
 func TestColdReader_ConcurrentGets(t *testing.T) {

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/hot_store.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/hot_store.go
@@ -1,6 +1,7 @@
 // Package txhash holds the hot transaction-hash store (RocksDB-backed, a single
-// txhash CF) and its value types. A future cold reader (RecSplit-backed) will
-// live alongside the HotStore in this package.
+// txhash CF), the cold artifacts (the raw per-chunk .bin file and the
+// streamhash-MPHF-backed cold index reader/builder), and the read-assembly
+// layer that resolves a hash across tiers.
 package txhash
 
 import (

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/read_assembly.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/read_assembly.go
@@ -56,6 +56,13 @@ func (r *TxReader) GetTransaction(hash [32]byte) (ingest.LedgerTransactionView, 
 		return txv, found, err
 	}
 	if softErr != nil {
+		// Deliberately an error, not a clean not-found: a soft failure
+		// means some candidate (including a cold fingerprint false
+		// positive naming an unservable ledger) could not be verified,
+		// so "the tx does not exist" cannot be asserted. The safe
+		// direction — a false not-found would be indistinguishable
+		// from the tx genuinely not existing (#772's read path relies
+		// on this).
 		return ingest.LedgerTransactionView{}, false, fmt.Errorf("txhash: lookup incomplete: %w", softErr)
 	}
 	return ingest.LedgerTransactionView{}, false, nil

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/read_assembly_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/read_assembly_test.go
@@ -156,7 +156,7 @@ func buildColdReader(t *testing.T, baseChunk chunk.ID, entries []fixtureEntry) *
 		maxSeq = max(maxSeq, e.seq)
 	}
 	inputs := writeFixtureBins(t, dir, entries)
-	idxPath := filepath.Join(dir, IndexFileName(baseChunk))
+	idxPath := filepath.Join(dir, indexFileName(baseChunk))
 	require.NoError(t, BuildColdIndex(context.Background(), inputs, idxPath, minSeq, maxSeq))
 	rd, err := OpenColdReader(idxPath)
 	require.NoError(t, err)


### PR DESCRIPTION
Closes #841.

Deletes the dead pre-wired surface the freeze rework left behind and corrects the stale contract docs that would misdirect the #772 read-path work. Pure-negative diff plus doc corrections — no behavior change on any production path.

## Deletions

**Freeze-handoff mirror surface.** `ConcurrentBitmaps.Snapshot`/`Len`, `ConcurrentLedgerOffsets.Snapshot`/`EventIDs`, and the Clone-safe/COW ownership contract that existed only for them. `Snapshot`'s doc cited a WriteColdIndex call chain that does not exist — the cold index is built from a single-threaded `Bitmaps` in `ingest/events.go`, and the live freeze re-derives from raw LCMs.

**`Reader.Lookup`.** `Query` uses `LookupKeys` exclusively; `Lookup(k) ≡ LookupKeys([k])[0]`, and `ColdReader.Lookup` hand-duplicated the whole resolve pipeline for one key. Deleting it retires `ErrTermNotFound` — a per-key miss is a nil bitmap from `LookupKeys`, and the closed-store sentinel is unified below.

**`events.TermsFor`.** Test-only; its doc named cold backfill as the consumer, which actually uses `TermsForBytes`.

**Dead `IndexBaseChunk`/`IndexFileName` naming scheme.** `OpenColdReader`'s doc told future wiring to compose a filename that never exists on disk; it now points at the real layout (`geometry.Layout.TxHashIndexFilePath`).

**Census tail.**
- `ColdWriter.ChunkID()`/`Dir()` + backing fields, and the unused `eventstore.ErrWriterClosed` re-export (docs now name `packfile.ErrWriterClosed`).
- The unreachable early-success branch in `ledgerCold.Finalize` + the `appended` latch; a zero-append Finalize now fails loudly via `Commit`, which is the honest shape for driver misuse.
- The unreachable nil/empty guards in `ConcurrentBitmaps.Get` (a published termState always carries a non-nil bm or non-empty ids).
- The redundant closed-store sentinels: `eventstore.ErrClosed` and `txhash.ErrClosed` (no caller distinguished them) are gone; both stores now return `stores.ErrStoreClosed` per the `stores/errors.go` translation contract, matching the ledger store. (The metastore half of this bullet was already resolved by the #835 fold — `catalog.Open` delegates its guards to `rocksdb.New`.)
- The eventstore cold writer no longer mkdirs its own bucket dir; directory creation moved to the ingest layer (`NewEventsColdIngester`), matching the ledger/txhash siblings.
- Tip knobs are no longer double-defaulted: `daemon.go` leaves `StartConfig.TipBackoff`/`TipMaxAttempts` zero for `withDefaults` to fill, and `validateConfig` references the named defaults directly.
- `validateConfig` now returns only `error` — its returned earliest ledger had no consumer (tests read the pin via `cat.EarliestLedger()`).
- Test-only exports: `txhash.ReadColdBin` (tests use an `fhtest` helper / in-package copy), `TxHashIndexLayout.ChunksPerIndex` (in-package tests read `cpi`), `events.NewConcurrentBitmaps` (tests convert from an empty `Bitmaps`), `ledger.ColdReader.FirstSeq`.

## Doc corrections (the #772-misdirection set)

- `Reader.All` no longer claims the freeze loop uses it (the freeze re-derives from raw LCMs); `Reader.Offsets` no longer describes the retired hot-side Snapshot allocation (it's a `View` now).
- The three contract comments naming the deleted `IngestLedgerEvents` as the single writer now name the actual writer: `HotStore.applyLedger` via the post-commit hook (`bitmaps.go`, `concurrent_bitmaps.go`, `concurrent_ledgeroffsets.go`).
- `db/event.go` no longer claims full-history stores no per-event index — it stores `EventIdx` explicitly per the byte-stable-ID decision.
- `rocksdb.CFOptions.BlockSize`: RocksDB's BBTO default is 4 KiB, not 16 KiB — so hot_store's explicit 4-KiB values pin the default rather than override it, and future CF sizing isn't reasoned from a 4× wrong baseline.
- The txhash package doc no longer promises a future "RecSplit-backed" cold reader; it names the existing streamhash-MPHF-backed one.
- `cold_bin.go` credits `scanBinHeader` (the production on-disk guard), and no longer claims duplicate truncated keys are "preserved" — the streamhash build fails on them.
- The three packfile-laziness comments in `eventstore/cold_reader.go` were false: `packfile.Open` starts each open (and holds its fd) in a background goroutine immediately; only the metadata decode is deferred. The ledger store's description was already accurate.
- `TxReader.GetTransaction`'s "lookup incomplete" (rather than not-found) shape for an unverifiable candidate is now documented as deliberate for #772.
- The stale `query.go:248` line ref in `ConcurrentBitmaps.Get`'s borrow-guard note names the guard instead of a line number.

## Notes

- The `streaming:` error/log-prefix bullet was already closed by #844 (commit 8fa6c1a7).
- Tests exercising deleted API were ported to the surviving surface (e.g. warmup mirror comparison now derives expected term keys via `TermsForBytes` and compares per-key lookups); tests that existed only to pin a deleted symbol's own contract were removed.
