### PR TITLE
fullhistory: fix two comments stale against the shipped design

### DIFF
--- a/cmd/stellar-rpc/internal/fullhistory/e2e_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/e2e_test.go
@@ -6,8 +6,9 @@ package fullhistory
 // WHAT IS REAL HERE
 //   Everything inside the process is the real production code path:
 //     - runDaemonWith (the true daemon entrypoint): TOML load + form-validate,
-//       per-root flock, catalog open (its own KV store), the stateful
-//       validateConfig gate (pins the floor), and the supervised run loop.
+//       root prep, catalog open (its own KV store, holding the single-process
+//       lock), the stateful validateConfig gate (pins the floor), and the
+//       supervised run loop.
 //     - run → backfillToTip → openHotDBForChunk → runIngestionLoop (the real
 //       atomic per-ledger WriteBatch across all CFs of the real per-chunk
 //       hotchunk RocksDB), the real boundary handoff, the real boundary signal.

--- a/cmd/stellar-rpc/internal/fullhistory/hotloop.go
+++ b/cmd/stellar-rpc/internal/fullhistory/hotloop.go
@@ -22,9 +22,9 @@ import (
 // committing each ledger as one atomic synced WriteBatch across all CFs. It keeps
 // NO progress variable — the last synced batch IS the last-committed ledger,
 // re-derived at startup. Its only coupling to the lifecycle is the boundary
-// signal: at each boundary it publishes the just-completed chunk id (the two
-// goroutines share no memory). Clean-shutdown vs crash is decided at the daemon
-// top level (a ctx-canceled return is clean).
+// signal: at each boundary it publishes the just-completed chunk id.
+// Clean-shutdown vs crash is decided at the daemon top level (a ctx-canceled
+// return is clean).
 
 // openHotDBForChunk opens/recovers/creates the chunk's shared hot DB, keyed on
 // the durable hot:chunk state:


### PR DESCRIPTION
Two comments described designs that were decided against or since replaced:

- The e2e header claimed `runDaemonWith` takes a per-root flock. Single-process enforcement is the catalog RocksDB's own lock, and per-root locks were decided against.
- The hotloop header claimed the ingestion and lifecycle goroutines share no memory. Their boundary handoff is a shared atomic latest-cell plus a wake channel.

Comment-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
