### PR TITLE
fullhistory: readiness/health signal from the last committed ledger (#839)

### DIFF
--- a/cmd/stellar-rpc/internal/fullhistory/daemon.go
+++ b/cmd/stellar-rpc/internal/fullhistory/daemon.go
@@ -90,6 +90,12 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 		}
 	}
 
+	// Readiness/health signal, fed by the ingestion loop per commit; both signals
+	// derive from the last committed ledger. Created outside the supervised run
+	// loop so it survives restarts (readiness stays latched across them).
+	// TODO(#772): serve it from the read server (as HealthSignal).
+	hs := &healthState{}
+
 	paths := cfg.ResolvePaths()
 
 	// --- Reject shared roots, then create + fsync any missing ones. Single-
@@ -180,7 +186,7 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 
 	// --- Assemble the StartConfig and run the supervised run loop. ---
 	start := startConfig(
-		cfg, cat, logger, backend, core, serveReads, metrics, sink)
+		cfg, cat, logger, backend, core, serveReads, metrics, sink, hs)
 
 	backoff := opts.RestartBackoff
 	if backoff <= 0 {
@@ -195,7 +201,7 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 func startConfig(
 	cfg config.Config, cat *catalog.Catalog, logger *supportlog.Entry,
 	backend backfill.Backend, core CoreOpener, serveReads func(context.Context) error,
-	metrics observability.Metrics, sink ingest.MetricSink,
+	metrics observability.Metrics, sink ingest.MetricSink, hs *healthState,
 ) StartConfig {
 	exec := backfill.ExecConfig{
 		Catalog:    cat,
@@ -213,6 +219,7 @@ func startConfig(
 		RetentionChunks: deref(cfg.Retention.RetentionChunks),
 		Core:            core,
 		ServeReads:      serveReads,
+		health:          hs,
 	}
 }
 

--- a/cmd/stellar-rpc/internal/fullhistory/health.go
+++ b/cmd/stellar-rpc/internal/fullhistory/health.go
@@ -1,0 +1,63 @@
+package fullhistory
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// HealthSignal is the read side of the daemon's readiness/health signal — the
+// seam #772's read server consumes (the way v1's getHealth is a method on the
+// main server). It exposes exactly the raw signal: the readiness latch and the
+// last committed ledger's close time. The staleness judgment (close-time age vs
+// a latency threshold, the v1 getHealth semantic) is check policy that lives
+// with the consumer.
+type HealthSignal interface {
+	Ready() bool
+	LastCommitClose() (time.Time, bool)
+}
+
+// healthState is the daemon's readiness + health signal, written by the
+// ingestion loop and read via HealthSignal. It adds no new tracking machinery —
+// it is derived entirely from state the loop already owns, the last committed
+// ledger — as one atomic holding the unix close time of that ledger
+// (0 = none committed yet). That single value encodes both signals:
+//
+//   - Readiness latches true once it is non-zero: the ingestion loop has committed
+//     at least one ledger, which can only happen after startup completed (backfill
+//     done, resume hot tier opened, core stream opened). A misconfigured deploy — a
+//     broken hot tier, a bad core binary/config, an exec-time core failure — never
+//     commits, so it never reports ready and the rollout fails at deploy time. It
+//     stays ready afterwards (a "proven itself once" latch, not a liveness signal);
+//     close times only move forward, so the value never falls back to zero.
+//   - Health is live: the last committed ledger is fresh iff now-closeTime is within
+//     the consumer's latency threshold — the same close-time-vs-now semantic as the
+//     v1 RPC getHealth (methods/get_health.go).
+type healthState struct {
+	lastCommitCloseUnix atomic.Int64
+}
+
+// Ready reports whether the ingestion loop has committed at least one ledger. Latched.
+func (h *healthState) Ready() bool {
+	return h.lastCommitCloseUnix.Load() != 0
+}
+
+// LastCommitClose returns the close time of the last committed ledger and whether
+// any ledger has been committed yet.
+func (h *healthState) LastCommitClose() (time.Time, bool) {
+	u := h.lastCommitCloseUnix.Load()
+	if u == 0 {
+		return time.Time{}, false
+	}
+	return time.Unix(u, 0), true
+}
+
+// observe records the close time of a just-committed ledger. Nil-receiver safe so
+// the ingestion loop can call it unconditionally (tests build the loop without one).
+func (h *healthState) observe(closeUnix int64) {
+	if h == nil {
+		return
+	}
+	h.lastCommitCloseUnix.Store(closeUnix)
+}
+
+var _ HealthSignal = (*healthState)(nil)

--- a/cmd/stellar-rpc/internal/fullhistory/health_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/health_test.go
@@ -1,0 +1,89 @@
+package fullhistory
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+)
+
+// TestHealthState_ReadyLatches: readiness is false until the first commit is
+// observed, then latches true and stays true (a stale close time does not unlatch
+// it — "proven itself once").
+func TestHealthState_ReadyLatches(t *testing.T) {
+	var hs healthState
+	assert.False(t, hs.Ready(), "no commit yet ⇒ not ready")
+
+	hs.observe(time.Now().Unix())
+	assert.True(t, hs.Ready(), "first commit latches ready")
+
+	// An old close time (a stalled/lagging source) keeps ready latched.
+	hs.observe(time.Now().Add(-time.Hour).Unix())
+	assert.True(t, hs.Ready(), "ready stays latched after a stale commit")
+}
+
+// TestHealthState_ObserveNilSafe: the ingestion loop calls observe unconditionally,
+// so a nil healthState (tests build the loop without one) must be a no-op, not a panic.
+func TestHealthState_ObserveNilSafe(t *testing.T) {
+	var hs *healthState
+	require.NotPanics(t, func() { hs.observe(time.Now().Unix()) })
+}
+
+// TestRunIngestionLoop_FeedsHealthFromCommit: the ingestion loop feeds the
+// readiness/health signal from the SAME per-ledger commit — after ingesting real
+// ledgers with a known close time, the loop is ready and the recorded close time
+// is that of the last committed ledger.
+func TestRunIngestionLoop_FeedsHealthFromCommit(t *testing.T) {
+	cat, _ := testCatalog(t)
+	c := chunk.ID(0)
+	first := c.FirstLedger()
+	closeTime := time.Now().Add(-2 * time.Second).Truncate(time.Second)
+
+	stream := &fakeCoreStream{frames: map[uint32][]byte{
+		first:     lcmBytesAtCloseTime(t, first, closeTime),
+		first + 1: lcmBytesAtCloseTime(t, first+1, closeTime),
+	}}
+	stream.endErr = errors.New("end")
+
+	cfg, _ := loopConfig(t, stream, cat, first)
+	hs := &healthState{}
+	cfg.Health = hs
+
+	require.Error(t, runIngestionLoop(context.Background(), cfg))
+
+	assert.True(t, hs.Ready(), "the loop's first commit latched readiness")
+	got, ok := hs.LastCommitClose()
+	require.True(t, ok)
+	assert.Equal(t, closeTime.Unix(), got.Unix(), "health tracks the last committed ledger's close time")
+}
+
+// lcmBytesAtCloseTime is a zero-tx LCM (like fhtest.ZeroTxLCMBytes) with an explicit
+// close time, so a test can drive the health signal off a known value.
+func lcmBytesAtCloseTime(t *testing.T, seq uint32, closeTime time.Time) []byte {
+	t.Helper()
+	lcm := xdr.LedgerCloseMeta{
+		V: 2,
+		V2: &xdr.LedgerCloseMetaV2{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+				Header: xdr.LedgerHeader{
+					ScpValue:  xdr.StellarValue{CloseTime: xdr.TimePoint(closeTime.Unix())},
+					LedgerSeq: xdr.Uint32(seq),
+				},
+			},
+			TxSet: xdr.GeneralizedTransactionSet{
+				V:       1,
+				V1TxSet: &xdr.TransactionSetV1{Phases: nil},
+			},
+		},
+	}
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	return raw
+}

--- a/cmd/stellar-rpc/internal/fullhistory/hotloop.go
+++ b/cmd/stellar-rpc/internal/fullhistory/hotloop.go
@@ -91,6 +91,7 @@ type ingestionLoopConfig struct {
 	Logger   *supportlog.Entry
 	Metrics  observability.Metrics
 	Sink     ingest.MetricSink
+	Health   *healthState
 }
 
 // runIngestionLoop is the hot tier's OWNER: the single goroutine that opens,
@@ -146,13 +147,22 @@ func runIngestionLoop(ctx context.Context, cfg ingestionLoopConfig) error {
 		}
 
 		// One atomic synced WriteBatch across all hot CFs (via hotDB.IngestLedger).
-		if ierr := hotService.Ingest(ctx, seq, xdr.LedgerCloseMetaView(raw)); ierr != nil {
+		view := xdr.LedgerCloseMetaView(raw)
+		if ierr := hotService.Ingest(ctx, seq, view); ierr != nil {
 			return fmt.Errorf("ingest ledger %d: %w", seq, ierr)
 		}
 		// The ingestion loop owns the last-committed gauge: this is the TRUE
 		// committed ledger (mid-chunk included), one atomic gauge set per ledger.
 		// The tick must not touch it — its chunk-aligned value would regress it.
 		metrics.LastCommitted(seq)
+
+		// Feed the readiness/health signal from the SAME commit: the first commit
+		// latches readiness, and the close time drives the health staleness check.
+		// A committed ledger's close time always decodes; skip the signal on the
+		// near-impossible decode error rather than fail an already-durable commit.
+		if closeUnix, cerr := view.LedgerCloseTime(); cerr == nil {
+			cfg.Health.observe(closeUnix)
+		}
 
 		// Chunk boundary: this seq is the chunk's last ledger.
 		if closed := chunk.IDFromLedger(seq); seq == closed.LastLedger() {

--- a/cmd/stellar-rpc/internal/fullhistory/startup.go
+++ b/cmd/stellar-rpc/internal/fullhistory/startup.go
@@ -152,6 +152,7 @@ func run(ctx context.Context, cfg StartConfig) error {
 			Logger:   logger,
 			Metrics:  metrics,
 			Sink:     cfg.Exec.Process.Sink,
+			Health:   cfg.health,
 		})
 		if err == nil {
 			// WithContext cancels gctx (unblocking the lifecycle sibling in g.Wait)
@@ -302,6 +303,10 @@ type StartConfig struct {
 
 	// runBackfill is a test-only seam for one backfill pass; nil ⇒ backfill.RunBackfill.
 	runBackfill func(ctx context.Context, exec backfill.ExecConfig, lo, hi chunk.ID) error
+
+	// health is the readiness/health signal the ingestion loop feeds per commit;
+	// #772's read server consumes it (as HealthSignal). nil ⇒ observe is a no-op.
+	health *healthState
 }
 
 // withDefaults fills the embedded Exec defaults (Workers -> GOMAXPROCS). The


### PR DESCRIPTION
Progresses #839 (the HTTP surface is deferred to #772).

The daemon gains its readiness/health **signal**, derived from state the ingestion loop already owns — the last committed ledger — held as one atomic close-time (0 = none yet), fed from the same per-ledger commit that sets the `last_committed_ledger` gauge. No new metrics, no new tracking machinery, no new config.

**The signal** — `healthState`, fed by the ingestion loop per commit:
- **Readiness** latches true on the first committed ledger ("proven itself once"). A misconfigured deployment — broken hot tier, bad core binary or config, exec-time core failures — never commits, so it never reports ready.
- **Last-commit close time** is the raw input for the health/staleness check (the v1 `getHealth` close-time-vs-now semantic). The judgment itself (`time.Since(closeTime)` vs a latency threshold) is check policy and deliberately does NOT live here.

**The seam** — `HealthSignal` (`Ready() bool`, `LastCommitClose() (time.Time, bool)`), created in `runDaemonWith` outside the supervised run loop so readiness stays latched across restarts. When #772 builds the read server, it serves the checks from this signal (as handlers or methods, the way v1's `getHealth` is a method on the main server) and picks the surface topology then — per review, landing an HTTP contract plus a second listener now would pre-empt that decision.

Tests: readiness latching (including staying latched on stale close times), nil-safety of the loop-side hook, and the ingestion loop feeding the signal from real commits (drives `runIngestionLoop` with real ledgers). Full `fullhistory` `-short` suite green; health tests `-race` clean; golangci clean vs base.
