### PR TITLE
fullhistory: skip events warmup on read-only hot-DB opens (#834)

### DIFF
--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk/hotchunk.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk/hotchunk.go
@@ -92,8 +92,16 @@ func OpenExisting(path string, chunkID chunk.ID, logger *supportlog.Entry) (*DB,
 // synced-but-unflushed WAL into in-memory memtables (persisting nothing), so a
 // reader sees every synced write even after an ungraceful crash — the last-committed
 // refinement DEPENDS on that replay to read a correct MaxCommittedSeq. (An
-// unsynced tail is exactly what a crash loses, and is not recovered.) Composing
-// the facades only reads.
+// unsynced tail is exactly what a crash loses, and is not recovered.)
+//
+// A read-only open is a LEDGERS-ONLY view: it composes the ledger + txhash facades
+// but SKIPS the events facade, because both read-only callers (freeze re-derives the
+// cold artifacts from raw LCMs via Source(); the startup refiner reads only
+// MaxCommittedSeq()) touch the ledgers CF alone and never the events mirror/offsets.
+// Composing the events facade would run eventstore's unconditional warmup — a full
+// index-CF scan plus bitmap/offsets rebuild — discarded unread at Close (#834). The
+// skip is enforced structurally: a read-only DB has no events facade, so Events()
+// panics and IngestLedger errors rather than serving a cold, unwarmed surface.
 func OpenReadOnly(path string, chunkID chunk.ID, logger *supportlog.Entry) (*DB, error) {
 	return open(path, chunkID, logger, true, false)
 }
@@ -149,18 +157,26 @@ func open(path string, chunkID chunk.ID, logger *supportlog.Entry, readOnly, mus
 		return nil, fmt.Errorf("open chunk %s: %w", chunkID, err)
 	}
 
+	db := &DB{
+		store:   store,
+		chunkID: chunkID,
+		ledger:  ledger.NewWithStore(store),
+		txhash:  txhash.NewWithStore(store),
+	}
+	// A read-only open is a ledgers-only freeze/probe view (see OpenReadOnly): it
+	// never reads events, so skip composing the events facade and its unconditional
+	// warmup scan. Read-WRITE opens (ingestion) MUST warm — the write path assigns
+	// event IDs off the warmed offsets — so they always compose it.
+	if readOnly {
+		return db, nil
+	}
 	es, err := eventstore.NewWithStore(store, chunkID)
 	if err != nil {
 		_ = store.Close()
 		return nil, fmt.Errorf("compose events facade for chunk %s: %w", chunkID, err)
 	}
-	return &DB{
-		store:   store,
-		chunkID: chunkID,
-		ledger:  ledger.NewWithStore(store),
-		txhash:  txhash.NewWithStore(store),
-		events:  es,
-	}, nil
+	db.events = es
+	return db, nil
 }
 
 // ChunkID returns the chunk this DB is bound to. No production caller yet —
@@ -181,7 +197,17 @@ func (d *DB) Txhash() *txhash.HotStore { return d.txhash }
 
 // Events returns the events read/write facade over the shared store.
 // Same status as Txhash: writes feed ingestion, reads are the #772 seam.
-func (d *DB) Events() *eventstore.HotStore { return d.events }
+//
+// Panics on a read-only DB: OpenReadOnly composes a ledgers-only view with no
+// events facade (#834), so reaching for events there is a programming error — a
+// caller that needs a warmed events surface must open read-WRITE (or #772 must
+// add a warmed read-only variant), never silently read a cold, unwarmed store.
+func (d *DB) Events() *eventstore.HotStore {
+	if d.events == nil {
+		panic(fmt.Sprintf("hotchunk: Events() on read-only chunk %s: no events facade (ledgers-only view)", d.chunkID))
+	}
+	return d.events
+}
 
 // Source streams the chunk's LCMs from the ledgers CF as a ledgerbackend.LedgerStream
 // the cold writer (backfill's WriteColdChunk) drains, so a just-closed chunk freezes
@@ -273,6 +299,14 @@ type LedgerReport struct {
 // is the authoritative closed-store guard, so there is no separate pre-check here.
 func (d *DB) IngestLedger(seq uint32, lcm xdr.LedgerCloseMetaView) (LedgerReport, error) {
 	var rep LedgerReport
+
+	// A read-only (ledgers-only) DB has no events facade to assign event IDs, and
+	// its store rejects writes anyway. Fail loudly up front rather than nil-deref
+	// the missing facade inside the batch callback (Store.Batch runs the callback
+	// before the write-side rejection fires).
+	if d.events == nil {
+		return rep, fmt.Errorf("chunk %s: IngestLedger on a read-only (ledgers-only) hot DB", d.chunkID)
+	}
 
 	// Pre-extract anything that can fail BEFORE opening the batch, so a decode
 	// error rejects the ledger without a half-built batch.

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk/hotchunk.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk/hotchunk.go
@@ -5,7 +5,9 @@
 // SINGLE per-chunk last-committed ledger (max committed seq, from the ledgers CF's last key)
 // and no per-store frontiers / min-of-three. The three typed facades
 // (ledger/txhash/eventstore HotStore) are composed over the shared store via
-// NewWithStore; their write paths queue Puts into the one shared batch.
+// NewWithStore; their write paths queue Puts into the one shared batch. A
+// read-only open composes a ledgers-only view without the events facade (see
+// OpenReadOnly).
 package hotchunk
 
 import (
@@ -30,9 +32,10 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash"
 )
 
-// DB is one chunk's hot tier: a single multi-CF rocksdb.Store plus the three
-// typed facades composed over it. It owns the store (Close closes it once); the
-// facades wrap it without owning it.
+// DB is one chunk's hot tier: a single multi-CF rocksdb.Store plus the typed
+// facades composed over it — all three on a read-write open; a read-only open
+// leaves events nil (see OpenReadOnly). It owns the store (Close closes it
+// once); the facades wrap it without owning it.
 //
 // Concurrency: ingestion is single-writer; IngestLedger is not safe to call
 // concurrently with itself. Reads via the facades follow each facade's own

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk/hotchunk_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk/hotchunk_test.go
@@ -432,6 +432,67 @@ func TestOpenReadOnly_ReadsCommittedAndRejectsWrites(t *testing.T) {
 	require.Error(t, err, "read-only DB must reject writes")
 }
 
+// TestOpenReadOnly_SkipsEventsWarmup pins #834: a read-only (freeze/probe) open is
+// a ledgers-only view that never runs eventstore's index-CF warmup scan, while a
+// read-WRITE open still warms. The proof is a poisoned events-index row that
+// warmup's key-length check rejects: the write open fails on it (warmup ran), the
+// read-only open ignores it (warmup skipped) and still serves the ledgers-only
+// surface — MaxCommittedSeq and Source() byte-for-byte — that freeze/probe use.
+func TestOpenReadOnly_SkipsEventsWarmup(t *testing.T) {
+	chunkID := chunk.ID(0)
+	first := chunkID.FirstLedger()
+	dir := t.TempDir()
+
+	// Writer: ingest two ledgers, capture the exact wire bytes, then close.
+	db, err := Open(dir, chunkID, silentLogger())
+	require.NoError(t, err)
+	want := map[uint32][]byte{}
+	for _, seq := range []uint32{first, first + 1} {
+		raw := zeroTxLCM(t, seq)
+		want[seq] = raw
+		_, ierr := db.IngestLedger(seq, xdr.LedgerCloseMetaView(raw))
+		require.NoError(t, ierr)
+	}
+	require.NoError(t, db.Close())
+
+	// Poison the events index with a malformed row (wrong key length). warmup's
+	// index scan rejects it; a scan-skipping open never sees it. Written through a
+	// bare read-write open of the same multi-CF DB, closed to free the LOCK.
+	raw, err := rocksdb.New(config(dir, silentLogger(), false, true))
+	require.NoError(t, err)
+	require.NoError(t, raw.Put(eventstore.IndexCF, []byte("bad"), nil))
+	require.NoError(t, raw.Close())
+
+	// Read-WRITE open warms → the poisoned index row fails the scan.
+	_, werr := OpenExisting(dir, chunkID, silentLogger())
+	require.ErrorContains(t, werr, "events_index key length",
+		"a read-write open must run the events warmup scan and reject the poison")
+
+	// Read-only open skips the warmup → opens clean despite the poison.
+	ro, err := OpenReadOnly(dir, chunkID, silentLogger())
+	require.NoError(t, err, "read-only open must skip the events warmup and ignore the poison")
+	t.Cleanup(func() { require.NoError(t, ro.Close()) })
+
+	// Probe surface: MaxCommittedSeq resolves through the skipped open.
+	seq, ok, err := ro.MaxCommittedSeq()
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, first+1, seq)
+
+	// Freeze surface: Source() yields the committed ledgers byte-for-byte.
+	got := map[uint32][]byte{}
+	for b, err := range ro.Source().RawLedgers(context.Background(), ledgerbackend.UnboundedRange(first)) {
+		require.NoError(t, err)
+		s, serr := xdr.LedgerCloseMetaView(b).LedgerSequence()
+		require.NoError(t, serr)
+		got[s] = append([]byte(nil), b...) // b is borrowed; clone before the next step
+	}
+	assert.Equal(t, want, got, "freeze reads are byte-identical through the warmup-skipped open")
+
+	// Structural safety: the ledgers-only view has no events facade to hand out.
+	assert.Panics(t, func() { ro.Events() }, "Events() on a ledgers-only view must fail loudly")
+}
+
 // TestIngestLedger_ClosedDBFails confirms a closed shared DB rejects ingest. The
 // closed-store guard is Store.Batch's authoritative lifecycle RLock + checkOpen
 // (the per-facade pre-checks were dropped in #30), so the surfaced sentinel is


### PR DESCRIPTION
Closes #834.

The read-only hot-DB callers (freeze's `backfill.tryHotSource`, startup's `progress.refineWithHotDB`) only read the ledgers CF, but `hotchunk.open` composed the events facade on every open, running eventstore's unconditional warmup (a full index-CF scan plus bitmap/offsets rebuild) and discarding it unread at `Close`. A mid-chunk restart paid that twice on the same chunk.

A read-only open is now a ledgers-only view: no events facade, no warmup. Read-WRITE opens (ingestion) still warm, since the write path assigns event IDs off the warmed offsets. On a view, `Events()` panics and `IngestLedger` errors up front (`Store.Batch` runs its callback before the read-only write rejection fires), so nothing can silently read a cold, unwarmed events surface. No warmed read-only events variant — nothing needs one today; the panic makes the #772 read path a loud change point.

Tests: `TestOpenReadOnly_SkipsEventsWarmup` poisons the events index — a read-WRITE open fails on it (warmup ran) while a read-only open opens clean and serves `MaxCommittedSeq()` plus byte-identical `Source()` ledgers, and `Events()` panics on the view.
