### PR TITLE
fullhistory: halve cold per-ledger extraction with one ExtractLedgerEvents walk (#836)

### DIFF
--- a/cmd/stellar-rpc/internal/events/extract.go
+++ b/cmd/stellar-rpc/internal/events/extract.go
@@ -7,12 +7,13 @@ import (
 	"github.com/stellar/go-stellar-sdk/xdr"
 )
 
-// LCMViewToPayloads walks a zero-copy LedgerCloseMetaView and returns one
-// Payload per emitted contract event, in ASCENDING getEvents cursor order —
-// the order the SQLite path serves (ORDER BY id ASC in db/event.go). The event
-// store serves in write order (event IDs are assigned by arrival position and
-// the term bitmaps iterate in ID order), so emission order here IS the cursor
-// contract. Concretely, per ledger:
+// PayloadsFromLedgerEvents shapes an already-extracted per-transaction event
+// slice (ingest.ExtractLedgerEvents output) into one Payload per emitted
+// contract event, in ASCENDING getEvents cursor order — the order the SQLite
+// path serves (ORDER BY id ASC in db/event.go). The event store serves in write
+// order (event IDs are assigned by arrival position and the term bitmaps iterate
+// in ID order), so emission order here IS the cursor contract. Concretely, per
+// ledger:
 //
 //  1. every transaction's BeforeAllTxs events (cursor (0, 0)), in tx apply
 //     order — a stable partition of the SDK's per-tx traversal;
@@ -34,33 +35,14 @@ import (
 // (ingest.ExtractLedgerEvents — one TxProcessing walk yields hash + events
 // together). This function adds only the RPC-specific Payload shape, the
 // Stage→(TxIdx, OpIdx) cursor-sentinel mapping, EventIdx, and the cursor
-// ordering — all in PayloadsFromLedgerEvents, over which this is the thin
-// view-reading wrapper.
-func LCMViewToPayloads(lcm xdr.LedgerCloseMetaView) ([]Payload, error) {
-	ledgerSeq, err := lcm.LedgerSequence()
-	if err != nil {
-		return nil, err
-	}
-	ledgerClosedAt, err := lcm.LedgerCloseTime()
-	if err != nil {
-		return nil, err
-	}
-	txEvents, err := ingest.ExtractLedgerEvents(lcm)
-	if err != nil {
-		return nil, err
-	}
-	return PayloadsFromLedgerEvents(txEvents, ledgerSeq, ledgerClosedAt)
-}
-
-// PayloadsFromLedgerEvents shapes an already-extracted per-transaction event
-// slice (ingest.ExtractLedgerEvents output) into cursor-ordered Payloads. It is
-// the body of LCMViewToPayloads minus the SDK walk, so a caller that already
-// holds the txEvents — the hot ingest path, which also needs the paired tx
-// hashes (txEvents[i].Hash) — can feed BOTH txhash and events from ONE
-// ExtractLedgerEvents call instead of walking TxProcessing twice. ledgerSeq and
-// ledgerClosedAt are the view's header values (cheap reads, not a walk). The
-// cursor ordering and EventIdx assignment are IDENTICAL to what LCMViewToPayloads
-// produced inline, so event IDs are unchanged across the refactor.
+// ordering.
+//
+// Taking the already-extracted txEvents (rather than re-walking a view) lets a
+// caller that already holds them — the hot ingest path and the cold materializer,
+// both of which also need the paired tx hashes (txEvents[i].Hash) — feed BOTH
+// txhash and events from ONE ExtractLedgerEvents call instead of walking
+// TxProcessing twice. ledgerSeq and ledgerClosedAt are the view's header values
+// (cheap reads, not a walk).
 func PayloadsFromLedgerEvents(
 	txEvents []ingest.LedgerTransactionEvents, ledgerSeq uint32, ledgerClosedAt int64,
 ) ([]Payload, error) {
@@ -130,7 +112,7 @@ func PayloadsFromLedgerEvents(
 }
 
 // countPayloads sums the per-tx top-level event + per-op event counts — the
-// exact number of payloads LCMViewToPayloads emits across its three passes,
+// exact number of payloads PayloadsFromLedgerEvents emits across its three passes,
 // used to size the result slice once.
 func countPayloads(txEvents []ingest.LedgerTransactionEvents) int {
 	total := 0
@@ -144,7 +126,7 @@ func countPayloads(txEvents []ingest.LedgerTransactionEvents) int {
 }
 
 // appendStageEventPayloads emits the V4 top-level TransactionEvents whose
-// Stage equals wantStage, skipping the other (known) stages — LCMViewToPayloads
+// Stage equals wantStage, skipping the other (known) stages — PayloadsFromLedgerEvents
 // calls it once per stage per its cursor-ordered pass structure. An UNKNOWN
 // stage errors in every pass (via StageSentinels), so a new protocol stage can
 // never be silently dropped by the stage filter. Stage and the inner

--- a/cmd/stellar-rpc/internal/events/extract_test.go
+++ b/cmd/stellar-rpc/internal/events/extract_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stellar/go-stellar-sdk/ingest"
 	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stellar/go-stellar-sdk/network"
 	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
@@ -22,6 +23,28 @@ import (
 )
 
 const testPassphrase = "Test SDF Network ; September 2015"
+
+// lcmViewToPayloads is the view→payloads convenience the production
+// LCMViewToPayloads wrapper used to provide before #836 deleted it as test-only:
+// the header reads plus the single ExtractLedgerEvents walk, fed to
+// PayloadsFromLedgerEvents. The cursor-contract tests exercise it from raw LCM
+// bytes; production now walks once at a higher level (hot IngestLedger, cold
+// ColdService) and calls PayloadsFromLedgerEvents directly.
+func lcmViewToPayloads(lcm xdr.LedgerCloseMetaView) ([]events.Payload, error) {
+	seq, err := lcm.LedgerSequence()
+	if err != nil {
+		return nil, err
+	}
+	closedAt, err := lcm.LedgerCloseTime()
+	if err != nil {
+		return nil, err
+	}
+	txEvents, err := ingest.ExtractLedgerEvents(lcm)
+	if err != nil {
+		return nil, err
+	}
+	return events.PayloadsFromLedgerEvents(txEvents, seq, closedAt)
+}
 
 // buildContractEvent returns a ContractEvent with a contractID and a
 // single symbol topic.
@@ -307,7 +330,7 @@ func TestExtractEvents_MatchesSQLite(t *testing.T) {
 		// from chronological order.
 		raw, err := lcm.MarshalBinary()
 		require.NoError(t, err)
-		payloads, err := events.LCMViewToPayloads(xdr.LedgerCloseMetaView(raw))
+		payloads, err := lcmViewToPayloads(xdr.LedgerCloseMetaView(raw))
 		require.NoError(t, err)
 		require.Len(t, payloads, 6)
 		assertViewMatchesSQLite(t, lcm)
@@ -362,7 +385,7 @@ func TestExtractEvents_V0NoPayloads(t *testing.T) {
 	}}
 	raw, err := lcm.MarshalBinary()
 	require.NoError(t, err)
-	payloads, err := events.LCMViewToPayloads(xdr.LedgerCloseMetaView(raw))
+	payloads, err := lcmViewToPayloads(xdr.LedgerCloseMetaView(raw))
 	require.NoError(t, err)
 	require.Empty(t, payloads)
 }
@@ -436,7 +459,7 @@ func TestExtractEvents_EmissionOrderCursorAscending(t *testing.T) {
 	raw, err := lcm.MarshalBinary()
 	require.NoError(t, err)
 
-	payloads, err := events.LCMViewToPayloads(xdr.LedgerCloseMetaView(raw))
+	payloads, err := lcmViewToPayloads(xdr.LedgerCloseMetaView(raw))
 	require.NoError(t, err)
 	require.Len(t, payloads, 10, "2 txs x (3 stage events + 2 op events)")
 
@@ -487,7 +510,7 @@ func TestExtractEvents_AliasesViewBuffer(t *testing.T) {
 	raw, err := lcm.MarshalBinary()
 	require.NoError(t, err)
 
-	payloads, err := events.LCMViewToPayloads(xdr.LedgerCloseMetaView(raw))
+	payloads, err := lcmViewToPayloads(xdr.LedgerCloseMetaView(raw))
 	require.NoError(t, err)
 	require.Len(t, payloads, 1)
 	require.NotEmpty(t, payloads[0].ContractEventBytes)
@@ -525,7 +548,7 @@ func TestExtractEvents_LegacyMetaV0(t *testing.T) {
 	raw, err := lcm.MarshalBinary()
 	require.NoError(t, err)
 
-	payloads, err := events.LCMViewToPayloads(xdr.LedgerCloseMetaView(raw))
+	payloads, err := lcmViewToPayloads(xdr.LedgerCloseMetaView(raw))
 	require.NoError(t, err, "V0 meta must be skipped, not error")
 	// Only the second (V4) tx emits an event; the V0 tx contributes none.
 	require.Len(t, payloads, 1)
@@ -606,7 +629,7 @@ func assertViewMatchesSQLite(t *testing.T, lcm xdr.LedgerCloseMeta) {
 
 	raw, err := lcm.MarshalBinary()
 	require.NoError(t, err)
-	viewPayloads, err := events.LCMViewToPayloads(xdr.LedgerCloseMetaView(raw))
+	viewPayloads, err := lcmViewToPayloads(xdr.LedgerCloseMetaView(raw))
 	require.NoError(t, err, "view path LCMViewToPayloads")
 
 	rows := sqliteEventRows(t, lcm)
@@ -655,7 +678,7 @@ func BenchmarkExtractEvents(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for range b.N {
-		if _, err := events.LCMViewToPayloads(view); err != nil {
+		if _, err := lcmViewToPayloads(view); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -695,7 +718,7 @@ func TestExtractEvents_TopLevelEventsAliasViewBuffer(t *testing.T) {
 	raw, err := lcm.MarshalBinary()
 	require.NoError(t, err)
 
-	payloads, err := events.LCMViewToPayloads(xdr.LedgerCloseMetaView(raw))
+	payloads, err := lcmViewToPayloads(xdr.LedgerCloseMetaView(raw))
 	require.NoError(t, err)
 	require.Len(t, payloads, 1)
 	require.NotEmpty(t, payloads[0].ContractEventBytes)

--- a/cmd/stellar-rpc/internal/events/extract_test.go
+++ b/cmd/stellar-rpc/internal/events/extract_test.go
@@ -27,7 +27,7 @@ const testPassphrase = "Test SDF Network ; September 2015"
 // lcmViewToPayloads is the view→payloads convenience the cursor-contract tests
 // need to run from raw LCM bytes: the header reads plus the single
 // ExtractLedgerEvents walk, fed to PayloadsFromLedgerEvents. Test-only —
-// production walks once at a higher level (hot IngestLedger, cold ColdService)
+// production walks once at a higher level (hot IngestLedger, cold coldChunk.ingest)
 // and calls PayloadsFromLedgerEvents directly.
 func lcmViewToPayloads(lcm xdr.LedgerCloseMetaView) ([]events.Payload, error) {
 	seq, err := lcm.LedgerSequence()

--- a/cmd/stellar-rpc/internal/events/extract_test.go
+++ b/cmd/stellar-rpc/internal/events/extract_test.go
@@ -175,7 +175,7 @@ func buildTxEnvelopeAndHash(t testing.TB) (xdr.TransactionEnvelope, xdr.Hash) {
 
 // buildLCMVersion builds either an LCM V1 (LedgerCloseMetaV1 with
 // TransactionResultMeta — the *non*-V1 result-meta type — exercising
-// LCMViewToPayloads case 1) or an LCM V2 (LedgerCloseMetaV2 with
+// lcmViewToPayloads case 1) or an LCM V2 (LedgerCloseMetaV2 with
 // TransactionResultMetaV1, case 2). Both use a GeneralizedTransactionSet
 // (V1) which is already in apply order, so the SQLite oracle's
 // LedgerTransactionReader and the view path agree on ordering.
@@ -248,7 +248,7 @@ func buildLCMVersion(
 }
 
 // TestExtractEvents_MatchesSQLite is the cross-backend differential: the
-// view-based LCMViewToPayloads must emit, for the same xdr.LedgerCloseMeta, the
+// view-based lcmViewToPayloads must emit, for the same xdr.LedgerCloseMeta, the
 // SAME event sequence the legacy SQLite backend serves — insert via
 // db's InsertEvents, read back through the GetEvents cursor-ordered query
 // (ORDER BY id ASC), and assert the view path's emission order and per-event
@@ -391,7 +391,7 @@ func TestExtractEvents_V0NoPayloads(t *testing.T) {
 }
 
 // TestExtractEvents_V1DifferentialArm exercises the LCM V1 dispatch arm
-// (case 1, TransactionResultMetaView) of LCMViewToPayloads, which the V2-only
+// (case 1, TransactionResultMetaView) of lcmViewToPayloads, which the V2-only
 // differential tests never run. V1 uses LedgerCloseMetaV1 + the non-V1
 // TransactionResultMeta result-meta type — the whole point of this case.
 func TestExtractEvents_V1DifferentialArm(t *testing.T) {
@@ -421,7 +421,7 @@ func TestExtractEvents_V1DifferentialArm(t *testing.T) {
 }
 
 // TestExtractEvents_EmissionOrderCursorAscending pins the emission-order
-// invariant directly on the payload slice: LCMViewToPayloads emits a ledger's
+// invariant directly on the payload slice: lcmViewToPayloads emits a ledger's
 // payloads non-decreasing in (TxIdx, OpIdx) — ascending getEvents cursor
 // order. The fixture MUST carry V4 stage events across multiple txs (each tx
 // here emits BeforeAllTxs + AfterTx + AfterAllTxs events AND two op events):
@@ -615,7 +615,7 @@ func sqliteEventRows(t *testing.T, lcm xdr.LedgerCloseMeta) []sqliteEventRow {
 }
 
 // assertViewMatchesSQLite is the differential oracle: it marshals lcm, runs
-// the view path (LCMViewToPayloads) on the bytes and the legacy SQLite
+// the view path (lcmViewToPayloads) on the bytes and the legacy SQLite
 // path (db InsertEvents → GetEvents) on the struct, and asserts the view's
 // emission sequence equals the SQLite cursor-ascending read sequence
 // position-for-position — tx hash, (TxIdx, OpIdx) cursor key, ledger
@@ -630,7 +630,7 @@ func assertViewMatchesSQLite(t *testing.T, lcm xdr.LedgerCloseMeta) {
 	raw, err := lcm.MarshalBinary()
 	require.NoError(t, err)
 	viewPayloads, err := lcmViewToPayloads(xdr.LedgerCloseMetaView(raw))
-	require.NoError(t, err, "view path LCMViewToPayloads")
+	require.NoError(t, err, "view path lcmViewToPayloads")
 
 	rows := sqliteEventRows(t, lcm)
 	require.Len(t, viewPayloads, len(rows),

--- a/cmd/stellar-rpc/internal/events/extract_test.go
+++ b/cmd/stellar-rpc/internal/events/extract_test.go
@@ -24,12 +24,11 @@ import (
 
 const testPassphrase = "Test SDF Network ; September 2015"
 
-// lcmViewToPayloads is the view→payloads convenience the production
-// LCMViewToPayloads wrapper used to provide before #836 deleted it as test-only:
-// the header reads plus the single ExtractLedgerEvents walk, fed to
-// PayloadsFromLedgerEvents. The cursor-contract tests exercise it from raw LCM
-// bytes; production now walks once at a higher level (hot IngestLedger, cold
-// ColdService) and calls PayloadsFromLedgerEvents directly.
+// lcmViewToPayloads is the view→payloads convenience the cursor-contract tests
+// need to run from raw LCM bytes: the header reads plus the single
+// ExtractLedgerEvents walk, fed to PayloadsFromLedgerEvents. Test-only —
+// production walks once at a higher level (hot IngestLedger, cold ColdService)
+// and calls PayloadsFromLedgerEvents directly.
 func lcmViewToPayloads(lcm xdr.LedgerCloseMetaView) ([]events.Payload, error) {
 	seq, err := lcm.LedgerSequence()
 	if err != nil {

--- a/cmd/stellar-rpc/internal/events/payload.go
+++ b/cmd/stellar-rpc/internal/events/payload.go
@@ -29,7 +29,7 @@
 // assigned identically to the SQLite path (db/event.go), so the two backends
 // return the same IDs.
 //
-// Because LCMViewToPayloads emits each ledger in ascending getEvents cursor
+// Because PayloadsFromLedgerEvents emits each ledger in ascending getEvents cursor
 // order, every (txIdx, opIdx) group is contiguous in stream order, so eventIdx
 // could be reconstructed positionally at read time. It is stored explicitly
 // anyway: that keeps the public ID format byte-stable without a payload

--- a/cmd/stellar-rpc/internal/events/stage.go
+++ b/cmd/stellar-rpc/internal/events/stage.go
@@ -11,7 +11,7 @@ import (
 // (TxIdx, OpIdx) sentinels the v1 getEvents cursor encoding uses. applyIdx is
 // the 1-based transaction apply index (consumed by the AfterTx arm). This is
 // the SINGLE definition of the cursor-encoding policy for both storage
-// backends: the full-history view path (LCMViewToPayloads) and the legacy
+// backends: the full-history view path (PayloadsFromLedgerEvents) and the legacy
 // SQL path (db/event.go's InsertEvents) both consume it, so a new stage or
 // sentinel revision lands in one place and getEvents cursors stay compatible
 // across backends by construction.

--- a/cmd/stellar-rpc/internal/events/stage_test.go
+++ b/cmd/stellar-rpc/internal/events/stage_test.go
@@ -12,7 +12,7 @@ import (
 
 // TestStageSentinels pins the Stage→(TxIdx, OpIdx) cursor-sentinel mapping.
 // StageSentinels is the SINGLE definition of this policy for both storage
-// backends (LCMViewToPayloads and db/event.go's InsertEvents), so these
+// backends (PayloadsFromLedgerEvents and db/event.go's InsertEvents), so these
 // values ARE the v1 getEvents cursor-encoding contract:
 //
 //   - BeforeAllTxs → (0, 0): sorts before any real transaction (TxIdx >= 1);

--- a/cmd/stellar-rpc/internal/fullhistory/catalog/artifacts.go
+++ b/cmd/stellar-rpc/internal/fullhistory/catalog/artifacts.go
@@ -13,7 +13,7 @@ import (
 // idempotency).
 //
 // Backed by a fixed-width bitmask over allKinds' canonical order, so Kinds()
-// yields that order (matching buildColdIngesters) and membership is alloc-free.
+// yields that order (matching openColdChunk) and membership is alloc-free.
 type ArtifactSet struct {
 	mask uint8
 }

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/doc.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/doc.go
@@ -6,8 +6,8 @@
 // events.PayloadsFromLedgerEvents emitter.
 //
 // Both tiers extract each ledger with a SINGLE ExtractLedgerEvents walk
-// (the hot DB's IngestLedger, the cold ColdService) — txhash reads each
-// element's paired Hash and events shapes the same slice — but they
+// (the hot DB's IngestLedger, the cold coldChunk.ingest) — txhash reads
+// each element's paired Hash and events shapes the same slice — but they
 // differ in everything else:
 //
 //   - Hot (HotService): one ledger at a time into the long-lived,
@@ -21,9 +21,9 @@
 //     SOURCE-BLIND — the caller resolves the chunk's ledger source and
 //     passes the raw ledger iterator, so the materializer never learns
 //     whether the bytes came from a local .pack or the bulk backend.
-//     Each cold ingester OPENS its own per-chunk writer; Finalize
-//     publishes the artifact and Close drops partials on the failure
-//     path (ColdService orchestrates).
+//     Each enabled data type gets its own per-chunk cold writer, opened
+//     by openColdChunk; finalize publishes the artifacts and close drops
+//     partials on the failure path (coldChunk orchestrates).
 //
 // Artifact model (cold) — the contract every layer here relies on:
 //
@@ -46,24 +46,24 @@
 // Failure semantics (cold) follow from the model: a chunk either fully
 // finalizes — and only then may the orchestrator record completion — or
 // the attempt is abandoned and re-run from scratch; there is no
-// mid-chunk resume. Once any Ingest fails, the chunk is released via
-// Close (Finalize must not run; see the ColdIngester contract). Once
-// any Finalize fails, ColdService stops at the first error; whatever
-// the earlier ingesters already wrote stays on disk as inert scratch.
+// mid-chunk resume. Once any ingest fails, the chunk is released via
+// close (finalize must not run; see the coldChunk contract). Once any
+// finalize fails, coldChunk stops at the first error; whatever the
+// earlier writers already wrote stays on disk as inert scratch.
 //
 // Data types are processed in canonical ledgers→txhash→events order;
-// the constructor table in buildColdIngesters is the order's single
-// definition site. The on-disk formats and per-chunk filenames are
-// owned by the store packages (ledger.PackName, txhash.ColdBinName +
-// its .bin codec, eventstore's cold-format helpers); this package only
-// composes the {bucketID:05d}/ bucket directories around them.
+// openColdChunk is the order's single definition site. The on-disk
+// formats and per-chunk filenames are owned by the store packages
+// (ledger.PackName, txhash.ColdBinName + its .bin codec, eventstore's
+// cold-format helpers); this package only composes the {bucketID:05d}/
+// bucket directories around them.
 //
-// Inputs are borrowed: every Ingest receives a view over the source
+// Inputs are borrowed: every ingest receives a view over the source
 // stream's buffer, valid only until the next ledger is pulled, and
-// each ingester copies what it retains (see ColdIngester). The raw
+// each writer copies what it retains (see coldChunk.ingest). The raw
 // ledger iterator's contract includes yielding an error on ctx
 // cancellation — the drain loop relies on it for cancellation rather
 // than polling ctx itself. Metrics flow through MetricSink (Prometheus in prod,
 // recorders in tests); the cold tier's invariant is exactly one
-// ColdChunkTotal per chunk attempt, including pre-service failures.
+// ColdChunkTotal per chunk attempt, including pre-open failures.
 package ingest

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/doc.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/doc.go
@@ -3,10 +3,12 @@
 // and writes the three data types — ledgers, txhashes, contract events —
 // into the full-history stores, one chunk at a time, via the zero-copy
 // view extractors in the go-stellar-sdk ingest package and the RPC-side
-// events.LCMViewToPayloads emitter.
+// events.PayloadsFromLedgerEvents emitter.
 //
-// Two tiers share the per-ledger extraction but differ in everything
-// else:
+// Both tiers extract each ledger with a SINGLE ExtractLedgerEvents walk
+// (the hot DB's IngestLedger, the cold ColdService) — txhash reads each
+// element's paired Hash and events shapes the same slice — but they
+// differ in everything else:
 //
 //   - Hot (HotService): one ledger at a time into the long-lived,
 //     caller-owned per-chunk hot DB, driven by the daemon's live

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/driver.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/driver.go
@@ -148,7 +148,9 @@ func WriteColdChunk(
 		return berr
 	}
 	logger.Debugf("cold ingest chunk %d [%d, %d]", uint32(chunkID), chunkID.FirstLedger(), chunkID.LastLedger())
-	service := NewColdService(ings, sink)
+	// txhash and events share the single ExtractLedgerEvents walk; a ledgers-only
+	// chunk needs no walk at all.
+	service := NewColdService(ings, sink, cfg.Txhash || cfg.Events)
 	defer func() {
 		if cerr := service.Close(); cerr != nil {
 			err = errors.Join(err, fmt.Errorf("close: %w", cerr))

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/driver.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/driver.go
@@ -13,30 +13,16 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
 )
 
-// closeColdAll closes every cold ingester built so far, joining each Close error
-// into err. Used when a LATER constructor fails mid-build. The already-built
-// ingesters never ingested or finalized, and Close emits no per-ingester
-// ColdIngest sample, so a rolled-back build produces no phantom-success sample — no
-// abort bookkeeping needed here.
-func closeColdAll(ings []ColdIngester, err error) error {
-	for _, ing := range ings {
-		if cerr := ing.Close(); cerr != nil {
-			err = errors.Join(err, fmt.Errorf("close: %w", cerr))
-		}
-	}
-	return err
-}
-
-// drain feeds each of the chunk's raw ledgers (as a borrowed view) to the
-// service on a local sequence counter, then verifies the full [first,last] range
-// was consumed — for cold this runs before Finalize, so a short stream never
-// finalizes a truncated artifact. The in-order contract is enforced at the SOURCE
+// drain feeds each of the chunk's raw ledgers (as a borrowed view) to the cold
+// chunk on a local sequence counter, then verifies the full [first,last] range
+// was consumed — this runs before finalize, so a short stream never finalizes a
+// truncated artifact. The in-order contract is enforced at the SOURCE
 // (packStream reads positionally by key; hotLedgerStream key-checks its own
 // keyspace; the SDK backends validate their own output), so drain trusts the
 // counter rather than re-parsing every view's sequence. Cancellation is the
 // iterator's job (RawLedgers errors on a canceled ctx), so there is no ctx poll
 // here.
-func drain(ctx context.Context, ledgers iter.Seq2[[]byte, error], chunkID chunk.ID, svc *ColdService) error {
+func drain(ledgers iter.Seq2[[]byte, error], chunkID chunk.ID, cc *coldChunk) error {
 	first, last := chunkID.FirstLedger(), chunkID.LastLedger()
 	seq := first
 	for raw, serr := range ledgers {
@@ -49,7 +35,7 @@ func drain(ctx context.Context, ledgers iter.Seq2[[]byte, error], chunkID chunk.
 			return fmt.Errorf("ingest: stream for chunk %d yielded a ledger past %d (chunk overrun)",
 				uint32(chunkID), last)
 		}
-		if err := svc.Ingest(ctx, seq, xdr.LedgerCloseMetaView(raw)); err != nil {
+		if err := cc.ingest(seq, xdr.LedgerCloseMetaView(raw)); err != nil {
 			return err
 		}
 		seq++
@@ -72,50 +58,20 @@ type ColdDirs struct {
 	EventsDir  string
 }
 
-// buildColdIngesters opens one ColdIngester per enabled type at its resolved path.
-// Single definition site of the ctor table, order, and rollback.
-func buildColdIngesters(dirs ColdDirs, chunkID chunk.ID, sink MetricSink, cfg Config) ([]ColdIngester, error) {
-	ctors := []struct {
-		enabled  bool
-		dataType string
-		path     string
-		open     func(string, chunk.ID, MetricSink) (ColdIngester, error)
-	}{
-		{cfg.Ledgers, dataTypeLedgers, dirs.LedgerPack, NewLedgerColdIngester},
-		{cfg.Txhash, dataTypeTxhash, dirs.TxhashBin, NewTxhashColdIngester},
-		{cfg.Events, dataTypeEvents, dirs.EventsDir, NewEventsColdIngester},
-	}
-	ings := make([]ColdIngester, 0, len(ctors))
-	for _, c := range ctors {
-		if !c.enabled {
-			continue
-		}
-		if c.path == "" {
-			return nil, closeColdAll(ings, fmt.Errorf("ingest: %s enabled but its ColdDirs path is empty", c.dataType))
-		}
-		ing, err := c.open(c.path, chunkID, sink)
-		if err != nil {
-			return nil, closeColdAll(ings, fmt.Errorf("open %s cold ingester: %w", c.dataType, err))
-		}
-		ings = append(ings, ing)
-	}
-	return ings, nil
-}
-
 // WriteColdChunk materializes ONE chunk's cold artifacts at the resolved paths
 // named by dirs, in a single pass, from the already-opened raw ledger iterator. It is
 // SOURCE-BLIND: the caller (backfill) resolves the chunk's ledger source — the
 // local frozen .pack or the bulk backend — and hands its RawLedgers iterator here,
 // so the cold materializer never learns where the bytes came from and is faked in
-// tests with a literal slice iterator. The ingesters overwrite any crashed
+// tests with a literal slice iterator. The writers overwrite any crashed
 // partial, so this is the freeze protocol's re-materialization. On any failure the
 // attempt is abandoned — leftover files are inert scratch (see the package doc's
 // artifact model) and a retry's overwrite is the cleanup.
 //
 // Source resolution (pack-stat, coverage wait) runs in the caller BEFORE this, so
 // a pack-missing or coverage-timeout failure is metered there rather than as a
-// ColdChunkTotal attempt here. The only pre-service failures left to meter here
-// are a canceled ctx and a cold-ingester constructor failure.
+// ColdChunkTotal attempt here. The only pre-open failures left to meter here
+// are a canceled ctx and a cold-writer open failure.
 func WriteColdChunk(
 	ctx context.Context,
 	logger *supportlog.Entry,
@@ -130,37 +86,29 @@ func WriteColdChunk(
 	}
 	sink = orNop(sink)
 
-	// Pre-service failures (ctx and the constructor failure below) emit the
-	// chunk's single ColdChunkTotal here: the ColdService that normally owns that
-	// aggregate isn't built yet, but the invariant is "exactly one ColdChunkTotal
-	// per chunk attempt, including failures."
+	// One deferred emit covers every return below exactly once — the invariant
+	// "exactly one ColdChunkTotal per chunk attempt, including pre-open
+	// failures" is a property of the control flow, not a runtime latch. It sits
+	// after validate, so a config error still emits nothing. The window is
+	// deliberately the whole attempt — open, the drain of the source stream,
+	// every ingest, finalize, and the deferred close (see coldBuckets).
 	start := time.Now()
+	defer func() { sink.ColdChunkTotal(time.Since(start)) }()
+
 	if cerr := ctx.Err(); cerr != nil {
-		sink.ColdChunkTotal(time.Since(start))
 		return cerr
 	}
-
-	ings, berr := buildColdIngesters(dirs, chunkID, sink, cfg)
-	if berr != nil {
-		// A constructor failure is still a chunk attempt: emit the aggregate
-		// (closeColdAll rolled back the built ingesters with no per-ingester emit).
-		sink.ColdChunkTotal(time.Since(start))
-		return berr
+	cc, oerr := openColdChunk(dirs, chunkID, sink, cfg)
+	if oerr != nil {
+		return oerr
 	}
+	defer func() { err = errors.Join(err, cc.close()) }()
 	logger.Debugf("cold ingest chunk %d [%d, %d]", uint32(chunkID), chunkID.FirstLedger(), chunkID.LastLedger())
-	// txhash and events share the single ExtractLedgerEvents walk; a ledgers-only
-	// chunk needs no walk at all.
-	service := NewColdService(ings, sink, cfg.Txhash || cfg.Events)
-	defer func() {
-		if cerr := service.Close(); cerr != nil {
-			err = errors.Join(err, fmt.Errorf("close: %w", cerr))
-		}
-	}()
 
-	if derr := drain(ctx, raw, chunkID, service); derr != nil {
+	if derr := drain(raw, chunkID, cc); derr != nil {
 		return derr
 	}
-	// drain verified the full range was consumed, so Finalize never commits a
+	// drain verified the full range was consumed, so finalize never commits a
 	// truncated artifact.
-	return service.Finalize(ctx)
+	return cc.finalize(ctx)
 }

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/events.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/events.go
@@ -7,17 +7,19 @@ import (
 	"os"
 	"time"
 
+	sdkingest "github.com/stellar/go-stellar-sdk/ingest"
+
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore"
 )
 
-// ───────────────────────── Cold ingester ─────────────────────────
+// ───────────────────────── Cold writer ─────────────────────────
 
-// eventsCold models the backfill path: per-ledger view → payloads → term-index
-// accumulate + cold append, then chunk-end Finish + WriteColdIndex. No HotStore
-// is involved — it maintains an in-memory events.Bitmaps mirror via NewBitmaps
-// + per-event TermsForBytes, and an events.LedgerOffsets to assign
+// eventsCold models the backfill path: shared-walk output → payloads →
+// term-index accumulate + cold append, then chunk-end Finish + WriteColdIndex.
+// No HotStore is involved — it maintains an in-memory events.Bitmaps mirror via
+// NewBitmaps + per-event TermsForBytes, and an events.LedgerOffsets to assign
 // chunk-relative event IDs.
 type eventsCold struct {
 	chunkID   chunk.ID
@@ -26,21 +28,21 @@ type eventsCold struct {
 	offsets   *events.LedgerOffsets
 	bucketDir string
 	metrics   coldMetrics
-	// failed latches any Ingest error. A failed Ingest can leave the mirror
+	// failed latches any write error. A failed write can leave the mirror
 	// and the pack ahead of offsets (offsets is the per-ledger commit point,
-	// appended last), so a subsequent Finalize would commit an index whose
+	// appended last), so a subsequent finalize would commit an index whose
 	// bitmaps reference event IDs past offsets.TotalEvents(). The latch makes
-	// Finalize refuse instead — the chunk must be abandoned via Close and
-	// retried from scratch (see ColdIngester's contract).
+	// finalize refuse instead — the chunk must be abandoned via close and
+	// retried from scratch (see coldChunk's contract).
 	failed bool
 }
 
-// NewEventsColdIngester opens a per-chunk events.pack cold writer in bucketDir —
+// newEventsCold opens a per-chunk events.pack cold writer in bucketDir —
 // the caller's geometry.Layout.EventsBucketDir(chunkID), so the write path is
-// Layout's single derivation — and returns a ColdIngester that owns it. The
-// writer opts into the batch tuning (coldEncoderConcurrency/coldBytesPerSync):
-// WriteColdChunk, the sole caller, is always a batch freeze/backfill.
-func NewEventsColdIngester(bucketDir string, chunkID chunk.ID, sink MetricSink) (ColdIngester, error) {
+// Layout's single derivation. The writer opts into the batch tuning
+// (coldEncoderConcurrency/coldBytesPerSync): WriteColdChunk, the sole
+// production caller, is always a batch freeze/backfill.
+func newEventsCold(bucketDir string, chunkID chunk.ID, sink MetricSink) (*eventsCold, error) {
 	if err := os.MkdirAll(bucketDir, 0o755); err != nil {
 		return nil, fmt.Errorf("mkdir %s: %w", bucketDir, err)
 	}
@@ -61,31 +63,34 @@ func NewEventsColdIngester(bucketDir string, chunkID chunk.ID, sink MetricSink) 
 	}, nil
 }
 
-func (e *eventsCold) Ingest(_ context.Context, l ledgerData) error {
+// write ingests one ledger's events from the shared walk's output. txEvents
+// and its byte slices alias the source stream's borrowed buffer, valid only
+// for this call — everything retained is copied synchronously (see ingestSeq).
+func (e *eventsCold) write(seq uint32, closedAt int64, txEvents []sdkingest.LedgerTransactionEvents) error {
 	start := time.Now()
-	n, ierr := e.ingestSeq(l)
-	e.metrics.observe(time.Since(start), n, ierr) // terminal on err: observe emits the per-ingester signal
+	n, ierr := e.ingestSeq(seq, closedAt, txEvents)
+	e.metrics.observe(time.Since(start), n, ierr) // terminal on err: observe emits the per-writer signal
 	if ierr != nil {
-		e.failed = true // refuse a post-failure Finalize
+		e.failed = true // refuse a post-failure finalize
 		return ierr
 	}
 	return nil
 }
 
-// Finalize writes the events.pack trailer (Finish) + materializes the cold
+// finalize writes the events.pack trailer (Finish) + materializes the cold
 // index (WriteColdIndex). An eventless chunk (zero terms — the common case
 // for pre-Soroban backfill ranges) is handled inside WriteColdIndex, which
 // publishes a valid empty index, so all three cold artifacts exist for every
 // finalized chunk. An error from either step means the chunk did not durably
-// land. Refuses to run after a failed Ingest (see the `failed` field): the
+// land. Refuses to run after a failed write (see the `failed` field): the
 // mirror/pack may be ahead of offsets, and committing would publish an index
 // referencing event IDs past the offsets commit point.
-func (e *eventsCold) Finalize(ctx context.Context) error {
+func (e *eventsCold) finalize(ctx context.Context) error {
 	start := time.Now()
 	if e.failed {
-		// Ingest already metered and latched this failure; refuse to finalize a
+		// write already metered and latched this failure; refuse to finalize a
 		// chunk whose mirror/pack may be ahead of the offsets commit point.
-		return fmt.Errorf("events cold ingester for chunk %s: Finalize after failed Ingest", e.chunkID)
+		return fmt.Errorf("events cold writer for chunk %s: Finalize after failed Ingest", e.chunkID)
 	}
 	if err := e.writer.Finish(e.offsets); err != nil {
 		err = fmt.Errorf("events ColdWriter.Finish: %w", err)
@@ -106,28 +111,27 @@ func (e *eventsCold) Finalize(ctx context.Context) error {
 	return nil
 }
 
-// Close drops the partial events.pack when Finalize never ran. It does NOT emit
-// the cold metric: a terminal Ingest error or Finalize already emitted it, and an
-// ingester that never got that far (a rolled-back build) must produce no phantom
+// close drops the partial events.pack when finalize never ran. It does NOT emit
+// the cold metric: a terminal write error or finalize already emitted it, and a
+// writer that never got that far (a rolled-back build) must produce no phantom
 // sample. The writer.Close error is returned unchanged.
-func (e *eventsCold) Close() error {
+func (e *eventsCold) close() error {
 	return e.writer.Close()
 }
 
 // ingestSeq writes one ledger's events and returns the count written. It shapes
-// the ColdService's shared ExtractLedgerEvents walk into cursor-ordered payloads
+// coldChunk's shared ExtractLedgerEvents walk into cursor-ordered payloads
 // via events.PayloadsFromLedgerEvents — the SAME function the hot tier uses, so
 // event-ID assignment is byte-identical to the hot path (same shaping). A
 // pre-Soroban (V0) ledger yields zero payloads, recorded like any event-free
-// ledger. Shaping folds into the per-ingester ColdIngest total; the extraction
-// itself is metered once, ledger-scoped, as the shared extract stage.
-func (e *eventsCold) ingestSeq(l ledgerData) (int, error) {
-	payloads, err := events.PayloadsFromLedgerEvents(l.txEvents, l.seq, l.closedAt)
+// ledger. Shaping folds into the per-writer ColdIngest total; the extraction
+// itself is metered once, ledger-scoped, as the ColdExtract signal.
+func (e *eventsCold) ingestSeq(seq uint32, closedAt int64, txEvents []sdkingest.LedgerTransactionEvents) (int, error) {
+	payloads, err := events.PayloadsFromLedgerEvents(txEvents, seq, closedAt)
 	if err != nil {
-		return 0, fmt.Errorf("shape events seq %d: %w", l.seq, err)
+		return 0, fmt.Errorf("shape events seq %d: %w", seq, err)
 	}
 
-	seq := l.seq
 	startID := e.offsets.TotalEvents()
 	if uint64(startID)+uint64(len(payloads)) > math.MaxUint32 {
 		return 0, fmt.Errorf("chunk %s would overflow uint32 event-id space at ledger %d", e.chunkID, seq)
@@ -139,9 +143,9 @@ func (e *eventsCold) ingestSeq(l ledgerData) (int, error) {
 	// ContractEventBytes are synchronous (TermsForBytes does not retain them;
 	// Append marshals into a scratch buffer copied synchronously), so the borrow
 	// is safe. On any error here offsets is not advanced below — but the mirror and
-	// pack may already be ahead of offsets, which is why Ingest latches `failed`
-	// and Finalize refuses afterwards: recovery means abandoning the chunk via
-	// Close, not resuming mid-chunk. An empty-payload ledger (genuinely zero
+	// pack may already be ahead of offsets, which is why write latches `failed`
+	// and finalize refuses afterwards: recovery means abandoning the chunk via
+	// close, not resuming mid-chunk. An empty-payload ledger (genuinely zero
 	// events, or a V0 ledger that PayloadsFromLedgerEvents shapes to zero payloads)
 	// runs zero iterations but still emits term_index/write samples and advances
 	// offsets below, so every ledger contributes exactly one sample to each of the
@@ -168,9 +172,11 @@ func (e *eventsCold) ingestSeq(l ledgerData) (int, error) {
 	e.metrics.sink.IngestStage(dataTypeEvents, stageTermIndex, termDur, len(payloads))
 
 	// offsets.Append LAST — it is the commit point for the ledger. Its cost folds
-	// into the write stage (rather than landing in the per-chunk total but in no
-	// stage), so extract + term_index + write partitions the per-ledger observe
-	// window with no unexplained remainder. uint32(len(payloads)) is 0 for an
+	// into the write stage, so term_index and write are the two per-ledger stages
+	// this writer emits. The PayloadsFromLedgerEvents shaping at the top of the
+	// function folds into the ColdIngest total without its own stage; the shared
+	// ExtractLedgerEvents walk is metered once, ledger-scoped, by the ColdExtract
+	// signal (cold_extract_duration_seconds). uint32(len(payloads)) is 0 for an
 	// empty ledger — an explicit Append(seq, 0) that records the empty ledger.
 	wstart := time.Now()
 	//nolint:gosec // the overflow guard above proved startID+len(payloads) fits in uint32

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/events.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/events.go
@@ -90,7 +90,7 @@ func (e *eventsCold) finalize(ctx context.Context) error {
 	if e.failed {
 		// write already metered and latched this failure; refuse to finalize a
 		// chunk whose mirror/pack may be ahead of the offsets commit point.
-		return fmt.Errorf("events cold writer for chunk %s: Finalize after failed Ingest", e.chunkID)
+		return fmt.Errorf("events cold writer for chunk %s: finalize after failed write", e.chunkID)
 	}
 	if err := e.writer.Finish(e.offsets); err != nil {
 		err = fmt.Errorf("events ColdWriter.Finish: %w", err)

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/events.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/events.go
@@ -7,23 +7,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/stellar/go-stellar-sdk/xdr"
-
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore"
 )
-
-// eventPayloads derives one ledger's event payloads from the view. A V0
-// (pre-Soroban) ledger has no contract events and yields zero payloads,
-// recorded like any event-free ledger.
-func eventPayloads(seq uint32, lcm xdr.LedgerCloseMetaView) ([]events.Payload, error) {
-	payloads, err := events.LCMViewToPayloads(lcm)
-	if err != nil {
-		return nil, fmt.Errorf("LCMViewToPayloads seq %d: %w", seq, err)
-	}
-	return payloads, nil
-}
 
 // ───────────────────────── Cold ingester ─────────────────────────
 
@@ -51,12 +38,16 @@ type eventsCold struct {
 // NewEventsColdIngester opens a per-chunk events.pack cold writer in bucketDir —
 // the caller's geometry.Layout.EventsBucketDir(chunkID), so the write path is
 // Layout's single derivation — and returns a ColdIngester that owns it. The
-// writer uses its zero-value options; driver-level tuning is a follow-up (issue #836).
+// writer opts into the batch tuning (coldEncoderConcurrency/coldBytesPerSync):
+// WriteColdChunk, the sole caller, is always a batch freeze/backfill.
 func NewEventsColdIngester(bucketDir string, chunkID chunk.ID, sink MetricSink) (ColdIngester, error) {
 	if err := os.MkdirAll(bucketDir, 0o755); err != nil {
 		return nil, fmt.Errorf("mkdir %s: %w", bucketDir, err)
 	}
-	w, err := eventstore.NewColdWriter(chunkID, bucketDir, eventstore.ColdWriterOptions{})
+	w, err := eventstore.NewColdWriter(chunkID, bucketDir, eventstore.ColdWriterOptions{
+		Concurrency:  coldEncoderConcurrency,
+		BytesPerSync: coldBytesPerSync,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("eventstore.NewColdWriter: %w", err)
 	}
@@ -70,9 +61,9 @@ func NewEventsColdIngester(bucketDir string, chunkID chunk.ID, sink MetricSink) 
 	}, nil
 }
 
-func (e *eventsCold) Ingest(_ context.Context, seq uint32, lcm xdr.LedgerCloseMetaView) error {
+func (e *eventsCold) Ingest(_ context.Context, l ledgerData) error {
 	start := time.Now()
-	n, ierr := e.ingestSeq(seq, lcm)
+	n, ierr := e.ingestSeq(l)
 	e.metrics.observe(time.Since(start), n, ierr) // terminal on err: observe emits the per-ingester signal
 	if ierr != nil {
 		e.failed = true // refuse a post-failure Finalize
@@ -123,17 +114,20 @@ func (e *eventsCold) Close() error {
 	return e.writer.Close()
 }
 
-// ingestSeq writes one ledger's events and returns the count written. The
-// pre-Soroban (V0) policy lives in events.LCMViewToPayloads, shared with the
-// hot tier.
-func (e *eventsCold) ingestSeq(seq uint32, lcm xdr.LedgerCloseMetaView) (int, error) {
-	estart := time.Now()
-	payloads, err := eventPayloads(seq, lcm)
+// ingestSeq writes one ledger's events and returns the count written. It shapes
+// the ColdService's shared ExtractLedgerEvents walk into cursor-ordered payloads
+// via events.PayloadsFromLedgerEvents — the SAME function the hot tier uses, so
+// event-ID assignment is byte-identical to the hot path (same shaping). A
+// pre-Soroban (V0) ledger yields zero payloads, recorded like any event-free
+// ledger. Shaping folds into the per-ingester ColdIngest total; the extraction
+// itself is metered once, ledger-scoped, as the shared extract stage.
+func (e *eventsCold) ingestSeq(l ledgerData) (int, error) {
+	payloads, err := events.PayloadsFromLedgerEvents(l.txEvents, l.seq, l.closedAt)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("shape events seq %d: %w", l.seq, err)
 	}
-	e.metrics.sink.IngestStage(dataTypeEvents, stageExtract, time.Since(estart), len(payloads))
 
+	seq := l.seq
 	startID := e.offsets.TotalEvents()
 	if uint64(startID)+uint64(len(payloads)) > math.MaxUint32 {
 		return 0, fmt.Errorf("chunk %s would overflow uint32 event-id space at ledger %d", e.chunkID, seq)
@@ -148,10 +142,11 @@ func (e *eventsCold) ingestSeq(seq uint32, lcm xdr.LedgerCloseMetaView) (int, er
 	// pack may already be ahead of offsets, which is why Ingest latches `failed`
 	// and Finalize refuses afterwards: recovery means abandoning the chunk via
 	// Close, not resuming mid-chunk. An empty-payload ledger (genuinely zero
-	// events, or a V0 ledger handled by eventPayloads) runs zero iterations but
-	// still emits term_index/write samples and advances offsets below, so every
-	// ledger contributes exactly one sample to each of the three cold stage
-	// histograms — a consumer can divide a stage total by the ledger count.
+	// events, or a V0 ledger that PayloadsFromLedgerEvents shapes to zero payloads)
+	// runs zero iterations but still emits term_index/write samples and advances
+	// offsets below, so every ledger contributes exactly one sample to each of the
+	// two per-ledger events stage histograms — a consumer can divide a stage total
+	// by the ledger count.
 	var termDur, writeDur time.Duration
 	for i := range payloads {
 		tstart := time.Now()

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/ingest_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/ingest_test.go
@@ -903,9 +903,9 @@ func eventRichLedger(t *testing.T, seq uint32) []byte {
 //     is the OLD txhash extractor — a separate SDK walk from the shared
 //     ExtractLedgerEvents the ingester now reads — so an entry-by-entry match
 //     proves the switch to `.Hash` off the shared walk changed no byte.
-//   - events per-term bitmaps + count vs. PayloadsFromLedgerEvents (the shaping
-//     LCMViewToPayloads used), with chunk-relative event IDs assigned in ingest
-//     (ascending-seq) order — proving the event-ID assignment is unchanged.
+//   - events per-term bitmaps + count vs. an independent PayloadsFromLedgerEvents
+//     shaping, with chunk-relative event IDs assigned in ingest (ascending-seq)
+//     order — proving the event-ID assignment is unchanged.
 func TestWriteColdChunk_ByteIdentity_SharedWalk(t *testing.T) {
 	chunkID := chunk.ID(0)
 	first := chunkID.FirstLedger()

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/ingest_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/ingest_test.go
@@ -58,6 +58,11 @@ type stageCall struct {
 	items    int
 }
 
+type coldExtractCall struct {
+	items int
+	err   error
+}
+
 // testSink records every MetricSink call for assertions. Safe for concurrent
 // use (the hot methods fire from the per-ledger ingestion goroutine).
 type testSink struct {
@@ -65,7 +70,7 @@ type testSink struct {
 	hotPhases       []hotPhaseCall
 	coldIngests     []coldCall
 	stages          []stageCall
-	coldExtracts    []int // items per shared-walk ColdExtract call
+	coldExtracts    []coldExtractCall // one entry per shared-walk ColdExtract call
 	coldChunkTotals int
 }
 
@@ -87,10 +92,10 @@ func (s *testSink) ColdChunkTotal(time.Duration) {
 	s.coldChunkTotals++
 }
 
-func (s *testSink) ColdExtract(_ time.Duration, items int) {
+func (s *testSink) ColdExtract(_ time.Duration, items int, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.coldExtracts = append(s.coldExtracts, items)
+	s.coldExtracts = append(s.coldExtracts, coldExtractCall{items, err})
 }
 
 func (s *testSink) IngestStage(dataType, stage string, _ time.Duration, items int) {
@@ -707,8 +712,11 @@ func TestColdChunk_Success(t *testing.T) {
 	require.Empty(t, sink.coldErrorTypes(), "success path records no writer errors")
 
 	// The shared per-ledger walk fires ONE ColdExtract per ledger — not one per
-	// consuming type.
+	// consuming type — and none carries an error on the success path.
 	require.Len(t, sink.coldExtracts, 2, "one shared extract walk per ledger")
+	for _, ce := range sink.coldExtracts {
+		require.NoError(t, ce.err, "success path records no extract errors")
+	}
 
 	// Per-stage signals: the per-ledger stages fire once per (non-empty) ledger,
 	// the per-chunk finalize stage once per writer. The exact map is asserted so
@@ -754,6 +762,12 @@ func TestColdChunk_MidChunkFailure_NoArtifact(t *testing.T) {
 	err = cc.ingest(first+1, xdr.LedgerCloseMetaView(garbage))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "extract ledger events", "the shared walk rejects the garbage ledger")
+
+	// The failed walk is metered: an error-carrying ColdExtract (its one metric —
+	// no writer ran for that ledger), after the first ledger's clean one.
+	require.Len(t, sink.coldExtracts, 2)
+	require.NoError(t, sink.coldExtracts[0].err)
+	require.Error(t, sink.coldExtracts[1].err, "the failed shared walk emits an error-carrying ColdExtract")
 
 	// Nothing has emitted: both writers ingested cleanly (no terminal error of
 	// their own) and never finalized.
@@ -818,7 +832,8 @@ func TestPrometheusSink_Smoke(t *testing.T) {
 		sink.HotPhase(hotchunk.PhaseApply, time.Millisecond, 0, nil)
 		sink.ColdIngest(dataTypeTxhash, time.Second, 100, nil)
 		sink.ColdChunkTotal(time.Second)
-		sink.ColdExtract(time.Millisecond, 3)
+		sink.ColdExtract(time.Millisecond, 3, nil)
+		sink.ColdExtract(time.Millisecond, 0, errors.New("induced extract failure"))
 		sink.IngestStage(dataTypeEvents, stageFinalize, time.Second, 0)
 	})
 
@@ -1467,7 +1482,7 @@ func TestEventsCold_FinalizeAfterFailedIngest_Refuses(t *testing.T) {
 
 	ferr := ing.finalize(context.Background())
 	require.Error(t, ferr)
-	require.Contains(t, ferr.Error(), "Finalize after failed Ingest")
+	require.Contains(t, ferr.Error(), "finalize after failed write")
 }
 
 // ───────────────────────── coldChunk.finalize first-error ─────────────────────────

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/ingest_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/ingest_test.go
@@ -7,6 +7,7 @@ import (
 	"iter"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	sdkingest "github.com/stellar/go-stellar-sdk/ingest"
 	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
 	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stellar/go-stellar-sdk/network"
@@ -391,6 +393,20 @@ func viewOf(t *testing.T, seq uint32) xdr.LedgerCloseMetaView {
 	return xdr.LedgerCloseMetaView(marshalLCM(t, seq))
 }
 
+// coldInput builds the ledgerData that ColdService would hand a cold ingester
+// for one raw ledger: the shared ExtractLedgerEvents walk plus the close time.
+// Tests that drive a single ingester directly (no ColdService) use it in place
+// of the old per-view Ingest signature.
+func coldInput(t *testing.T, seq uint32, raw []byte) ledgerData {
+	t.Helper()
+	view := xdr.LedgerCloseMetaView(raw)
+	txEvents, err := sdkingest.ExtractLedgerEvents(view)
+	require.NoError(t, err)
+	closedAt, err := view.LedgerCloseTime()
+	require.NoError(t, err)
+	return ledgerData{seq: seq, raw: raw, closedAt: closedAt, txEvents: txEvents}
+}
+
 // marshalV0LCM builds a minimal V0 (pre-Soroban) LedgerCloseMeta with no
 // transactions and returns its wire bytes. V0 LCMs carry no contract events,
 // so the events ingesters record them as a zero-payload ledger.
@@ -447,7 +463,7 @@ func TestLedgerColdIngester_Readback(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, ing.Close()) }()
 
-	require.NoError(t, ing.Ingest(context.Background(), seq, xdr.LedgerCloseMetaView(raw)))
+	require.NoError(t, ing.Ingest(context.Background(), coldInput(t, seq, raw)))
 	require.NoError(t, ing.Finalize(context.Background()))
 
 	cr, err := ledger.OpenColdReader(packPath(coldDir, chunkID))
@@ -478,7 +494,7 @@ func TestTxhashColdIngester_Bin(t *testing.T) {
 
 	for _, seq := range []uint32{first, first + 1} {
 		raw, _, _ := marshalLCMWithEvent(t, seq)
-		require.NoError(t, ing.Ingest(context.Background(), seq, xdr.LedgerCloseMetaView(raw)))
+		require.NoError(t, ing.Ingest(context.Background(), coldInput(t, seq, raw)))
 	}
 	require.NoError(t, ing.Finalize(context.Background()))
 
@@ -501,7 +517,7 @@ func TestEventsColdIngester_Readback(t *testing.T) {
 	for _, seq := range []uint32{first, first + 1} {
 		raw, _, tk := marshalLCMWithEvent(t, seq)
 		term = tk
-		require.NoError(t, ing.Ingest(context.Background(), seq, xdr.LedgerCloseMetaView(raw)))
+		require.NoError(t, ing.Ingest(context.Background(), coldInput(t, seq, raw)))
 	}
 	require.NoError(t, ing.Finalize(context.Background()))
 
@@ -534,10 +550,10 @@ func TestEventsColdIngester_V0KeepsOffsetsContiguous(t *testing.T) {
 	defer func() { require.NoError(t, ing.Close()) }()
 
 	// Ledger `first`: V0 → zero events, no error.
-	require.NoError(t, ing.Ingest(context.Background(), first, xdr.LedgerCloseMetaView(marshalV0LCM(t, first))))
+	require.NoError(t, ing.Ingest(context.Background(), coldInput(t, first, marshalV0LCM(t, first))))
 	// Ledger `first+1`: one contract event.
 	rawEv, _, term := marshalLCMWithEvent(t, first+1)
-	require.NoError(t, ing.Ingest(context.Background(), first+1, xdr.LedgerCloseMetaView(rawEv)))
+	require.NoError(t, ing.Ingest(context.Background(), coldInput(t, first+1, rawEv)))
 	require.NoError(t, ing.Finalize(context.Background()))
 
 	bucketDir := filepath.Join(coldDir, chunkID.BucketID())
@@ -635,7 +651,7 @@ func TestColdService_Success(t *testing.T) {
 	ings, err := buildColdIngesters(
 		coldDirsAt(coldDir, chunkID), chunkID, sink, Config{Ledgers: true, Txhash: true, Events: true})
 	require.NoError(t, err)
-	service := NewColdService(ings, sink)
+	service := NewColdService(ings, sink, true)
 	defer func() { require.NoError(t, service.Close()) }()
 
 	var term events.TermKey
@@ -679,17 +695,18 @@ func TestColdService_Success(t *testing.T) {
 	require.Equal(t, 1, cdt[dataTypeEvents])
 	require.Empty(t, sink.coldErrorTypes(), "success path records no ingester errors")
 
-	// Per-stage signals: per-ledger cold stages fired once per (non-empty)
-	// ledger, the per-chunk finalize stage once per ingester. The exact map is
-	// asserted so an unexpected stage emission (or a missing one) also fails —
-	// events now emits term_index/write for every ledger, and txhash's extract
-	// spans its whole per-ledger Ingest.
+	// Per-stage signals: the shared per-ledger walk fires ONE extract stage per
+	// ledger (dataTypeShared) — not one per consuming type — and the other
+	// per-ledger stages fire once per (non-empty) ledger, the per-chunk finalize
+	// stage once per ingester. The exact map is asserted so an unexpected stage
+	// emission (or a missing one) also fails — events emits term_index/write for
+	// every ledger, and txhash now does only its finalize sort + .bin write (its
+	// cheap per-ledger accumulate folds into the ColdIngest total).
 	require.Equal(t, map[string]int{
+		dataTypeShared + "/" + stageExtract:   2,
 		dataTypeLedgers + "/" + stageWrite:    2,
 		dataTypeLedgers + "/" + stageFinalize: 1,
-		dataTypeTxhash + "/" + stageExtract:   2,
 		dataTypeTxhash + "/" + stageFinalize:  1,
-		dataTypeEvents + "/" + stageExtract:   2,
 		dataTypeEvents + "/" + stageTermIndex: 2,
 		dataTypeEvents + "/" + stageWrite:     2,
 		dataTypeEvents + "/" + stageFinalize:  1,
@@ -711,7 +728,7 @@ type failingCold struct {
 
 var errFailingCold = errors.New("failingCold: induced ingest failure")
 
-func (f *failingCold) Ingest(context.Context, uint32, xdr.LedgerCloseMetaView) error {
+func (f *failingCold) Ingest(context.Context, ledgerData) error {
 	return errFailingCold
 }
 func (f *failingCold) Finalize(context.Context) error { f.finalized = true; return nil }
@@ -734,7 +751,7 @@ func TestColdService_FailurePath_NoArtifact(t *testing.T) {
 	realEvents, err := NewEventsColdIngester(filepath.Join(coldDir, dataTypeEvents, chunkID.BucketID()), chunkID, sink)
 	require.NoError(t, err)
 	failing := &failingCold{}
-	service := NewColdService([]ColdIngester{realLedger, realEvents, failing}, sink)
+	service := NewColdService([]ColdIngester{realLedger, realEvents, failing}, sink, true)
 
 	// First ledger: the real ingesters succeed, failing returns an error → the
 	// sequential Ingest aborts the ledger with the sibling's error.
@@ -774,7 +791,7 @@ func TestColdIngester_Failure_RecordsErrorMetric(t *testing.T) {
 
 	realLedger, err := NewLedgerColdIngester(packPath(filepath.Join(coldDir, dataTypeLedgers), chunkID), chunkID, sink)
 	require.NoError(t, err)
-	service := NewColdService([]ColdIngester{realLedger}, sink)
+	service := NewColdService([]ColdIngester{realLedger}, sink, false)
 
 	// An out-of-order seq makes the writer's own AppendLedger fail inside the
 	// ingester's Ingest, so it records its firstErr and emits the error-carrying
@@ -850,6 +867,127 @@ func TestWriteColdChunk_RoundTrip(t *testing.T) {
 
 	require.Equal(t, 1, sink.coldChunkTotals)
 	require.Equal(t, 1, sink.coldDataTypes()[dataTypeLedgers])
+}
+
+// eventRichLedger builds a multi-tx, multi-event ledger: tx0 with two op events,
+// tx1 with BeforeAllTxs + AfterTx stage events straddling one op event, tx2 with
+// no events. It exercises cross-tx and cross-stage cursor ordering, so the
+// byte-identity check below is a real ordering test, not a single-event smoke.
+func eventRichLedger(t *testing.T, seq uint32) []byte {
+	t.Helper()
+	tx0 := xdr.TransactionMeta{V: 4, V4: &xdr.TransactionMetaV4{
+		Operations: []xdr.OperationMetaV2{{Events: []xdr.ContractEvent{
+			buildContractEvent("a"), buildContractEvent("b"),
+		}}},
+	}}
+	tx1 := xdr.TransactionMeta{V: 4, V4: &xdr.TransactionMetaV4{
+		Events: []xdr.TransactionEvent{
+			{Stage: xdr.TransactionEventStageTransactionEventStageBeforeAllTxs, Event: buildContractEvent("fee")},
+			{Stage: xdr.TransactionEventStageTransactionEventStageAfterTx, Event: buildContractEvent("refund")},
+		},
+		Operations: []xdr.OperationMetaV2{{Events: []xdr.ContractEvent{buildContractEvent("c")}}},
+	}}
+	tx2 := xdr.TransactionMeta{V: 4, V4: &xdr.TransactionMetaV4{}}
+	raw, err := buildLCM(t, seq, []xdr.TransactionMeta{tx0, tx1, tx2}).MarshalBinary()
+	require.NoError(t, err)
+	return raw
+}
+
+// TestWriteColdChunk_ByteIdentity_SharedWalk is the #836 invariant guard: the
+// single-walk cold path must produce artifacts byte-identical to the old
+// two-walk path. It drives the real WriteColdChunk entrypoint over a chunk with
+// several rich sentinel ledgers and compares the artifacts to INDEPENDENT
+// reference computations:
+//
+//   - txhash .bin vs. sorted, truncated ExtractTxHashes output. ExtractTxHashes
+//     is the OLD txhash extractor — a separate SDK walk from the shared
+//     ExtractLedgerEvents the ingester now reads — so an entry-by-entry match
+//     proves the switch to `.Hash` off the shared walk changed no byte.
+//   - events per-term bitmaps + count vs. PayloadsFromLedgerEvents (the shaping
+//     LCMViewToPayloads used), with chunk-relative event IDs assigned in ingest
+//     (ascending-seq) order — proving the event-ID assignment is unchanged.
+func TestWriteColdChunk_ByteIdentity_SharedWalk(t *testing.T) {
+	chunkID := chunk.ID(0)
+	first := chunkID.FirstLedger()
+	coldDir := t.TempDir()
+
+	// Rich sentinels scattered across the chunk; the rest are cheap zero-tx
+	// ledgers (no hashes, no events). Capture each sentinel's raw for the
+	// reference computations.
+	sentinels := []uint32{first, first + 1, first + 7}
+	raws := map[uint32][]byte{}
+	gen := func(tt *testing.T, seq uint32) []byte {
+		if slices.Contains(sentinels, seq) {
+			raw := eventRichLedger(tt, seq)
+			raws[seq] = raw
+			return raw
+		}
+		return marshalLCM(tt, seq)
+	}
+	require.NoError(t, WriteColdChunk(
+		context.Background(), testLogger(), chunkID, rawChunk(fullStream(t, chunkID, gen), chunkID),
+		coldDirsAt(coldDir, chunkID), nil, Config{Ledgers: true, Txhash: true, Events: true},
+	))
+
+	// Reference #1 — txhash: sorted, truncated ExtractTxHashes over the sentinels.
+	var wantEntries []txhash.ColdEntry
+	for _, seq := range sentinels {
+		hashes, err := sdkingest.ExtractTxHashes(xdr.LedgerCloseMetaView(raws[seq]))
+		require.NoError(t, err)
+		for _, h := range hashes {
+			var ke txhash.ColdEntry
+			copy(ke.Key[:], h[:txhash.ColdKeySize])
+			ke.Seq = seq
+			wantEntries = append(wantEntries, ke)
+		}
+	}
+	slices.SortFunc(wantEntries, func(a, b txhash.ColdEntry) int { return bytes.Compare(a.Key[:], b.Key[:]) })
+	gotEntries := fhtest.ReadColdBin(t, txhashBinPath(filepath.Join(coldDir, dataTypeTxhash)))
+	require.Equal(t, wantEntries, gotEntries, "cold .bin must match the old ExtractTxHashes path byte-for-byte")
+
+	// Reference #2 — events: PayloadsFromLedgerEvents with chunk-relative IDs
+	// assigned in ingest (ascending-seq) order, mapped to their term keys.
+	wantTermIDs := map[events.TermKey][]uint32{}
+	var nextID uint32
+	for _, seq := range sentinels {
+		view := xdr.LedgerCloseMetaView(raws[seq])
+		txEvents, err := sdkingest.ExtractLedgerEvents(view)
+		require.NoError(t, err)
+		closedAt, err := view.LedgerCloseTime()
+		require.NoError(t, err)
+		payloads, err := events.PayloadsFromLedgerEvents(txEvents, seq, closedAt)
+		require.NoError(t, err)
+		for i := range payloads {
+			keys, kerr := events.TermsForBytes(payloads[i].ContractEventBytes)
+			require.NoError(t, kerr)
+			for _, k := range keys {
+				wantTermIDs[k] = append(wantTermIDs[k], nextID)
+			}
+			nextID++
+		}
+	}
+	require.NotEmpty(t, wantTermIDs, "sentinels must carry events")
+
+	ecr, err := eventstore.OpenColdReader(
+		chunkID, filepath.Join(coldDir, dataTypeEvents, chunkID.BucketID()), eventstore.ColdReaderOptions{})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, ecr.Close()) }()
+
+	cnt, err := ecr.EventCount()
+	require.NoError(t, err)
+	require.Equal(t, nextID, cnt, "cold event count must match the reference payload count")
+
+	terms := make([]events.TermKey, 0, len(wantTermIDs))
+	for k := range wantTermIDs {
+		terms = append(terms, k)
+	}
+	bms, err := ecr.LookupKeys(context.Background(), terms)
+	require.NoError(t, err)
+	for i, k := range terms {
+		require.NotNil(t, bms[i], "term %d present in reference must resolve", i)
+		require.Equal(t, wantTermIDs[k], bms[i].ToArray(),
+			"cold term bitmap must carry the same event IDs as the shaping reference")
+	}
 }
 
 // TestWriteColdChunk_ShortStream_NoArtifact verifies a short stream makes WriteColdChunk error
@@ -1129,7 +1267,7 @@ func TestTxhashColdIngester_BinContent(t *testing.T) {
 		var key [txhash.ColdKeySize]byte
 		copy(key[:], hash[:txhash.ColdKeySize])
 		wantSeqByKey[key] = seq
-		require.NoError(t, ing.Ingest(context.Background(), seq, xdr.LedgerCloseMetaView(raw)))
+		require.NoError(t, ing.Ingest(context.Background(), coldInput(t, seq, raw)))
 	}
 	require.NoError(t, ing.Finalize(context.Background()))
 
@@ -1292,7 +1430,7 @@ func TestEventsCold_FinishThenIndexFails_LeavesInertPack(t *testing.T) {
 	// Ingest one event-bearing ledger so the mirror is non-empty, exercising a
 	// real (non-empty) MPHF build.
 	rawEv, _, _ := marshalLCMWithEvent(t, first)
-	require.NoError(t, ing.Ingest(context.Background(), first, xdr.LedgerCloseMetaView(rawEv)))
+	require.NoError(t, ing.Ingest(context.Background(), coldInput(t, first, rawEv)))
 
 	// Plant a DIRECTORY where index.hash must be written → buildMPHF fails.
 	bucketDir := filepath.Join(coldDir, chunkID.BucketID())
@@ -1316,9 +1454,9 @@ func TestEventsCold_FinishThenIndexFails_LeavesInertPack(t *testing.T) {
 }
 
 // TestEventsCold_FinalizeAfterFailedIngest_Refuses asserts the failed-Ingest
-// latch: once an Ingest errors (here via a malformed view), Finalize must
-// refuse rather than commit a pack+index whose mirror may be ahead of the
-// offsets commit point.
+// latch: once an Ingest errors (here shaping a malformed TransactionEvent),
+// Finalize must refuse rather than commit a pack+index whose mirror may be ahead
+// of the offsets commit point.
 func TestEventsCold_FinalizeAfterFailedIngest_Refuses(t *testing.T) {
 	chunkID := chunk.ID(0)
 	coldDir := t.TempDir()
@@ -1327,8 +1465,14 @@ func TestEventsCold_FinalizeAfterFailedIngest_Refuses(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, ing.Close()) }()
 
-	bad := xdr.LedgerCloseMetaView([]byte{0x00, 0x01, 0x02})
-	require.Error(t, ing.Ingest(context.Background(), chunkID.FirstLedger(), bad))
+	// A garbage top-level TransactionEvent fails PayloadsFromLedgerEvents' Stage
+	// decode inside Ingest — the walk itself is ColdService's job now, so the
+	// per-ingester failure is a shaping error over the shared walk's output.
+	bad := ledgerData{
+		seq:      chunkID.FirstLedger(),
+		txEvents: []sdkingest.LedgerTransactionEvents{{TransactionEvents: [][]byte{{0xff, 0xff}}}},
+	}
+	require.Error(t, ing.Ingest(context.Background(), bad))
 
 	ferr := ing.Finalize(context.Background())
 	require.Error(t, ferr)
@@ -1345,7 +1489,7 @@ type finalizeErrCold struct {
 	closed    bool
 }
 
-func (f *finalizeErrCold) Ingest(context.Context, uint32, xdr.LedgerCloseMetaView) error { return nil }
+func (f *finalizeErrCold) Ingest(context.Context, ledgerData) error { return nil }
 func (f *finalizeErrCold) Finalize(context.Context) error {
 	f.finalized = true
 	return f.err
@@ -1358,7 +1502,7 @@ type recordFinalizeCold struct {
 	closed    bool
 }
 
-func (r *recordFinalizeCold) Ingest(context.Context, uint32, xdr.LedgerCloseMetaView) error {
+func (r *recordFinalizeCold) Ingest(context.Context, ledgerData) error {
 	return nil
 }
 func (r *recordFinalizeCold) Finalize(context.Context) error { r.finalized = true; return nil }
@@ -1374,7 +1518,7 @@ func TestColdService_Finalize_FirstErrorStopsRemaining(t *testing.T) {
 	failing := &finalizeErrCold{err: firstErr}
 	later := &recordFinalizeCold{}
 
-	service := NewColdService([]ColdIngester{failing, later}, &testSink{})
+	service := NewColdService([]ColdIngester{failing, later}, &testSink{}, false)
 	ferr := service.Finalize(context.Background())
 
 	require.ErrorIs(t, ferr, firstErr, "Finalize returns the first error")
@@ -1392,7 +1536,7 @@ func TestColdService_Finalize_FirstErrorStopsRemaining(t *testing.T) {
 // ColdIngester seam (a ColdService drives it), the layer drain consumes.
 type countingIngester struct{ ingested int }
 
-func (c *countingIngester) Ingest(context.Context, uint32, xdr.LedgerCloseMetaView) error {
+func (c *countingIngester) Ingest(context.Context, ledgerData) error {
 	c.ingested++
 	return nil
 }
@@ -1409,7 +1553,7 @@ func TestDrain_OverrunPastChunk(t *testing.T) {
 	// One ledger past the chunk, still in order.
 	stream := &fakeStream{t: t, count: ledgersInChunk + 1}
 	counter := &countingIngester{}
-	service := NewColdService([]ColdIngester{counter}, nil)
+	service := NewColdService([]ColdIngester{counter}, nil, false)
 
 	err := drain(context.Background(), rawChunk(stream, chunkID), chunkID, service)
 	require.Error(t, err)
@@ -1498,7 +1642,7 @@ func TestColdService_FinalizeAbort_KeepsEarlierArtifact(t *testing.T) {
 	require.NoError(t, err)
 	failErr := errors.New("induced finalize failure")
 	failing := &finalizeErrCold{err: failErr}
-	service := NewColdService([]ColdIngester{realLedger, failing}, sink)
+	service := NewColdService([]ColdIngester{realLedger, failing}, sink, false)
 
 	require.NoError(t, service.Ingest(context.Background(), chunkID.FirstLedger(), viewOf(t, chunkID.FirstLedger())))
 

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/ingest_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/ingest_test.go
@@ -65,6 +65,7 @@ type testSink struct {
 	hotPhases       []hotPhaseCall
 	coldIngests     []coldCall
 	stages          []stageCall
+	coldExtracts    []int // items per shared-walk ColdExtract call
 	coldChunkTotals int
 }
 
@@ -84,6 +85,12 @@ func (s *testSink) ColdChunkTotal(time.Duration) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.coldChunkTotals++
+}
+
+func (s *testSink) ColdExtract(_ time.Duration, items int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.coldExtracts = append(s.coldExtracts, items)
 }
 
 func (s *testSink) IngestStage(dataType, stage string, _ time.Duration, items int) {
@@ -393,18 +400,18 @@ func viewOf(t *testing.T, seq uint32) xdr.LedgerCloseMetaView {
 	return xdr.LedgerCloseMetaView(marshalLCM(t, seq))
 }
 
-// coldInput builds the ledgerData that ColdService would hand a cold ingester
-// for one raw ledger: the shared ExtractLedgerEvents walk plus the close time.
-// Tests that drive a single ingester directly (no ColdService) use it in place
-// of the old per-view Ingest signature.
-func coldInput(t *testing.T, seq uint32, raw []byte) ledgerData {
+// extractFor runs the shared ExtractLedgerEvents walk plus the close-time read
+// over one raw ledger — what coldChunk.ingest hands the txhash/events writers.
+// Tests that drive a single writer directly (no coldChunk) use it in place of
+// the walk.
+func extractFor(t *testing.T, raw []byte) ([]sdkingest.LedgerTransactionEvents, int64) {
 	t.Helper()
 	view := xdr.LedgerCloseMetaView(raw)
 	txEvents, err := sdkingest.ExtractLedgerEvents(view)
 	require.NoError(t, err)
 	closedAt, err := view.LedgerCloseTime()
 	require.NoError(t, err)
-	return ledgerData{seq: seq, raw: raw, closedAt: closedAt, txEvents: txEvents}
+	return txEvents, closedAt
 }
 
 // marshalV0LCM builds a minimal V0 (pre-Soroban) LedgerCloseMeta with no
@@ -449,22 +456,22 @@ func (s *errAtSeqStream) RawLedgers(
 	}
 }
 
-// ───────────────────────── per-ingester unit tests ─────────────────────────
+// ───────────────────────── per-writer unit tests ─────────────────────────
 
-// TestLedgerColdIngester_Readback ingests one ledger via the cold ledger
-// ingester, finalizes, and reads back through the cold reader.
-func TestLedgerColdIngester_Readback(t *testing.T) {
+// TestLedgerColdWriter_Readback ingests one ledger via the cold ledger
+// writer, finalizes, and reads back through the cold reader.
+func TestLedgerColdWriter_Readback(t *testing.T) {
 	chunkID := chunk.ID(0)
 	seq := chunkID.FirstLedger()
 	raw := marshalLCM(t, seq)
 	coldDir := t.TempDir()
 
-	ing, err := NewLedgerColdIngester(packPath(coldDir, chunkID), chunkID, nil)
+	ing, err := newLedgerCold(packPath(coldDir, chunkID), chunkID, nil)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ing.Close()) }()
+	defer func() { require.NoError(t, ing.close()) }()
 
-	require.NoError(t, ing.Ingest(context.Background(), coldInput(t, seq, raw)))
-	require.NoError(t, ing.Finalize(context.Background()))
+	require.NoError(t, ing.write(seq, raw))
+	require.NoError(t, ing.finalize(context.Background()))
 
 	cr, err := ledger.OpenColdReader(packPath(coldDir, chunkID))
 	require.NoError(t, err)
@@ -481,45 +488,47 @@ func txhashBinPath(root string) string {
 	return filepath.Join(root, c.BucketID(), txhash.ColdBinName(c))
 }
 
-// TestTxhashColdIngester_Bin ingests two tx-bearing ledgers via the cold txhash
-// ingester, finalizes, and reads the .bin back through the store codec.
-func TestTxhashColdIngester_Bin(t *testing.T) {
+// TestTxhashColdWriter_Bin ingests two tx-bearing ledgers via the cold txhash
+// writer, finalizes, and reads the .bin back through the store codec.
+func TestTxhashColdWriter_Bin(t *testing.T) {
 	chunkID := chunk.ID(0)
 	first := chunkID.FirstLedger()
 	coldDir := t.TempDir()
 
-	ing, err := NewTxhashColdIngester(txhashBinPath(coldDir), chunkID, nil)
+	ing, err := newTxhashCold(txhashBinPath(coldDir), chunkID, nil)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ing.Close()) }()
+	defer func() { require.NoError(t, ing.close()) }()
 
 	for _, seq := range []uint32{first, first + 1} {
 		raw, _, _ := marshalLCMWithEvent(t, seq)
-		require.NoError(t, ing.Ingest(context.Background(), coldInput(t, seq, raw)))
+		txEvents, _ := extractFor(t, raw)
+		require.NoError(t, ing.write(seq, txEvents))
 	}
-	require.NoError(t, ing.Finalize(context.Background()))
+	require.NoError(t, ing.finalize(context.Background()))
 
 	entries := fhtest.ReadColdBin(t, txhashBinPath(coldDir))
 	require.Len(t, entries, 2)
 }
 
-// TestEventsColdIngester_Readback ingests two event-bearing ledgers via the cold
-// events ingester, finalizes, and resolves the term through the cold reader.
-func TestEventsColdIngester_Readback(t *testing.T) {
+// TestEventsColdWriter_Readback ingests two event-bearing ledgers via the cold
+// events writer, finalizes, and resolves the term through the cold reader.
+func TestEventsColdWriter_Readback(t *testing.T) {
 	chunkID := chunk.ID(0)
 	first := chunkID.FirstLedger()
 	coldDir := t.TempDir()
 
-	ing, err := NewEventsColdIngester(filepath.Join(coldDir, chunkID.BucketID()), chunkID, nil)
+	ing, err := newEventsCold(filepath.Join(coldDir, chunkID.BucketID()), chunkID, nil)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ing.Close()) }()
+	defer func() { require.NoError(t, ing.close()) }()
 
 	var term events.TermKey
 	for _, seq := range []uint32{first, first + 1} {
 		raw, _, tk := marshalLCMWithEvent(t, seq)
 		term = tk
-		require.NoError(t, ing.Ingest(context.Background(), coldInput(t, seq, raw)))
+		txEvents, closedAt := extractFor(t, raw)
+		require.NoError(t, ing.write(seq, closedAt, txEvents))
 	}
-	require.NoError(t, ing.Finalize(context.Background()))
+	require.NoError(t, ing.finalize(context.Background()))
 
 	bucketDir := filepath.Join(coldDir, chunkID.BucketID())
 	cr, err := eventstore.OpenColdReader(chunkID, bucketDir, eventstore.ColdReaderOptions{})
@@ -536,25 +545,27 @@ func TestEventsColdIngester_Readback(t *testing.T) {
 
 // ───────────────────────── V0 (pre-Soroban) events handling ─────────────────────────
 
-// TestEventsColdIngester_V0KeepsOffsetsContiguous ingests a V0 ledger followed by
+// TestEventsColdWriter_V0KeepsOffsetsContiguous ingests a V0 ledger followed by
 // an event-bearing V2 ledger and asserts: the V0 ledger does not error, and the
 // LedgerOffsets stay contiguous (both ledgers present, the event-bearing one's
 // single event ID immediately follows the empty V0 ledger).
-func TestEventsColdIngester_V0KeepsOffsetsContiguous(t *testing.T) {
+func TestEventsColdWriter_V0KeepsOffsetsContiguous(t *testing.T) {
 	chunkID := chunk.ID(0)
 	first := chunkID.FirstLedger()
 	coldDir := t.TempDir()
 
-	ing, err := NewEventsColdIngester(filepath.Join(coldDir, chunkID.BucketID()), chunkID, nil)
+	ing, err := newEventsCold(filepath.Join(coldDir, chunkID.BucketID()), chunkID, nil)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ing.Close()) }()
+	defer func() { require.NoError(t, ing.close()) }()
 
 	// Ledger `first`: V0 → zero events, no error.
-	require.NoError(t, ing.Ingest(context.Background(), coldInput(t, first, marshalV0LCM(t, first))))
+	v0Events, v0ClosedAt := extractFor(t, marshalV0LCM(t, first))
+	require.NoError(t, ing.write(first, v0ClosedAt, v0Events))
 	// Ledger `first+1`: one contract event.
 	rawEv, _, term := marshalLCMWithEvent(t, first+1)
-	require.NoError(t, ing.Ingest(context.Background(), coldInput(t, first+1, rawEv)))
-	require.NoError(t, ing.Finalize(context.Background()))
+	evEvents, evClosedAt := extractFor(t, rawEv)
+	require.NoError(t, ing.write(first+1, evClosedAt, evEvents))
+	require.NoError(t, ing.finalize(context.Background()))
 
 	bucketDir := filepath.Join(coldDir, chunkID.BucketID())
 	cr, err := eventstore.OpenColdReader(chunkID, bucketDir, eventstore.ColdReaderOptions{})
@@ -638,29 +649,28 @@ func TestWriteColdChunk_EventlessChunk_FullyReadable(t *testing.T) {
 	require.Zero(t, sink.coldErrorTypes()[dataTypeEvents], "eventless chunk is not an error")
 }
 
-// ───────────────────────── ColdService tests ─────────────────────────
+// ───────────────────────── coldChunk tests ─────────────────────────
 
-// TestColdService_Success drives ledger+txhash+events cold ingesters through a
-// ColdService and asserts readback plus the metrics signals.
-func TestColdService_Success(t *testing.T) {
+// TestColdChunk_Success drives ledger+txhash+events cold writers through a
+// coldChunk and asserts readback plus the metrics signals.
+func TestColdChunk_Success(t *testing.T) {
 	chunkID := chunk.ID(0)
 	first := chunkID.FirstLedger()
 	coldDir := t.TempDir()
 	sink := &testSink{}
 
-	ings, err := buildColdIngesters(
+	cc, err := openColdChunk(
 		coldDirsAt(coldDir, chunkID), chunkID, sink, Config{Ledgers: true, Txhash: true, Events: true})
 	require.NoError(t, err)
-	service := NewColdService(ings, sink, true)
-	defer func() { require.NoError(t, service.Close()) }()
+	defer func() { require.NoError(t, cc.close()) }()
 
 	var term events.TermKey
 	for _, seq := range []uint32{first, first + 1} {
 		raw, _, tk := marshalLCMWithEvent(t, seq)
 		term = tk
-		require.NoError(t, service.Ingest(context.Background(), seq, xdr.LedgerCloseMetaView(raw)))
+		require.NoError(t, cc.ingest(seq, xdr.LedgerCloseMetaView(raw)))
 	}
-	require.NoError(t, service.Finalize(context.Background()))
+	require.NoError(t, cc.finalize(context.Background()))
 
 	// Ledger cold readback: tx hashes use random keypairs, so bytes can't be
 	// regenerated for comparison — assert the boundary ledger reads back and
@@ -687,23 +697,26 @@ func TestColdService_Success(t *testing.T) {
 	binEntries := fhtest.ReadColdBin(t, txhashBinPath(filepath.Join(coldDir, dataTypeTxhash)))
 	require.Len(t, binEntries, 2)
 
-	// Metrics: one ColdChunkTotal, one ColdIngest per data type, no errors.
-	require.Equal(t, 1, sink.coldChunkTotals)
+	// Metrics: one ColdIngest per data type, no errors. (The aggregate
+	// ColdChunkTotal is WriteColdChunk's, not coldChunk's — see the driver tests.)
+	require.Zero(t, sink.coldChunkTotals, "the aggregate belongs to WriteColdChunk, not coldChunk")
 	cdt := sink.coldDataTypes()
 	require.Equal(t, 1, cdt[dataTypeLedgers])
 	require.Equal(t, 1, cdt[dataTypeTxhash])
 	require.Equal(t, 1, cdt[dataTypeEvents])
-	require.Empty(t, sink.coldErrorTypes(), "success path records no ingester errors")
+	require.Empty(t, sink.coldErrorTypes(), "success path records no writer errors")
 
-	// Per-stage signals: the shared per-ledger walk fires ONE extract stage per
-	// ledger (dataTypeShared) — not one per consuming type — and the other
-	// per-ledger stages fire once per (non-empty) ledger, the per-chunk finalize
-	// stage once per ingester. The exact map is asserted so an unexpected stage
-	// emission (or a missing one) also fails — events emits term_index/write for
-	// every ledger, and txhash now does only its finalize sort + .bin write (its
-	// cheap per-ledger accumulate folds into the ColdIngest total).
+	// The shared per-ledger walk fires ONE ColdExtract per ledger — not one per
+	// consuming type.
+	require.Len(t, sink.coldExtracts, 2, "one shared extract walk per ledger")
+
+	// Per-stage signals: the per-ledger stages fire once per (non-empty) ledger,
+	// the per-chunk finalize stage once per writer. The exact map is asserted so
+	// an unexpected stage emission (or a missing one) also fails — events emits
+	// term_index/write for every ledger, and txhash does only its finalize sort +
+	// .bin write (its cheap per-ledger accumulate folds into the ColdIngest
+	// total).
 	require.Equal(t, map[string]int{
-		dataTypeShared + "/" + stageExtract:   2,
 		dataTypeLedgers + "/" + stageWrite:    2,
 		dataTypeLedgers + "/" + stageFinalize: 1,
 		dataTypeTxhash + "/" + stageFinalize:  1,
@@ -712,64 +725,43 @@ func TestColdService_Success(t *testing.T) {
 		dataTypeEvents + "/" + stageFinalize:  1,
 	}, sink.stageCounts())
 
-	// No double-emit: the deferred Close (after this body) must not add a second
-	// ColdIngest or ColdChunkTotal, since Finalize already emitted.
-	require.NoError(t, service.Close())
-	require.Equal(t, 1, sink.coldChunkTotals, "Close after Finalize must not re-emit the aggregate")
-	require.Len(t, sink.coldIngests, 3, "Close after Finalize must not re-emit per-ingester signals")
+	// No double-emit: the deferred close (after this body) must not add a second
+	// ColdIngest, since finalize already emitted.
+	require.NoError(t, cc.close())
+	require.Len(t, sink.coldIngests, 3, "close after finalize must not re-emit per-writer signals")
 }
 
-// failingCold is a ColdIngester whose Ingest always fails, modeling a mid-chunk
-// error. Finalize must NOT run on this path.
-type failingCold struct {
-	finalized bool
-	closed    bool
-}
-
-var errFailingCold = errors.New("failingCold: induced ingest failure")
-
-func (f *failingCold) Ingest(context.Context, ledgerData) error {
-	return errFailingCold
-}
-func (f *failingCold) Finalize(context.Context) error { f.finalized = true; return nil }
-func (f *failingCold) Close() error                   { f.closed = true; return nil }
-
-// TestColdService_FailurePath_NoArtifact uses two real cold ingesters plus a
-// failing sibling: ColdService.Ingest returns the sibling's error, Finalize is
-// not called, the deferred Close drops the partial ledger pack, and no finalized
-// artifact remains. It asserts the aggregate ColdChunkTotal still fires for the
-// attempt, but the two real ingesters emit NO per-ingester ColdIngest: each
-// ingested cleanly (no terminal error of its own) and never finalized, and Close
-// no longer emits — so a chunk abandoned by a sibling leaves no phantom sample.
-func TestColdService_FailurePath_NoArtifact(t *testing.T) {
+// TestColdChunk_MidChunkFailure_NoArtifact aborts a chunk mid-ingest: the first
+// ledger lands in both writers, then the second ledger's shared extract walk
+// fails on garbage LCM bytes — AFTER the ledgers writer already appended them
+// (the raw append does not decode). finalize must not run (coldChunk contract);
+// close drops the partial ledger pack, so no finalized artifact remains, and
+// neither writer emits a per-writer ColdIngest: each ingested cleanly (no
+// terminal error of its own) and never finalized — a chunk abandoned by the
+// shared walk leaves no phantom sample.
+func TestColdChunk_MidChunkFailure_NoArtifact(t *testing.T) {
 	chunkID := chunk.ID(0)
+	first := chunkID.FirstLedger()
 	coldDir := t.TempDir()
 	sink := &testSink{}
 
-	realLedger, err := NewLedgerColdIngester(packPath(filepath.Join(coldDir, dataTypeLedgers), chunkID), chunkID, sink)
+	cc, err := openColdChunk(coldDirsAt(coldDir, chunkID), chunkID, sink, Config{Ledgers: true, Events: true})
 	require.NoError(t, err)
-	realEvents, err := NewEventsColdIngester(filepath.Join(coldDir, dataTypeEvents, chunkID.BucketID()), chunkID, sink)
-	require.NoError(t, err)
-	failing := &failingCold{}
-	service := NewColdService([]ColdIngester{realLedger, realEvents, failing}, sink, true)
 
-	// First ledger: the real ingesters succeed, failing returns an error → the
-	// sequential Ingest aborts the ledger with the sibling's error.
-	err = service.Ingest(context.Background(), chunkID.FirstLedger(), viewOf(t, chunkID.FirstLedger()))
-	require.ErrorIs(t, err, errFailingCold)
-	require.False(t, failing.finalized, "Finalize must not run on the failure path")
+	require.NoError(t, cc.ingest(first, viewOf(t, first)))
 
-	// Nothing has emitted: the real ingesters ingested cleanly (no terminal error)
-	// and never finalized; the mock sibling records nothing.
-	require.Empty(t, sink.coldDataTypes(), "no per-ingester ColdIngest on the sibling-failure path")
-	require.Zero(t, sink.coldChunkTotals, "no ColdChunkTotal before Close")
+	garbage := bytes.Repeat([]byte{0xff}, 16)
+	err = cc.ingest(first+1, xdr.LedgerCloseMetaView(garbage))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "extract ledger events", "the shared walk rejects the garbage ledger")
 
-	// Close drops partials and emits the aggregate only.
-	require.NoError(t, service.Close())
-	require.True(t, failing.closed)
+	// Nothing has emitted: both writers ingested cleanly (no terminal error of
+	// their own) and never finalized.
+	require.Empty(t, sink.coldDataTypes(), "no per-writer ColdIngest on the shared-walk failure path")
 
-	require.Empty(t, sink.coldDataTypes(), "a chunk abandoned by a sibling emits no per-ingester ColdIngest")
-	require.Equal(t, 1, sink.coldChunkTotals, "exactly one aggregate ColdChunkTotal")
+	// Close drops partials; still no per-writer sample.
+	require.NoError(t, cc.close())
+	require.Empty(t, sink.coldDataTypes(), "an abandoned chunk emits no per-writer ColdIngest")
 
 	// No finalized ledger pack must exist.
 	path := packPath(filepath.Join(coldDir, dataTypeLedgers), chunkID)
@@ -777,37 +769,34 @@ func TestColdService_FailurePath_NoArtifact(t *testing.T) {
 	require.True(t, os.IsNotExist(statErr), "expected no cold ledger artifact at %s, stat err: %v", path, statErr)
 }
 
-// TestColdIngester_Failure_RecordsErrorMetric drives a real cold ledger ingester
-// so its OWN Ingest fails (recording firstErr), then Close. The failure is an
+// TestColdWriter_Failure_RecordsErrorMetric drives a real cold ledger writer
+// so its OWN write fails (recording firstErr), then close. The failure is an
 // out-of-order seq: the per-chunk ColdWriter expects the chunk's first ledger,
 // so AppendLedger rejects a later one. Per #765 a failed cold chunk must record
-// a per-ingester error count and an aggregate duration sample. A terminal Ingest
-// error emits the single per-ingester ColdIngest right there (Close no longer
-// emits), so the error-carrying sample is present after Ingest returns.
-func TestColdIngester_Failure_RecordsErrorMetric(t *testing.T) {
+// a per-writer error count. A terminal write error emits the single per-writer
+// ColdIngest right there (close never emits), so the error-carrying sample is
+// present after ingest returns.
+func TestColdWriter_Failure_RecordsErrorMetric(t *testing.T) {
 	chunkID := chunk.ID(0)
 	coldDir := t.TempDir()
 	sink := &testSink{}
 
-	realLedger, err := NewLedgerColdIngester(packPath(filepath.Join(coldDir, dataTypeLedgers), chunkID), chunkID, sink)
+	cc, err := openColdChunk(coldDirsAt(coldDir, chunkID), chunkID, sink, Config{Ledgers: true})
 	require.NoError(t, err)
-	service := NewColdService([]ColdIngester{realLedger}, sink, false)
 
-	// An out-of-order seq makes the writer's own AppendLedger fail inside the
-	// ingester's Ingest, so it records its firstErr and emits the error-carrying
-	// ColdIngest. (drain would never feed this — the test targets the ingester's
-	// metric path directly.)
+	// An out-of-order seq makes the writer's own AppendLedger fail inside write,
+	// so it records its firstErr and emits the error-carrying ColdIngest. (drain
+	// would never feed this — the test targets the writer's metric path directly.)
 	wrongSeq := chunkID.FirstLedger() + 5
-	require.Error(t, service.Ingest(context.Background(), wrongSeq, viewOf(t, wrongSeq)))
-	require.Equal(t, 1, sink.coldDataTypes()[dataTypeLedgers], "the failed Ingest emits its ColdIngest immediately")
+	require.Error(t, cc.ingest(wrongSeq, viewOf(t, wrongSeq)))
+	require.Equal(t, 1, sink.coldDataTypes()[dataTypeLedgers], "the failed write emits its ColdIngest immediately")
 
-	// Finalize is skipped on this path; Close emits nothing more.
-	require.NoError(t, service.Close())
+	// finalize is skipped on this path; close emits nothing more.
+	require.NoError(t, cc.close())
 
-	// Exactly one ColdIngest for ledgers, carrying the error, plus one aggregate.
+	// Exactly one ColdIngest for ledgers, carrying the error.
 	require.Equal(t, 1, sink.coldDataTypes()[dataTypeLedgers])
-	require.Equal(t, 1, sink.coldErrorTypes()[dataTypeLedgers], "the recorded ColdIngest carries the ingest error")
-	require.Equal(t, 1, sink.coldChunkTotals)
+	require.Equal(t, 1, sink.coldErrorTypes()[dataTypeLedgers], "the recorded ColdIngest carries the write error")
 }
 
 // ───────────────────────── metrics sink tests ─────────────────────────
@@ -825,10 +814,11 @@ func TestPrometheusSink_Smoke(t *testing.T) {
 		sink.HotPhase(hotchunk.PhaseLedgers, time.Millisecond, 1, nil)
 		sink.HotPhase(hotchunk.PhaseTxhash, time.Millisecond, 5, nil)
 		sink.HotPhase(hotchunk.PhaseEvents, time.Millisecond, 3, nil)
-		sink.HotPhase(hotchunk.PhaseCommit, time.Millisecond, 0, errFailingCold)
+		sink.HotPhase(hotchunk.PhaseCommit, time.Millisecond, 0, errors.New("induced commit failure"))
 		sink.HotPhase(hotchunk.PhaseApply, time.Millisecond, 0, nil)
 		sink.ColdIngest(dataTypeTxhash, time.Second, 100, nil)
 		sink.ColdChunkTotal(time.Second)
+		sink.ColdExtract(time.Millisecond, 3)
 		sink.IngestStage(dataTypeEvents, stageFinalize, time.Second, 0)
 	})
 
@@ -906,6 +896,8 @@ func eventRichLedger(t *testing.T, seq uint32) []byte {
 //   - events per-term bitmaps + count vs. an independent PayloadsFromLedgerEvents
 //     shaping, with chunk-relative event IDs assigned in ingest (ascending-seq)
 //     order — proving the event-ID assignment is unchanged.
+//
+//nolint:funlen // one invariant, two inline reference computations — splitting would obscure it
 func TestWriteColdChunk_ByteIdentity_SharedWalk(t *testing.T) {
 	chunkID := chunk.ID(0)
 	first := chunkID.FirstLedger()
@@ -1245,20 +1237,20 @@ func TestHotService_FailedPhaseCarriesPartialDuration(t *testing.T) {
 
 // ───────────────────────── cold txhash .bin content (P1-d) ─────────────────────────
 
-// TestTxhashColdIngester_BinContent ingests two tx-bearing ledgers, finalizes,
+// TestTxhashColdWriter_BinContent ingests two tx-bearing ledgers, finalizes,
 // then reads the .bin back through the store codec and asserts the contract
 // the deferred streamhash builder relies on: each key == the fixture tx hash
 // truncated to txhash.ColdKeySize (pinned to streamhash.MinKeySize by the
 // codec), each seq == the ledger it was ingested in, and entries are in
 // non-decreasing key order.
-func TestTxhashColdIngester_BinContent(t *testing.T) {
+func TestTxhashColdWriter_BinContent(t *testing.T) {
 	chunkID := chunk.ID(0)
 	first := chunkID.FirstLedger()
 	coldDir := t.TempDir()
 
-	ing, err := NewTxhashColdIngester(txhashBinPath(coldDir), chunkID, nil)
+	ing, err := newTxhashCold(txhashBinPath(coldDir), chunkID, nil)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ing.Close()) }()
+	defer func() { require.NoError(t, ing.close()) }()
 
 	// Capture each fixture hash + the seq it was ingested in.
 	wantSeqByKey := map[[txhash.ColdKeySize]byte]uint32{}
@@ -1267,9 +1259,10 @@ func TestTxhashColdIngester_BinContent(t *testing.T) {
 		var key [txhash.ColdKeySize]byte
 		copy(key[:], hash[:txhash.ColdKeySize])
 		wantSeqByKey[key] = seq
-		require.NoError(t, ing.Ingest(context.Background(), coldInput(t, seq, raw)))
+		txEvents, _ := extractFor(t, raw)
+		require.NoError(t, ing.write(seq, txEvents))
 	}
-	require.NoError(t, ing.Finalize(context.Background()))
+	require.NoError(t, ing.finalize(context.Background()))
 
 	entries := fhtest.ReadColdBin(t, txhashBinPath(coldDir))
 	require.Len(t, entries, 2)
@@ -1340,56 +1333,56 @@ func countCleanColdIngests(s *testSink) int {
 	return n
 }
 
-// TestBuildColdIngesters_RollbackOneBuilt makes a LATER constructor (txhash) fail
-// by planting a regular file at the txhash per-type directory, so the
-// constructor's own MkdirAll fails. The earlier-built ledger ingester is rolled
-// back via closeColdAll — which only closes it. Since Close no longer emits a
-// per-ingester ColdIngest, a rolled-back ingester (built, never ingested or
-// finalized) produces NO sample at all: no phantom success, no synthetic abort.
-func TestBuildColdIngesters_RollbackOneBuilt(t *testing.T) {
+// TestOpenColdChunk_RollbackOneBuilt makes a LATER writer's open (txhash) fail
+// by planting a regular file at the txhash per-type directory, so its own
+// MkdirAll fails. The earlier-opened ledger writer is rolled back — closed
+// only. Since close never emits a per-writer ColdIngest, a rolled-back writer
+// (opened, never ingested or finalized) produces NO sample at all: no phantom
+// success, no synthetic abort.
+func TestOpenColdChunk_RollbackOneBuilt(t *testing.T) {
 	chunkID := chunk.ID(0)
 	coldDir := t.TempDir()
 	sink := &testSink{}
 
 	// Plant a regular FILE where the txhash per-type directory must be
-	// created: the ledger ingester builds first, then NewTxhashColdIngester
-	// fails its bucket-dir MkdirAll.
+	// created: the ledger writer opens first, then newTxhashCold fails its
+	// bucket-dir MkdirAll.
 	require.NoError(t, os.WriteFile(filepath.Join(coldDir, dataTypeTxhash), []byte("not a dir"), 0o644))
 
-	_, err := buildColdIngesters(coldDirsAt(coldDir, chunkID), chunkID, sink, Config{Ledgers: true, Txhash: true})
-	require.Error(t, err, "txhash constructor must fail on the planted file")
+	_, err := openColdChunk(coldDirsAt(coldDir, chunkID), chunkID, sink, Config{Ledgers: true, Txhash: true})
+	require.Error(t, err, "the txhash open must fail on the planted file")
 
-	// The ledger ingester was built then rolled back with no Ingest/Finalize, so
+	// The ledger writer was opened then rolled back with no write/finalize, so
 	// it emits nothing.
-	require.Empty(t, sink.coldDataTypes(), "a rolled-back ingester emits no per-ingester ColdIngest")
+	require.Empty(t, sink.coldDataTypes(), "a rolled-back writer emits no per-writer ColdIngest")
 }
 
-// TestBuildColdIngesters_RollbackTwoBuilt makes the LAST constructor (events)
-// fail AFTER both the ledger AND txhash ingesters were already built, so
-// closeColdAll rolls back two ingesters. Same invariant at greater rollback
-// depth: neither rolled-back ingester emits a per-ingester ColdIngest.
-func TestBuildColdIngesters_RollbackTwoBuilt(t *testing.T) {
+// TestOpenColdChunk_RollbackTwoBuilt makes the LAST writer's open (events)
+// fail AFTER both the ledger AND txhash writers were already opened, so the
+// rollback closes two writers. Same invariant at greater rollback depth:
+// neither rolled-back writer emits a per-writer ColdIngest.
+func TestOpenColdChunk_RollbackTwoBuilt(t *testing.T) {
 	chunkID := chunk.ID(0)
 	coldDir := t.TempDir()
 	sink := &testSink{}
 
 	// Plant a directory at the events.pack path: the ledger and txhash
-	// ingesters build first, then NewEventsColdIngester fails opening the
-	// pack over the directory.
+	// writers open first, then newEventsCold fails opening the pack over
+	// the directory.
 	packPath := filepath.Join(coldDir, dataTypeEvents, chunkID.BucketID(), eventstore.EventsPackName(chunkID))
 	require.NoError(t, os.MkdirAll(packPath, 0o755))
 
-	_, err := buildColdIngesters(coldDirsAt(coldDir, chunkID), chunkID, sink,
+	_, err := openColdChunk(coldDirsAt(coldDir, chunkID), chunkID, sink,
 		Config{Ledgers: true, Txhash: true, Events: true})
-	require.Error(t, err, "events constructor must fail on the planted directory")
+	require.Error(t, err, "the events open must fail on the planted directory")
 
-	// Both the ledger and txhash ingesters were built then rolled back with no
-	// Ingest/Finalize, so neither emits a per-ingester ColdIngest.
-	require.Empty(t, sink.coldDataTypes(), "rolled-back ingesters emit no per-ingester ColdIngest")
+	// Both the ledger and txhash writers were opened then rolled back with no
+	// write/finalize, so neither emits a per-writer ColdIngest.
+	require.Empty(t, sink.coldDataTypes(), "rolled-back writers emit no per-writer ColdIngest")
 }
 
 // TestWriteColdChunk_ConstructorFailure_EmitsAggregate drives a constructor failure
-// through WriteColdChunk (not buildColdIngesters directly) and asserts the chunk
+// through WriteColdChunk (not openColdChunk directly) and asserts the chunk
 // attempt still produces its single aggregate ColdChunkTotal — the invariant
 // is one aggregate per chunk attempt, including pre-service failures.
 func TestWriteColdChunk_ConstructorFailure_EmitsAggregate(t *testing.T) {
@@ -1424,20 +1417,21 @@ func TestEventsCold_FinishThenIndexFails_LeavesInertPack(t *testing.T) {
 	first := chunkID.FirstLedger()
 	coldDir := t.TempDir()
 
-	ing, err := NewEventsColdIngester(filepath.Join(coldDir, chunkID.BucketID()), chunkID, nil)
+	ing, err := newEventsCold(filepath.Join(coldDir, chunkID.BucketID()), chunkID, nil)
 	require.NoError(t, err)
 
 	// Ingest one event-bearing ledger so the mirror is non-empty, exercising a
 	// real (non-empty) MPHF build.
 	rawEv, _, _ := marshalLCMWithEvent(t, first)
-	require.NoError(t, ing.Ingest(context.Background(), coldInput(t, first, rawEv)))
+	txEvents, closedAt := extractFor(t, rawEv)
+	require.NoError(t, ing.write(first, closedAt, txEvents))
 
 	// Plant a DIRECTORY where index.hash must be written → buildMPHF fails.
 	bucketDir := filepath.Join(coldDir, chunkID.BucketID())
 	indexHashPath := filepath.Join(bucketDir, eventstore.IndexHashName(chunkID))
 	require.NoError(t, os.Mkdir(indexHashPath, 0o755))
 
-	ferr := ing.Finalize(context.Background())
+	ferr := ing.finalize(context.Background())
 	require.Error(t, ferr, "Finalize must fail when WriteColdIndex fails")
 	require.Contains(t, ferr.Error(), "WriteColdIndex")
 
@@ -1448,118 +1442,104 @@ func TestEventsCold_FinishThenIndexFails_LeavesInertPack(t *testing.T) {
 	require.NoError(t, statErr, "the index-less events.pack stays on disk after WriteColdIndex failure")
 
 	// Close is still safe/idempotent afterwards and does not remove the pack.
-	require.NoError(t, ing.Close())
+	require.NoError(t, ing.close())
 	_, statErr = os.Stat(packPath)
-	require.NoError(t, statErr, "Close after a committed Finish must not drop the pack")
+	require.NoError(t, statErr, "close after a committed Finish must not drop the pack")
 }
 
-// TestEventsCold_FinalizeAfterFailedIngest_Refuses asserts the failed-Ingest
-// latch: once an Ingest errors (here shaping a malformed TransactionEvent),
-// Finalize must refuse rather than commit a pack+index whose mirror may be ahead
+// TestEventsCold_FinalizeAfterFailedIngest_Refuses asserts the failed-write
+// latch: once a write errors (here shaping a malformed TransactionEvent),
+// finalize must refuse rather than commit a pack+index whose mirror may be ahead
 // of the offsets commit point.
 func TestEventsCold_FinalizeAfterFailedIngest_Refuses(t *testing.T) {
 	chunkID := chunk.ID(0)
 	coldDir := t.TempDir()
 
-	ing, err := NewEventsColdIngester(filepath.Join(coldDir, chunkID.BucketID()), chunkID, nil)
+	ing, err := newEventsCold(filepath.Join(coldDir, chunkID.BucketID()), chunkID, nil)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, ing.Close()) }()
+	defer func() { require.NoError(t, ing.close()) }()
 
 	// A garbage top-level TransactionEvent fails PayloadsFromLedgerEvents' Stage
-	// decode inside Ingest — the walk itself is ColdService's job now, so the
-	// per-ingester failure is a shaping error over the shared walk's output.
-	bad := ledgerData{
-		seq:      chunkID.FirstLedger(),
-		txEvents: []sdkingest.LedgerTransactionEvents{{TransactionEvents: [][]byte{{0xff, 0xff}}}},
-	}
-	require.Error(t, ing.Ingest(context.Background(), bad))
+	// decode inside write — the walk itself is coldChunk's job, so the
+	// per-writer failure is a shaping error over the shared walk's output.
+	bad := []sdkingest.LedgerTransactionEvents{{TransactionEvents: [][]byte{{0xff, 0xff}}}}
+	require.Error(t, ing.write(chunkID.FirstLedger(), 0, bad))
 
-	ferr := ing.Finalize(context.Background())
+	ferr := ing.finalize(context.Background())
 	require.Error(t, ferr)
 	require.Contains(t, ferr.Error(), "Finalize after failed Ingest")
 }
 
-// ───────────────────────── ColdService.Finalize first-error ─────────────────────────
+// ───────────────────────── coldChunk.finalize first-error ─────────────────────────
 
-// finalizeErrCold is a ColdIngester whose Finalize errors; it records whether
-// Finalize/Close ran.
-type finalizeErrCold struct {
-	err       error
-	finalized bool
-	closed    bool
-}
+// TestColdChunk_Finalize_FirstErrorStopsRemaining asserts coldChunk.finalize
+// stops at the first writer's error and does NOT finalize (publish) the later
+// writers — once a sibling failed, the rest are released (never finalized) by
+// the caller's deferred close, so a failed chunk never gains newly committed
+// artifacts past the failure. It also asserts the flip side: the artifact an
+// EARLIER writer already committed in this attempt stays on disk as inert
+// scratch (see the package doc's artifact model). All three writers are real:
+// the txhash finalize is made to fail by planting a directory at its .bin
+// path, after the ledgers finalize already committed its pack and before the
+// events finalize would publish its index.
+func TestColdChunk_Finalize_FirstErrorStopsRemaining(t *testing.T) {
+	chunkID := chunk.ID(0)
+	first := chunkID.FirstLedger()
+	coldDir := t.TempDir()
+	sink := &testSink{}
 
-func (f *finalizeErrCold) Ingest(context.Context, ledgerData) error { return nil }
-func (f *finalizeErrCold) Finalize(context.Context) error {
-	f.finalized = true
-	return f.err
-}
-func (f *finalizeErrCold) Close() error { f.closed = true; return nil }
+	cc, err := openColdChunk(coldDirsAt(coldDir, chunkID), chunkID, sink,
+		Config{Ledgers: true, Txhash: true, Events: true})
+	require.NoError(t, err)
 
-// recordFinalizeCold is a ColdIngester that records it was finalized (no error).
-type recordFinalizeCold struct {
-	finalized bool
-	closed    bool
-}
+	raw, _, _ := marshalLCMWithEvent(t, first)
+	require.NoError(t, cc.ingest(first, xdr.LedgerCloseMetaView(raw)))
 
-func (r *recordFinalizeCold) Ingest(context.Context, ledgerData) error {
-	return nil
-}
-func (r *recordFinalizeCold) Finalize(context.Context) error { r.finalized = true; return nil }
-func (r *recordFinalizeCold) Close() error                   { r.closed = true; return nil }
+	// Plant a DIRECTORY at the .bin path: txhash's finalize (WriteColdBin's
+	// os.Create) fails after the ledgers finalize already ran.
+	binPath := txhashBinPath(filepath.Join(coldDir, dataTypeTxhash))
+	require.NoError(t, os.Mkdir(binPath, 0o755))
 
-// TestColdService_Finalize_FirstErrorStopsRemaining asserts ColdService.Finalize
-// returns the first ingester's error and does NOT finalize (publish) the later
-// ingesters — once a sibling failed, the rest are released (never finalized) by
-// the caller's deferred Close, so a failed chunk never gains newly committed
-// artifacts past the failure.
-func TestColdService_Finalize_FirstErrorStopsRemaining(t *testing.T) {
-	firstErr := errors.New("first finalize failure")
-	failing := &finalizeErrCold{err: firstErr}
-	later := &recordFinalizeCold{}
+	ferr := cc.finalize(context.Background())
+	require.Error(t, ferr, "finalize must surface the txhash failure")
 
-	service := NewColdService([]ColdIngester{failing, later}, &testSink{}, false)
-	ferr := service.Finalize(context.Background())
+	// The earlier writer's already-committed pack REMAINS on disk.
+	path := packPath(filepath.Join(coldDir, dataTypeLedgers), chunkID)
+	_, statErr := os.Stat(path)
+	require.NoError(t, statErr, "the earlier writer's published artifact stays on disk")
 
-	require.ErrorIs(t, ferr, firstErr, "Finalize returns the first error")
-	require.True(t, failing.finalized, "first ingester's Finalize ran (and failed)")
-	require.False(t, later.finalized, "later ingester must NOT be finalized after a sibling failure")
+	// The later (events) writer was never finalized: no index artifacts.
+	bucketDir := filepath.Join(coldDir, dataTypeEvents, chunkID.BucketID())
+	_, statErr = os.Stat(filepath.Join(bucketDir, eventstore.IndexPackName(chunkID)))
+	require.True(t, os.IsNotExist(statErr), "a later writer must NOT be finalized after a sibling failure")
 
-	require.NoError(t, service.Close())
-	require.True(t, later.closed, "later ingester is released via Close instead")
+	require.NoError(t, cc.close())
+	_, statErr = os.Stat(path)
+	require.NoError(t, statErr, "close after a committed finalize must not drop the published pack")
 }
 
 // ───────────────────────── drain overrun guard ─────────────────────────
 
-// countingIngester counts Ingest calls; used to prove the overrun guard fires
-// BEFORE the out-of-chunk ledger is handed to the ingesters. It fakes the
-// ColdIngester seam (a ColdService drives it), the layer drain consumes.
-type countingIngester struct{ ingested int }
-
-func (c *countingIngester) Ingest(context.Context, ledgerData) error {
-	c.ingested++
-	return nil
-}
-func (*countingIngester) Finalize(context.Context) error { return nil }
-func (*countingIngester) Close() error                   { return nil }
-
 // TestDrain_OverrunPastChunk asserts a stream that keeps yielding in order
 // PAST the chunk's last ledger is rejected before the overrun ledger is
 // ingested — not after the stream ends, by which point the extra ledgers
-// would already be durably written on the hot path.
+// would already be durably written on the hot path. The per-ledger write-stage
+// count is the proof: the ledgers writer emits one per accepted ledger.
 func TestDrain_OverrunPastChunk(t *testing.T) {
 	chunkID := chunk.ID(0)
 	ledgersInChunk := chunkID.LastLedger() - chunkID.FirstLedger() + 1
 	// One ledger past the chunk, still in order.
 	stream := &fakeStream{t: t, count: ledgersInChunk + 1}
-	counter := &countingIngester{}
-	service := NewColdService([]ColdIngester{counter}, nil, false)
+	sink := &testSink{}
+	cc, err := openColdChunk(coldDirsAt(t.TempDir(), chunkID), chunkID, sink, Config{Ledgers: true})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, cc.close()) }()
 
-	err := drain(context.Background(), rawChunk(stream, chunkID), chunkID, service)
+	err = drain(rawChunk(stream, chunkID), chunkID, cc)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "overrun")
-	require.Equal(t, int(ledgersInChunk), counter.ingested,
-		"the out-of-chunk ledger must not reach the ingesters")
+	require.Equal(t, int(ledgersInChunk), sink.stageCounts()[dataTypeLedgers+"/"+stageWrite],
+		"the out-of-chunk ledger must not reach the writers")
 }
 
 // ───────────────────────── lazy-source / empty-stream failures ─────────────────────────
@@ -1627,35 +1607,5 @@ func TestWriteColdChunk_EmptyStream(t *testing.T) {
 	require.Equal(t, 1, sink.coldChunkTotals, "the failed attempt still emits its aggregate")
 }
 
-// TestColdService_FinalizeAbort_KeepsEarlierArtifact: when a LATER ingester's
-// Finalize fails, the loop stops and the error is returned — but the artifact
-// an earlier ingester already published in this attempt stays on disk. The
-// orchestrator never records completion for the failed chunk, so the leftover
-// is inert scratch (see the package doc's artifact model) and the retry's
-// overwrite is the cleanup.
-func TestColdService_FinalizeAbort_KeepsEarlierArtifact(t *testing.T) {
-	chunkID := chunk.ID(0)
-	coldDir := t.TempDir()
-	sink := &testSink{}
-
-	realLedger, err := NewLedgerColdIngester(packPath(filepath.Join(coldDir, dataTypeLedgers), chunkID), chunkID, sink)
-	require.NoError(t, err)
-	failErr := errors.New("induced finalize failure")
-	failing := &finalizeErrCold{err: failErr}
-	service := NewColdService([]ColdIngester{realLedger, failing}, sink, false)
-
-	require.NoError(t, service.Ingest(context.Background(), chunkID.FirstLedger(), viewOf(t, chunkID.FirstLedger())))
-
-	ferr := service.Finalize(context.Background())
-	require.ErrorIs(t, ferr, failErr)
-	require.True(t, failing.finalized, "the failing ingester's Finalize ran (and stopped the loop)")
-
-	// The earlier ingester's already-published pack REMAINS on disk.
-	path := packPath(filepath.Join(coldDir, dataTypeLedgers), chunkID)
-	_, statErr := os.Stat(path)
-	require.NoError(t, statErr, "the earlier ingester's published artifact stays on disk")
-
-	require.NoError(t, service.Close())
-	_, statErr = os.Stat(path)
-	require.NoError(t, statErr, "Close after a committed Finalize must not drop the published pack")
-}
+// The earlier-artifact-stays-on-disk invariant when a LATER writer's finalize
+// fails is covered by TestColdChunk_Finalize_FirstErrorStopsRemaining above.

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/ingester.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/ingester.go
@@ -3,8 +3,33 @@ package ingest
 import (
 	"context"
 
-	"github.com/stellar/go-stellar-sdk/xdr"
+	sdkingest "github.com/stellar/go-stellar-sdk/ingest"
 )
+
+// ledgerData is one ledger's shared, already-extracted input to every cold
+// ingester. ColdService walks the borrowed view ONCE (ExtractLedgerEvents) and
+// hands the result to each per-type writer, so txhash and events share the
+// single TxProcessing walk instead of each running their own — halving cold
+// per-ledger extraction, matching the hot path's IngestLedger (issue #836).
+//
+//   - seq is the ledger sequence on drain's contiguous counter (the in-order
+//     contract is enforced at the source).
+//   - raw is the wire-format LedgerCloseMeta bytes for the ledgers writer; it
+//     ALIASES the source stream's borrowed buffer, valid only for the current
+//     Ingest call, so an implementation must copy what it retains.
+//   - txEvents is the per-transaction hash + contract events (apply order); each
+//     element's Hash feeds txhash and the slice feeds events via
+//     events.PayloadsFromLedgerEvents. Its byte slices alias the same buffer.
+//   - closedAt is the view's LedgerCloseTime, needed for event shaping.
+//
+// txEvents/closedAt are zero when neither txhash nor events is enabled
+// (ledgers-only: ColdService skips the walk entirely).
+type ledgerData struct {
+	seq      uint32
+	raw      []byte
+	closedAt int64
+	txEvents []sdkingest.LedgerTransactionEvents
+}
 
 // ColdIngester ingests one data type for one chunk into a per-chunk cold writer.
 //
@@ -21,14 +46,30 @@ import (
 // artifact; implementations are encouraged to latch the failure and refuse
 // (eventsCold does).
 //
-// Input: seq is the ledger sequence of lcm on drain's contiguous counter (the
-// in-order contract is enforced at the source), and lcm is a zero-copy
-// xdr.LedgerCloseMetaView over the source stream's BORROWED buffer, valid only for
-// the current iteration step — an implementation must copy any bytes it retains.
-// ColdService drives the per-ledger Ingest calls sequentially, so each view is
-// fully consumed before the next.
+// Input: l carries one ledger's shared pre-extracted data (see ledgerData). Its
+// borrowed byte slices are valid only for the current call — an implementation
+// must copy any bytes it retains. ColdService drives the per-ledger Ingest calls
+// sequentially, so each ledger is fully consumed before the next.
 type ColdIngester interface {
-	Ingest(ctx context.Context, seq uint32, lcm xdr.LedgerCloseMetaView) error
+	Ingest(ctx context.Context, l ledgerData) error
 	Finalize(ctx context.Context) error
 	Close() error
 }
+
+// Cold writers run ONLY on the batch freeze/backfill path — WriteColdChunk is
+// their sole production caller — so they opt into the packfile writer's batch
+// tuning rather than the serial zero-value defaults (issue #836): parallel zstd
+// encoding plus background dirty-page writeback that smooths the final fsync.
+const (
+	// coldEncoderConcurrency parallelizes zstd record encoding per writer. The
+	// backfill pool already runs DefaultWorkers (GOMAXPROCS) chunks concurrently,
+	// so this stays modest — enough to overlap a chunk's compression with its
+	// download without heavily oversubscribing that pool.
+	// ponytail: fixed at 4 (the writer docs' low end); drop toward 1 if the
+	// GOMAXPROCS-wide pool ever shows CPU contention under profiling.
+	coldEncoderConcurrency = 4
+	// coldBytesPerSync triggers background writeback every 1 MiB so Commit/Finish
+	// doesn't flush a whole pack's dirty pages at once (a large win on networked
+	// storage, per the writer docs).
+	coldBytesPerSync = 1 << 20
+)

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/ingester.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/ingester.go
@@ -2,58 +2,175 @@ package ingest
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"time"
 
 	sdkingest "github.com/stellar/go-stellar-sdk/ingest"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
 )
 
-// ledgerData is one ledger's shared, already-extracted input to every cold
-// ingester. ColdService walks the borrowed view ONCE (ExtractLedgerEvents) and
-// hands the result to each per-type writer, so txhash and events share the
-// single TxProcessing walk instead of each running their own — halving cold
-// per-ledger extraction, matching the hot path's IngestLedger (issue #836).
+// coldChunk is one chunk's set of cold writers — one concrete field per data
+// type, nil when the type is not enabled. The set is fixed at three, so there
+// is no ingester interface or fan-out: ingest mirrors what the hot path's
+// hotchunk.DB.IngestLedger does inline (extract once, then concrete writes),
+// and each writer takes exactly the inputs it uses.
 //
-//   - seq is the ledger sequence on drain's contiguous counter (the in-order
-//     contract is enforced at the source).
-//   - raw is the wire-format LedgerCloseMeta bytes for the ledgers writer; it
-//     ALIASES the source stream's borrowed buffer, valid only for the current
-//     Ingest call, so an implementation must copy what it retains.
-//   - txEvents is the per-transaction hash + contract events (apply order); each
-//     element's Hash feeds txhash and the slice feeds events via
-//     events.PayloadsFromLedgerEvents. Its byte slices alias the same buffer.
-//   - closedAt is the view's LedgerCloseTime, needed for event shaping.
+// Ownership: openColdChunk opens each enabled writer's per-chunk file; finalize
+// commits the chunk's artifacts (explicit, error-checked, never deferred);
+// close is always deferred and idempotent — on the failure path (finalize never
+// ran) each writer drops its partial file.
 //
-// txEvents/closedAt are zero when neither txhash nor events is enabled
-// (ledgers-only: ColdService skips the walk entirely).
-type ledgerData struct {
-	seq      uint32
-	raw      []byte
-	closedAt int64
-	txEvents []sdkingest.LedgerTransactionEvents
+// Contract: finalize must NOT be called after a failed ingest — once any ingest
+// errors, the chunk is abandoned via close and retried from scratch. A writer
+// may have committed partial per-ledger state before the error (the events
+// writer's mirror/pack run ahead of its offsets commit point), so a
+// post-failure finalize could publish an inconsistent artifact; eventsCold
+// latches the failure and refuses.
+type coldChunk struct {
+	ledgers *ledgerCold
+	txhash  *txhashCold
+	events  *eventsCold
+	sink    MetricSink
 }
 
-// ColdIngester ingests one data type for one chunk into a per-chunk cold writer.
+// openColdChunk opens one cold writer per enabled type at its resolved path —
+// the single definition site of the canonical ledgers→txhash→events order and
+// the build rollback. An enabled type with an empty ColdDirs path is a config
+// error. On any failure the already-opened writers are closed; they never
+// ingested or finalized, and close emits no per-writer ColdIngest sample, so a
+// rolled-back build produces no phantom-success sample.
+func openColdChunk(dirs ColdDirs, chunkID chunk.ID, sink MetricSink, cfg Config) (*coldChunk, error) {
+	cc := &coldChunk{sink: sink}
+	fail := func(err error) (*coldChunk, error) { return nil, errors.Join(err, cc.close()) }
+	if cfg.Ledgers {
+		if dirs.LedgerPack == "" {
+			return fail(errors.New("ingest: ledgers enabled but its ColdDirs path is empty"))
+		}
+		w, err := newLedgerCold(dirs.LedgerPack, chunkID, sink)
+		if err != nil {
+			return fail(fmt.Errorf("open ledgers cold writer: %w", err))
+		}
+		cc.ledgers = w
+	}
+	if cfg.Txhash {
+		if dirs.TxhashBin == "" {
+			return fail(errors.New("ingest: txhash enabled but its ColdDirs path is empty"))
+		}
+		w, err := newTxhashCold(dirs.TxhashBin, chunkID, sink)
+		if err != nil {
+			return fail(fmt.Errorf("open txhash cold writer: %w", err))
+		}
+		cc.txhash = w
+	}
+	if cfg.Events {
+		if dirs.EventsDir == "" {
+			return fail(errors.New("ingest: events enabled but its ColdDirs path is empty"))
+		}
+		w, err := newEventsCold(dirs.EventsDir, chunkID, sink)
+		if err != nil {
+			return fail(fmt.Errorf("open events cold writer: %w", err))
+		}
+		cc.events = w
+	}
+	return cc, nil
+}
+
+// ingest writes one ledger into every enabled writer, in canonical order. lcm
+// is a borrowed view over the source stream's buffer, valid only for this call
+// — each writer copies what it retains. seq is the ledger sequence on drain's
+// contiguous counter (the in-order contract is enforced at the source).
 //
-// Ownership: the ingester OPENS its own per-chunk writer in its constructor and
-// owns its lifecycle. Finalize commits the chunk's artifact (explicit,
-// error-checked, never deferred). Close is always deferred and idempotent; on
-// the failure path (Finalize never ran) it drops any partial file.
-//
-// Contract: Finalize must NOT be called after a failed Ingest — once any
-// Ingest errors, the chunk is abandoned via Close and retried from scratch.
-// Implementations may have committed partial per-ledger state before the
-// error (e.g. the events ingester's mirror/pack run ahead of its offsets
-// commit point), so a post-failure Finalize could publish an inconsistent
-// artifact; implementations are encouraged to latch the failure and refuse
-// (eventsCold does).
-//
-// Input: l carries one ledger's shared pre-extracted data (see ledgerData). Its
-// borrowed byte slices are valid only for the current call — an implementation
-// must copy any bytes it retains. ColdService drives the per-ledger Ingest calls
-// sequentially, so each ledger is fully consumed before the next.
-type ColdIngester interface {
-	Ingest(ctx context.Context, l ledgerData) error
-	Finalize(ctx context.Context) error
-	Close() error
+// When txhash or events is enabled, the view is walked ONCE (the shared
+// ExtractLedgerEvents, mirroring the hot path's IngestLedger) and both read the
+// result — halving cold per-ledger extraction (issue #836). The walk-or-not
+// decision is structural: no consumer of the walk → no walk, so a ledgers-only
+// chunk never pays it and an enabled events writer can never miss it. The walk
+// is metered as the ledger-scoped ColdExtract signal. The first error aborts
+// the ledger.
+func (c *coldChunk) ingest(seq uint32, lcm xdr.LedgerCloseMetaView) error {
+	if c.ledgers != nil {
+		if err := c.ledgers.write(seq, []byte(lcm)); err != nil {
+			return err
+		}
+	}
+	if c.txhash == nil && c.events == nil {
+		return nil
+	}
+	start := time.Now()
+	txEvents, err := sdkingest.ExtractLedgerEvents(lcm)
+	if err != nil {
+		return fmt.Errorf("extract ledger events seq %d: %w", seq, err)
+	}
+	closedAt, err := lcm.LedgerCloseTime()
+	if err != nil {
+		return fmt.Errorf("ledger close time seq %d: %w", seq, err)
+	}
+	c.sink.ColdExtract(time.Since(start), len(txEvents))
+	if c.txhash != nil {
+		if err := c.txhash.write(seq, txEvents); err != nil {
+			return err
+		}
+	}
+	if c.events != nil {
+		if err := c.events.write(seq, closedAt, txEvents); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// finalize commits each enabled writer's chunk artifact, in canonical order.
+// The first error STOPS: the remaining (unfinalized) writers are released by
+// the caller's deferred close, and the failed chunk attempt is reported to the
+// orchestrator, which never records completion for it. Artifacts the earlier
+// writers already committed are left in place — without the orchestrator's
+// completion record they are inert scratch (see the package doc's artifact
+// model), and the retry's overwrite is the cleanup.
+func (c *coldChunk) finalize(ctx context.Context) error {
+	if c.ledgers != nil {
+		if err := c.ledgers.finalize(ctx); err != nil {
+			return fmt.Errorf("finalize: %w", err)
+		}
+	}
+	if c.txhash != nil {
+		if err := c.txhash.finalize(ctx); err != nil {
+			return fmt.Errorf("finalize: %w", err)
+		}
+	}
+	if c.events != nil {
+		if err := c.events.finalize(ctx); err != nil {
+			return fmt.Errorf("finalize: %w", err)
+		}
+	}
+	return nil
+}
+
+// close closes every opened writer, joining each close error. Idempotent: on
+// the failure path a writer's close drops its partial file; after a successful
+// finalize it is a no-op. A per-writer ColdIngest is emitted only from a
+// TERMINAL step (a failed write, via coldMetrics.observe, or finalize) — never
+// from close, so a writer rolled back before any work produces no sample.
+func (c *coldChunk) close() error {
+	var err error
+	if c.ledgers != nil {
+		if cerr := c.ledgers.close(); cerr != nil {
+			err = errors.Join(err, fmt.Errorf("close: %w", cerr))
+		}
+	}
+	if c.txhash != nil {
+		if cerr := c.txhash.close(); cerr != nil {
+			err = errors.Join(err, fmt.Errorf("close: %w", cerr))
+		}
+	}
+	if c.events != nil {
+		if cerr := c.events.close(); cerr != nil {
+			err = errors.Join(err, fmt.Errorf("close: %w", cerr))
+		}
+	}
+	return err
 }
 
 // Cold writers run ONLY on the batch freeze/backfill path — WriteColdChunk is

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/ingester.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/ingester.go
@@ -99,16 +99,21 @@ func (c *coldChunk) ingest(seq uint32, lcm xdr.LedgerCloseMetaView) error {
 	if c.txhash == nil && c.events == nil {
 		return nil
 	}
+	// A walk failure aborts the ledger before any writer runs, so no per-writer
+	// signal fires for it — the error-carrying ColdExtract (with the partial
+	// walk's duration) is its one metric, mirroring hot's PhaseExtract failure.
 	start := time.Now()
 	txEvents, err := sdkingest.ExtractLedgerEvents(lcm)
 	if err != nil {
+		c.sink.ColdExtract(time.Since(start), 0, err)
 		return fmt.Errorf("extract ledger events seq %d: %w", seq, err)
 	}
 	closedAt, err := lcm.LedgerCloseTime()
 	if err != nil {
+		c.sink.ColdExtract(time.Since(start), 0, err)
 		return fmt.Errorf("ledger close time seq %d: %w", seq, err)
 	}
-	c.sink.ColdExtract(time.Since(start), len(txEvents))
+	c.sink.ColdExtract(time.Since(start), len(txEvents), nil)
 	if c.txhash != nil {
 		if err := c.txhash.write(seq, txEvents); err != nil {
 			return err

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/ledgers.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/ledgers.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/stellar/go-stellar-sdk/xdr"
-
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/ledger"
 )
@@ -27,23 +25,27 @@ type ledgerCold struct {
 // NewLedgerColdIngester opens a per-chunk cold ledger writer at packPath — the
 // caller's geometry.Layout.LedgerPackPath(chunkID), so the write path is Layout's
 // single derivation, not a second copy — and returns a ColdIngester that owns it.
-// The writer uses its zero-value options; driver-level tuning is a follow-up (issue #836).
+// The writer opts into the batch tuning (coldEncoderConcurrency/coldBytesPerSync):
+// WriteColdChunk, the sole caller, is always a batch freeze/backfill.
 func NewLedgerColdIngester(packPath string, chunkID chunk.ID, sink MetricSink) (ColdIngester, error) {
 	if err := os.MkdirAll(filepath.Dir(packPath), 0o755); err != nil {
 		return nil, fmt.Errorf("mkdir %s: %w", filepath.Dir(packPath), err)
 	}
-	w, err := ledger.NewColdWriter(packPath, chunkID.FirstLedger(), ledger.ColdWriterOptions{})
+	w, err := ledger.NewColdWriter(packPath, chunkID.FirstLedger(), ledger.ColdWriterOptions{
+		Concurrency:  coldEncoderConcurrency,
+		BytesPerSync: coldBytesPerSync,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("ledger.NewColdWriter %s: %w", packPath, err)
 	}
 	return &ledgerCold{path: packPath, writer: w, metrics: newColdMetrics(sink, dataTypeLedgers)}, nil
 }
 
-func (c *ledgerCold) Ingest(_ context.Context, seq uint32, lcm xdr.LedgerCloseMetaView) error {
+func (c *ledgerCold) Ingest(_ context.Context, l ledgerData) error {
 	start := time.Now()
-	if err := c.writer.AppendLedger(seq, []byte(lcm)); err != nil {
+	if err := c.writer.AppendLedger(l.seq, l.raw); err != nil {
 		c.metrics.observe(time.Since(start), 0, err) // terminal: observe emits the per-ingester signal
-		return fmt.Errorf("AppendLedger(seq=%d): %w", seq, err)
+		return fmt.Errorf("AppendLedger(seq=%d): %w", l.seq, err)
 	}
 	c.metrics.sink.IngestStage(dataTypeLedgers, stageWrite, time.Since(start), 1)
 	c.metrics.observe(time.Since(start), 1, nil)

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/ledgers.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/ledgers.go
@@ -11,23 +11,23 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/ledger"
 )
 
-// ───────────────────────── Cold ingester ─────────────────────────
+// ───────────────────────── Cold writer ─────────────────────────
 
 // ledgerCold writes raw ledger bytes into a per-chunk ledger.ColdWriter (one
-// packfile per chunk). Finalize calls Commit (trailer + fsync). Close cleans up
-// the partial file when Finalize never ran (idempotent — no-op after Commit).
+// packfile per chunk). finalize calls Commit (trailer + fsync). close cleans up
+// the partial file when finalize never ran (idempotent — no-op after Commit).
 type ledgerCold struct {
 	path    string
 	writer  *ledger.ColdWriter
 	metrics coldMetrics
 }
 
-// NewLedgerColdIngester opens a per-chunk cold ledger writer at packPath — the
+// newLedgerCold opens a per-chunk cold ledger writer at packPath — the
 // caller's geometry.Layout.LedgerPackPath(chunkID), so the write path is Layout's
-// single derivation, not a second copy — and returns a ColdIngester that owns it.
-// The writer opts into the batch tuning (coldEncoderConcurrency/coldBytesPerSync):
-// WriteColdChunk, the sole caller, is always a batch freeze/backfill.
-func NewLedgerColdIngester(packPath string, chunkID chunk.ID, sink MetricSink) (ColdIngester, error) {
+// single derivation, not a second copy. The writer opts into the batch tuning
+// (coldEncoderConcurrency/coldBytesPerSync): WriteColdChunk, the sole production
+// caller, is always a batch freeze/backfill.
+func newLedgerCold(packPath string, chunkID chunk.ID, sink MetricSink) (*ledgerCold, error) {
 	if err := os.MkdirAll(filepath.Dir(packPath), 0o755); err != nil {
 		return nil, fmt.Errorf("mkdir %s: %w", filepath.Dir(packPath), err)
 	}
@@ -41,18 +41,21 @@ func NewLedgerColdIngester(packPath string, chunkID chunk.ID, sink MetricSink) (
 	return &ledgerCold{path: packPath, writer: w, metrics: newColdMetrics(sink, dataTypeLedgers)}, nil
 }
 
-func (c *ledgerCold) Ingest(_ context.Context, l ledgerData) error {
+// write appends one ledger's raw wire bytes. raw ALIASES the source stream's
+// borrowed buffer, valid only for this call — AppendLedger copies it
+// synchronously.
+func (c *ledgerCold) write(seq uint32, raw []byte) error {
 	start := time.Now()
-	if err := c.writer.AppendLedger(l.seq, l.raw); err != nil {
-		c.metrics.observe(time.Since(start), 0, err) // terminal: observe emits the per-ingester signal
-		return fmt.Errorf("AppendLedger(seq=%d): %w", l.seq, err)
+	if err := c.writer.AppendLedger(seq, raw); err != nil {
+		c.metrics.observe(time.Since(start), 0, err) // terminal: observe emits the per-writer signal
+		return fmt.Errorf("AppendLedger(seq=%d): %w", seq, err)
 	}
 	c.metrics.sink.IngestStage(dataTypeLedgers, stageWrite, time.Since(start), 1)
 	c.metrics.observe(time.Since(start), 1, nil)
 	return nil
 }
 
-func (c *ledgerCold) Finalize(_ context.Context) error {
+func (c *ledgerCold) finalize(_ context.Context) error {
 	start := time.Now()
 	if err := c.writer.Commit(); err != nil {
 		err = fmt.Errorf("ledger ColdWriter.Commit: %w", err)
@@ -64,10 +67,10 @@ func (c *ledgerCold) Finalize(_ context.Context) error {
 	return nil
 }
 
-// Close drops the partial pack when Finalize never ran. It does NOT emit the cold
-// metric: a terminal Ingest error or Finalize already emitted it, and an ingester
+// close drops the partial pack when finalize never ran. It does NOT emit the cold
+// metric: a terminal write error or finalize already emitted it, and a writer
 // that never got that far (a rolled-back build) must produce no phantom sample.
 // The writer.Close error is returned unchanged.
-func (c *ledgerCold) Close() error {
+func (c *ledgerCold) close() error {
 	return c.writer.Close()
 }

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/metrics.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/metrics.go
@@ -79,10 +79,13 @@ type MetricSink interface {
 	// ColdExtract reports the ONE shared per-ledger ExtractLedgerEvents walk the
 	// cold chunk runs and both txhash and events read (issue #836) — ledger-scoped,
 	// not per data type, mirroring the hot path's type-less extract phase. items
-	// is the walk's transaction count. Since the walk left the per-type writers,
-	// their ColdIngest totals are post-extraction figures and the per-type stages
-	// a partial breakdown of them.
-	ColdExtract(d time.Duration, items int)
+	// is the walk's transaction count (0 on failure); err is non-nil when the
+	// walk itself failed, which aborts the ledger before any writer runs — the
+	// duration then covers the partial walk, mirroring hot's PhaseExtract error
+	// signal. Since the walk left the per-type writers, their ColdIngest totals
+	// are post-extraction figures and the per-type stages a partial breakdown of
+	// them.
+	ColdExtract(d time.Duration, items int, err error)
 	// IngestStage reports one COLD writer's per-stage wall-clock inside an
 	// ingest/finalize call: stage is one of the stage* constants (term_index,
 	// write, finalize), items the stage's natural item count (0 where none
@@ -99,7 +102,7 @@ type NopSink struct{}
 func (NopSink) HotPhase(hotchunk.Phase, time.Duration, int, error) {}
 func (NopSink) ColdIngest(string, time.Duration, int, error)       {}
 func (NopSink) ColdChunkTotal(time.Duration)                       {}
-func (NopSink) ColdExtract(time.Duration, int)                     {}
+func (NopSink) ColdExtract(time.Duration, int, error)              {}
 func (NopSink) IngestStage(string, string, time.Duration, int)     {}
 
 // orNop returns sink, or NopSink{} when sink is nil, so call sites never
@@ -241,7 +244,8 @@ type PrometheusSink struct {
 	// Aggregate per-chunk cold wall-clock (the WriteColdChunk attempt).
 	coldChunkTotal prometheus.Observer
 	// The shared per-ledger extract walk — ledger-scoped, label-less.
-	coldExtract prometheus.Observer
+	coldExtract     prometheus.Observer
+	coldExtractErrs prometheus.Counter
 }
 
 // NewPrometheusSink builds a PrometheusSink and MustRegisters its collectors on
@@ -312,14 +316,22 @@ func NewPrometheusSink(registry *prometheus.Registry, namespace string) *Prometh
 		Buckets: coldStageBuckets,
 	})
 
+	coldExtractErrs := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: namespace, Subsystem: metricsSubsystem,
+		Name: "cold_extract_errors_total",
+		Help: "shared-walk failures (the ledger aborts before any writer runs); " +
+			"the cold mirror of hot_phase_errors_total{phase=\"extract\"}",
+	})
+
 	registry.MustRegister(hotPhaseDurVec, hotPhaseItemsVec, hotPhaseErrsVec,
-		coldDuration, coldItems, coldErrors, coldChunkTotal, coldStageVec, coldExtract)
+		coldDuration, coldItems, coldErrors, coldChunkTotal, coldStageVec, coldExtract, coldExtractErrs)
 
 	sink := &PrometheusSink{
-		cold:           make(map[string]ingestCollectors, 3),
-		coldStage:      make(map[string]prometheus.Observer, len(coldStagePairs)),
-		coldChunkTotal: coldChunkTotal,
-		coldExtract:    coldExtract,
+		cold:            make(map[string]ingestCollectors, 3),
+		coldStage:       make(map[string]prometheus.Observer, len(coldStagePairs)),
+		coldChunkTotal:  coldChunkTotal,
+		coldExtract:     coldExtract,
+		coldExtractErrs: coldExtractErrs,
 	}
 	// Hot phases: one child per phase, indexed by the phase value.
 	for p := range hotchunk.NumPhases {
@@ -359,11 +371,16 @@ func (p *PrometheusSink) ColdChunkTotal(d time.Duration) {
 	p.coldChunkTotal.Observe(d.Seconds())
 }
 
-// ColdExtract records the shared per-ledger walk's duration. The item count is
-// not exported to Prometheus (cold_items_total{txhash} already counts the
-// chunk's transactions); it exists on the interface for the CSV bench sink.
-func (p *PrometheusSink) ColdExtract(d time.Duration, _ int) {
+// ColdExtract records the shared per-ledger walk's duration (the partial walk
+// on failure — a phase that blocked then failed is signal) and counts failures.
+// The item count is not exported to Prometheus (cold_items_total{txhash}
+// already counts the chunk's transactions); it exists on the interface for the
+// CSV bench sink.
+func (p *PrometheusSink) ColdExtract(d time.Duration, _ int, err error) {
 	p.coldExtract.Observe(d.Seconds())
+	if err != nil {
+		p.coldExtractErrs.Inc()
+	}
 }
 
 // IngestStage records the per-stage cold duration. The per-stage item counts are

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/metrics.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/metrics.go
@@ -15,35 +15,29 @@ const (
 	dataTypeLedgers = "ledgers"
 	dataTypeTxhash  = "txhash"
 	dataTypeEvents  = "events"
-	// dataTypeShared labels the ONE per-ledger ExtractLedgerEvents walk the cold
-	// service runs once and shares across txhash + events (issue #836) — it is
-	// not a stored data type, only the scope of the shared extract stage, mirroring
-	// the hot path's single (data-type-less) extract phase.
-	dataTypeShared = "shared"
 )
 
 // Cold stage labels reported via MetricSink.IngestStage. These sit at the seams
-// the rpc-hack bench collectors measured (per-stage extract / term-index /
-// store-write samples plus a per-chunk finish), so a CSV sink can reproduce
-// those reports from production ingesters without re-instrumenting.
+// the rpc-hack bench collectors measured (per-stage term-index / store-write
+// samples plus a per-chunk finish), so a CSV sink can reproduce those reports
+// from production writers without re-instrumenting. The shared per-ledger
+// ExtractLedgerEvents walk is NOT a stage: it belongs to no single data type,
+// so it is its own ledger-scoped signal (MetricSink.ColdExtract), mirroring the
+// hot path's type-less extract phase.
 const (
-	stageExtract   = "extract"    // the shared per-ledger ExtractLedgerEvents walk (ColdService)
 	stageTermIndex = "term_index" // per-event term derivation + mirror update (events cold)
 	stageWrite     = "write"      // store write / pack append
 	stageFinalize  = "finalize"   // per-chunk commit (pack trailer, index build, .bin write)
 )
 
 // coldStagePairs is the set of (data_type, stage) pairs the cold path actually
-// emits — the seven real ones, not a cross-product. A sink pre-resolves exactly
-// these, so it registers no series no code path can feed. The extract stage is
-// keyed dataTypeShared: after issue #836 the ledger walk is done once by
-// ColdService and shared, so it is metered once per ledger rather than once per
-// consuming type. txhash's per-ledger work is a cheap truncate-append that folds
-// into its ColdIngest total (its stage cost is the finalize sort + .bin write).
+// emits — the six real ones, not a cross-product. A sink pre-resolves exactly
+// these, so it registers no series no code path can feed. txhash's per-ledger
+// work is a cheap truncate-append that folds into its ColdIngest total (its
+// stage cost is the finalize sort + .bin write).
 //
 //nolint:gochecknoglobals // fixed label set, read-only
 var coldStagePairs = []struct{ dataType, stage string }{
-	{dataTypeShared, stageExtract},
 	{dataTypeLedgers, stageWrite},
 	{dataTypeLedgers, stageFinalize},
 	{dataTypeTxhash, stageFinalize},
@@ -78,13 +72,21 @@ type MetricSink interface {
 	// err the first error (nil on success).
 	ColdIngest(dataType string, d time.Duration, items int, err error)
 	// ColdChunkTotal reports the per-chunk aggregate wall-clock: the whole
-	// ColdService lifetime, from construction through the drain of the source stream
-	// and every Ingest and Finalize, to the single emit.
+	// WriteColdChunk attempt, from just after config validation through open,
+	// the drain of the source stream, every ingest and finalize, to the
+	// deferred close.
 	ColdChunkTotal(d time.Duration)
-	// IngestStage reports one COLD ingester's per-stage wall-clock inside an
-	// Ingest/Finalize call: stage is one of the stage* constants (extract,
-	// term_index, write, finalize), items the stage's natural item count (0 where
-	// none applies). The whole-call ColdIngest signal cannot be decomposed by a
+	// ColdExtract reports the ONE shared per-ledger ExtractLedgerEvents walk the
+	// cold chunk runs and both txhash and events read (issue #836) — ledger-scoped,
+	// not per data type, mirroring the hot path's type-less extract phase. items
+	// is the walk's transaction count. Since the walk left the per-type writers,
+	// their ColdIngest totals are post-extraction figures and the per-type stages
+	// a partial breakdown of them.
+	ColdExtract(d time.Duration, items int)
+	// IngestStage reports one COLD writer's per-stage wall-clock inside an
+	// ingest/finalize call: stage is one of the stage* constants (term_index,
+	// write, finalize), items the stage's natural item count (0 where none
+	// applies). The whole-call ColdIngest signal cannot be decomposed by a
 	// sink after the fact, so the per-stage granularity the bench reports need is
 	// exposed as its own signal — a sink that doesn't want it can no-op it.
 	IngestStage(dataType, stage string, d time.Duration, items int)
@@ -97,6 +99,7 @@ type NopSink struct{}
 func (NopSink) HotPhase(hotchunk.Phase, time.Duration, int, error) {}
 func (NopSink) ColdIngest(string, time.Duration, int, error)       {}
 func (NopSink) ColdChunkTotal(time.Duration)                       {}
+func (NopSink) ColdExtract(time.Duration, int)                     {}
 func (NopSink) IngestStage(string, string, time.Duration, int)     {}
 
 // orNop returns sink, or NopSink{} when sink is nil, so call sites never
@@ -108,8 +111,18 @@ func orNop(sink MetricSink) MetricSink {
 	return sink
 }
 
+// errOrFirst returns prev if it is non-nil, else cur. Used to retain the FIRST
+// error a cold writer saw across its ingest/finalize lifetime for the sink's
+// per-chunk err report.
+func errOrFirst(prev, cur error) error {
+	if prev != nil {
+		return prev
+	}
+	return cur
+}
+
 // coldMetrics is the per-chunk metric accumulator shared by all three cold
-// ingesters. Each ingester accumulates Ingest wall-clock (accum), item count
+// writers. Each ingester accumulates Ingest wall-clock (accum), item count
 // (items), and the FIRST error it saw (firstErr) across the chunk, then emits a
 // single ColdIngest signal on a TERMINAL step only: Finalize (success or error),
 // or an Ingest error (which abandons the chunk). Close NEVER emits — an ingester
@@ -134,7 +147,7 @@ func newColdMetrics(sink MetricSink, dataType string) coldMetrics {
 }
 
 // observe records one Ingest's wall-clock and (on error) the first error. An
-// Ingest error is TERMINAL by the ColdIngester contract (the chunk is abandoned
+// write error is TERMINAL by the coldChunk contract (the chunk is abandoned
 // and the ingester is never reused), so observe emits the single per-ingester
 // ColdIngest itself here — callers just observe-and-return, no hand-paired emit.
 func (m *coldMetrics) observe(d time.Duration, items int, err error) {
@@ -180,9 +193,9 @@ var (
 	hotBuckets = prometheus.DefBuckets
 	// 1s … ~34min, doubling.
 	coldBuckets = prometheus.ExponentialBuckets(1, 2, 12)
-	// Cold STAGE observations span per-ledger sub-stages (sub-millisecond
-	// extract/append) through the per-chunk finalize (minutes): 1ms … ~70min,
-	// ×4 per bucket.
+	// Cold STAGE observations (also the shared extract walk) span per-ledger
+	// sub-stages (sub-millisecond appends) through the per-chunk finalize
+	// (minutes): 1ms … ~70min, ×4 per bucket.
 	coldStageBuckets = prometheus.ExponentialBuckets(0.001, 4, 12)
 )
 
@@ -222,11 +235,13 @@ type PrometheusSink struct {
 	// their data_type from the same constant set the map is built from, so a lookup
 	// can never miss — indexed directly, no on-the-fly vector fallback.
 	cold map[string]ingestCollectors
-	// Per-cold-stage durations, pre-resolved for the eight real (data_type, stage)
+	// Per-cold-stage durations, pre-resolved for the six real (data_type, stage)
 	// pairs only (coldStagePairs), keyed "dataType/stage".
 	coldStage map[string]prometheus.Observer
-	// Aggregate per-chunk cold wall-clock (ColdService lifetime).
+	// Aggregate per-chunk cold wall-clock (the WriteColdChunk attempt).
 	coldChunkTotal prometheus.Observer
+	// The shared per-ledger extract walk — ledger-scoped, label-less.
+	coldExtract prometheus.Observer
 }
 
 // NewPrometheusSink builds a PrometheusSink and MustRegisters its collectors on
@@ -255,8 +270,9 @@ func NewPrometheusSink(registry *prometheus.Registry, namespace string) *Prometh
 
 	coldDuration := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: namespace, Subsystem: metricsSubsystem,
-		Name:    "cold_ingest_duration_seconds",
-		Help:    "per-ingester cold wall-clock (per chunk, incl. Finalize)",
+		Name: "cold_ingest_duration_seconds",
+		Help: "per-writer cold wall-clock (per chunk, incl. finalize; post-extraction — " +
+			"the shared walk is cold_extract_duration_seconds)",
 		Buckets: coldBuckets,
 	}, []string{"data_type"})
 
@@ -275,25 +291,35 @@ func NewPrometheusSink(registry *prometheus.Registry, namespace string) *Prometh
 	coldChunkTotal := prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: namespace, Subsystem: metricsSubsystem,
 		Name:    "cold_chunk_duration_seconds",
-		Help:    "aggregate per-chunk wall-clock across all cold ingesters (ColdService lifetime)",
+		Help:    "aggregate per-chunk wall-clock across all cold writers (the WriteColdChunk attempt)",
 		Buckets: coldBuckets,
 	})
 
 	coldStageVec := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: namespace, Subsystem: metricsSubsystem,
 		Name: "cold_stage_duration_seconds",
-		Help: "per-stage wall-clock inside a cold Ingest/Finalize " +
-			"(extract, term_index, write, finalize; not every data type emits every stage)",
+		Help: "per-stage wall-clock inside a cold ingest/finalize " +
+			"(term_index, write, finalize; not every data type emits every stage; a partial " +
+			"breakdown — the unstaged remainder folds into cold_ingest_duration_seconds)",
 		Buckets: coldStageBuckets,
 	}, []string{"data_type", "stage"})
 
+	coldExtract := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: namespace, Subsystem: metricsSubsystem,
+		Name: "cold_extract_duration_seconds",
+		Help: "the shared per-ledger ExtractLedgerEvents walk (one per ledger, read by " +
+			"txhash and events; ledger-scoped, so no data_type)",
+		Buckets: coldStageBuckets,
+	})
+
 	registry.MustRegister(hotPhaseDurVec, hotPhaseItemsVec, hotPhaseErrsVec,
-		coldDuration, coldItems, coldErrors, coldChunkTotal, coldStageVec)
+		coldDuration, coldItems, coldErrors, coldChunkTotal, coldStageVec, coldExtract)
 
 	sink := &PrometheusSink{
 		cold:           make(map[string]ingestCollectors, 3),
 		coldStage:      make(map[string]prometheus.Observer, len(coldStagePairs)),
 		coldChunkTotal: coldChunkTotal,
+		coldExtract:    coldExtract,
 	}
 	// Hot phases: one child per phase, indexed by the phase value.
 	for p := range hotchunk.NumPhases {
@@ -308,7 +334,7 @@ func NewPrometheusSink(registry *prometheus.Registry, namespace string) *Prometh
 			errors:   coldErrors.WithLabelValues(dataType),
 		}
 	}
-	// Cold stages: only the eight real (data_type, stage) pairs.
+	// Cold stages: only the six real (data_type, stage) pairs.
 	for _, k := range coldStagePairs {
 		sink.coldStage[k.dataType+"/"+k.stage] = coldStageVec.WithLabelValues(k.dataType, k.stage)
 	}
@@ -331,6 +357,13 @@ func (p *PrometheusSink) ColdIngest(dataType string, d time.Duration, items int,
 
 func (p *PrometheusSink) ColdChunkTotal(d time.Duration) {
 	p.coldChunkTotal.Observe(d.Seconds())
+}
+
+// ColdExtract records the shared per-ledger walk's duration. The item count is
+// not exported to Prometheus (cold_items_total{txhash} already counts the
+// chunk's transactions); it exists on the interface for the CSV bench sink.
+func (p *PrometheusSink) ColdExtract(d time.Duration, _ int) {
+	p.coldExtract.Observe(d.Seconds())
 }
 
 // IngestStage records the per-stage cold duration. The per-stage item counts are

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/metrics.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/metrics.go
@@ -15,6 +15,11 @@ const (
 	dataTypeLedgers = "ledgers"
 	dataTypeTxhash  = "txhash"
 	dataTypeEvents  = "events"
+	// dataTypeShared labels the ONE per-ledger ExtractLedgerEvents walk the cold
+	// service runs once and shares across txhash + events (issue #836) — it is
+	// not a stored data type, only the scope of the shared extract stage, mirroring
+	// the hot path's single (data-type-less) extract phase.
+	dataTypeShared = "shared"
 )
 
 // Cold stage labels reported via MetricSink.IngestStage. These sit at the seams
@@ -22,23 +27,26 @@ const (
 // store-write samples plus a per-chunk finish), so a CSV sink can reproduce
 // those reports from production ingesters without re-instrumenting.
 const (
-	stageExtract   = "extract"    // view → payloads / hashes derivation
+	stageExtract   = "extract"    // the shared per-ledger ExtractLedgerEvents walk (ColdService)
 	stageTermIndex = "term_index" // per-event term derivation + mirror update (events cold)
 	stageWrite     = "write"      // store write / pack append
 	stageFinalize  = "finalize"   // per-chunk commit (pack trailer, index build, .bin write)
 )
 
-// coldStagePairs is the set of (data_type, stage) pairs the cold ingesters
-// actually emit — the eight real ones, not the 3×4 cross-product. A sink
-// pre-resolves exactly these, so it registers no series no code path can feed.
+// coldStagePairs is the set of (data_type, stage) pairs the cold path actually
+// emits — the seven real ones, not a cross-product. A sink pre-resolves exactly
+// these, so it registers no series no code path can feed. The extract stage is
+// keyed dataTypeShared: after issue #836 the ledger walk is done once by
+// ColdService and shared, so it is metered once per ledger rather than once per
+// consuming type. txhash's per-ledger work is a cheap truncate-append that folds
+// into its ColdIngest total (its stage cost is the finalize sort + .bin write).
 //
 //nolint:gochecknoglobals // fixed label set, read-only
 var coldStagePairs = []struct{ dataType, stage string }{
+	{dataTypeShared, stageExtract},
 	{dataTypeLedgers, stageWrite},
 	{dataTypeLedgers, stageFinalize},
-	{dataTypeTxhash, stageExtract},
 	{dataTypeTxhash, stageFinalize},
-	{dataTypeEvents, stageExtract},
 	{dataTypeEvents, stageTermIndex},
 	{dataTypeEvents, stageWrite},
 	{dataTypeEvents, stageFinalize},

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/service.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	sdkingest "github.com/stellar/go-stellar-sdk/ingest"
 	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk"
@@ -79,25 +80,46 @@ func (s *HotService) Ingest(_ context.Context, seq uint32, lcm xdr.LedgerCloseMe
 type ColdService struct {
 	ingesters    []ColdIngester
 	sink         MetricSink
+	extract      bool
 	start        time.Time
 	totalEmitted bool
 }
 
 // NewColdService builds a ColdService over the enabled cold ingesters. A nil
-// sink defaults to NopSink. The per-chunk aggregate timer starts here; the only
-// case where no Ingest follows is an already-errored short/empty stream, where
-// the timing sample is meaningless anyway.
-func NewColdService(ingesters []ColdIngester, sink MetricSink) *ColdService {
-	return &ColdService{ingesters: ingesters, sink: orNop(sink), start: time.Now()}
+// sink defaults to NopSink. extract selects whether Ingest runs the shared
+// per-ledger ExtractLedgerEvents walk: true iff txhash or events is enabled
+// (a ledgers-only chunk needs no walk). The per-chunk aggregate timer starts
+// here; the only case where no Ingest follows is an already-errored short/empty
+// stream, where the timing sample is meaningless anyway.
+func NewColdService(ingesters []ColdIngester, sink MetricSink, extract bool) *ColdService {
+	return &ColdService{ingesters: ingesters, sink: orNop(sink), extract: extract, start: time.Now()}
 }
 
-// Ingest runs every cold ingester on lcm sequentially (each owns mutable
-// per-chunk state, so no concurrency within the service). seq is the
-// driver-validated sequence of lcm, passed through unchanged. The first error
-// aborts the ledger.
+// Ingest walks the borrowed view ONCE (the shared ExtractLedgerEvents, mirroring
+// the hot path's IngestLedger), then runs every cold ingester on the resulting
+// ledgerData sequentially (each owns mutable per-chunk state, so no concurrency
+// within the service). seq is the driver-validated sequence of lcm, passed
+// through unchanged. The single walk is timed and emitted as one ledger-scoped
+// extract stage (dataTypeShared) — txhash and events read it instead of each
+// re-walking. The first error aborts the ledger.
 func (s *ColdService) Ingest(ctx context.Context, seq uint32, lcm xdr.LedgerCloseMetaView) error {
+	l := ledgerData{seq: seq, raw: []byte(lcm)}
+	if s.extract {
+		start := time.Now()
+		txEvents, err := sdkingest.ExtractLedgerEvents(lcm)
+		if err != nil {
+			return fmt.Errorf("extract ledger events seq %d: %w", seq, err)
+		}
+		closedAt, err := lcm.LedgerCloseTime()
+		if err != nil {
+			return fmt.Errorf("ledger close time seq %d: %w", seq, err)
+		}
+		l.txEvents = txEvents
+		l.closedAt = closedAt
+		s.sink.IngestStage(dataTypeShared, stageExtract, time.Since(start), len(txEvents))
+	}
 	for _, ing := range s.ingesters {
-		if err := ing.Ingest(ctx, seq, lcm); err != nil {
+		if err := ing.Ingest(ctx, l); err != nil {
 			return err
 		}
 	}

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/service.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/service.go
@@ -2,25 +2,11 @@ package ingest
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"time"
 
-	sdkingest "github.com/stellar/go-stellar-sdk/ingest"
 	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk"
 )
-
-// errOrFirst returns prev if it is non-nil, else cur. Used to retain the FIRST
-// error a cold ingester saw across its Ingest/Finalize lifetime for the sink's
-// per-chunk err report.
-func errOrFirst(prev, cur error) error {
-	if prev != nil {
-		return prev
-	}
-	return cur
-}
 
 // HotService commits one ledger to the shared per-chunk hot DB as ONE atomic
 // synced WriteBatch across all hot CFs (decision (a)) and emits the single hot
@@ -64,111 +50,4 @@ func (s *HotService) Ingest(_ context.Context, seq uint32, lcm xdr.LedgerCloseMe
 		s.sink.HotPhase(p, rep.Phases[p].Dur, items, perr)
 	}
 	return err
-}
-
-// ColdService drives a set of ColdIngesters for one chunk: sequential per-ledger
-// Ingest, then Finalize on each. The per-chunk aggregate timer starts at
-// construction (NewColdService), so its window spans the caller's drain of the
-// source stream plus every Ingest and Finalize — a deliberately wide window (see
-// coldBuckets). It emits the aggregate ColdChunkTotal exactly once for the chunk —
-// in Finalize on the success path, otherwise in Close on the failure path (an
-// Ingest error or short stream short-circuits before Finalize).
-// The totalEmitted flag prevents a double-emit: Finalize sets it so the caller's
-// deferred Close is a no-op for the aggregate. (A ctx or constructor failure
-// happens before the service is built — WriteColdChunk emits that chunk's single
-// ColdChunkTotal directly.)
-type ColdService struct {
-	ingesters    []ColdIngester
-	sink         MetricSink
-	extract      bool
-	start        time.Time
-	totalEmitted bool
-}
-
-// NewColdService builds a ColdService over the enabled cold ingesters. A nil
-// sink defaults to NopSink. extract selects whether Ingest runs the shared
-// per-ledger ExtractLedgerEvents walk: true iff txhash or events is enabled
-// (a ledgers-only chunk needs no walk). The per-chunk aggregate timer starts
-// here; the only case where no Ingest follows is an already-errored short/empty
-// stream, where the timing sample is meaningless anyway.
-func NewColdService(ingesters []ColdIngester, sink MetricSink, extract bool) *ColdService {
-	return &ColdService{ingesters: ingesters, sink: orNop(sink), extract: extract, start: time.Now()}
-}
-
-// Ingest walks the borrowed view ONCE (the shared ExtractLedgerEvents, mirroring
-// the hot path's IngestLedger), then runs every cold ingester on the resulting
-// ledgerData sequentially (each owns mutable per-chunk state, so no concurrency
-// within the service). seq is the driver-validated sequence of lcm, passed
-// through unchanged. The single walk is timed and emitted as one ledger-scoped
-// extract stage (dataTypeShared) — txhash and events read it instead of each
-// re-walking. The first error aborts the ledger.
-func (s *ColdService) Ingest(ctx context.Context, seq uint32, lcm xdr.LedgerCloseMetaView) error {
-	l := ledgerData{seq: seq, raw: []byte(lcm)}
-	if s.extract {
-		start := time.Now()
-		txEvents, err := sdkingest.ExtractLedgerEvents(lcm)
-		if err != nil {
-			return fmt.Errorf("extract ledger events seq %d: %w", seq, err)
-		}
-		closedAt, err := lcm.LedgerCloseTime()
-		if err != nil {
-			return fmt.Errorf("ledger close time seq %d: %w", seq, err)
-		}
-		l.txEvents = txEvents
-		l.closedAt = closedAt
-		s.sink.IngestStage(dataTypeShared, stageExtract, time.Since(start), len(txEvents))
-	}
-	for _, ing := range s.ingesters {
-		if err := ing.Ingest(ctx, l); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// Finalize commits each cold ingester's chunk artifact (explicit, error-checked,
-// never deferred). The first Finalize error STOPS the loop: the remaining
-// (unfinalized) ingesters are released by the caller's deferred Close, and the
-// failed chunk attempt is reported to the orchestrator, which never records
-// completion for it. Artifacts the earlier ingesters already wrote are left in
-// place — without the orchestrator's completion record they are inert scratch
-// (see the package doc's artifact model), and the retry's overwrite is the
-// cleanup. The per-chunk ColdChunkTotal is emitted here on the success path.
-func (s *ColdService) Finalize(ctx context.Context) error {
-	var ferr error
-	for _, ing := range s.ingesters {
-		if err := ing.Finalize(ctx); err != nil {
-			ferr = fmt.Errorf("finalize: %w", err)
-			break
-		}
-	}
-	s.emitChunkTotal()
-	return ferr
-}
-
-// Close closes every cold ingester, joining each Close error, and emits the
-// aggregate ColdChunkTotal if Finalize never reached it (the failure path). A
-// per-ingester ColdIngest is emitted only from a TERMINAL step (a failed Ingest,
-// via coldMetrics.observe, or Finalize) — never from Close, so an ingester rolled
-// back before any work produces no per-ingester sample (only the aggregate here).
-// Idempotent: on the failure path a writer's Close drops its partial file; after
-// a successful Finalize this is a no-op for the aggregate.
-func (s *ColdService) Close() error {
-	var err error
-	for _, ing := range s.ingesters {
-		if cerr := ing.Close(); cerr != nil {
-			err = errors.Join(err, fmt.Errorf("close: %w", cerr))
-		}
-	}
-	s.emitChunkTotal()
-	return err
-}
-
-// emitChunkTotal reports the aggregate ColdChunkTotal exactly once for the chunk.
-func (s *ColdService) emitChunkTotal() {
-	if s.totalEmitted {
-		return
-	}
-	s.totalEmitted = true
-	s.sink.ColdChunkTotal(time.Since(s.start))
 }

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/txhash.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/txhash.go
@@ -9,14 +9,16 @@ import (
 	"slices"
 	"time"
 
+	sdkingest "github.com/stellar/go-stellar-sdk/ingest"
+
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash"
 )
 
-// ───────────────────────── Cold ingester ─────────────────────────
+// ───────────────────────── Cold writer ─────────────────────────
 
 // txhashCold accumulates (txhash[:ColdKeySize], seq) tuples per ledger; at
-// Finalize time it lex-sorts by the truncated key and writes a per-chunk
+// finalize time it lex-sorts by the truncated key and writes a per-chunk
 // sorted .bin file under <out-root>/<bucketID:05d>/<chunkID:08d>.bin (the
 // documented raw-txhash layout). The .bin codec — including the matching
 // reader the index-build step uses — lives in pkg/stores/txhash
@@ -29,11 +31,11 @@ type txhashCold struct {
 	metrics coldMetrics
 }
 
-// NewTxhashColdIngester returns a ColdIngester that accumulates a per-chunk
+// newTxhashCold returns a cold txhash writer that accumulates a per-chunk
 // sorted .bin at binPath — the caller's geometry.Layout.TxHashBinPath(chunkID),
-// so the write path is Layout's single derivation — written at Finalize
+// so the write path is Layout's single derivation — written at finalize
 // (overwriting any prior attempt's file — see the package doc's artifact model).
-func NewTxhashColdIngester(binPath string, chunkID chunk.ID, sink MetricSink) (ColdIngester, error) {
+func newTxhashCold(binPath string, chunkID chunk.ID, sink MetricSink) (*txhashCold, error) {
 	if err := os.MkdirAll(filepath.Dir(binPath), 0o755); err != nil {
 		return nil, fmt.Errorf("mkdir %s: %w", filepath.Dir(binPath), err)
 	}
@@ -48,32 +50,32 @@ func NewTxhashColdIngester(binPath string, chunkID chunk.ID, sink MetricSink) (C
 	}, nil
 }
 
-func (t *txhashCold) Ingest(_ context.Context, l ledgerData) error {
+// write accumulates one ledger's tx hashes. They come from coldChunk's shared
+// ExtractLedgerEvents walk: each element's Hash is the ledger's tx hash in
+// apply order — byte-identical, and in the same order, as the ExtractTxHashes
+// call this used to run (both read txProcessingHash off the same TxProcessing
+// iteration). Each is truncated to ColdKeySize and appended STRAIGHT into the
+// accumulator — no intermediate per-ledger entry slice; over a ~3M-tx chunk
+// that intermediate would be hundreds of MB of transient garbage. The
+// extraction itself is metered once, ledger-scoped, as the ColdExtract signal;
+// this cheap truncate-append folds into the per-writer ColdIngest total (its
+// per-chunk cost is the finalize sort + .bin write).
+func (t *txhashCold) write(seq uint32, txEvents []sdkingest.LedgerTransactionEvents) error {
 	start := time.Now()
-	// Hashes come from ColdService's shared ExtractLedgerEvents walk: each
-	// element's Hash is the ledger's tx hash in apply order — byte-identical, and
-	// in the same order, as the ExtractTxHashes call this used to run (both read
-	// txProcessingHash off the same TxProcessing iteration). Each is truncated to
-	// ColdKeySize and appended STRAIGHT into the accumulator — no intermediate
-	// per-ledger entry slice; over a ~3M-tx chunk that intermediate would be
-	// hundreds of MB of transient garbage. The extraction itself is metered once,
-	// ledger-scoped, as the shared extract stage; this cheap truncate-append folds
-	// into the per-ingester ColdIngest total (its per-chunk cost is the finalize
-	// sort + .bin write).
-	for i := range l.txEvents {
+	for i := range txEvents {
 		var ke txhash.ColdEntry
-		copy(ke.Key[:], l.txEvents[i].Hash[:txhash.ColdKeySize])
-		ke.Seq = l.seq
+		copy(ke.Key[:], txEvents[i].Hash[:txhash.ColdKeySize])
+		ke.Seq = seq
 		t.entries = append(t.entries, ke)
 	}
-	t.metrics.observe(time.Since(start), len(l.txEvents), nil)
+	t.metrics.observe(time.Since(start), len(txEvents), nil)
 	return nil
 }
 
-// Finalize sorts the in-memory accumulator and writes the per-chunk .bin file
+// finalize sorts the in-memory accumulator and writes the per-chunk .bin file
 // via txhash.WriteColdBin (the codec's documentation in
 // pkg/stores/txhash/cold_bin.go pins the layout).
-func (t *txhashCold) Finalize(_ context.Context) error {
+func (t *txhashCold) finalize(_ context.Context) error {
 	start := time.Now()
 	// slices.SortFunc over sort.Slice: reflection-free, meaningfully faster
 	// on a ~3M-element sort.
@@ -88,9 +90,9 @@ func (t *txhashCold) Finalize(_ context.Context) error {
 	return err
 }
 
-// Close is a no-op: there is no open file handle to release (the .bin is written
-// in Finalize), and the cold metric is emitted on a terminal Ingest error or in
-// Finalize — never here, so a rolled-back build produces no phantom sample.
-func (t *txhashCold) Close() error {
+// close is a no-op: there is no open file handle to release (the .bin is written
+// in finalize), and the cold metric is emitted on a terminal write error or in
+// finalize — never here, so a rolled-back build produces no phantom sample.
+func (t *txhashCold) close() error {
 	return nil
 }

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/txhash.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/txhash.go
@@ -9,9 +9,6 @@ import (
 	"slices"
 	"time"
 
-	sdkingest "github.com/stellar/go-stellar-sdk/ingest"
-	"github.com/stellar/go-stellar-sdk/xdr"
-
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash"
 )
@@ -51,33 +48,25 @@ func NewTxhashColdIngester(binPath string, chunkID chunk.ID, sink MetricSink) (C
 	}, nil
 }
 
-func (t *txhashCold) Ingest(_ context.Context, seq uint32, lcm xdr.LedgerCloseMetaView) error {
+func (t *txhashCold) Ingest(_ context.Context, l ledgerData) error {
 	start := time.Now()
-	// ExtractTxHashes returns full 32-byte hashes (copied, not view-aliased).
-	// Each is truncated to ColdKeySize and appended STRAIGHT into the
-	// accumulator — no intermediate per-ledger entry slice; over a ~3M-tx
-	// chunk that intermediate would be hundreds of MB of transient garbage.
-	hashes, err := sdkingest.ExtractTxHashes(lcm)
-	if err != nil {
-		t.metrics.observe(time.Since(start), 0, err) // terminal: observe emits the per-ingester signal
-		return fmt.Errorf("ExtractTxHashes seq %d: %w", seq, err)
-	}
-	for i := range hashes {
+	// Hashes come from ColdService's shared ExtractLedgerEvents walk: each
+	// element's Hash is the ledger's tx hash in apply order — byte-identical, and
+	// in the same order, as the ExtractTxHashes call this used to run (both read
+	// txProcessingHash off the same TxProcessing iteration). Each is truncated to
+	// ColdKeySize and appended STRAIGHT into the accumulator — no intermediate
+	// per-ledger entry slice; over a ~3M-tx chunk that intermediate would be
+	// hundreds of MB of transient garbage. The extraction itself is metered once,
+	// ledger-scoped, as the shared extract stage; this cheap truncate-append folds
+	// into the per-ingester ColdIngest total (its per-chunk cost is the finalize
+	// sort + .bin write).
+	for i := range l.txEvents {
 		var ke txhash.ColdEntry
-		copy(ke.Key[:], hashes[i][:txhash.ColdKeySize])
-		ke.Seq = seq
+		copy(ke.Key[:], l.txEvents[i].Hash[:txhash.ColdKeySize])
+		ke.Seq = l.seq
 		t.entries = append(t.entries, ke)
 	}
-	// The extract stage spans the SDK hash extraction AND the truncate-and-append
-	// loop — this ingester's only per-ledger CPU. Emitting it here, not right after
-	// ExtractTxHashes, makes the per-ledger stage total equal the Ingest wall-clock,
-	// so the cold stages (extract here, finalize at chunk end) partition the
-	// per-chunk ColdIngest total with no unexplained remainder. (The .bin sort +
-	// write is the finalize stage; there is no separate cold write stage for
-	// txhash.)
-	d := time.Since(start)
-	t.metrics.sink.IngestStage(dataTypeTxhash, stageExtract, d, len(hashes))
-	t.metrics.observe(d, len(hashes), nil)
+	t.metrics.observe(time.Since(start), len(l.txEvents), nil)
 	return nil
 }
 

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/hot_store.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/hot_store.go
@@ -371,7 +371,7 @@ func (h *HotStore) All(ctx context.Context) iter.Seq2[events.Payload, error] {
 // before any Put; on any error Store.Batch discards the whole WriteBatch, so a
 // rejected ledger never leaves committed rows behind.
 //
-// payloads is produced by events.LCMViewToPayloads, which emits each ledger's
+// payloads is produced by events.PayloadsFromLedgerEvents, which emits each ledger's
 // events in ascending getEvents cursor order — write order here IS the cursor
 // contract (event IDs are assigned by arrival position). Terms are derived via
 // events.TermsForBytes on each payload's ContractEventBytes.

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk/hotchunk.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk/hotchunk.go
@@ -281,10 +281,10 @@ func (d *DB) IngestLedger(seq uint32, lcm xdr.LedgerCloseMetaView) (LedgerReport
 	// per transaction in apply order, the tx hash AND its contract events. txhash
 	// reads each element's Hash and events shapes the same slice
 	// (PayloadsFromLedgerEvents), so the two share one walk instead of the two
-	// (ExtractTxHashes + LCMViewToPayloads-internal ExtractLedgerEvents) they used
-	// to each run — halving per-ledger extraction. Shaping the already-extracted
-	// slice (not re-walking) keeps the event-ID assignment order identical to
-	// LCMViewToPayloads. The atomic batch below serializes only the commit; the
+	// (ExtractTxHashes + a second ExtractLedgerEvents walk) they would each run —
+	// halving per-ledger extraction. Shaping the already-extracted slice (not
+	// re-walking) keeps the event-ID assignment order identical to a per-view
+	// shaping. The atomic batch below serializes only the commit; the
 	// extractors are independent and could run concurrently into the same batch if
 	// catch-up profiling ever demands it — sequential is right at live cadence.
 	// Every failure below stamps the failed phase's PARTIAL duration before


### PR DESCRIPTION
Closes #836.

The cold path ran two per-ledger walks over the same borrowed view — `ExtractTxHashes` in the txhash ingester and `LCMViewToPayloads` (internal `ExtractLedgerEvents`) in the events ingester. Backfill runs this across all of history on the CPU worker pool, so the redundant walk was pure waste.

**One walk.** `ColdService.Ingest` now extracts each ledger once (`ExtractLedgerEvents`), mirroring the hot path's `IngestLedger`, and hands the shared result to the per-type ingesters as a `ledgerData` bundle: txhash reads each element's `.Hash`, events shapes the slice with `events.PayloadsFromLedgerEvents`, the ledgers writer takes the raw bytes with no walk. The substitution is exact: both SDK extractors iterate the same `TxProcessing()` and take `txProcessingHash` per element — one element per transaction, event-less or not, V0–V4 alike — so the `.Hash` read is byte-identical, in the same order, to the deleted `ExtractTxHashes` call. A ledgers-only chunk skips the walk entirely.

**Byte-identity is proven, not asserted:** `TestWriteColdChunk_ByteIdentity_SharedWalk` drives the real `WriteColdChunk` over a chunk with event-rich sentinel ledgers and compares the artifacts to independent references — the txhash `.bin` against sorted/truncated `ExtractTxHashes` output (the OLD extractor, a separate walk), and the events term bitmaps + count against `PayloadsFromLedgerEvents` shaping with chunk-relative IDs. Same tx-hash entries, same event-ID assignment.

**Seam thinning.** `ColdIngester.Ingest` takes the pre-extracted `ledgerData` instead of the raw view; the shared walk is metered once per ledger as a ledger-scoped extract stage (`data_type="shared"`, mirroring the hot path's single extract phase) instead of once per consuming type, and the cold stage pair set shrinks 8→7.

**Wrapper stack deleted:** `events.LCMViewToPayloads` (this was its last production caller; its tests keep a local helper) and `ingest.eventPayloads`.

**Writer tuning wired.** Both cold pack writers opt into batch tuning — `Concurrency: 4`, `BytesPerSync: 1 MiB` — instead of the zero-value serial defaults, per the writer's own docs ("bump for large backfills where zstd encoding is CPU-bound"; background writeback smooths the final fsync). `WriteColdChunk` is their sole production caller and is always a batch freeze/backfill. Concurrency stays modest because the backfill pool already runs GOMAXPROCS chunks concurrently; the construction site notes the downgrade path if profiling ever shows contention.

Tests: the byte-identity guard above plus the existing ingest suite migrated to the new seam. Full `fullhistory` + `events` `-short` suites green; `-race -count=1` on `ingest`/`events` green.

Behavioral note: a mid-walk extraction failure now surfaces from `ColdService` before any ingester runs, so it no longer bumps a per-`data_type` `cold_errors_total` — the error still propagates and `ColdChunkTotal` still fires, matching how the hot path attributes decode failures to its data-type-less extract phase. No test asserted the old attribution.