### PR TITLE
fullhistory: archive tip + captive-core backfill for no-lake deployments (#833)

### DIFF
--- a/cmd/stellar-rpc/internal/fullhistory/backfill/backend.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/backend.go
@@ -17,12 +17,12 @@ import (
 // it is complete, so backfillSource constructs a bare ledgerbackend.LedgerStream
 // (ledger.NewPackStream) for it, with nothing to wait on.
 //
-// The one implementation is bsbSource (Tip = datastore.FindLatestLedgerSequence,
-// the lake frontier). A frontfill-only deployment configures no datastore and so
-// has no Backend at all — it never freezes bulk history; captive core ingests
-// from the pinned floor. Its network tip comes from the history archives at the
-// daemon layer (a tip source, not a Backend, since no LedgerStream is needed),
-// and is the lake tip's fallback when a datastore IS configured.
+// Two implementations: bsbSource here (Tip = datastore.FindLatestLedgerSequence,
+// the lake frontier) and the daemon layer's captiveSource for a no-lake
+// deployment (captive core replays each chunk's bounded range; Tip is the
+// history archives' root HAS). Only a deployment with neither a datastore nor
+// archives has no Backend — then nothing below the pinned floor is fillable and
+// backfillSource errors on any backend-only chunk.
 //
 // Tip is its own method because the SDK's LedgerBackend.GetLatestLedgerSequence is
 // NOT the frontier we want — it is prepared-relative (errors before PrepareRange on

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/backend.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/backend.go
@@ -17,15 +17,12 @@ import (
 // it is complete, so backfillSource constructs a bare ledgerbackend.LedgerStream
 // (ledger.NewPackStream) for it, with nothing to wait on.
 //
-// Implementations (one wired now, one deferred):
-//
-//	bsbSource     (now)   Tip = datastore.FindLatestLedgerSequence (the lake frontier)
-//	captiveSource (later) Tip = historyarchive GetRootHAS().CurrentLedger
-//
-// Captive core is the only deferred piece, and the interface is the seam that
-// keeps the path open: it is one new struct (embed ledgerbackend.NewCaptiveCoreStream
-// plus a history-archive Tip) and one daemon factory case, with zero changes to
-// ProcessConfig, backfillSource, waitForCoverage, or ingest.WriteColdChunk.
+// The one implementation is bsbSource (Tip = datastore.FindLatestLedgerSequence,
+// the lake frontier). A frontfill-only deployment configures no datastore and so
+// has no Backend at all — it never freezes bulk history; captive core ingests
+// from the pinned floor. Its network tip comes from the history archives at the
+// daemon layer (a tip source, not a Backend, since no LedgerStream is needed),
+// and is the lake tip's fallback when a datastore IS configured.
 //
 // Tip is its own method because the SDK's LedgerBackend.GetLatestLedgerSequence is
 // NOT the frontier we want — it is prepared-relative (errors before PrepareRange on

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/process.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/process.go
@@ -30,10 +30,10 @@ type ProcessConfig struct {
 	Logger  *supportlog.Entry
 	Sink    ingest.MetricSink
 
-	// Backend is the bulk source for a chunk with no local copy (BSB now, captive
-	// core later — see the Backend interface). It carries its own frontier Tip, so
-	// the coverage wait needs no separate waiter. May be nil for frontfill-only;
-	// backfillSource errors if a chunk then needs it.
+	// Backend is the bulk source for a chunk with no local copy (the bulk lake or
+	// a captive-core replay — see the Backend interface). It carries its own
+	// frontier Tip, so the coverage wait needs no separate waiter. May be nil when
+	// no bulk source is configured; backfillSource errors if a chunk then needs it.
 	Backend Backend
 }
 

--- a/cmd/stellar-rpc/internal/fullhistory/config/config.go
+++ b/cmd/stellar-rpc/internal/fullhistory/config/config.go
@@ -79,8 +79,9 @@ type BackfillConfig struct {
 	// DefaultMaxRetries.
 	MaxRetries *int `toml:"max_retries"`
 
-	// DataStore is the bulk ledger source. An empty Type means frontfill-only (no
-	// backfill backend); otherwise any SDK datastore type is accepted.
+	// DataStore is the bulk ledger source. An empty Type means no lake — backfill
+	// then replays through captive core from the history archives; otherwise any
+	// SDK datastore type is accepted.
 	DataStore datastore.DataStoreConfig `toml:"datastore"`
 
 	// BSB tunes the buffered-storage stream over DataStore; zero fields fall back to

--- a/cmd/stellar-rpc/internal/fullhistory/config_validate.go
+++ b/cmd/stellar-rpc/internal/fullhistory/config_validate.go
@@ -18,7 +18,7 @@ func validateConfig(
 	ctx context.Context,
 	cfg config.Config,
 	cat *catalog.Catalog,
-	tip *tipSampler,
+	tip tipSource,
 ) error {
 	if cat == nil {
 		return errors.New("validateConfig requires a non-nil Catalog")
@@ -109,8 +109,9 @@ func validateEarliestForm(earliest string) error {
 // resolveEarliestFirstStart turns the form-validated earliest_ledger into the
 // chunk-aligned ledger to pin on first start. Genesis needs no tip; "now" and a
 // numeric floor each require a reachable backend so neither pins a future floor.
+// tip is the backend's raw frontier query; the retry policy is applied here.
 func resolveEarliestFirstStart(
-	ctx context.Context, earliest string, tip *tipSampler,
+	ctx context.Context, earliest string, tip tipSource,
 ) (uint32, error) {
 	switch earliest {
 	case config.EarliestGenesis:
@@ -118,7 +119,7 @@ func resolveEarliestFirstStart(
 
 	case config.EarliestNow:
 		// Resolving "now" requires a tip.
-		t, err := tip.Sample(ctx)
+		t, err := sampleTipWithRetry(ctx, tip, defaultTipBackoff, defaultTipMaxAttempts)
 		if err != nil {
 			return 0, fmt.Errorf("earliest_ledger=%q needs a reachable, ready backend: %w",
 				config.EarliestNow, err)
@@ -130,7 +131,7 @@ func resolveEarliestFirstStart(
 		// Numeric: pinned immutably, so it must be checked against a real tip — a
 		// floor ahead of the network would become permanent and resume from a future ledger.
 		floor := mustParseUint32(earliest)
-		t, err := tip.Sample(ctx)
+		t, err := sampleTipWithRetry(ctx, tip, defaultTipBackoff, defaultTipMaxAttempts)
 		if err != nil {
 			return 0, fmt.Errorf("first start with a numeric earliest_ledger needs a "+
 				"reachable, ready backend to validate the floor against the network tip: %w", err)

--- a/cmd/stellar-rpc/internal/fullhistory/config_validate.go
+++ b/cmd/stellar-rpc/internal/fullhistory/config_validate.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/catalog"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/config"
@@ -19,9 +18,7 @@ func validateConfig(
 	ctx context.Context,
 	cfg config.Config,
 	cat *catalog.Catalog,
-	tip NetworkTipBackend,
-	tipBackoff time.Duration,
-	tipMaxAttempts int,
+	tip *tipSampler,
 ) error {
 	if cat == nil {
 		return errors.New("validateConfig requires a non-nil Catalog")
@@ -59,7 +56,7 @@ func validateConfig(
 	}
 
 	// --- 3. First start: resolve, then pin earliest_ledger. ---
-	earliest, err := resolveEarliestFirstStart(ctx, cfg.Retention.EarliestLedger, tip, tipBackoff, tipMaxAttempts)
+	earliest, err := resolveEarliestFirstStart(ctx, cfg.Retention.EarliestLedger, tip)
 	if err != nil {
 		return err
 	}
@@ -113,7 +110,7 @@ func validateEarliestForm(earliest string) error {
 // chunk-aligned ledger to pin on first start. Genesis needs no tip; "now" and a
 // numeric floor each require a reachable backend so neither pins a future floor.
 func resolveEarliestFirstStart(
-	ctx context.Context, earliest string, tip NetworkTipBackend, backoff time.Duration, maxAttempts int,
+	ctx context.Context, earliest string, tip *tipSampler,
 ) (uint32, error) {
 	switch earliest {
 	case config.EarliestGenesis:
@@ -121,7 +118,7 @@ func resolveEarliestFirstStart(
 
 	case config.EarliestNow:
 		// Resolving "now" requires a tip.
-		t, err := networkTip(ctx, tip, backoff, maxAttempts)
+		t, err := tip.Sample(ctx)
 		if err != nil {
 			return 0, fmt.Errorf("earliest_ledger=%q needs a reachable, ready backend: %w",
 				config.EarliestNow, err)
@@ -133,7 +130,7 @@ func resolveEarliestFirstStart(
 		// Numeric: pinned immutably, so it must be checked against a real tip — a
 		// floor ahead of the network would become permanent and resume from a future ledger.
 		floor := mustParseUint32(earliest)
-		t, err := networkTip(ctx, tip, backoff, maxAttempts)
+		t, err := tip.Sample(ctx)
 		if err != nil {
 			return 0, fmt.Errorf("first start with a numeric earliest_ledger needs a "+
 				"reachable, ready backend to validate the floor against the network tip: %w", err)

--- a/cmd/stellar-rpc/internal/fullhistory/config_validate_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/config_validate_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,9 +37,9 @@ func downTip() *fakeTipBackend {
 // callValidate runs validateConfig and, on success, returns the earliest_ledger
 // value it pinned (read back from the catalog, since validateConfig no longer
 // returns it). On failure the earliest is meaningless, so it returns 0.
-func callValidate(t *testing.T, cfg config.Config, cat *catalog.Catalog, tip NetworkTipBackend) (uint32, error) {
+func callValidate(t *testing.T, cfg config.Config, cat *catalog.Catalog, tip *fakeTipBackend) (uint32, error) {
 	t.Helper()
-	if err := validateConfig(context.Background(), cfg, cat, tip, time.Millisecond, 3); err != nil {
+	if err := validateConfig(context.Background(), cfg, cat, testSampler(3, tip)); err != nil {
 		return 0, err
 	}
 	el, _, err := cat.EarliestLedger()

--- a/cmd/stellar-rpc/internal/fullhistory/config_validate_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/config_validate_test.go
@@ -2,7 +2,6 @@ package fullhistory
 
 import (
 	"context"
-	"errors"
 	"strconv"
 	"testing"
 
@@ -29,9 +28,11 @@ func readyTip(ledger uint32) *fakeTipBackend {
 	return &fakeTipBackend{tips: []uint32{ledger}}
 }
 
-// downTip returns a tip backend that never comes up.
+// downTip returns a tip backend that never becomes usable. Sub-genesis reads as
+// a permanent "not ready", so validateConfig (which applies the production retry
+// policy) fails fast instead of sleeping through the backoff.
 func downTip() *fakeTipBackend {
-	return &fakeTipBackend{err: errors.New("backend unreachable"), errFirst: 99}
+	return &fakeTipBackend{tips: []uint32{0}}
 }
 
 // callValidate runs validateConfig and, on success, returns the earliest_ledger
@@ -39,7 +40,7 @@ func downTip() *fakeTipBackend {
 // returns it). On failure the earliest is meaningless, so it returns 0.
 func callValidate(t *testing.T, cfg config.Config, cat *catalog.Catalog, tip *fakeTipBackend) (uint32, error) {
 	t.Helper()
-	if err := validateConfig(context.Background(), cfg, cat, testSampler(3, tip)); err != nil {
+	if err := validateConfig(context.Background(), cfg, cat, tip.Tip); err != nil {
 		return 0, err
 	}
 	el, _, err := cat.EarliestLedger()

--- a/cmd/stellar-rpc/internal/fullhistory/daemon.go
+++ b/cmd/stellar-rpc/internal/fullhistory/daemon.go
@@ -320,9 +320,22 @@ type captiveSource struct {
 
 var _ backfill.Backend = (*captiveSource)(nil)
 
-// Tip reports the archives' current frontier — the root HAS CurrentLedger.
-func (s *captiveSource) Tip(ctx context.Context) (uint32, error) {
-	return archiveTip(s.archives)(ctx)
+// rootHASGetter is the slice of historyarchive.ArchiveInterface Tip needs: the
+// network frontier is the CurrentLedger the root HAS publishes.
+type rootHASGetter interface {
+	GetRootHAS() (historyarchive.HistoryArchiveState, error)
+}
+
+// Tip reports the archives' current frontier — the root HAS CurrentLedger. The
+// archives lag the network by up to one checkpoint (64 ledgers); backfill's
+// anchor = max(tip, lastCommitted) and the signed withinOneChunkOfTip already
+// absorb that, so no lag adjustment here.
+func (s *captiveSource) Tip(context.Context) (uint32, error) {
+	has, err := s.archives.GetRootHAS()
+	if err != nil {
+		return 0, fmt.Errorf("history archive root HAS: %w", err)
+	}
+	return has.CurrentLedger, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/stellar-rpc/internal/fullhistory/daemon.go
+++ b/cmd/stellar-rpc/internal/fullhistory/daemon.go
@@ -13,8 +13,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
+	"github.com/stellar/go-stellar-sdk/historyarchive"
 	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
 	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+	"github.com/stellar/go-stellar-sdk/support/storage"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/daemon/interfaces"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/backfill"
@@ -128,7 +130,15 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 		}
 		backend = built
 	}
-	networkTip := resolveNetworkTip(backend)
+
+	// The network-tip sampler: the lake frontier (when a backfill datastore is
+	// configured) first, the history archives' root HAS as the fallback (and the
+	// sole source for a frontfill-only daemon, which is how it bootstraps its
+	// earliest_ledger pin). validateConfig needs it, so build it first.
+	sampler, err := buildTipSampler(ctx, backend, cfg.Ingestion.HistoryArchiveURLs, logger)
+	if err != nil {
+		return fmt.Errorf("build tip sampler: %w", err)
+	}
 
 	serveReads := opts.ServeReads
 	if serveReads == nil {
@@ -137,7 +147,7 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	}
 
 	// --- validateConfig: pin/confirm the layout, resolve the earliest floor. ---
-	if err := validateConfig(ctx, cfg, cat, networkTip, defaultTipBackoff, defaultTipMaxAttempts); err != nil {
+	if err := validateConfig(ctx, cfg, cat, sampler); err != nil {
 		return err
 	}
 
@@ -161,7 +171,7 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 
 	// --- Assemble the StartConfig and run the supervised run loop. ---
 	start := startConfig(
-		cfg, cat, logger, backend, networkTip, core, serveReads, metrics, sink)
+		cfg, cat, logger, backend, sampler, core, serveReads, metrics, sink)
 
 	backoff := opts.RestartBackoff
 	if backoff <= 0 {
@@ -175,7 +185,7 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 // goroutine share ONE catalog, worker pool, and retention floor by construction.
 func startConfig(
 	cfg config.Config, cat *catalog.Catalog, logger *supportlog.Entry,
-	backend backfill.Backend, networkTip NetworkTipBackend, core CoreOpener, serveReads func(context.Context) error,
+	backend backfill.Backend, sampler *tipSampler, core CoreOpener, serveReads func(context.Context) error,
 	metrics observability.Metrics, sink ingest.MetricSink,
 ) StartConfig {
 	exec := backfill.ExecConfig{
@@ -189,12 +199,10 @@ func startConfig(
 			Sink:    sink,
 		},
 	}
-	// TipBackoff / TipMaxAttempts are left zero here on purpose:
-	// StartConfig.withDefaults fills them at Start.
 	return StartConfig{
 		Exec:            exec,
 		RetentionChunks: deref(cfg.Retention.RetentionChunks),
-		NetworkTip:      networkTip,
+		Tip:             sampler,
 		Core:            core,
 		ServeReads:      serveReads,
 	}
@@ -376,31 +384,32 @@ func (c *captiveCoreOpener) OpenCore(ctx context.Context) (ledgerbackend.LedgerS
 	return ledgerbackend.NewCaptiveCoreStream(cfg, c.config.Log), nil
 }
 
-// resolveNetworkTip adapts the backfill backend to backfill's tip sampler — its Tip
-// frontier (so the tip and the freeze's coverage frontier are one source) — or the
-// not-configured placeholder for a frontfill-only daemon (nil backend).
-func resolveNetworkTip(backend backfill.Backend) NetworkTipBackend {
-	if backend == nil {
-		return notConfiguredTip{}
+// buildTipSampler assembles the network-tip sampler from the wired sources: the
+// bulk lake frontier (backend.Tip, so the tip and the freeze's coverage frontier
+// are one source) first when a backfill datastore is configured, and the history
+// archives' root HAS as a fallback. For a frontfill-only daemon (nil backend) the
+// archives are the only source — and are how it bootstraps its earliest_ledger
+// pin on first start. The archive URLs are the same ones captive core reads from
+// ([ingestion].history_archive_urls); no new config.
+func buildTipSampler(
+	ctx context.Context, backend backfill.Backend, archiveURLs []string, logger *supportlog.Entry,
+) (*tipSampler, error) {
+	var sources []tipSource
+	if backend != nil {
+		sources = append(sources, backend.Tip)
 	}
-	return backendTip{backend}
+	if len(archiveURLs) > 0 {
+		pool, err := historyarchive.NewArchivePool(archiveURLs, historyarchive.ArchiveOptions{
+			ConnectOptions: storage.ConnectOptions{Context: ctx},
+			Logger:         logger.WithField("subservice", "history-archive-tip"),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("connect history archives: %w", err)
+		}
+		sources = append(sources, archiveTip(pool))
+	}
+	return newTipSampler(sources...), nil
 }
-
-// notConfiguredTip is the NetworkTipBackend placeholder when no bulk backend is
-// configured: every sample returns a clear not-configured error (until #772 wires
-// the real lake tip).
-type notConfiguredTip struct{}
-
-func (notConfiguredTip) NetworkTip(context.Context) (uint32, error) {
-	return 0, errors.New("no bulk backend configured ([backfill.datastore].type empty); " +
-		"cannot sample the network tip (configure a backend, or this is a frontfill-only deployment)")
-}
-
-// backendTip adapts a backfill.Backend to NetworkTipBackend via its Tip frontier, so
-// backfill's tip and the freeze's coverage frontier are sampled from one source.
-type backendTip struct{ backend backfill.Backend }
-
-func (t backendTip) NetworkTip(ctx context.Context) (uint32, error) { return t.backend.Tip(ctx) }
 
 // newLogger builds a daemon logger from the [logging] config.
 func newLogger(cfg config.LoggingConfig) (*supportlog.Entry, error) {
@@ -417,8 +426,4 @@ func newLogger(cfg config.LoggingConfig) (*supportlog.Entry, error) {
 }
 
 // compile-time interface checks.
-var (
-	_ CoreOpener        = (*captiveCoreOpener)(nil)
-	_ NetworkTipBackend = notConfiguredTip{}
-	_ NetworkTipBackend = backendTip{}
-)
+var _ CoreOpener = (*captiveCoreOpener)(nil)

--- a/cmd/stellar-rpc/internal/fullhistory/daemon.go
+++ b/cmd/stellar-rpc/internal/fullhistory/daemon.go
@@ -37,8 +37,9 @@ func RunDaemon(ctx context.Context, configPath string) error {
 // daemonOptions carries the daemon's injectable seams; production leaves every field zero.
 type daemonOptions struct {
 	// Backend is the bulk ledger source backfill freezes from and samples the tip from.
-	// nil ⇒ runDaemonWith builds it from [backfill.datastore] (which itself yields a
-	// frontfill-only daemon when no datastore is configured). Tests inject a fakeBackend.
+	// nil ⇒ runDaemonWith builds it: the bulk lake from [backfill.datastore], else —
+	// with history archives configured — captive core replaying from the archives
+	// (#833). Tests inject a fakeBackend.
 	Backend backfill.Backend
 
 	// Core starts captive core at the resume ledger and yields the live getter the
@@ -115,13 +116,33 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	}
 	defer func() { _ = cat.Close() }()
 
-	// --- Resolve the backfill backend: injected (tests) or built from
-	// [backfill.datastore] (production; nil ⇒ frontfill-only). Its Tip drives both
-	// backfill's network tip and the freeze's coverage frontier, so validateConfig
-	// (which needs the tip) runs after this. ---
+	// --- The history-archive pool: the no-lake backfill source's frontier and the
+	// lake tip's fallback. nil when [ingestion].history_archive_urls is unset. ---
+	var pool rootHASGetter
+	if len(cfg.Ingestion.HistoryArchiveURLs) > 0 {
+		pool, err = newArchivePool(ctx, cfg.Ingestion.HistoryArchiveURLs, logger)
+		if err != nil {
+			return err
+		}
+	}
+
+	// --- Resolve the backfill backend: injected (tests), the bulk lake
+	// ([backfill.datastore]), or captive core replaying from the archives when no
+	// lake is configured (#833). Its Tip drives both backfill's network tip and the
+	// freeze's coverage frontier, so validateConfig (which needs the tip) runs after
+	// this. The captive path resolves the core opener early — its stream IS the
+	// backend — so there [ingestion] config errors surface before validateConfig's;
+	// every other path keeps the opener after validateConfig, below. ---
 	backend := opts.Backend
+	core := opts.Core
 	if backend == nil {
-		built, cleanup, berr := buildBackfillBackend(ctx, cfg, logger)
+		if core == nil && cfg.Backfill.DataStore.Type == "" && pool != nil {
+			core, err = newCaptiveCoreOpener(cfg.Ingestion, cfg.Service.DefaultDataDir, logger)
+			if err != nil {
+				return err
+			}
+		}
+		built, cleanup, berr := buildBackfillBackend(ctx, cfg, core, pool, logger)
 		if berr != nil {
 			return fmt.Errorf("build backfill backend: %w", berr)
 		}
@@ -131,11 +152,11 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 		backend = built
 	}
 
-	// The network-tip sampler: the lake frontier (when a backfill datastore is
-	// configured) first, the history archives' root HAS as the fallback (and the
-	// sole source for a frontfill-only daemon, which is how it bootstraps its
-	// earliest_ledger pin). validateConfig needs it, so build it first.
-	sampler, err := buildTipSampler(ctx, backend, cfg.Ingestion.HistoryArchiveURLs, logger)
+	// The network-tip sampler: the backend's own frontier first (the lake for
+	// bsbSource, the archives for captiveSource), the archive pool as the lake's
+	// fallback. On first start the sampled tip is how a below-now earliest_ledger
+	// pin resolves. validateConfig needs it, so build it first.
+	sampler, err := buildTipSampler(backend, pool)
 	if err != nil {
 		return fmt.Errorf("build tip sampler: %w", err)
 	}
@@ -157,10 +178,10 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	registry := prometheus.NewRegistry()
 	metrics, sink := buildSinks(opts, registry)
 
-	// Resolve the captive-core opener: injected (tests) or built from
-	// [ingestion].captive_core_config (a complete production opener) — done after
-	// validateConfig so config errors surface first.
-	core := opts.Core
+	// Resolve the captive-core opener if still unset: injected (tests), resolved
+	// early by the captive backfill path above, or built here from
+	// [ingestion].captive_core_config — after validateConfig so config errors
+	// surface first.
 	if core == nil {
 		built, cerr := newCaptiveCoreOpener(cfg.Ingestion, cfg.Service.DefaultDataDir, logger)
 		if cerr != nil {
@@ -263,24 +284,57 @@ func sleepCtx(ctx context.Context, d time.Duration) error {
 // Production backfill backend construction.
 // ---------------------------------------------------------------------------
 
-// buildBackfillBackend opens the bulk ledger source from [backfill.datastore]: any
-// SDK datastore (GCS/S3/Filesystem/...) wrapped as a backfill.Backend, plus a cleanup
-// that releases the datastore handle at shutdown. With no datastore configured it
-// returns (nil, nil, nil) — a frontfill-only daemon (the network tip then comes from
-// the history-archive source wired in buildTipSampler, and backfillSource errors only
-// on a backend-only chunk).
+// buildBackfillBackend opens the bulk ledger source backfill freezes from. With a
+// [backfill.datastore] it is the SDK datastore (GCS/S3/Filesystem/...) wrapped as a
+// backfill.Backend, plus a cleanup that releases the datastore handle at shutdown.
+// With no datastore but history archives configured it is captive core instead
+// (captiveSource): core replays each chunk's bounded range and the archives' root
+// HAS is the frontier — so a below-now earliest_ledger floor is fillable, not just
+// pinnable (#833). With neither it returns (nil, nil, nil), and the tip-sampler
+// build fails startup with the config-shaped message.
 func buildBackfillBackend(
-	ctx context.Context, cfg config.Config, logger *supportlog.Entry,
+	ctx context.Context, cfg config.Config, core CoreOpener, pool rootHASGetter, logger *supportlog.Entry,
 ) (backfill.Backend, func(), error) {
-	if cfg.Backfill.DataStore.Type == "" {
-		return nil, nil, nil // frontfill-only
+	if cfg.Backfill.DataStore.Type != "" {
+		backend, cleanup, err := backfill.NewBSBBackendFromConfig(ctx, cfg.Backfill.DataStore, cfg.Backfill.BSB)
+		if err != nil {
+			return nil, nil, err
+		}
+		logger.WithField("datastore_type", cfg.Backfill.DataStore.Type).Info("wired BSB backfill backend")
+		return backend, cleanup, nil
 	}
-	backend, cleanup, err := backfill.NewBSBBackendFromConfig(ctx, cfg.Backfill.DataStore, cfg.Backfill.BSB)
+	if pool == nil || core == nil {
+		return nil, nil, nil // no bulk source at all; the tip-sampler build gates this
+	}
+	stream, err := core.OpenCore(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("open captive-core backfill stream: %w", err)
 	}
-	logger.WithField("datastore_type", cfg.Backfill.DataStore.Type).Info("wired BSB backfill backend")
-	return backend, cleanup, nil
+	logger.Info("wired captive-core backfill backend (no bulk lake configured)")
+	return &captiveSource{LedgerStream: stream, archives: pool}, nil, nil
+}
+
+// captiveSource is the backfill.Backend for a no-lake deployment: captive core
+// replays each chunk's bounded range, and the history archives' root HAS — the
+// same archives core itself reads — is the frontier Tip. The SDK's captive stream
+// builds a FRESH core per RawLedgers call (each in its own ephemeral working
+// dir), so executePlan's parallel per-chunk pulls run independent cores rather
+// than contending on one cursor.
+//
+// Each bounded replay catches its core up to the range start, so the cost is one
+// catch-up per chunk: fine for a small retention window, infeasible for deep
+// history — a deep-history deployment configures the bulk lake instead.
+type captiveSource struct {
+	ledgerbackend.LedgerStream // the captive-core stream (CoreOpener.OpenCore)
+
+	archives rootHASGetter
+}
+
+var _ backfill.Backend = (*captiveSource)(nil)
+
+// Tip reports the archives' current frontier — the root HAS CurrentLedger.
+func (s *captiveSource) Tip(ctx context.Context) (uint32, error) {
+	return archiveTip(s.archives)(ctx)
 }
 
 // ---------------------------------------------------------------------------
@@ -385,29 +439,34 @@ func (c *captiveCoreOpener) OpenCore(ctx context.Context) (ledgerbackend.LedgerS
 	return ledgerbackend.NewCaptiveCoreStream(cfg, c.config.Log), nil
 }
 
-// buildTipSampler assembles the network-tip sampler from the wired sources: the
-// bulk lake frontier (backend.Tip, so the tip and the freeze's coverage frontier
-// are one source) first when a backfill datastore is configured, and the history
-// archives' root HAS as a fallback. For a frontfill-only daemon (nil backend) the
-// archives are the only source — and are how it bootstraps its earliest_ledger
-// pin on first start. The archive URLs are the same ones captive core reads from
-// ([ingestion].history_archive_urls); no new config.
-func buildTipSampler(
-	ctx context.Context, backend backfill.Backend, archiveURLs []string, logger *supportlog.Entry,
-) (*tipSampler, error) {
+// newArchivePool connects [ingestion].history_archive_urls — the same archives
+// captive core reads; no new config. urls must be non-empty (the caller skips the
+// pool entirely when none are configured).
+func newArchivePool(ctx context.Context, urls []string, logger *supportlog.Entry) (rootHASGetter, error) {
+	pool, err := historyarchive.NewArchivePool(urls, historyarchive.ArchiveOptions{
+		ConnectOptions: storage.ConnectOptions{Context: ctx},
+		Logger:         logger.WithField("subservice", "history-archive"),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("connect history archives: %w", err)
+	}
+	return pool, nil
+}
+
+// buildTipSampler assembles the network-tip sampler: the backend's own frontier
+// first (backend.Tip, so the tip and the freeze's coverage frontier are one
+// source — the lake for bsbSource, the archives for captiveSource), and the
+// archive pool as the lake's fallback. The pool is skipped when the backend's Tip
+// already IS the archive (captiveSource), so no source is consulted twice.
+func buildTipSampler(backend backfill.Backend, pool rootHASGetter) (*tipSampler, error) {
 	var sources []tipSource
 	if backend != nil {
 		sources = append(sources, backend.Tip)
 	}
-	if len(archiveURLs) > 0 {
-		pool, err := historyarchive.NewArchivePool(archiveURLs, historyarchive.ArchiveOptions{
-			ConnectOptions: storage.ConnectOptions{Context: ctx},
-			Logger:         logger.WithField("subservice", "history-archive-tip"),
-		})
-		if err != nil {
-			return nil, fmt.Errorf("connect history archives: %w", err)
+	if pool != nil {
+		if _, archiveBacked := backend.(*captiveSource); !archiveBacked {
+			sources = append(sources, archiveTip(pool))
 		}
-		sources = append(sources, archiveTip(pool))
 	}
 	if len(sources) == 0 {
 		// Fail at startup with the config-shaped message; captive core would reject

--- a/cmd/stellar-rpc/internal/fullhistory/daemon.go
+++ b/cmd/stellar-rpc/internal/fullhistory/daemon.go
@@ -266,8 +266,9 @@ func sleepCtx(ctx context.Context, d time.Duration) error {
 // buildBackfillBackend opens the bulk ledger source from [backfill.datastore]: any
 // SDK datastore (GCS/S3/Filesystem/...) wrapped as a backfill.Backend, plus a cleanup
 // that releases the datastore handle at shutdown. With no datastore configured it
-// returns (nil, nil, nil) — a frontfill-only daemon (the network tip is then the
-// not-configured placeholder and backfillSource errors only on a backend-only chunk).
+// returns (nil, nil, nil) — a frontfill-only daemon (the network tip then comes from
+// the history-archive source wired in buildTipSampler, and backfillSource errors only
+// on a backend-only chunk).
 func buildBackfillBackend(
 	ctx context.Context, cfg config.Config, logger *supportlog.Entry,
 ) (backfill.Backend, func(), error) {

--- a/cmd/stellar-rpc/internal/fullhistory/daemon.go
+++ b/cmd/stellar-rpc/internal/fullhistory/daemon.go
@@ -116,10 +116,22 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	}
 	defer func() { _ = cat.Close() }()
 
-	// --- The history-archive pool: the no-lake backfill source's frontier and the
-	// lake tip's fallback. nil when [ingestion].history_archive_urls is unset. ---
+	// --- Resolve the captive-core opener up front: every daemon runs the live
+	// ingestion loop, and the no-lake backfill source is built from its stream. A
+	// bad [ingestion] config therefore surfaces before validateConfig's errors —
+	// cosmetic, both are fatal startup errors. ---
+	core := opts.Core
+	if core == nil {
+		core, err = newCaptiveCoreOpener(cfg.Ingestion, cfg.Service.DefaultDataDir, logger)
+		if err != nil {
+			return err
+		}
+	}
+
+	// --- The history-archive pool: the no-lake backfill source's frontier. nil
+	// when a bulk lake is configured (unused there) or no URLs are set. ---
 	var pool rootHASGetter
-	if len(cfg.Ingestion.HistoryArchiveURLs) > 0 {
+	if cfg.Backfill.DataStore.Type == "" && len(cfg.Ingestion.HistoryArchiveURLs) > 0 {
 		pool, err = newArchivePool(ctx, cfg.Ingestion.HistoryArchiveURLs, logger)
 		if err != nil {
 			return err
@@ -128,20 +140,11 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 
 	// --- Resolve the backfill backend: injected (tests), the bulk lake
 	// ([backfill.datastore]), or captive core replaying from the archives when no
-	// lake is configured (#833). Its Tip drives both backfill's network tip and the
-	// freeze's coverage frontier, so validateConfig (which needs the tip) runs after
-	// this. The captive path resolves the core opener early — its stream IS the
-	// backend — so there [ingestion] config errors surface before validateConfig's;
-	// every other path keeps the opener after validateConfig, below. ---
+	// lake is configured (#833). Its Tip is THE network frontier — every backfill
+	// pass samples it and the freeze's coverage wait polls it — so validateConfig
+	// (which needs the tip) runs after this. ---
 	backend := opts.Backend
-	core := opts.Core
 	if backend == nil {
-		if core == nil && cfg.Backfill.DataStore.Type == "" && pool != nil {
-			core, err = newCaptiveCoreOpener(cfg.Ingestion, cfg.Service.DefaultDataDir, logger)
-			if err != nil {
-				return err
-			}
-		}
 		built, cleanup, berr := buildBackfillBackend(ctx, cfg, core, pool, logger)
 		if berr != nil {
 			return fmt.Errorf("build backfill backend: %w", berr)
@@ -151,14 +154,11 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 		}
 		backend = built
 	}
-
-	// The network-tip sampler: the backend's own frontier first (the lake for
-	// bsbSource, the archives for captiveSource), the archive pool as the lake's
-	// fallback. On first start the sampled tip is how a below-now earliest_ledger
-	// pin resolves. validateConfig needs it, so build it first.
-	sampler, err := buildTipSampler(backend, pool)
-	if err != nil {
-		return fmt.Errorf("build tip sampler: %w", err)
+	if backend == nil {
+		// In production newCaptiveCoreOpener already rejects missing archive URLs;
+		// this config-shaped message covers an injected Core bypassing that gate.
+		return errors.New("no bulk ledger source configured: set [backfill.datastore] " +
+			"or [ingestion].history_archive_urls")
 	}
 
 	serveReads := opts.ServeReads
@@ -168,7 +168,7 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	}
 
 	// --- validateConfig: pin/confirm the layout, resolve the earliest floor. ---
-	if err := validateConfig(ctx, cfg, cat, sampler); err != nil {
+	if err := validateConfig(ctx, cfg, cat, backend.Tip); err != nil {
 		return err
 	}
 
@@ -178,21 +178,9 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	registry := prometheus.NewRegistry()
 	metrics, sink := buildSinks(opts, registry)
 
-	// Resolve the captive-core opener if still unset: injected (tests), resolved
-	// early by the captive backfill path above, or built here from
-	// [ingestion].captive_core_config — after validateConfig so config errors
-	// surface first.
-	if core == nil {
-		built, cerr := newCaptiveCoreOpener(cfg.Ingestion, cfg.Service.DefaultDataDir, logger)
-		if cerr != nil {
-			return cerr
-		}
-		core = built
-	}
-
 	// --- Assemble the StartConfig and run the supervised run loop. ---
 	start := startConfig(
-		cfg, cat, logger, backend, sampler, core, serveReads, metrics, sink)
+		cfg, cat, logger, backend, core, serveReads, metrics, sink)
 
 	backoff := opts.RestartBackoff
 	if backoff <= 0 {
@@ -206,7 +194,7 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 // goroutine share ONE catalog, worker pool, and retention floor by construction.
 func startConfig(
 	cfg config.Config, cat *catalog.Catalog, logger *supportlog.Entry,
-	backend backfill.Backend, sampler *tipSampler, core CoreOpener, serveReads func(context.Context) error,
+	backend backfill.Backend, core CoreOpener, serveReads func(context.Context) error,
 	metrics observability.Metrics, sink ingest.MetricSink,
 ) StartConfig {
 	exec := backfill.ExecConfig{
@@ -223,7 +211,6 @@ func startConfig(
 	return StartConfig{
 		Exec:            exec,
 		RetentionChunks: deref(cfg.Retention.RetentionChunks),
-		Tip:             sampler,
 		Core:            core,
 		ServeReads:      serveReads,
 	}
@@ -290,8 +277,9 @@ func sleepCtx(ctx context.Context, d time.Duration) error {
 // With no datastore but history archives configured it is captive core instead
 // (captiveSource): core replays each chunk's bounded range and the archives' root
 // HAS is the frontier — so a below-now earliest_ledger floor is fillable, not just
-// pinnable (#833). With neither it returns (nil, nil, nil), and the tip-sampler
-// build fails startup with the config-shaped message.
+// pinnable (#833). With neither it returns (nil, nil, nil) and runDaemonWith fails
+// startup with the config-shaped message. core must be non-nil (runDaemonWith
+// resolves the opener first).
 func buildBackfillBackend(
 	ctx context.Context, cfg config.Config, core CoreOpener, pool rootHASGetter, logger *supportlog.Entry,
 ) (backfill.Backend, func(), error) {
@@ -303,8 +291,8 @@ func buildBackfillBackend(
 		logger.WithField("datastore_type", cfg.Backfill.DataStore.Type).Info("wired BSB backfill backend")
 		return backend, cleanup, nil
 	}
-	if pool == nil || core == nil {
-		return nil, nil, nil // no bulk source at all; the tip-sampler build gates this
+	if pool == nil {
+		return nil, nil, nil // no bulk source at all; runDaemonWith fails fast on this
 	}
 	stream, err := core.OpenCore(ctx)
 	if err != nil {
@@ -451,30 +439,6 @@ func newArchivePool(ctx context.Context, urls []string, logger *supportlog.Entry
 		return nil, fmt.Errorf("connect history archives: %w", err)
 	}
 	return pool, nil
-}
-
-// buildTipSampler assembles the network-tip sampler: the backend's own frontier
-// first (backend.Tip, so the tip and the freeze's coverage frontier are one
-// source — the lake for bsbSource, the archives for captiveSource), and the
-// archive pool as the lake's fallback. The pool is skipped when the backend's Tip
-// already IS the archive (captiveSource), so no source is consulted twice.
-func buildTipSampler(backend backfill.Backend, pool rootHASGetter) (*tipSampler, error) {
-	var sources []tipSource
-	if backend != nil {
-		sources = append(sources, backend.Tip)
-	}
-	if pool != nil {
-		if _, archiveBacked := backend.(*captiveSource); !archiveBacked {
-			sources = append(sources, archiveTip(pool))
-		}
-	}
-	if len(sources) == 0 {
-		// Fail at startup with the config-shaped message; captive core would reject
-		// the missing archive URLs later anyway, but less helpfully.
-		return nil, errors.New("no network tip source configured: set [backfill.datastore] " +
-			"or [ingestion].history_archive_urls")
-	}
-	return newTipSampler(sources...), nil
 }
 
 // newLogger builds a daemon logger from the [logging] config.

--- a/cmd/stellar-rpc/internal/fullhistory/daemon.go
+++ b/cmd/stellar-rpc/internal/fullhistory/daemon.go
@@ -409,6 +409,12 @@ func buildTipSampler(
 		}
 		sources = append(sources, archiveTip(pool))
 	}
+	if len(sources) == 0 {
+		// Fail at startup with the config-shaped message; captive core would reject
+		// the missing archive URLs later anyway, but less helpfully.
+		return nil, errors.New("no network tip source configured: set [backfill.datastore] " +
+			"or [ingestion].history_archive_urls")
+	}
 	return newTipSampler(sources...), nil
 }
 

--- a/cmd/stellar-rpc/internal/fullhistory/daemon_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/daemon_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/go-stellar-sdk/historyarchive"
+	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
 	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stellar/go-stellar-sdk/network"
 	"github.com/stellar/go-stellar-sdk/xdr"
@@ -109,20 +111,25 @@ func TestRunDaemon_LoadValidateWireStartCleanShutdown(t *testing.T) {
 	assert.Equal(t, uint32(chunk.FirstLedgerSeq), earliest)
 }
 
-// someTxBackend serves mostly zero-tx ledgers with a sparse few carrying one tx:
+// someTxGen generates mostly zero-tx ledgers with a sparse few carrying one tx:
 // an all-zero-tx chunk can't build a txhash index ("zero keys"), so it needs some.
-func someTxBackend(t *testing.T) *fakeBackend {
+func someTxGen(t *testing.T) func(*testing.T, uint32) []byte {
 	t.Helper()
 	src := xdr.MustMuxedAddress(keypair.MustRandom().Address())
-	gen := func(t *testing.T, seq uint32) []byte {
+	return func(t *testing.T, seq uint32) []byte {
 		if seq%2500 != 0 {
 			return fhtest.ZeroTxLCMBytes(t, seq)
 		}
 		raw, _ := oneTxLCMBytes(t, seq, src)
 		return raw
 	}
+}
+
+// someTxBackend is a fake bulk backend over someTxGen's ledgers.
+func someTxBackend(t *testing.T) *fakeBackend {
+	t.Helper()
 	return &fakeBackend{
-		LedgerStream: &fullChunkStream{t: t, gen: gen},
+		LedgerStream: &fullChunkStream{t: t, gen: someTxGen(t)},
 		// Tip covers chunk 0 ⇒ the freeze's coverage wait passes at once.
 		tip: chunk.ID(0).LastLedger(),
 	}
@@ -458,33 +465,65 @@ func TestSupervise_FirstStartNoTipRetries(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// buildBackfillBackend / buildTipSampler — the frontfill (no datastore) path.
+// buildBackfillBackend / buildTipSampler — the no-lake (no datastore) paths.
 // ---------------------------------------------------------------------------
 
-// With no [backfill.datastore], buildBackfillBackend returns no backend (frontfill).
-func TestBuildBackfillBackend_FrontfillNoBackend(t *testing.T) {
+// With neither [backfill.datastore] nor an archive pool, buildBackfillBackend
+// returns no backend (the tip-sampler build then fails startup).
+func TestBuildBackfillBackend_NoSourcesNoBackend(t *testing.T) {
 	cfg := config.Config{}.WithDefaults()
-	backend, cleanup, err := buildBackfillBackend(context.Background(), cfg, silentLogger())
+	backend, cleanup, err := buildBackfillBackend(context.Background(), cfg, &fakeCore{}, nil, silentLogger())
 	require.NoError(t, err)
-	require.Nil(t, backend, "no datastore ⇒ frontfill-only, no backend")
+	require.Nil(t, backend, "no datastore and no archives ⇒ no bulk source")
 	require.Nil(t, cleanup, "nothing to release when no backend was opened")
 }
 
-// A frontfill-only daemon (nil backend) with history archives configured gets an
-// archive-backed tip source, so it can bootstrap its earliest_ledger pin — the
-// #833 fix. The archive frontier resolves through GetRootHAS().CurrentLedger.
-func TestBuildTipSampler_FrontfillBootstrapsFromArchive(t *testing.T) {
-	sampler, err := buildTipSampler(
-		context.Background(), nil, []string{"file:///nonexistent-archive"}, silentLogger())
+// With no lake but archives configured, the backfill backend is captive core
+// (#833): the stream is the core opener's, and Tip is the archives' root HAS —
+// so a below-now earliest_ledger floor is fillable, not just pinnable.
+func TestBuildBackfillBackend_NoLakeBuildsCaptiveSource(t *testing.T) {
+	cfg := config.Config{}.WithDefaults()
+	core := &fakeCore{}
+	backend, cleanup, err := buildBackfillBackend(
+		context.Background(), cfg, core, fakeRootHAS{current: 70_000}, silentLogger())
 	require.NoError(t, err)
-	require.NotNil(t, sampler)
+	require.Nil(t, cleanup, "no datastore handle to release")
+	require.IsType(t, &captiveSource{}, backend)
+	assert.Equal(t, int32(1), core.openedCount.Load(), "the backend stream is the core opener's")
+
+	tip, err := backend.Tip(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, uint32(70_000), tip, "the frontier is the archives' root HAS CurrentLedger")
+}
+
+// A no-lake daemon's sampler has the archives as its sole source, so it can
+// bootstrap its earliest_ledger pin — the #833 fix. The archive frontier
+// resolves through GetRootHAS().CurrentLedger.
+func TestBuildTipSampler_NoBackendBootstrapsFromArchive(t *testing.T) {
+	sampler, err := buildTipSampler(nil, fakeRootHAS{current: 50_000})
+	require.NoError(t, err)
 	require.Len(t, sampler.sources, 1, "the archive is the sole tip source when no backend is configured")
 
-	// Drive the archive tip mapping directly against a fake root HAS, proving the
-	// CurrentLedger is what the tip source returns.
-	tip, err := archiveTip(fakeRootHAS{current: 50_000})(context.Background())
+	tip, err := sampler.Sample(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, uint32(50_000), tip)
+}
+
+// A lake backend keeps the archive pool as its fallback: two sources, lake first.
+func TestBuildTipSampler_LakeGetsArchiveFallback(t *testing.T) {
+	sampler, err := buildTipSampler(
+		&fakeBackend{tip: chunk.FirstLedgerSeq}, fakeRootHAS{current: 50_000})
+	require.NoError(t, err)
+	require.Len(t, sampler.sources, 2, "lake frontier first, archive fallback second")
+}
+
+// The captive backend's Tip already IS the archive, so the pool is not added
+// again as a fallback — one source, never consulted twice per attempt.
+func TestBuildTipSampler_CaptiveBackendNotDuplicated(t *testing.T) {
+	has := fakeRootHAS{current: 60_000}
+	sampler, err := buildTipSampler(&captiveSource{archives: has}, has)
+	require.NoError(t, err)
+	require.Len(t, sampler.sources, 1, "captiveSource.Tip is the archive; no duplicate source")
 }
 
 // fakeRootHAS is a rootHASGetter over a fixed CurrentLedger (or a fixed error),
@@ -509,13 +548,139 @@ func TestArchiveTip_RootHASErrorSurfaces(t *testing.T) {
 	assert.Contains(t, err.Error(), "archive 503")
 }
 
-// With neither a backend nor archive URLs there is no tip source, and the
-// frontfill-only misconfiguration that cannot bootstrap fails at build time —
-// startup, not first sample — with the config-shaped message.
+// With neither a backend nor an archive pool there is no tip source, and the
+// misconfiguration that cannot bootstrap fails at build time — startup, not
+// first sample — with the config-shaped message.
 func TestBuildTipSampler_NoSourcesErrors(t *testing.T) {
-	_, err := buildTipSampler(context.Background(), nil, nil, silentLogger())
+	_, err := buildTipSampler(nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no network tip source configured")
+}
+
+// ---------------------------------------------------------------------------
+// The no-lake backfill path, end to end through the real entrypoint.
+// ---------------------------------------------------------------------------
+
+// streamCore is a CoreOpener over a fixed LedgerStream (the captive-core seam
+// for the no-lake backfill test: production hands the same opener's stream to
+// both the captive backfill source and the live loop).
+type streamCore struct{ stream ledgerbackend.LedgerStream }
+
+func (c *streamCore) OpenCore(context.Context) (ledgerbackend.LedgerStream, error) {
+	return c.stream, nil
+}
+
+// coreReplayStream is the fake captive-core stream for the no-lake path: a
+// BOUNDED pull (the captive backfill source replaying a chunk) serves gen's
+// ledgers for exactly [From, To], and an UNBOUNDED pull (the live loop's steady
+// state) blocks until ctx cancel — the fake analog of core's catchup-vs-runFrom
+// modes.
+type coreReplayStream struct {
+	t   *testing.T
+	gen func(*testing.T, uint32) []byte
+}
+
+var _ ledgerbackend.LedgerStream = (*coreReplayStream)(nil)
+
+func (s *coreReplayStream) RawLedgers(
+	ctx context.Context, r ledgerbackend.Range, _ ...ledgerbackend.StreamOption,
+) iter.Seq2[[]byte, error] {
+	return func(yield func([]byte, error) bool) {
+		if !r.Bounded() {
+			<-ctx.Done()
+			yield(nil, ctx.Err())
+			return
+		}
+		for seq := r.From(); seq <= r.To(); seq++ {
+			if !yield(s.gen(s.t, seq), nil) {
+				return
+			}
+		}
+	}
+}
+
+// writeFileArchive lays out a minimal file:// history archive — just the root
+// HAS naming the frontier — and returns its URL.
+func writeFileArchive(t *testing.T, currentLedger uint32) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".well-known"), 0o755))
+	has := fmt.Sprintf(`{"version": 1, "server": "test", "currentLedger": %d, "currentBuckets": []}`,
+		currentLedger)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, ".well-known", "stellar-history.json"), []byte(has), 0o644))
+	return "file://" + dir
+}
+
+// #833 acceptance: a no-lake daemon (no [backfill.datastore]) with history
+// archives BACKFILLS — a below-now floor is fillable through captive core, not
+// just pinnable. Boots the real entrypoint with a genesis floor, a file://
+// archive whose root HAS covers chunk 0 (the REAL pool construction and frontier
+// read), and a core stream serving the bounded replay; chunk 0's cold artifacts
+// freeze exactly as on the lake path.
+func TestRunDaemon_NoLakeBackfillsThroughCaptiveCore(t *testing.T) {
+	archiveURL := writeFileArchive(t, chunk.ID(0).LastLedger())
+
+	dataDir := t.TempDir()
+	configPath := filepath.Join(t.TempDir(), "daemon.toml")
+	body := fmt.Sprintf(`
+[service]
+default_data_dir = %q
+
+[retention]
+earliest_ledger = "genesis"
+
+[backfill]
+workers = 1
+
+[ingestion]
+captive_core_config = "/dev/null"
+history_archive_urls = [%q]
+`, dataDir, archiveURL)
+	require.NoError(t, os.WriteFile(configPath, []byte(body), 0o644))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	servedCh := make(chan struct{}, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runDaemonWith(ctx, configPath, daemonOptions{
+			// NO Backend injected: the daemon wires the captive source itself from
+			// the injected core opener + the file:// archive pool.
+			Core:       &streamCore{stream: &coreReplayStream{t: t, gen: someTxGen(t)}},
+			ServeReads: func(context.Context) error { servedCh <- struct{}{}; return nil },
+			Logger:     silentLogger(),
+		})
+	}()
+	select {
+	case <-servedCh: // backfill complete; the daemon is now parked in ingestion
+	case err := <-errCh:
+		t.Fatalf("daemon returned before backfill completed: %v", err)
+	case <-time.After(60 * time.Second):
+		cancel()
+		t.Fatal("no-lake backfill did not finish within 60s")
+	}
+	cancel()
+	select {
+	case err := <-errCh:
+		require.NoError(t, err, "a ctx-canceled ingestion loop is a clean shutdown")
+	case <-time.After(10 * time.Second):
+		t.Fatal("runDaemonWith did not return after ctx cancel")
+	}
+
+	// Chunk 0 froze from the captive replay: ledgers + events + the index coverage.
+	cat := openCatalogAt(t, dataDir)
+	for _, kind := range []geometry.Kind{geometry.KindLedgers, geometry.KindEvents} {
+		state, err := cat.State(0, kind)
+		require.NoError(t, err)
+		assert.Equal(t, geometry.StateFrozen, state, "chunk 0 %s frozen from the captive replay", kind)
+	}
+	assert.FileExists(t, cat.Layout().LedgerPackPath(0))
+	cov, ok, err := cat.FrozenTxHashIndex(0)
+	require.NoError(t, err)
+	require.True(t, ok, "window 0 has a frozen txhash index coverage")
+	assert.Equal(t, chunk.ID(0), cov.Lo)
+	assert.Equal(t, chunk.ID(0), cov.Hi)
 }
 
 func TestNewLogger(t *testing.T) {

--- a/cmd/stellar-rpc/internal/fullhistory/daemon_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/daemon_test.go
@@ -509,14 +509,13 @@ func TestArchiveTip_RootHASErrorSurfaces(t *testing.T) {
 	assert.Contains(t, err.Error(), "archive 503")
 }
 
-// With neither a backend nor archive URLs, the sampler has no sources and errors
-// clearly — the frontfill-only misconfiguration that cannot bootstrap.
+// With neither a backend nor archive URLs there is no tip source, and the
+// frontfill-only misconfiguration that cannot bootstrap fails at build time —
+// startup, not first sample — with the config-shaped message.
 func TestBuildTipSampler_NoSourcesErrors(t *testing.T) {
-	sampler, err := buildTipSampler(context.Background(), nil, nil, silentLogger())
-	require.NoError(t, err)
-	_, sampleErr := sampler.Sample(context.Background())
-	require.Error(t, sampleErr)
-	assert.Contains(t, sampleErr.Error(), "no network tip source configured")
+	_, err := buildTipSampler(context.Background(), nil, nil, silentLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no network tip source configured")
 }
 
 func TestNewLogger(t *testing.T) {

--- a/cmd/stellar-rpc/internal/fullhistory/daemon_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/daemon_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stellar/go-stellar-sdk/historyarchive"
 	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stellar/go-stellar-sdk/network"
 	"github.com/stellar/go-stellar-sdk/xdr"
@@ -437,7 +438,7 @@ func TestSupervise_FirstStartNoTipRetries(t *testing.T) {
 	// Unreachable tip + no local progress: every run fails the first-start check.
 	tip := &fakeTipBackend{err: errors.New("unreachable"), errFirst: 99}
 	start := startTestConfig(t, cat, tip, &fakeCore{}, nil)
-	start.TipMaxAttempts = 1 // one tip poll per run, so callCount tracks restart count
+	start.Tip = testSampler(1, tip) // one tip poll per run, so callCount tracks restart count
 
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
@@ -457,32 +458,65 @@ func TestSupervise_FirstStartNoTipRetries(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// notConfiguredTip — frontfill-only deployment behavior.
+// buildBackfillBackend / buildTipSampler — the frontfill (no datastore) path.
 // ---------------------------------------------------------------------------
 
-func TestNotConfiguredTip_ErrorsClearly(t *testing.T) {
-	_, err := notConfiguredTip{}.NetworkTip(context.Background())
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no bulk backend configured")
-}
-
-// ---------------------------------------------------------------------------
-// buildBackfillBackend — the frontfill (no datastore) path.
-// ---------------------------------------------------------------------------
-
-// With no [backfill.datastore], buildBackfillBackend returns no backend (frontfill),
-// and resolveNetworkTip then yields the not-configured placeholder.
+// With no [backfill.datastore], buildBackfillBackend returns no backend (frontfill).
 func TestBuildBackfillBackend_FrontfillNoBackend(t *testing.T) {
 	cfg := config.Config{}.WithDefaults()
 	backend, cleanup, err := buildBackfillBackend(context.Background(), cfg, silentLogger())
 	require.NoError(t, err)
 	require.Nil(t, backend, "no datastore ⇒ frontfill-only, no backend")
 	require.Nil(t, cleanup, "nothing to release when no backend was opened")
+}
 
-	// The derived tip is the not-configured placeholder: sampling it errors clearly.
-	_, tipErr := resolveNetworkTip(backend).NetworkTip(context.Background())
-	require.Error(t, tipErr)
-	assert.Contains(t, tipErr.Error(), "no bulk backend configured")
+// A frontfill-only daemon (nil backend) with history archives configured gets an
+// archive-backed tip source, so it can bootstrap its earliest_ledger pin — the
+// #833 fix. The archive frontier resolves through GetRootHAS().CurrentLedger.
+func TestBuildTipSampler_FrontfillBootstrapsFromArchive(t *testing.T) {
+	sampler, err := buildTipSampler(
+		context.Background(), nil, []string{"file:///nonexistent-archive"}, silentLogger())
+	require.NoError(t, err)
+	require.NotNil(t, sampler)
+	require.Len(t, sampler.sources, 1, "the archive is the sole tip source when no backend is configured")
+
+	// Drive the archive tip mapping directly against a fake root HAS, proving the
+	// CurrentLedger is what the tip source returns.
+	tip, err := archiveTip(fakeRootHAS{current: 50_000})(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, uint32(50_000), tip)
+}
+
+// fakeRootHAS is a rootHASGetter over a fixed CurrentLedger (or a fixed error),
+// the narrow archive seam archiveTip reads.
+type fakeRootHAS struct {
+	current uint32
+	err     error
+}
+
+func (f fakeRootHAS) GetRootHAS() (historyarchive.HistoryArchiveState, error) {
+	if f.err != nil {
+		return historyarchive.HistoryArchiveState{}, f.err
+	}
+	return historyarchive.HistoryArchiveState{CurrentLedger: f.current}, nil
+}
+
+// A GetRootHAS failure surfaces as a wrapped tip-source error (retryable upstream).
+func TestArchiveTip_RootHASErrorSurfaces(t *testing.T) {
+	_, err := archiveTip(fakeRootHAS{err: errors.New("archive 503")})(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "root HAS")
+	assert.Contains(t, err.Error(), "archive 503")
+}
+
+// With neither a backend nor archive URLs, the sampler has no sources and errors
+// clearly — the frontfill-only misconfiguration that cannot bootstrap.
+func TestBuildTipSampler_NoSourcesErrors(t *testing.T) {
+	sampler, err := buildTipSampler(context.Background(), nil, nil, silentLogger())
+	require.NoError(t, err)
+	_, sampleErr := sampler.Sample(context.Background())
+	require.Error(t, sampleErr)
+	assert.Contains(t, sampleErr.Error(), "no network tip source configured")
 }
 
 func TestNewLogger(t *testing.T) {

--- a/cmd/stellar-rpc/internal/fullhistory/daemon_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/daemon_test.go
@@ -344,15 +344,17 @@ func TestRunDaemon_LockContentionFailsFast(t *testing.T) {
 	assert.Zero(t, served.Load(), "run never reached when the catalog is held")
 }
 
-// First start with a "now" floor and an unreachable tip is fatal at
-// validateConfig: "now" cannot resolve, so the daemon surfaces it.
+// First start with a "now" floor and no usable tip is fatal at validateConfig:
+// "now" cannot resolve, so the daemon surfaces it.
 func TestRunDaemon_NowFloorRequiresTip(t *testing.T) {
 	configPath, _ := writeTempConfigNow(t)
 
 	err := runDaemonWith(context.Background(), configPath, daemonOptions{
-		// An unreachable bulk source (Tip errors) ⇒ the derived network tip can't
-		// resolve "now".
-		Backend:        &fakeBackend{tipErr: errors.New("unreachable")},
+		// A never-ready bulk source (sub-genesis tip ⇒ fast permanent failure) means
+		// the network tip can't resolve "now". Core injected: the opener now resolves
+		// up front and the stub captive_core_config would otherwise error first.
+		Backend:        &fakeBackend{tip: 0},
+		Core:           &fakeCore{},
 		Logger:         silentLogger(),
 		RestartBackoff: time.Millisecond,
 	})
@@ -442,10 +444,11 @@ func TestSupervise_RetriesThenCleanShutdown(t *testing.T) {
 func TestSupervise_FirstStartNoTipRetries(t *testing.T) {
 	cat, _ := testCatalog(t)
 	pinGenesis(t, cat)
-	// Unreachable tip + no local progress: every run fails the first-start check.
-	tip := &fakeTipBackend{err: errors.New("unreachable"), errFirst: 99}
+	// A never-ready tip (sub-genesis ⇒ one permanent-failure poll per run, no
+	// retry sleeps) + no local progress: every run fails the first-start check,
+	// so callCount tracks the restart count.
+	tip := &fakeTipBackend{tips: []uint32{0}}
 	start := startTestConfig(t, cat, tip, &fakeCore{}, nil)
-	start.Tip = testSampler(1, tip) // one tip poll per run, so callCount tracks restart count
 
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
@@ -465,17 +468,30 @@ func TestSupervise_FirstStartNoTipRetries(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// buildBackfillBackend / buildTipSampler — the no-lake (no datastore) paths.
+// buildBackfillBackend — the no-lake (no datastore) paths.
 // ---------------------------------------------------------------------------
 
 // With neither [backfill.datastore] nor an archive pool, buildBackfillBackend
-// returns no backend (the tip-sampler build then fails startup).
+// returns no backend (runDaemonWith then fails startup).
 func TestBuildBackfillBackend_NoSourcesNoBackend(t *testing.T) {
 	cfg := config.Config{}.WithDefaults()
 	backend, cleanup, err := buildBackfillBackend(context.Background(), cfg, &fakeCore{}, nil, silentLogger())
 	require.NoError(t, err)
 	require.Nil(t, backend, "no datastore and no archives ⇒ no bulk source")
 	require.Nil(t, cleanup, "nothing to release when no backend was opened")
+}
+
+// A daemon with no bulk source at all (no datastore, no archives; the injected
+// Core bypasses newCaptiveCoreOpener's own archive-URL requirement) fails fast at
+// startup with the config-shaped message — not at the first backfill pass.
+func TestRunDaemon_NoBulkSourceFailsFast(t *testing.T) {
+	configPath, _ := writeTempConfig(t, "")
+	err := runDaemonWith(context.Background(), configPath, daemonOptions{
+		Core:   &fakeCore{},
+		Logger: silentLogger(),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no bulk ledger source configured")
 }
 
 // With no lake but archives configured, the backfill backend is captive core
@@ -494,36 +510,6 @@ func TestBuildBackfillBackend_NoLakeBuildsCaptiveSource(t *testing.T) {
 	tip, err := backend.Tip(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, uint32(70_000), tip, "the frontier is the archives' root HAS CurrentLedger")
-}
-
-// A no-lake daemon's sampler has the archives as its sole source, so it can
-// bootstrap its earliest_ledger pin — the #833 fix. The archive frontier
-// resolves through GetRootHAS().CurrentLedger.
-func TestBuildTipSampler_NoBackendBootstrapsFromArchive(t *testing.T) {
-	sampler, err := buildTipSampler(nil, fakeRootHAS{current: 50_000})
-	require.NoError(t, err)
-	require.Len(t, sampler.sources, 1, "the archive is the sole tip source when no backend is configured")
-
-	tip, err := sampler.Sample(context.Background())
-	require.NoError(t, err)
-	assert.Equal(t, uint32(50_000), tip)
-}
-
-// A lake backend keeps the archive pool as its fallback: two sources, lake first.
-func TestBuildTipSampler_LakeGetsArchiveFallback(t *testing.T) {
-	sampler, err := buildTipSampler(
-		&fakeBackend{tip: chunk.FirstLedgerSeq}, fakeRootHAS{current: 50_000})
-	require.NoError(t, err)
-	require.Len(t, sampler.sources, 2, "lake frontier first, archive fallback second")
-}
-
-// The captive backend's Tip already IS the archive, so the pool is not added
-// again as a fallback — one source, never consulted twice per attempt.
-func TestBuildTipSampler_CaptiveBackendNotDuplicated(t *testing.T) {
-	has := fakeRootHAS{current: 60_000}
-	sampler, err := buildTipSampler(&captiveSource{archives: has}, has)
-	require.NoError(t, err)
-	require.Len(t, sampler.sources, 1, "captiveSource.Tip is the archive; no duplicate source")
 }
 
 // fakeRootHAS is a rootHASGetter over a fixed CurrentLedger (or a fixed error),
@@ -546,15 +532,6 @@ func TestArchiveTip_RootHASErrorSurfaces(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "root HAS")
 	assert.Contains(t, err.Error(), "archive 503")
-}
-
-// With neither a backend nor an archive pool there is no tip source, and the
-// misconfiguration that cannot bootstrap fails at build time — startup, not
-// first sample — with the config-shaped message.
-func TestBuildTipSampler_NoSourcesErrors(t *testing.T) {
-	_, err := buildTipSampler(nil, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no network tip source configured")
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/stellar-rpc/internal/fullhistory/daemon_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/daemon_test.go
@@ -513,7 +513,7 @@ func TestBuildBackfillBackend_NoLakeBuildsCaptiveSource(t *testing.T) {
 }
 
 // fakeRootHAS is a rootHASGetter over a fixed CurrentLedger (or a fixed error),
-// the narrow archive seam archiveTip reads.
+// the narrow archive seam captiveSource.Tip reads.
 type fakeRootHAS struct {
 	current uint32
 	err     error
@@ -526,9 +526,10 @@ func (f fakeRootHAS) GetRootHAS() (historyarchive.HistoryArchiveState, error) {
 	return historyarchive.HistoryArchiveState{CurrentLedger: f.current}, nil
 }
 
-// A GetRootHAS failure surfaces as a wrapped tip-source error (retryable upstream).
-func TestArchiveTip_RootHASErrorSurfaces(t *testing.T) {
-	_, err := archiveTip(fakeRootHAS{err: errors.New("archive 503")})(context.Background())
+// A GetRootHAS failure surfaces as a wrapped tip error (retryable upstream).
+func TestCaptiveSourceTip_RootHASErrorSurfaces(t *testing.T) {
+	src := &captiveSource{archives: fakeRootHAS{err: errors.New("archive 503")}}
+	_, err := src.Tip(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "root HAS")
 	assert.Contains(t, err.Error(), "archive 503")

--- a/cmd/stellar-rpc/internal/fullhistory/startup.go
+++ b/cmd/stellar-rpc/internal/fullhistory/startup.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
@@ -170,7 +169,7 @@ func run(ctx context.Context, cfg StartConfig) error {
 }
 
 // backfillToTip runs the backfill loop, returning lastCommitted as backfill makes
-// progress. Each pass samples networkTip, anchors on max(tip, lastCommitted),
+// progress. Each pass samples the network tip, anchors on max(tip, lastCommitted),
 // computes [rangeStart, rangeEnd] with the mid-chunk exclusion, and breaks on an
 // empty or non-advancing range.
 func backfillToTip(ctx context.Context, cfg StartConfig, lastCommitted, earliest uint32) (uint32, error) {
@@ -195,18 +194,13 @@ func backfillToTip(ctx context.Context, cfg StartConfig, lastCommitted, earliest
 		// it rather than only around runBackfill. Passes that break early (empty range)
 		// record nothing — the metrics call is below the break.
 		passStart := time.Now()
-		tip, err := networkTip(ctx, cfg.NetworkTip, cfg.TipBackoff, cfg.TipMaxAttempts)
+		// The tip sampler falls back from the lake to the history archives, so an
+		// unavailable tip means no source could be reached at all. Error out rather
+		// than proceed — the daemon must never serve behind an unknown frontier, and
+		// each supervised restart re-samples (a transient outage self-heals).
+		tip, err := cfg.Tip.Sample(ctx)
 		if err != nil {
-			if lastCommitted < earliest {
-				// First start, no reachable backend: error out — the daemon must never
-				// serve incomplete history. Restartable: the property is enforced by
-				// returning an error at all (each restart re-checks lastCommitted <
-				// earliest), not by the exit shape, so a datastore mid-outage or a young
-				// lake below genesis self-heals on a later restart.
-				return 0, fmt.Errorf("network tip unavailable and no local history to serve: %w", err)
-			}
-			// Restart with local progress: serve what's below lastCommitted, skip backfill.
-			tip = lastCommitted
+			return 0, fmt.Errorf("sample network tip: %w", err)
 		}
 
 		// max() guards a lagging bulk tip: the tip alone could regress the floor below
@@ -277,12 +271,6 @@ func lastCommittedMidChunk(lastCommitted uint32) bool {
 // Injected external boundaries (so startup is testable with fakes).
 // ---------------------------------------------------------------------------
 
-// NetworkTipBackend samples the bulk backend's current network tip during backfill.
-// It is consulted only during backfill; once ingestion runs, captive core is the tip.
-type NetworkTipBackend interface {
-	NetworkTip(ctx context.Context) (uint32, error)
-}
-
 // CoreOpener hands back the live ingestion stream the loop consumes. The stream
 // OWNS its source's lifecycle (started on the first RawLedgers pull over the
 // unbounded range from the loop's resume ledger, torn down when the loop exits),
@@ -304,8 +292,9 @@ type StartConfig struct {
 	// diverge on the catalog/pool (the invariant is structural, not by comment).
 	RetentionChunks uint32
 
-	// NetworkTip samples the bulk backend's tip during backfill. Required.
-	NetworkTip NetworkTipBackend
+	// Tip samples the network frontier during backfill (lake first, history
+	// archives as fallback). Its retry defaults are bound at construction. Required.
+	Tip *tipSampler
 
 	// Core starts captive core and yields the ingestion getter. Required.
 	Core CoreOpener
@@ -313,31 +302,15 @@ type StartConfig struct {
 	// ServeReads begins serving reads; it must return promptly, not block. Required.
 	ServeReads func(ctx context.Context) error
 
-	// TipBackoff is networkTip's inter-attempt sleep; TipMaxAttempts bounds the
-	// retries. Zero values fall back to defaults in withDefaults.
-	TipBackoff     time.Duration
-	TipMaxAttempts int
-
 	// runBackfill is a test-only seam for one backfill pass; nil ⇒ backfill.RunBackfill.
 	runBackfill func(ctx context.Context, exec backfill.ExecConfig, lo, hi chunk.ID) error
 }
 
-const (
-	defaultTipBackoff     = time.Second
-	defaultTipMaxAttempts = 5
-)
-
-// withDefaults fills the tip-backoff defaults and the embedded Exec defaults
-// (Workers -> GOMAXPROCS). The lifecycle.Config is assembled from Exec +
-// RetentionChunks in run().
+// withDefaults fills the embedded Exec defaults (Workers -> GOMAXPROCS). The
+// lifecycle.Config is assembled from Exec + RetentionChunks in run(); the tip
+// sampler's retry defaults are bound at its construction, not here.
 func (cfg StartConfig) withDefaults() StartConfig {
 	cfg.Exec = cfg.Exec.WithDefaults()
-	if cfg.TipBackoff <= 0 {
-		cfg.TipBackoff = defaultTipBackoff
-	}
-	if cfg.TipMaxAttempts <= 0 {
-		cfg.TipMaxAttempts = defaultTipMaxAttempts
-	}
 	return cfg
 }
 
@@ -348,8 +321,8 @@ func (cfg StartConfig) validate() error {
 	if cfg.Exec.Logger == nil {
 		return errors.New("nil StartConfig.Exec.Logger")
 	}
-	if cfg.NetworkTip == nil {
-		return errors.New("nil StartConfig.NetworkTip")
+	if cfg.Tip == nil {
+		return errors.New("nil StartConfig.Tip")
 	}
 	if cfg.Core == nil {
 		return errors.New("nil StartConfig.Core")
@@ -358,45 +331,4 @@ func (cfg StartConfig) validate() error {
 		return errors.New("nil StartConfig.ServeReads")
 	}
 	return nil
-}
-
-// networkTip samples backend.NetworkTip, retrying a transient error on a bounded
-// constant backoff (maxAttempts total tries) and rejecting a sub-genesis tip as
-// "not ready" so an unready backend never pins a garbage floor. Built on
-// cenkalti/backoff — the same retry primitive as withRetries and waitForCoverage —
-// so ctx cancellation aborts the wait and the sub-genesis case is backoff.Permanent.
-func networkTip(
-	ctx context.Context, backend NetworkTipBackend, interval time.Duration, maxAttempts int,
-) (uint32, error) {
-	if maxAttempts < 1 {
-		maxAttempts = 1 // never underflow WithMaxRetries' uint64 into an unbounded loop
-	}
-	var (
-		tip      uint32
-		notReady bool
-	)
-	poll := func() error {
-		t, err := backend.NetworkTip(ctx)
-		if err != nil {
-			return err // transient — retry
-		}
-		if t < chunk.FirstLedgerSeq {
-			// Below genesis ⇒ backend empty/not-synced; permanent (it would keep returning 0).
-			notReady = true
-			return backoff.Permanent(fmt.Errorf("backend tip %d is below genesis %d — backend not ready",
-				t, chunk.FirstLedgerSeq))
-		}
-		tip = t
-		return nil
-	}
-	// Constant interval, count-bounded: maxAttempts tries == 1 initial + (maxAttempts-1) retries.
-	bo := backoff.WithMaxRetries(backoff.NewConstantBackOff(interval), uint64(maxAttempts-1))
-	switch err := backoff.Retry(poll, backoff.WithContext(bo, ctx)); {
-	case err == nil:
-		return tip, nil
-	case notReady, ctx.Err() != nil:
-		return 0, err // permanent (not ready) or ctx-canceled: surface as-is, not "exhausted"
-	default:
-		return 0, fmt.Errorf("network tip unavailable after %d attempts: %w", maxAttempts, err)
-	}
 }

--- a/cmd/stellar-rpc/internal/fullhistory/startup.go
+++ b/cmd/stellar-rpc/internal/fullhistory/startup.go
@@ -194,11 +194,13 @@ func backfillToTip(ctx context.Context, cfg StartConfig, lastCommitted, earliest
 		// it rather than only around runBackfill. Passes that break early (empty range)
 		// record nothing — the metrics call is below the break.
 		passStart := time.Now()
-		// The tip sampler falls back from the lake to the history archives, so an
-		// unavailable tip means no source could be reached at all. Error out rather
-		// than proceed — the daemon must never serve behind an unknown frontier, and
-		// each supervised restart re-samples (a transient outage self-heals).
-		tip, err := cfg.Tip.Sample(ctx)
+		// The backend owns its frontier (the lake for bsbSource, the archives for
+		// captiveSource). A tip still unavailable after the bounded retry errors the
+		// pass rather than proceeding — the daemon must never serve behind an unknown
+		// frontier — and each supervised restart re-samples (a transient outage
+		// self-heals).
+		tip, err := sampleTipWithRetry(
+			ctx, cfg.Exec.Process.Backend.Tip, defaultTipBackoff, defaultTipMaxAttempts)
 		if err != nil {
 			return 0, fmt.Errorf("sample network tip: %w", err)
 		}
@@ -292,11 +294,6 @@ type StartConfig struct {
 	// diverge on the catalog/pool (the invariant is structural, not by comment).
 	RetentionChunks uint32
 
-	// Tip samples the network frontier during backfill (the backend's own frontier
-	// first, the archives as the lake's fallback). Its retry defaults are bound at
-	// construction. Required.
-	Tip *tipSampler
-
 	// Core starts captive core and yields the ingestion getter. Required.
 	Core CoreOpener
 
@@ -309,7 +306,7 @@ type StartConfig struct {
 
 // withDefaults fills the embedded Exec defaults (Workers -> GOMAXPROCS). The
 // lifecycle.Config is assembled from Exec + RetentionChunks in run(); the tip
-// sampler's retry defaults are bound at its construction, not here.
+// retry policy is the sampleTipWithRetry defaults at its call sites, not here.
 func (cfg StartConfig) withDefaults() StartConfig {
 	cfg.Exec = cfg.Exec.WithDefaults()
 	return cfg
@@ -322,8 +319,10 @@ func (cfg StartConfig) validate() error {
 	if cfg.Exec.Logger == nil {
 		return errors.New("nil StartConfig.Exec.Logger")
 	}
-	if cfg.Tip == nil {
-		return errors.New("nil StartConfig.Tip")
+	if cfg.Exec.Process.Backend == nil {
+		// The backend is the tip source every backfill pass samples (and the
+		// freeze's bulk fetch); runDaemonWith guarantees one at startup.
+		return errors.New("nil StartConfig.Exec.Process.Backend")
 	}
 	if cfg.Core == nil {
 		return errors.New("nil StartConfig.Core")

--- a/cmd/stellar-rpc/internal/fullhistory/startup.go
+++ b/cmd/stellar-rpc/internal/fullhistory/startup.go
@@ -292,8 +292,9 @@ type StartConfig struct {
 	// diverge on the catalog/pool (the invariant is structural, not by comment).
 	RetentionChunks uint32
 
-	// Tip samples the network frontier during backfill (lake first, history
-	// archives as fallback). Its retry defaults are bound at construction. Required.
+	// Tip samples the network frontier during backfill (the backend's own frontier
+	// first, the archives as the lake's fallback). Its retry defaults are bound at
+	// construction. Required.
 	Tip *tipSampler
 
 	// Core starts captive core and yields the ingestion getter. Required.

--- a/cmd/stellar-rpc/internal/fullhistory/startup_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/startup_test.go
@@ -314,20 +314,22 @@ func TestBackfill_LongDowntimeRePass(t *testing.T) {
 	assert.GreaterOrEqual(t, tip.callCount(), 3, "the loop re-sampled the tip across passes")
 }
 
-// Restart with an unreachable tip errors out even when local progress exists: the
-// synthetic tip:=lastCommitted degraded mode is gone (the sampler's lake→archive
-// fallback means an unavailable tip is a genuine "no source reachable"). No
-// backfill pass runs; the supervisor restarts and re-samples.
-func TestBackfill_RestartTipUnreachableErrors(t *testing.T) {
+// Restart with no usable tip errors out even when local progress exists: the
+// synthetic tip:=lastCommitted degraded mode is gone. No backfill pass runs; the
+// supervisor restarts and re-samples. Sub-genesis reads as a permanent "not
+// ready" — one poll, no retry sleeps — and resolves to the same "tip
+// unavailable" outcome as an erroring tip (whose retry exhaustion
+// TestSampleTip_ExhaustedRetriesErrors covers at a fast interval).
+func TestBackfill_RestartTipUnavailableErrors(t *testing.T) {
 	cat, _ := testCatalog(t)
 	pinGenesis(t, cat)
 	lastCommitted := chunk.ID(2).LastLedger() // local progress exists
-	tip := &fakeTipBackend{err: errors.New("backend down"), errFirst: 99}
+	tip := &fakeTipBackend{tips: []uint32{0}}
 	rec := &recordingPlan{}
 	cfg := startTestConfig(t, cat, tip, nil, rec)
 
 	_, err := backfillToTip(context.Background(), cfg, lastCommitted, chunk.FirstLedgerSeq)
-	require.Error(t, err, "an unreachable tip errors out — no degraded mode")
+	require.Error(t, err, "an unavailable tip errors out — no degraded mode")
 	require.Empty(t, rec.snapshot(), "no backfill pass runs when the tip is unavailable")
 }
 
@@ -483,13 +485,14 @@ func TestRun_OpensHotDBAndCoreBeforeServe(t *testing.T) {
 }
 
 // run errors on a first start with an unavailable tip (restartable, no sentinel);
-// reads are never served and ingestion never starts.
+// reads are never served and ingestion never starts. Sub-genesis ⇒ one
+// permanent-failure poll, no retry sleeps.
 func TestRun_FirstStartNoTipErrors(t *testing.T) {
 	cat, _ := testCatalog(t)
 	pinGenesis(t, cat)
 	served := atomic.Int32{}
 	core := &fakeCore{}
-	tip := &fakeTipBackend{err: errors.New("unreachable"), errFirst: 99}
+	tip := &fakeTipBackend{tips: []uint32{0}}
 	cfg := startTestConfig(t, cat, tip, core, nil)
 	cfg.ServeReads = func(context.Context) error { served.Add(1); return nil }
 

--- a/cmd/stellar-rpc/internal/fullhistory/startup_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/startup_test.go
@@ -25,8 +25,11 @@ import (
 
 // fakeTipBackend returns tips[i] per call (clamped to the last); if err is set it
 // returns err for the first errFirst calls, then the tip (errFirst large ⇒ always down).
-// Its tip method has the tipSource signature, so it wires straight into a tipSampler.
+// Its Tip method makes it a backfill.Backend — the embedded LedgerStream stays nil
+// since these tests never stream (the runBackfill seam records passes instead).
 type fakeTipBackend struct {
+	ledgerbackend.LedgerStream
+
 	mu       sync.Mutex
 	tips     []uint32
 	calls    int
@@ -34,7 +37,9 @@ type fakeTipBackend struct {
 	errFirst int // return err for the first errFirst calls, then the tip
 }
 
-func (b *fakeTipBackend) tip(context.Context) (uint32, error) {
+var _ backfill.Backend = (*fakeTipBackend)(nil)
+
+func (b *fakeTipBackend) Tip(context.Context) (uint32, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	n := b.calls
@@ -56,16 +61,6 @@ func (b *fakeTipBackend) callCount() int {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.calls
-}
-
-// testSampler builds a tipSampler over the given fake backends (tried in order)
-// with fast test backoff. maxAttempts bounds the retries per Sample call.
-func testSampler(maxAttempts int, backends ...*fakeTipBackend) *tipSampler {
-	sources := make([]tipSource, len(backends))
-	for i, b := range backends {
-		sources[i] = b.tip
-	}
-	return &tipSampler{sources: sources, interval: time.Millisecond, maxAttempts: maxAttempts}
 }
 
 // recordingPlan captures the [lo,hi] each backfill pass asked for via the
@@ -101,12 +96,11 @@ func startTestConfig(
 		Catalog: cat,
 		Logger:  silentLogger(),
 		Workers: 2,
-		Process: backfill.ProcessConfig{},
+		Process: backfill.ProcessConfig{Backend: tip}, // the tip source every pass samples
 	}
 	cfg := StartConfig{
 		Exec:            exec,
 		RetentionChunks: 0,
-		Tip:             testSampler(3, tip),
 		Core:            core,
 		ServeReads:      func(context.Context) error { return nil },
 	}
@@ -158,93 +152,54 @@ func pinGenesis(t *testing.T, cat *catalog.Catalog) {
 }
 
 // ---------------------------------------------------------------------------
-// tipSampler.Sample — backoff, sub-genesis rejection, exhausted retries,
-// and the lake→archive source fallback.
+// sampleTipWithRetry — backoff, sub-genesis rejection, exhausted retries, ctx cancel.
 // ---------------------------------------------------------------------------
 
-func TestSample_RejectsSubGenesisAsNotReady(t *testing.T) {
-	tip, err := testSampler(3, &fakeTipBackend{tips: []uint32{chunk.FirstLedgerSeq - 1}}).
-		Sample(context.Background())
+func TestSampleTip_RejectsSubGenesisAsNotReady(t *testing.T) {
+	b := &fakeTipBackend{tips: []uint32{chunk.FirstLedgerSeq - 1}}
+	tip, err := sampleTipWithRetry(context.Background(), b.Tip, time.Millisecond, 3)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not ready")
 	require.Zero(t, tip)
+	require.Equal(t, 1, b.callCount(), "sub-genesis is permanent — no retries burned")
 }
 
-func TestSample_RetriesThenSucceeds(t *testing.T) {
+func TestSampleTip_RetriesThenSucceeds(t *testing.T) {
 	b := &fakeTipBackend{tips: []uint32{50_000}, err: errors.New("object store down"), errFirst: 2}
-	tip, err := testSampler(5, b).Sample(context.Background())
+	tip, err := sampleTipWithRetry(context.Background(), b.Tip, time.Millisecond, 5)
 	require.NoError(t, err)
 	require.Equal(t, uint32(50_000), tip)
 	require.Equal(t, 3, b.callCount(), "two failures then a success")
 }
 
-func TestSample_ExhaustedRetriesErrors(t *testing.T) {
+func TestSampleTip_ExhaustedRetriesErrors(t *testing.T) {
 	b := &fakeTipBackend{err: errors.New("object store down"), errFirst: 99}
-	_, err := testSampler(4, b).Sample(context.Background())
+	_, err := sampleTipWithRetry(context.Background(), b.Tip, time.Millisecond, 4)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "after 4 attempts")
 	require.Equal(t, 4, b.callCount())
 }
 
-func TestSample_CtxCancelAbortsWait(t *testing.T) {
+func TestSampleTip_CtxCancelAbortsWait(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	b := &fakeTipBackend{err: errors.New("down"), errFirst: 99}
-	s := &tipSampler{sources: []tipSource{b.tip}, interval: time.Hour, maxAttempts: 5}
-	_, err := s.Sample(ctx)
+	_, err := sampleTipWithRetry(ctx, b.Tip, time.Hour, 5)
 	require.ErrorIs(t, err, context.Canceled)
-}
-
-// The lake tip is preferred: when the first source answers, the fallback is
-// never consulted.
-func TestSample_PrefersFirstSource(t *testing.T) {
-	lake := &fakeTipBackend{tips: []uint32{50_000}}
-	archive := &fakeTipBackend{tips: []uint32{49_936}} // one checkpoint behind
-	tip, err := testSampler(3, lake, archive).Sample(context.Background())
-	require.NoError(t, err)
-	require.Equal(t, uint32(50_000), tip, "the lake tip wins when it answers")
-	require.Zero(t, archive.callCount(), "the archive fallback is not consulted")
-}
-
-// The archive fallback answers on the same attempt when the lake tip is down —
-// no retry needed to fall over.
-func TestSample_FallsBackToArchiveWhenLakeDown(t *testing.T) {
-	lake := &fakeTipBackend{err: errors.New("lake unreachable"), errFirst: 99}
-	archive := &fakeTipBackend{tips: []uint32{49_936}}
-	tip, err := testSampler(3, lake, archive).Sample(context.Background())
-	require.NoError(t, err)
-	require.Equal(t, uint32(49_936), tip, "falls back to the archive frontier")
-	require.Equal(t, 1, archive.callCount(), "the fallback answers on the first attempt")
-}
-
-// With every source down, Sample exhausts its retries and joins their errors.
-func TestSample_AllSourcesDownExhausts(t *testing.T) {
-	lake := &fakeTipBackend{err: errors.New("lake down"), errFirst: 99}
-	archive := &fakeTipBackend{err: errors.New("archive down"), errFirst: 99}
-	_, err := testSampler(2, lake, archive).Sample(context.Background())
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "lake down")
-	require.Contains(t, err.Error(), "archive down")
-}
-
-// A sampler with no sources at all (neither a lake nor archives) errors clearly
-// — the frontfill-only misconfiguration that cannot bootstrap.
-func TestSample_NoSourcesErrorsClearly(t *testing.T) {
-	_, err := newTipSampler().Sample(context.Background())
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "no network tip source configured")
 }
 
 // ---------------------------------------------------------------------------
 // backfillToTip — backfill loop edge cases.
 // ---------------------------------------------------------------------------
 
-// First start (genesis, no local history) with the tip absent errors out
-// (restartable — no sentinel; the supervisor retries).
+// First start (genesis, no local history) with no usable tip errors out
+// (restartable — no sentinel; the supervisor retries). Sub-genesis reads as a
+// permanent "not ready", so the sample fails fast instead of burning the
+// production retry backoff backfillToTip now applies.
 func TestBackfill_FirstStartTipAbsentErrors(t *testing.T) {
 	cat, _ := testCatalog(t)
 	pinGenesis(t, cat)
-	tip := &fakeTipBackend{err: errors.New("backend unreachable"), errFirst: 99}
+	tip := &fakeTipBackend{tips: []uint32{0}}
 	cfg := startTestConfig(t, cat, tip, nil, &recordingPlan{})
 
 	// Empty catalog ⇒ lastCommitted=1 < earliest=2 ⇒ first start with no progress.
@@ -560,9 +515,9 @@ func TestRun_ValidatesConfig(t *testing.T) {
 	cat, _ := testCatalog(t)
 	base := startTestConfig(t, cat, &fakeTipBackend{tips: []uint32{50_000}}, &fakeCore{}, nil)
 
-	t.Run("nil Tip", func(t *testing.T) {
+	t.Run("nil Backend", func(t *testing.T) {
 		cfg := base
-		cfg.Tip = nil
+		cfg.Exec.Process.Backend = nil // the backfill tip + freeze source
 		require.Error(t, run(context.Background(), cfg))
 	})
 	t.Run("nil Core", func(t *testing.T) {

--- a/cmd/stellar-rpc/internal/fullhistory/startup_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/startup_test.go
@@ -25,6 +25,7 @@ import (
 
 // fakeTipBackend returns tips[i] per call (clamped to the last); if err is set it
 // returns err for the first errFirst calls, then the tip (errFirst large ⇒ always down).
+// Its tip method has the tipSource signature, so it wires straight into a tipSampler.
 type fakeTipBackend struct {
 	mu       sync.Mutex
 	tips     []uint32
@@ -33,7 +34,7 @@ type fakeTipBackend struct {
 	errFirst int // return err for the first errFirst calls, then the tip
 }
 
-func (b *fakeTipBackend) NetworkTip(context.Context) (uint32, error) {
+func (b *fakeTipBackend) tip(context.Context) (uint32, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	n := b.calls
@@ -55,6 +56,16 @@ func (b *fakeTipBackend) callCount() int {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.calls
+}
+
+// testSampler builds a tipSampler over the given fake backends (tried in order)
+// with fast test backoff. maxAttempts bounds the retries per Sample call.
+func testSampler(maxAttempts int, backends ...*fakeTipBackend) *tipSampler {
+	sources := make([]tipSource, len(backends))
+	for i, b := range backends {
+		sources[i] = b.tip
+	}
+	return &tipSampler{sources: sources, interval: time.Millisecond, maxAttempts: maxAttempts}
 }
 
 // recordingPlan captures the [lo,hi] each backfill pass asked for via the
@@ -95,11 +106,9 @@ func startTestConfig(
 	cfg := StartConfig{
 		Exec:            exec,
 		RetentionChunks: 0,
-		NetworkTip:      tip,
+		Tip:             testSampler(3, tip),
 		Core:            core,
 		ServeReads:      func(context.Context) error { return nil },
-		TipBackoff:      time.Millisecond,
-		TipMaxAttempts:  3,
 	}
 	if recordPlan != nil {
 		cfg.runBackfill = func(_ context.Context, _ backfill.ExecConfig, lo, hi chunk.ID) error {
@@ -149,39 +158,81 @@ func pinGenesis(t *testing.T, cat *catalog.Catalog) {
 }
 
 // ---------------------------------------------------------------------------
-// networkTip — backoff, sub-genesis rejection, exhausted retries.
+// tipSampler.Sample — backoff, sub-genesis rejection, exhausted retries,
+// and the lake→archive source fallback.
 // ---------------------------------------------------------------------------
 
-func TestNetworkTip_RejectsSubGenesisAsNotReady(t *testing.T) {
-	tip, err := networkTip(context.Background(),
-		&fakeTipBackend{tips: []uint32{chunk.FirstLedgerSeq - 1}}, time.Millisecond, 3)
+func TestSample_RejectsSubGenesisAsNotReady(t *testing.T) {
+	tip, err := testSampler(3, &fakeTipBackend{tips: []uint32{chunk.FirstLedgerSeq - 1}}).
+		Sample(context.Background())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not ready")
 	require.Zero(t, tip)
 }
 
-func TestNetworkTip_RetriesThenSucceeds(t *testing.T) {
+func TestSample_RetriesThenSucceeds(t *testing.T) {
 	b := &fakeTipBackend{tips: []uint32{50_000}, err: errors.New("object store down"), errFirst: 2}
-	tip, err := networkTip(context.Background(), b, time.Millisecond, 5)
+	tip, err := testSampler(5, b).Sample(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, uint32(50_000), tip)
 	require.Equal(t, 3, b.callCount(), "two failures then a success")
 }
 
-func TestNetworkTip_ExhaustedRetriesErrors(t *testing.T) {
+func TestSample_ExhaustedRetriesErrors(t *testing.T) {
 	b := &fakeTipBackend{err: errors.New("object store down"), errFirst: 99}
-	_, err := networkTip(context.Background(), b, time.Millisecond, 4)
+	_, err := testSampler(4, b).Sample(context.Background())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "after 4 attempts")
 	require.Equal(t, 4, b.callCount())
 }
 
-func TestNetworkTip_CtxCancelAbortsWait(t *testing.T) {
+func TestSample_CtxCancelAbortsWait(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	b := &fakeTipBackend{err: errors.New("down"), errFirst: 99}
-	_, err := networkTip(ctx, b, time.Hour, 5)
+	s := &tipSampler{sources: []tipSource{b.tip}, interval: time.Hour, maxAttempts: 5}
+	_, err := s.Sample(ctx)
 	require.ErrorIs(t, err, context.Canceled)
+}
+
+// The lake tip is preferred: when the first source answers, the fallback is
+// never consulted.
+func TestSample_PrefersFirstSource(t *testing.T) {
+	lake := &fakeTipBackend{tips: []uint32{50_000}}
+	archive := &fakeTipBackend{tips: []uint32{49_936}} // one checkpoint behind
+	tip, err := testSampler(3, lake, archive).Sample(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, uint32(50_000), tip, "the lake tip wins when it answers")
+	require.Zero(t, archive.callCount(), "the archive fallback is not consulted")
+}
+
+// The archive fallback answers on the same attempt when the lake tip is down —
+// no retry needed to fall over.
+func TestSample_FallsBackToArchiveWhenLakeDown(t *testing.T) {
+	lake := &fakeTipBackend{err: errors.New("lake unreachable"), errFirst: 99}
+	archive := &fakeTipBackend{tips: []uint32{49_936}}
+	tip, err := testSampler(3, lake, archive).Sample(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, uint32(49_936), tip, "falls back to the archive frontier")
+	require.Equal(t, 1, archive.callCount(), "the fallback answers on the first attempt")
+}
+
+// With every source down, Sample exhausts its retries and joins their errors.
+func TestSample_AllSourcesDownExhausts(t *testing.T) {
+	lake := &fakeTipBackend{err: errors.New("lake down"), errFirst: 99}
+	archive := &fakeTipBackend{err: errors.New("archive down"), errFirst: 99}
+	_, err := testSampler(2, lake, archive).Sample(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "lake down")
+	require.Contains(t, err.Error(), "archive down")
+}
+
+// A sampler with no sources at all (neither a lake nor archives) errors clearly
+// — the frontfill-only misconfiguration that cannot bootstrap.
+func TestSample_NoSourcesErrorsClearly(t *testing.T) {
+	_, err := newTipSampler().Sample(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no network tip source configured")
 }
 
 // ---------------------------------------------------------------------------
@@ -308,10 +359,11 @@ func TestBackfill_LongDowntimeRePass(t *testing.T) {
 	assert.GreaterOrEqual(t, tip.callCount(), 3, "the loop re-sampled the tip across passes")
 }
 
-// Degrade-and-serve restart: tip unreachable but local progress exists, so
-// backfill degrades to tip:=lastCommitted, re-resolves [0,2] once, terminates,
-// and never regresses the lastCommitted.
-func TestBackfill_RestartTipUnreachableDegrades(t *testing.T) {
+// Restart with an unreachable tip errors out even when local progress exists: the
+// synthetic tip:=lastCommitted degraded mode is gone (the sampler's lake→archive
+// fallback means an unavailable tip is a genuine "no source reachable"). No
+// backfill pass runs; the supervisor restarts and re-samples.
+func TestBackfill_RestartTipUnreachableErrors(t *testing.T) {
 	cat, _ := testCatalog(t)
 	pinGenesis(t, cat)
 	lastCommitted := chunk.ID(2).LastLedger() // local progress exists
@@ -319,12 +371,9 @@ func TestBackfill_RestartTipUnreachableDegrades(t *testing.T) {
 	rec := &recordingPlan{}
 	cfg := startTestConfig(t, cat, tip, nil, rec)
 
-	last, err := backfillToTip(context.Background(), cfg, lastCommitted, chunk.FirstLedgerSeq)
-	require.NoError(t, err, "local progress means no fatal")
-	passes := rec.snapshot()
-	require.Len(t, passes, 1, "exactly one degraded re-resolve pass, then terminate")
-	assert.Equal(t, chunk.ID(2), passes[0][1])
-	assert.Equal(t, lastCommitted, last, "lastCommitted does not regress")
+	_, err := backfillToTip(context.Background(), cfg, lastCommitted, chunk.FirstLedgerSeq)
+	require.Error(t, err, "an unreachable tip errors out — no degraded mode")
+	require.Empty(t, rec.snapshot(), "no backfill pass runs when the tip is unavailable")
 }
 
 // Lagging bulk tip below a chunk-aligned lastCommitted: the anchor is max(tip,
@@ -511,9 +560,9 @@ func TestRun_ValidatesConfig(t *testing.T) {
 	cat, _ := testCatalog(t)
 	base := startTestConfig(t, cat, &fakeTipBackend{tips: []uint32{50_000}}, &fakeCore{}, nil)
 
-	t.Run("nil NetworkTip", func(t *testing.T) {
+	t.Run("nil Tip", func(t *testing.T) {
 		cfg := base
-		cfg.NetworkTip = nil
+		cfg.Tip = nil
 		require.Error(t, run(context.Background(), cfg))
 	})
 	t.Run("nil Core", func(t *testing.T) {

--- a/cmd/stellar-rpc/internal/fullhistory/tip.go
+++ b/cmd/stellar-rpc/internal/fullhistory/tip.go
@@ -23,10 +23,11 @@ type tipSource func(ctx context.Context) (uint32, error)
 
 // tipSampler is the single home for network-tip sampling: first-start
 // earliest_ledger resolution and every backfill pass both go through it. It
-// queries its sources in order — the bulk lake frontier first, the history
-// archives' root HAS as a fallback (and the sole source for a frontfill-only
-// daemon) — and returns the first that answers, retrying a transient failure of
-// them all on a bounded constant backoff. Built on cenkalti/backoff, the same
+// queries its sources in order — the backend's own frontier first (the bulk lake
+// for bsbSource, the history archives for captiveSource), the archives' root HAS
+// as the lake's fallback — and returns the first that answers, retrying a
+// transient failure of them all on a bounded constant backoff. Built on
+// cenkalti/backoff, the same
 // retry primitive withRetries and waitForCoverage use, so ctx cancellation
 // aborts the wait. A sub-genesis tip is rejected as "not ready" (permanent) so
 // an unready backend never pins a garbage floor.
@@ -108,8 +109,8 @@ type rootHASGetter interface {
 }
 
 // archiveTip samples the network frontier from the history archives' root HAS.
-// It is the tip source for a frontfill-only daemon (no bulk lake) and the
-// fallback when the lake tip is unavailable. The archives lag the lake by up to
+// It is captiveSource's frontier for a no-lake daemon and the fallback when the
+// lake tip is unavailable. The archives lag the lake by up to
 // one checkpoint (64 ledgers); backfill's anchor = max(tip, lastCommitted) and
 // the signed withinOneChunkOfTip already absorb that, so no lag adjustment here.
 func archiveTip(a rootHASGetter) tipSource {

--- a/cmd/stellar-rpc/internal/fullhistory/tip.go
+++ b/cmd/stellar-rpc/internal/fullhistory/tip.go
@@ -1,0 +1,122 @@
+package fullhistory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+
+	"github.com/stellar/go-stellar-sdk/historyarchive"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+)
+
+const (
+	defaultTipBackoff     = time.Second
+	defaultTipMaxAttempts = 5
+)
+
+// tipSource queries one backend's current network frontier — its latest ledger.
+type tipSource func(ctx context.Context) (uint32, error)
+
+// tipSampler is the single home for network-tip sampling: first-start
+// earliest_ledger resolution and every backfill pass both go through it. It
+// queries its sources in order — the bulk lake frontier first, the history
+// archives' root HAS as a fallback (and the sole source for a frontfill-only
+// daemon) — and returns the first that answers, retrying a transient failure of
+// them all on a bounded constant backoff. Built on cenkalti/backoff, the same
+// retry primitive withRetries and waitForCoverage use, so ctx cancellation
+// aborts the wait. A sub-genesis tip is rejected as "not ready" (permanent) so
+// an unready backend never pins a garbage floor.
+type tipSampler struct {
+	sources     []tipSource // tried in order; first success wins
+	interval    time.Duration
+	maxAttempts int
+}
+
+// newTipSampler binds the retry defaults; sources are tried in the order given.
+func newTipSampler(sources ...tipSource) *tipSampler {
+	return &tipSampler{
+		sources:     sources,
+		interval:    defaultTipBackoff,
+		maxAttempts: defaultTipMaxAttempts,
+	}
+}
+
+// Sample returns the current network tip, trying each source in order and
+// retrying a transient failure of them all up to maxAttempts times.
+func (s *tipSampler) Sample(ctx context.Context) (uint32, error) {
+	if len(s.sources) == 0 {
+		return 0, errors.New("no network tip source configured: set [backfill.datastore] " +
+			"or [ingestion].history_archive_urls")
+	}
+	maxAttempts := s.maxAttempts
+	if maxAttempts < 1 {
+		maxAttempts = 1 // never underflow WithMaxRetries' uint64 into an unbounded loop
+	}
+	var (
+		tip      uint32
+		notReady bool
+	)
+	poll := func() error {
+		t, err := s.sampleOnce(ctx)
+		if err != nil {
+			return err // transient — every source failed; retry
+		}
+		if t < chunk.FirstLedgerSeq {
+			// Below genesis ⇒ backend empty/not-synced; permanent (it would keep returning 0).
+			notReady = true
+			return backoff.Permanent(fmt.Errorf("backend tip %d is below genesis %d — backend not ready",
+				t, chunk.FirstLedgerSeq))
+		}
+		tip = t
+		return nil
+	}
+	// Constant interval, count-bounded: maxAttempts tries == 1 initial + (maxAttempts-1) retries.
+	bo := backoff.WithMaxRetries(backoff.NewConstantBackOff(s.interval), uint64(maxAttempts-1))
+	switch err := backoff.Retry(poll, backoff.WithContext(bo, ctx)); {
+	case err == nil:
+		return tip, nil
+	case notReady, ctx.Err() != nil:
+		return 0, err // permanent (not ready) or ctx-canceled: surface as-is, not "exhausted"
+	default:
+		return 0, fmt.Errorf("network tip unavailable after %d attempts: %w", maxAttempts, err)
+	}
+}
+
+// sampleOnce tries each source in order, returning the first frontier that
+// answers; if all fail it joins their errors (retryable).
+func (s *tipSampler) sampleOnce(ctx context.Context) (uint32, error) {
+	errs := make([]error, 0, len(s.sources))
+	for _, src := range s.sources {
+		t, err := src(ctx)
+		if err == nil {
+			return t, nil
+		}
+		errs = append(errs, err)
+	}
+	return 0, errors.Join(errs...)
+}
+
+// rootHASGetter is the slice of historyarchive.ArchiveInterface archiveTip needs:
+// the network frontier is the CurrentLedger the root HAS publishes.
+type rootHASGetter interface {
+	GetRootHAS() (historyarchive.HistoryArchiveState, error)
+}
+
+// archiveTip samples the network frontier from the history archives' root HAS.
+// It is the tip source for a frontfill-only daemon (no bulk lake) and the
+// fallback when the lake tip is unavailable. The archives lag the lake by up to
+// one checkpoint (64 ledgers); backfill's anchor = max(tip, lastCommitted) and
+// the signed withinOneChunkOfTip already absorb that, so no lag adjustment here.
+func archiveTip(a rootHASGetter) tipSource {
+	return func(context.Context) (uint32, error) {
+		has, err := a.GetRootHAS()
+		if err != nil {
+			return 0, fmt.Errorf("history archive root HAS: %w", err)
+		}
+		return has.CurrentLedger, nil
+	}
+}

--- a/cmd/stellar-rpc/internal/fullhistory/tip.go
+++ b/cmd/stellar-rpc/internal/fullhistory/tip.go
@@ -2,7 +2,6 @@ package fullhistory
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -21,85 +20,49 @@ const (
 // tipSource queries one backend's current network frontier — its latest ledger.
 type tipSource func(ctx context.Context) (uint32, error)
 
-// tipSampler is the single home for network-tip sampling: first-start
-// earliest_ledger resolution and every backfill pass both go through it. It
-// queries its sources in order — the backend's own frontier first (the bulk lake
-// for bsbSource, the history archives for captiveSource), the archives' root HAS
-// as the lake's fallback — and returns the first that answers, retrying a
-// transient failure of them all on a bounded constant backoff. Built on
-// cenkalti/backoff, the same
-// retry primitive withRetries and waitForCoverage use, so ctx cancellation
-// aborts the wait. A sub-genesis tip is rejected as "not ready" (permanent) so
-// an unready backend never pins a garbage floor.
-type tipSampler struct {
-	sources     []tipSource // tried in order; first success wins
-	interval    time.Duration
-	maxAttempts int
-}
-
-// newTipSampler binds the retry defaults; sources are tried in the order given.
-func newTipSampler(sources ...tipSource) *tipSampler {
-	return &tipSampler{
-		sources:     sources,
-		interval:    defaultTipBackoff,
-		maxAttempts: defaultTipMaxAttempts,
-	}
-}
-
-// Sample returns the current network tip, trying each source in order and
-// retrying a transient failure of them all up to maxAttempts times.
-func (s *tipSampler) Sample(ctx context.Context) (uint32, error) {
-	if len(s.sources) == 0 {
-		return 0, errors.New("no network tip source configured: set [backfill.datastore] " +
-			"or [ingestion].history_archive_urls")
-	}
+// sampleTipWithRetry samples the network tip from the backend's frontier query —
+// the single home for tip-retry semantics: first-start earliest_ledger resolution
+// and every backfill pass both go through it (the freeze's coverage wait reads
+// Backend.Tip raw; waitForCoverage has its own poll loop). A transient failure
+// retries on a bounded constant backoff — built on cenkalti/backoff, the same
+// retry primitive withRetries and waitForCoverage use, so ctx cancellation aborts
+// the wait. A sub-genesis tip is rejected as "not ready" (permanent) so an
+// unready backend never pins a garbage floor. Production call sites pass
+// defaultTipBackoff/defaultTipMaxAttempts; tests pass their own.
+func sampleTipWithRetry(
+	ctx context.Context, tip tipSource, interval time.Duration, maxAttempts int,
+) (uint32, error) {
 	// Clamp so WithMaxRetries' uint64 never underflows into an unbounded loop.
-	maxAttempts := max(s.maxAttempts, 1)
+	maxAttempts = max(maxAttempts, 1)
 	var (
-		tip      uint32
+		sampled  uint32
 		notReady bool
 	)
 	poll := func() error {
-		t, err := s.sampleOnce(ctx)
+		t, err := tip(ctx)
 		if err != nil {
-			return err // transient — every source failed; retry
+			return err // transient — retry
 		}
 		if t < chunk.FirstLedgerSeq {
 			// Below genesis ⇒ backend empty/not-synced; permanent (it would keep returning 0).
-			// Order-blind: this gates whichever source answered first, so a source must
-			// error (not return 0) when empty or it shadows a healthy fallback in sampleOnce.
 			notReady = true
 			return backoff.Permanent(fmt.Errorf("backend tip %d is below genesis %d — backend not ready",
 				t, chunk.FirstLedgerSeq))
 		}
-		tip = t
+		sampled = t
 		return nil
 	}
 	// Constant interval, count-bounded: maxAttempts tries == 1 initial + (maxAttempts-1) retries.
 	retries := uint64(maxAttempts - 1) //nolint:gosec // clamped to >= 1 above
-	bo := backoff.WithMaxRetries(backoff.NewConstantBackOff(s.interval), retries)
+	bo := backoff.WithMaxRetries(backoff.NewConstantBackOff(interval), retries)
 	switch err := backoff.Retry(poll, backoff.WithContext(bo, ctx)); {
 	case err == nil:
-		return tip, nil
+		return sampled, nil
 	case notReady, ctx.Err() != nil:
 		return 0, err // permanent (not ready) or ctx-canceled: surface as-is, not "exhausted"
 	default:
 		return 0, fmt.Errorf("network tip unavailable after %d attempts: %w", maxAttempts, err)
 	}
-}
-
-// sampleOnce tries each source in order, returning the first frontier that
-// answers; if all fail it joins their errors (retryable).
-func (s *tipSampler) sampleOnce(ctx context.Context) (uint32, error) {
-	errs := make([]error, 0, len(s.sources))
-	for _, src := range s.sources {
-		t, err := src(ctx)
-		if err == nil {
-			return t, nil
-		}
-		errs = append(errs, err)
-	}
-	return 0, errors.Join(errs...)
 }
 
 // rootHASGetter is the slice of historyarchive.ArchiveInterface archiveTip needs:
@@ -108,11 +71,10 @@ type rootHASGetter interface {
 	GetRootHAS() (historyarchive.HistoryArchiveState, error)
 }
 
-// archiveTip samples the network frontier from the history archives' root HAS.
-// It is captiveSource's frontier for a no-lake daemon and the fallback when the
-// lake tip is unavailable. The archives lag the lake by up to
-// one checkpoint (64 ledgers); backfill's anchor = max(tip, lastCommitted) and
-// the signed withinOneChunkOfTip already absorb that, so no lag adjustment here.
+// archiveTip samples the network frontier from the history archives' root HAS —
+// captiveSource's frontier for a no-lake daemon. The archives lag the network by
+// up to one checkpoint (64 ledgers); backfill's anchor = max(tip, lastCommitted)
+// and the signed withinOneChunkOfTip already absorb that, so no lag adjustment here.
 func archiveTip(a rootHASGetter) tipSource {
 	return func(context.Context) (uint32, error) {
 		has, err := a.GetRootHAS()

--- a/cmd/stellar-rpc/internal/fullhistory/tip.go
+++ b/cmd/stellar-rpc/internal/fullhistory/tip.go
@@ -52,10 +52,8 @@ func (s *tipSampler) Sample(ctx context.Context) (uint32, error) {
 		return 0, errors.New("no network tip source configured: set [backfill.datastore] " +
 			"or [ingestion].history_archive_urls")
 	}
-	maxAttempts := s.maxAttempts
-	if maxAttempts < 1 {
-		maxAttempts = 1 // never underflow WithMaxRetries' uint64 into an unbounded loop
-	}
+	// Clamp so WithMaxRetries' uint64 never underflows into an unbounded loop.
+	maxAttempts := max(s.maxAttempts, 1)
 	var (
 		tip      uint32
 		notReady bool
@@ -75,7 +73,8 @@ func (s *tipSampler) Sample(ctx context.Context) (uint32, error) {
 		return nil
 	}
 	// Constant interval, count-bounded: maxAttempts tries == 1 initial + (maxAttempts-1) retries.
-	bo := backoff.WithMaxRetries(backoff.NewConstantBackOff(s.interval), uint64(maxAttempts-1))
+	retries := uint64(maxAttempts - 1) //nolint:gosec // clamped to >= 1 above
+	bo := backoff.WithMaxRetries(backoff.NewConstantBackOff(s.interval), retries)
 	switch err := backoff.Retry(poll, backoff.WithContext(bo, ctx)); {
 	case err == nil:
 		return tip, nil

--- a/cmd/stellar-rpc/internal/fullhistory/tip.go
+++ b/cmd/stellar-rpc/internal/fullhistory/tip.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 
-	"github.com/stellar/go-stellar-sdk/historyarchive"
-
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
 )
 
@@ -62,25 +60,5 @@ func sampleTipWithRetry(
 		return 0, err // permanent (not ready) or ctx-canceled: surface as-is, not "exhausted"
 	default:
 		return 0, fmt.Errorf("network tip unavailable after %d attempts: %w", maxAttempts, err)
-	}
-}
-
-// rootHASGetter is the slice of historyarchive.ArchiveInterface archiveTip needs:
-// the network frontier is the CurrentLedger the root HAS publishes.
-type rootHASGetter interface {
-	GetRootHAS() (historyarchive.HistoryArchiveState, error)
-}
-
-// archiveTip samples the network frontier from the history archives' root HAS —
-// captiveSource's frontier for a no-lake daemon. The archives lag the network by
-// up to one checkpoint (64 ledgers); backfill's anchor = max(tip, lastCommitted)
-// and the signed withinOneChunkOfTip already absorb that, so no lag adjustment here.
-func archiveTip(a rootHASGetter) tipSource {
-	return func(context.Context) (uint32, error) {
-		has, err := a.GetRootHAS()
-		if err != nil {
-			return 0, fmt.Errorf("history archive root HAS: %w", err)
-		}
-		return has.CurrentLedger, nil
 	}
 }

--- a/cmd/stellar-rpc/internal/fullhistory/tip.go
+++ b/cmd/stellar-rpc/internal/fullhistory/tip.go
@@ -65,6 +65,8 @@ func (s *tipSampler) Sample(ctx context.Context) (uint32, error) {
 		}
 		if t < chunk.FirstLedgerSeq {
 			// Below genesis ⇒ backend empty/not-synced; permanent (it would keep returning 0).
+			// Order-blind: this gates whichever source answered first, so a source must
+			// error (not return 0) when empty or it shadows a healthy fallback in sampleOnce.
 			notReady = true
 			return backoff.Permanent(fmt.Errorf("backend tip %d is below genesis %d — backend not ready",
 				t, chunk.FirstLedgerSeq))


### PR DESCRIPTION
Closes #833.

A no-lake deployment (`[backfill.datastore].type` empty) had no tip source on first start: the only source was `notConfiguredTip`, which always errors, so no `earliest_ledger` form could pin a floor. And a tip alone would only have made the floor *pinnable*, not *fillable* — `backfillSource` step (3) errors on a backend-less chunk, so the sole truly runnable no-lake config would have been `earliest_ledger = "now"`. Per [the review discussion](https://github.com/stellar/stellar-rpc/pull/850#issuecomment-4964906465), both halves land together: the archive tip **and** captive-core backfill.

**The tip is a property of the backend.** Every `backfill.Backend` owns its frontier — the lake's export frontier for `bsbSource` (`datastore.FindLatestLedgerSequence`), the archives' root HAS for `captiveSource` — and all three consumers read it: `validateConfig` and `backfillToTip` through `sampleTipWithRetry(ctx, backend.Tip, …)`, the freeze's `waitForCoverage` raw. `sampleTipWithRetry` is the single home for the retry semantics, moved verbatim from the old `networkTip` helper: cenkalti/backoff constant interval, count-bounded, sub-genesis tip is `backoff.Permanent` ("not ready"), ctx cancellation aborts the wait. This replaces both the round-1 `(NetworkTipBackend, TipBackoff, TipMaxAttempts)` trio *and* the interim `tipSampler` type — the multi-source lake→archive fallback from the #820 threads is deliberately dropped ([review rationale](https://github.com/stellar/stellar-rpc/pull/850#pullrequestreview-4692600365)): once each backend owns its frontier, the fallback's only user was the lake, where a failing LIST almost always means failing GETs too, and an anchor overshoot just times out coverage and re-samples on restart. With it go `StartConfig.Tip` and the `captiveSource` type-assertion the dedup needed.

**`captiveSource`: no-lake backfill through captive core.** With no datastore but `[ingestion].history_archive_urls` configured (which live ingestion requires anyway — no new config), `buildBackfillBackend` returns a `captiveSource`: the core opener's `LedgerStream` plus the archives' root HAS as `Tip`. Everything downstream runs unchanged — `executePlan`'s parallel pool, `backfillSource`, `WriteColdChunk`, and the `waitForCoverage` poll on `Backend.Tip`. Parallel per-chunk replays compose because the SDK's `captiveCoreStream.RawLedgers` is a stateless factory: each bounded call builds a fresh core in its own ephemeral working dir, so N concurrent `RawLedgers(BoundedRange(chunk))` calls run N independent cores. The real cost is one core catch-up per chunk, which makes the retention-window size the natural selector: no-lake + archives suits a small window; deep history stays on the bulk lake.

**One core opener, resolved up front.** Every daemon runs the live ingestion loop, so the opener resolves once before the backend (whose no-lake path is built from its stream), replacing the early/late split. The one behavior change: a bad `[ingestion]` config now surfaces before a bad `earliest_ledger` — cosmetic, both are fatal startup errors.

**Archives absorb their own lag.** The archives' one-checkpoint (64-ledger) lag is absorbed by the existing `anchor = max(tip, lastCommitted)` and the signed `withinOneChunkOfTip`; no lag handling is added.

**Synthetic tip deleted.** An unavailable tip now means the backend's frontier query kept failing — so the `tip = lastCommitted` degraded mode in `backfillToTip` is gone. A tip failure errors the pass and the supervisor restarts (a transient outage self-heals on re-sample); the daemon never serves behind an unknown frontier.

Tests: the #833 acceptance test boots the real entrypoint with no datastore, a `file://` archive (real pool construction + root-HAS frontier read), and a core stream serving the bounded replay, and asserts chunk 0's cold artifacts freeze exactly as on the lake path; `captiveSource` construction + frontier mapping; a fail-fast startup error when neither source is configured; the retry/sub-genesis/ctx-cancel suite on `sampleTipWithRetry`; and `TestBackfill_RestartTipUnavailableErrors` replacing the deleted degraded-mode test. Full `fullhistory` `-short` suite and `-race` on the `fullhistory` package pass; repo golangci-lint clean on the diff.

Deliberate skip: the archive pool is built without a network passphrase, so the SDK's HAS passphrase check is off. A wrong-network archive URL already fails loudly at live ingestion — captive core consumes the same `[ingestion].history_archive_urls` — with recovery being a wipe of the still-empty first-start data dir. (With the opener now resolved before the pool this is wireable if wanted; left out to keep the change to the reviewed scope.)
