### PR TITLE
fullhistory: build empty cold indexes for zero-key coverages (closes #826)

### DIFF
--- a/cmd/stellar-rpc/internal/fullhistory/backfill/resolve.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/resolve.go
@@ -116,10 +116,6 @@ func resolveTxHashIndex(
 			needs[cs.Chunk] = needs[cs.Chunk].Add(geometry.KindTxHash)
 		}
 	}
-	// TODO(#826): an all-empty range (no transactions — a quiet test network, or an
-	// early-history tail) still schedules a build here, which fails with ErrEmptyBuildSet
-	// and re-plans every restart. The txhash cold store needs an empty-index sentinel (as
-	// the eventstore has) before such a range can resolve to a covered, no-retry state.
 	return IndexBuild{Index: w, Lo: desired.Lo, Hi: desired.Hi}, true, nil
 }
 

--- a/cmd/stellar-rpc/internal/fullhistory/backfill/txindex_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/backfill/txindex_test.go
@@ -151,6 +151,30 @@ func TestBuildTxhashIndex_BuildsQueryableCoverage(t *testing.T) {
 	assertCoverageQueryable(t, cat, []txEntry{e0a, e0b, e1a})
 }
 
+// TestBuildTxhashIndex_AllEmptyWindowFreezes pins the #826 fix: a window whose
+// chunks all hold zero transactions (empty .bin files) builds a valid empty
+// index and freezes the coverage, instead of failing the build and re-planning
+// the same window on every restart.
+func TestBuildTxhashIndex_AllEmptyWindowFreezes(t *testing.T) {
+	cat, _ := smallTxHashIndexCatalog(t, 4)
+	cfg := testBuildConfig(cat)
+
+	// Chunks 0 and 1 are frozen with empty .bin files (no transactions).
+	freezeChunkBin(t, cat, 0, nil)
+	freezeChunkBin(t, cat, 1, nil)
+
+	require.NoError(t, buildTxhashIndex(context.Background(), 0, 0, 1, cfg))
+
+	// The coverage freezes rather than stalling in StateFreezing.
+	frozen, ok, err := cat.FrozenTxHashIndex(0)
+	require.NoError(t, err)
+	require.True(t, ok, "an all-empty window must freeze, not stall")
+	require.Equal(t, chunk.ID(0), frozen.Lo)
+	require.Equal(t, chunk.ID(1), frozen.Hi)
+	require.Equal(t, geometry.StateFrozen, frozen.State)
+	require.FileExists(t, cat.Layout().TxHashIndexFilePath(frozen))
+}
+
 // ---------------------------------------------------------------------------
 // Rolling case: hi advances by one each boundary; the predecessor is demoted
 // AND swept; exactly one frozen coverage exists at every instant.

--- a/cmd/stellar-rpc/internal/fullhistory/e2e_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/e2e_test.go
@@ -297,8 +297,8 @@ func TestE2E_DaemonLifecycle_FirstStartIngestFreezeLookupRestartPrune(t *testing
 	src := xdr.MustMuxedAddress(keypair.MustRandom().Address())
 	coldRaw, coldHash := oneTxLCMBytes(t, c0First, src) // → frozen cold .idx (chunk 0)
 	hotRaw, hotHash := oneTxLCMBytes(t, c2First, src)   // → live hot CF (chunk 2)
-	// Chunk 1's first ledger also carries a tx so its txhash .bin is non-empty —
-	// streamhash refuses to build a cold index over zero keys (ErrEmptyBuildSet).
+	// Chunk 1's first ledger also carries a tx so its txhash .bin is non-empty,
+	// exercising a real (non-empty) cold index build alongside the empty ones.
 	c1Raw, _ := oneTxLCMBytes(t, c1First, src)
 
 	frames := make(map[uint32][]byte, 2*int(chunk.LedgersPerChunk)+2)

--- a/cmd/stellar-rpc/internal/fullhistory/ingest/ingest_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/ingest/ingest_test.go
@@ -1289,8 +1289,8 @@ func TestEventsCold_FinishThenIndexFails_LeavesInertPack(t *testing.T) {
 	ing, err := NewEventsColdIngester(filepath.Join(coldDir, chunkID.BucketID()), chunkID, nil)
 	require.NoError(t, err)
 
-	// Ingest one event-bearing ledger so the mirror is non-empty (an empty
-	// build set would take the valid empty-index path instead of buildMPHF).
+	// Ingest one event-bearing ledger so the mirror is non-empty, exercising a
+	// real (non-empty) MPHF build.
 	rawEv, _, _ := marshalLCMWithEvent(t, first)
 	require.NoError(t, ing.Ingest(context.Background(), first, xdr.LedgerCloseMetaView(rawEv)))
 

--- a/cmd/stellar-rpc/internal/fullhistory/lifecycle/lifecycle_helpers_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/lifecycle/lifecycle_helpers_test.go
@@ -24,10 +24,9 @@ const lifecyclePassphrase = network.PublicNetworkPassphrase
 
 // oneTxLCMRand builds the wire bytes of a V2 LedgerCloseMeta carrying ONE
 // transaction for seq, so a chunk ingested with at least one such ledger yields
-// a NON-empty txhash .bin — streamhash refuses to build a cold index over zero
-// keys (txhash.ErrEmptyBuildSet), so a fully zero-tx chunk cannot exercise the
-// real index fold. Mirrors ingest_test's buildLCMReturningHashes, trimmed to one
-// tx.
+// a NON-empty txhash .bin, which exercises the real merge-and-fold index path
+// (a fully zero-tx chunk now builds a valid but trivial empty index instead).
+// Mirrors ingest_test's buildLCMReturningHashes, trimmed to one tx.
 func oneTxLCMRand(t *testing.T, seq uint32) []byte {
 	t.Helper()
 	envelope := xdr.TransactionEnvelope{

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/cold_format.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/cold_format.go
@@ -229,12 +229,6 @@ func DecodeLedgerOffsets(data []byte) (*events.LedgerOffsets, error) {
 // through. No double-hashing.
 // ──────────────────────────────────────────────────────────────────
 
-// ErrEmptyBuildSet is returned by buildMPHF when len(keys) == 0. An
-// MPHF over zero keys has no slots; the zero-term case is handled
-// one level up by WriteColdIndex, which writes the empty-index
-// sentinel instead of calling buildMPHF (see emptyIndexHash).
-var ErrEmptyBuildSet = errors.New("events: cannot build an MPHF with zero keys")
-
 // ErrKeyNotFound is returned by Lookup when streamhash decides the
 // supplied key was not in the build set. Vanilla MPHF semantics
 // return a slot for any input (the design doc assumes this and uses
@@ -247,9 +241,7 @@ var ErrEmptyBuildSet = errors.New("events: cannot build an MPHF with zero keys")
 var ErrKeyNotFound = errors.New("events: key not in build set")
 
 // mphf wraps a streamhash MPHF index, suitable for repeated Lookup
-// against term keys. A nil idx is the EMPTY index (zero terms,
-// produced for an eventless chunk): every Lookup reports
-// ErrKeyNotFound.
+// against term keys.
 type mphf struct {
 	idx *streamhash.Index
 }
@@ -268,8 +260,7 @@ type mphf struct {
 // Memory usage is bounded by streamhash's internal partition buffers,
 // not by the chunk's unique-term count.
 //
-// len(bitmaps) == 0 returns ErrEmptyBuildSet. Duplicate keys are
-// rejected by streamhash.
+// Duplicate keys are rejected by streamhash.
 //
 // ctx is propagated to streamhash.NewBuilder so a long index build
 // honors caller cancellation. The AddKey/Finish loop also checks
@@ -279,9 +270,6 @@ type mphf struct {
 //nolint:nonamedreturns // named err carries through to the deferred builder.Close
 func buildMPHF(ctx context.Context, bitmaps events.Bitmaps, outputPath string) (m *mphf, err error) {
 	total := len(bitmaps)
-	if total <= 0 {
-		return nil, ErrEmptyBuildSet
-	}
 
 	tmpDir, terr := os.MkdirTemp("", "eventstore-unsorted-")
 	if terr != nil {
@@ -324,11 +312,6 @@ func buildMPHF(ctx context.Context, bitmaps events.Bitmaps, outputPath string) (
 // <chunkDir>/index.hash produced by an earlier buildMPHF) for
 // query-time lookups.
 //
-// A zero-length file is the empty-index sentinel written by
-// WriteColdIndex for an eventless chunk (streamhash cannot build an
-// MPHF over zero keys, so there is nothing to serialize): it opens
-// as the empty mphf, whose every Lookup reports ErrKeyNotFound.
-//
 // The file is read into memory up-front via os.ReadFile +
 // streamhash.OpenBytes rather than mmapped. Rationale: a typical
 // MPHF for a single Chunk is small (~hundreds of KB at production
@@ -343,9 +326,6 @@ func openMPHF(path string) (*mphf, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("events: read %s: %w", path, err)
-	}
-	if len(data) == 0 {
-		return &mphf{}, nil // empty index: zero terms, every Lookup misses
 	}
 	idx, err := streamhash.OpenBytes(data)
 	if err != nil {
@@ -364,9 +344,6 @@ func openMPHF(path string) (*mphf, error) {
 // index.pack — an MPHF can map an unseen key to a valid build-set
 // slot, and only the fingerprint catches that residual collision.
 func (m *mphf) Lookup(key events.TermKey) (uint32, error) {
-	if m.idx == nil {
-		return 0, ErrKeyNotFound // empty index (eventless chunk)
-	}
 	slot, err := m.idx.QueryRank(key[:])
 	if err != nil {
 		if errors.Is(err, streamhash.ErrNotFound) {
@@ -383,15 +360,10 @@ func (m *mphf) Lookup(key events.TermKey) (uint32, error) {
 	return uint32(slot), nil
 }
 
-// Close releases the underlying mmap. Idempotent. The empty index
-// holds no resources.
+// Close releases the index; a no-op for the in-memory OpenBytes path.
 func (m *mphf) Close() error {
-	if m.idx == nil {
-		return nil
-	}
 	return m.idx.Close()
 }
 
-// isEmpty reports whether this is the empty index (zero terms, loaded
-// from the zero-length sentinel written for an eventless chunk).
-func (m *mphf) isEmpty() bool { return m.idx == nil }
+// isEmpty reports whether the index holds zero terms (an eventless chunk).
+func (m *mphf) isEmpty() bool { return m.idx.NumKeys() == 0 }

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/cold_format_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/cold_format_test.go
@@ -204,10 +204,15 @@ func TestLookup_UnseenKeyBehavior(t *testing.T) {
 	assert.Positive(t, collidedSlot, "some unseen keys collide into the slot space — that's why fingerprints exist")
 }
 
-func TestBuild_EmptyIndexErrors(t *testing.T) {
+func TestBuild_EmptyIndexSucceeds(t *testing.T) {
+	// Zero terms builds a valid empty index rather than erroring.
 	empty := events.NewBitmaps()
-	_, err := buildMPHF(context.Background(), empty, filepath.Join(t.TempDir(), "index.hash"))
-	assert.ErrorIs(t, err, ErrEmptyBuildSet)
+	m, err := buildMPHF(context.Background(), empty, filepath.Join(t.TempDir(), "index.hash"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = m.Close() })
+	assert.True(t, m.isEmpty())
+	_, lerr := m.Lookup(events.ComputeTermKey([]byte("anything"), events.FieldContractID))
+	assert.ErrorIs(t, lerr, ErrKeyNotFound)
 }
 
 func TestOpen_RoundTripsBuiltFile(t *testing.T) {

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/cold_index.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/cold_index.go
@@ -32,7 +32,7 @@ import (
 // of the cold artifact always live together.
 //
 // A zero-term bitmaps (an eventless chunk, e.g. a pre-Soroban
-// backfill range) produces the EMPTY index: a zero-length index.hash
+// backfill range) produces a real (empty) index.hash over zero terms
 // plus a zero-record index.pack. The cold reader resolves every
 // LookupKeys entry against it to a nil-bitmap miss through the
 // ordinary path, so neither readers nor orchestrators need a
@@ -84,22 +84,8 @@ import (
 // chunks); the subsequent index.pack write is a tight in-memory
 // loop that doesn't poll ctx.
 func WriteColdIndex(ctx context.Context, chunkID chunk.ID, bitmaps events.Bitmaps, bucketDir string) (err error) {
-	n := len(bitmaps)
-
 	indexPackPath := filepath.Join(bucketDir, IndexPackName(chunkID))
 	indexHashPath := filepath.Join(bucketDir, IndexHashName(chunkID))
-
-	// Zero terms (an eventless chunk, e.g. an all-pre-Soroban backfill
-	// range — the COMMON case for early history): streamhash cannot
-	// build an MPHF over zero keys, so write the empty index instead —
-	// a zero-length index.hash (the sentinel openMPHF recognizes) plus
-	// a zero-record index.pack. Readers then need no missing-file
-	// special case: every LookupKeys entry resolves to a nil-bitmap
-	// miss through the ordinary path, and all three cold artifacts
-	// always exist for a finalized chunk.
-	if n == 0 {
-		return writeEmptyColdIndex(indexPackPath, indexHashPath)
-	}
 
 	// On any error path past this point (including a partial write
 	// from buildMPHF itself), remove the orphaned index.hash. Joined
@@ -119,7 +105,7 @@ func WriteColdIndex(ctx context.Context, chunkID chunk.ID, bitmaps events.Bitmap
 	}
 	defer m.Close()
 
-	entries := make([]indexEntry, 0, n)
+	entries := make([]indexEntry, 0, len(bitmaps))
 	for term, bitmap := range bitmaps {
 		slot, lerr := m.Lookup(term)
 		if lerr != nil {
@@ -203,49 +189,4 @@ func writeIndexPackEntries(pw *packfile.Writer, entries []indexEntry) error {
 		}
 	}
 	return pw.Finish(nil)
-}
-
-// writeEmptyColdIndex publishes the empty cold index for an eventless
-// chunk: a zero-length index.hash (the sentinel openMPHF recognizes as
-// "zero terms") and a zero-record index.pack. Both are fsync'd, matching
-// WriteColdIndex's durability contract. On error any partial artifact is
-// removed so the bucket dir stays clean for retry.
-func writeEmptyColdIndex(indexPackPath, indexHashPath string) (err error) {
-	defer func() {
-		if err == nil {
-			return
-		}
-		if rmErr := os.Remove(indexHashPath); rmErr != nil && !errors.Is(rmErr, fs.ErrNotExist) {
-			err = errors.Join(err, fmt.Errorf("events: remove orphan %s: %w", indexHashPath, rmErr))
-		}
-	}()
-
-	f, err := os.Create(indexHashPath)
-	if err != nil {
-		return fmt.Errorf("events: create empty index.hash at %s: %w", indexHashPath, err)
-	}
-	if err = f.Sync(); err != nil {
-		_ = f.Close()
-		return fmt.Errorf("events: sync empty index.hash at %s: %w", indexHashPath, err)
-	}
-	if err = f.Close(); err != nil {
-		return fmt.Errorf("events: close empty index.hash at %s: %w", indexHashPath, err)
-	}
-
-	pw, err := packfile.Create(indexPackPath, packfile.WriterOptions{
-		Format:         indexPackFormat,
-		ItemsPerRecord: indexPackItemsPerRecord,
-		Overwrite:      true,
-	})
-	if err != nil {
-		return fmt.Errorf("events: create empty index.pack at %s: %w", indexPackPath, err)
-	}
-	if ferr := pw.Finish(nil); ferr != nil {
-		// pw.Close removes the partial index.pack.
-		if closeErr := pw.Close(); closeErr != nil {
-			ferr = errors.Join(ferr, fmt.Errorf("events: close partial index.pack: %w", closeErr))
-		}
-		return fmt.Errorf("events: finish empty index.pack at %s: %w", indexPackPath, ferr)
-	}
-	return nil
 }

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/cold_index_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/cold_index_test.go
@@ -200,17 +200,17 @@ func TestWriteIndex_RespectsContextCancellation(t *testing.T) {
 
 // TestWriteIndex_ZeroTerms_WritesEmptyIndex covers the eventless-chunk
 // case (the common one for pre-Soroban backfill ranges): WriteColdIndex
-// with zero terms must succeed, publishing the empty-index sentinel — a
-// zero-length index.hash plus a zero-record index.pack — and every
-// lookup against it must miss through the ordinary path.
+// with zero terms must succeed, publishing a real (empty) index.hash plus
+// a zero-record index.pack, and every lookup against it must miss through
+// the ordinary path.
 func TestWriteIndex_ZeroTerms_WritesEmptyIndex(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, WriteColdIndex(context.Background(), indexTestChunkID, events.NewBitmaps(), dir))
 
-	// index.hash exists and is the zero-length sentinel.
+	// index.hash exists (a real streamhash index built over zero terms).
 	hashInfo, err := os.Stat(filepath.Join(dir, IndexHashName(indexTestChunkID)))
 	require.NoError(t, err)
-	assert.Zero(t, hashInfo.Size(), "empty index.hash sentinel must be zero-length")
+	assert.Positive(t, hashInfo.Size(), "empty index.hash is a real streamhash index, not a zero-length sentinel")
 
 	// index.pack exists and holds zero records.
 	pr := packfile.Open(filepath.Join(dir, IndexPackName(indexTestChunkID)), packfile.ReaderOptions{})

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/cold_reader.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/cold_reader.go
@@ -166,19 +166,16 @@ func OpenColdReader(chunkID chunk.ID, bucketDir string, opts ColdReaderOptions) 
 		if res.err != nil || !res.idx.isEmpty() {
 			return res.idx, res.err
 		}
-		// The empty-index sentinel (zero-length index.hash) is only valid
-		// for an eventless chunk. Cross-check events.pack's count so a
-		// torn write that died at zero bytes — or a mispaired artifact —
-		// fails loudly here instead of silently matching nothing for a
-		// chunk that has events. (A partial index.hash of any nonzero
-		// size already fails loudly at parse.)
+		// A zero-term index is only valid for an eventless chunk: cross-check
+		// events.pack's count so a mispaired empty index fails loudly instead
+		// of silently matching nothing.
 		m, merr := c.waitMeta()
 		if merr != nil {
 			return nil, fmt.Errorf("events: validate empty index for chunk %s: %w", c.chunkID, merr)
 		}
 		if m.count != 0 {
 			return nil, fmt.Errorf(
-				"events: %s is the empty-index sentinel but events.pack holds %d events for chunk %s (torn or mispaired index)",
+				"events: %s holds zero terms but events.pack holds %d events for chunk %s (torn or mispaired index)",
 				indexHashPath, m.count, c.chunkID)
 		}
 		return res.idx, nil

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/cold_reader_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore/cold_reader_test.go
@@ -257,9 +257,9 @@ func TestColdReader_AllEmptyChunkYieldsNothing(t *testing.T) {
 }
 
 // TestColdReader_EventlessChunk round-trips a chunk with zero events
-// (e.g. a pre-Soroban backfill range): WriteColdIndex publishes the
-// empty-index sentinel, and every read path resolves cleanly — no
-// missing-file errors, no special casing for the orchestrator.
+// (e.g. a pre-Soroban backfill range): WriteColdIndex publishes a real
+// empty index, and every read path resolves cleanly — no missing-file
+// errors, no special casing for the orchestrator.
 func TestColdReader_EventlessChunk(t *testing.T) {
 	const chunkID = chunk.ID(0)
 	dir, payloads := buildColdFixture(t, chunkID, 0, 2)
@@ -293,19 +293,22 @@ func TestColdReader_EventlessChunk(t *testing.T) {
 	assert.Equal(t, 2, offsets.LedgerCount())
 }
 
-// TestColdReader_EmptyIndexOverNonEmptyPackErrors covers the
-// cross-check guarding the empty-index sentinel: a zero-length
-// index.hash is only valid when events.pack is also empty. A torn
-// write that died at zero bytes (buildMPHF writes the final path
-// directly, so a crash can truncate it) — or a mispaired artifact —
-// must fail loudly at the first lookup, not silently match nothing.
+// TestColdReader_EmptyIndexOverNonEmptyPackErrors covers the cross-check
+// guarding a zero-term index: it is only valid when events.pack is also
+// empty. A real empty index.hash mispaired onto a chunk whose events.pack
+// holds events must fail loudly at the first lookup, not silently match
+// nothing.
 func TestColdReader_EmptyIndexOverNonEmptyPackErrors(t *testing.T) {
 	const chunkID = chunk.ID(0)
 	dir, payloads := buildColdFixture(t, chunkID, 2, 1)
 	require.NotEmpty(t, payloads)
 
-	// Truncate index.hash to zero bytes, simulating the torn write.
-	require.NoError(t, os.WriteFile(filepath.Join(dir, IndexHashName(chunkID)), nil, 0o644))
+	// Mispair a real empty index.hash (from an eventless build of the same
+	// chunk) onto this non-empty chunk.
+	emptyDir, _ := buildColdFixture(t, chunkID, 0, 1)
+	emptyHash, err := os.ReadFile(filepath.Join(emptyDir, IndexHashName(chunkID)))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, IndexHashName(chunkID)), emptyHash, 0o644))
 
 	cr, err := OpenColdReader(chunkID, dir, ColdReaderOptions{})
 	require.NoError(t, err, "Open is lazy — the mismatch surfaces at first Lookup")
@@ -313,8 +316,8 @@ func TestColdReader_EmptyIndexOverNonEmptyPackErrors(t *testing.T) {
 
 	// The mismatch must surface as an error, not a clean miss (nil, no error).
 	_, lerr := cr.LookupKeys(context.Background(), []events.TermKey{contractTermKey(payloads[0])})
-	require.Error(t, lerr)
-	assert.Contains(t, lerr.Error(), "empty-index sentinel")
+	require.Error(t, lerr, "a mispaired empty index must error, not miss silently (nil bitmap)")
+	assert.Contains(t, lerr.Error(), "holds zero terms")
 }
 
 // OpenColdReader is non-blocking: it does no I/O, so a missing or

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/cold_index.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/cold_index.go
@@ -14,7 +14,6 @@ package txhash
 import (
 	"context"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -22,10 +21,6 @@ import (
 
 	"github.com/stellar/streamhash"
 )
-
-// ErrEmptyBuildSet is returned by BuildColdIndex when inputs hold no
-// entries (streamhash can't build an index over zero keys).
-var ErrEmptyBuildSet = errors.New("txhash: cannot build a cold index with zero keys")
 
 // BuildColdIndex builds one cold txhash index from inputs (the per-chunk
 // .bin files for the index) into outputPath. [minLedger, maxLedger] is the
@@ -35,9 +30,8 @@ var ErrEmptyBuildSet = errors.New("txhash: cannot build a cold index with zero k
 //
 // The .bin files are k-way merged (cold_merge.go) and fed single-pass to
 // streamhash. By default the block build uses runtime.NumCPU()/2 workers
-// (~2.7x over single-threaded); caller opts override. Returns
-// ErrEmptyBuildSet for empty inputs, removes the partial output on error,
-// and honors ctx cancellation.
+// (~2.7x over single-threaded); caller opts override. Removes the partial
+// output on error, and honors ctx cancellation.
 func BuildColdIndex(
 	ctx context.Context,
 	inputs []string,
@@ -45,9 +39,6 @@ func BuildColdIndex(
 	minLedger, maxLedger uint32,
 	opts ...streamhash.BuildOption,
 ) (err error) {
-	if len(inputs) == 0 {
-		return ErrEmptyBuildSet
-	}
 	if maxLedger < minLedger {
 		return fmt.Errorf("txhash: maxLedger %d < minLedger %d", maxLedger, minLedger)
 	}
@@ -59,9 +50,6 @@ func BuildColdIndex(
 	total, err := scanAndValidate(inputs)
 	if err != nil {
 		return err
-	}
-	if total == 0 {
-		return ErrEmptyBuildSet
 	}
 
 	// The cold format options go last so they win: a caller can override the
@@ -83,17 +71,21 @@ func BuildColdIndex(
 		}
 	}()
 
-	numLeaves := min(maxMergeLeaves(), len(inputs))
-	m := newMerger(ctx)
-	defer m.stop()
-	finalCh, finalPool := m.buildMergeTree(inputs, numLeaves, mergeFileBufBytes)
+	// Skip the merge for a zero-key coverage: the empty index comes from
+	// Finish alone, and the merge has nothing to feed.
+	if total > 0 {
+		numLeaves := min(maxMergeLeaves(), len(inputs))
+		m := newMerger(ctx)
+		defer m.stop()
+		finalCh, finalPool := m.buildMergeTree(inputs, numLeaves, mergeFileBufBytes)
 
-	added, err := feedMergedKeys(builder, finalCh, finalPool, m, minLedger, maxLedger)
-	if err != nil {
-		return err
-	}
-	if added != total {
-		return fmt.Errorf("txhash: key count mismatch: headers declared %d, merged %d", total, added)
+		added, ferr := feedMergedKeys(builder, finalCh, finalPool, m, minLedger, maxLedger)
+		if ferr != nil {
+			return ferr
+		}
+		if added != total {
+			return fmt.Errorf("txhash: key count mismatch: headers declared %d, merged %d", total, added)
+		}
 	}
 	if ferr := builder.Finish(); ferr != nil {
 		return fmt.Errorf("txhash: finalize cold index at %s: %w", outputPath, ferr)

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/cold_index_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash/cold_index_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stellar/streamhash"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores"
 )
 
 // ──────────────────────────────────────────────────────────────────
@@ -221,11 +222,28 @@ func TestBuildColdIndex_LargeFilesSpanMultipleBuffers(t *testing.T) {
 	}
 }
 
+// assertEmptyColdIndex checks that idxPath is a valid empty cold index: it
+// opens cleanly, carries its coverage's [wantMin, wantMax] metadata, and every
+// lookup misses.
+func assertEmptyColdIndex(t *testing.T, idxPath string, wantMin, wantMax uint32) {
+	t.Helper()
+	assert.FileExists(t, idxPath)
+	r, err := OpenColdReader(idxPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+	// The empty index must still carry correct coverage bounds.
+	assert.Equal(t, wantMin, r.MinLedger(), "empty index minLedger")
+	assert.Equal(t, wantMax, r.MaxLedger(), "empty index maxLedger")
+	_, err = r.Get(randHash(testRNG(99)))
+	require.ErrorIs(t, err, stores.ErrNotFound)
+}
+
 func TestBuildColdIndex_NoInputs(t *testing.T) {
+	// No .bin files at all: streamhash now builds a valid empty index rather
+	// than refusing.
 	idxPath := filepath.Join(t.TempDir(), indexFileName(0))
-	err := BuildColdIndex(context.Background(), nil, idxPath, 2, 2)
-	require.ErrorIs(t, err, ErrEmptyBuildSet)
-	assert.NoFileExists(t, idxPath)
+	require.NoError(t, BuildColdIndex(context.Background(), nil, idxPath, 2, 2))
+	assertEmptyColdIndex(t, idxPath, 2, 2)
 }
 
 func TestBuildColdIndex_MaxBelowMinErrors(t *testing.T) {
@@ -239,9 +257,9 @@ func TestBuildColdIndex_MaxBelowMinErrors(t *testing.T) {
 }
 
 func TestBuildColdIndex_AllEmptyInputs(t *testing.T) {
-	// .bin files that exist but declare zero entries: the group has no
-	// keys, so the build refuses with ErrEmptyBuildSet and writes no
-	// index.
+	// .bin files that exist but declare zero entries: the build produces a
+	// valid empty index rather than failing, so the backfill advances past a
+	// quiet range instead of stalling (#826).
 	dir := t.TempDir()
 	chunks := []chunk.ID{5, 6}
 	inputs := make([]string, 0, len(chunks))
@@ -251,9 +269,8 @@ func TestBuildColdIndex_AllEmptyInputs(t *testing.T) {
 		inputs = append(inputs, p)
 	}
 	idxPath := filepath.Join(dir, indexFileName(fixtureBaseChunk))
-	err := BuildColdIndex(context.Background(), inputs, idxPath, fixtureMinLedger(), fixtureMaxLedger())
-	require.ErrorIs(t, err, ErrEmptyBuildSet)
-	assert.NoFileExists(t, idxPath)
+	require.NoError(t, BuildColdIndex(context.Background(), inputs, idxPath, fixtureMinLedger(), fixtureMaxLedger()))
+	assertEmptyColdIndex(t, idxPath, fixtureMinLedger(), fixtureMaxLedger())
 }
 
 func TestBuildColdIndex_MissingInputErrors(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stellar/go-stellar-sdk v0.6.1-0.20260618191317-308407eca8c6
-	github.com/stellar/streamhash v0.0.0-20260622155330-9e08e05c5fa6
+	github.com/stellar/streamhash v0.0.0-20260713164615-c72a4e6f578d
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -445,6 +445,12 @@ github.com/stellar/go-xdr v0.0.0-20260529210834-0bf8f4956364 h1:gOKrfuWdZ92LFlv0
 github.com/stellar/go-xdr v0.0.0-20260529210834-0bf8f4956364/go.mod h1:If+U9Z1W5xU97VrOgJandQT+2dN7/iOpkCrxBJEyF80=
 github.com/stellar/streamhash v0.0.0-20260622155330-9e08e05c5fa6 h1:57+plrmWTOlCKeTRiYJnfJqU47F0qboBAMFsL9eRjoo=
 github.com/stellar/streamhash v0.0.0-20260622155330-9e08e05c5fa6/go.mod h1:fxKHewECHOFV08vy4rR/J40H7KVZcnNS96q6OdjR+TQ=
+github.com/stellar/streamhash v0.0.0-20260713121614-da9a38b1018e h1:zJrOvEk7g1rPOlU3o1tkEoucLIa0qCOI45j50FzIJEc=
+github.com/stellar/streamhash v0.0.0-20260713121614-da9a38b1018e/go.mod h1:fxKHewECHOFV08vy4rR/J40H7KVZcnNS96q6OdjR+TQ=
+github.com/stellar/streamhash v0.0.0-20260713140807-9f6eeb7acecf h1:0eG06xnYp14POIYGyFQiDHXZzlUdLLpoqhPTQgjAi1g=
+github.com/stellar/streamhash v0.0.0-20260713140807-9f6eeb7acecf/go.mod h1:fxKHewECHOFV08vy4rR/J40H7KVZcnNS96q6OdjR+TQ=
+github.com/stellar/streamhash v0.0.0-20260713164615-c72a4e6f578d h1:KOjgc+0Q2hsqnOa7Zn6sPiGMNDB/wyVC5WpriJV54s4=
+github.com/stellar/streamhash v0.0.0-20260713164615-c72a4e6f578d/go.mod h1:fxKHewECHOFV08vy4rR/J40H7KVZcnNS96q6OdjR+TQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=


### PR DESCRIPTION
## Summary

Closes #826. A window of only zero-transaction chunks stalled the full-history daemon: the txhash cold index build returned `ErrEmptyBuildSet`, so the coverage stayed `freezing` and the daemon re-planned the same window on every restart. streamhash now accepts zero-key builds (stellar/streamhash#12), so both cold stores build a real empty index for a zero-key coverage instead of special-casing it.

## What changed

**txhash (the stall).** `BuildColdIndex` drops both `ErrEmptyBuildSet` returns and builds a valid empty index for a zero-key coverage (no inputs, or inputs that hold no entries). It skips the k-way merge when there is nothing to feed. `buildTxhashIndex` then commits normally, so an all-empty window freezes instead of re-planning every restart. Removed the `TODO(#826)` at `resolveWindow`.

**events (fixing both stores consistently).** The events store already tolerated empty chunks via a zero-length `index.hash` sentinel, so it was not stalling, but this migrates it off the sentinel so both stores handle empty identically. `WriteColdIndex` builds a real streamhash empty index over zero terms and writes a zero-record `index.pack` through the ordinary path; `writeEmptyColdIndex` is deleted, `openMPHF` always opens the file, and `isEmpty()` is `NumKeys() == 0`.

## Testing

New `TestBuildTxhashIndex_AllEmptyWindowFreezes` proves the backfill flow (an all-empty window freezes rather than stalling), and the six tests that encoded `ErrEmptyBuildSet` or the zero-length sentinel were reworked to the real-empty-index behavior, including asserting the empty txhash index carries correct `[minLedger, maxLedger]` coverage metadata. All green: txhash, eventstore, backfill, lifecycle, and the full `TestE2E_DaemonLifecycle`. Build, vet, and gofmt clean. The change deletes more than it adds, since the sentinel and `ErrEmptyBuildSet` machinery is gone.

## Two dependencies before this can merge

1. **streamhash stellar/streamhash#12 must merge first.** `go.mod` points streamhash at that PR's commit so this builds and tests now. Re-pin it to a merged commit on streamhash `main` before landing.
2. **The events half overlaps #847.** It reworks `openMPHF`, `isEmpty`, and the cold-reader empty cross-check, which #847 also touches. Whichever lands second needs a rebase, so sequence the two deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
