### PR TITLE
Full-history query POC — combined latency results

### DIFF
--- a/cmd/stellar-rpc/internal/fullhistory/bench/bench_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/bench/bench_test.go
@@ -1,0 +1,329 @@
+package bench
+
+import (
+	"context"
+	"encoding/csv"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/fhtest"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/geometry"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/ledger"
+)
+
+// eventEvery: every eventEvery-th ledger of a fixture chunk carries one
+// transaction with one contract event; the rest are zero-tx ledgers.
+const eventEvery = 100
+
+func testLogger() *supportlog.Entry {
+	l := supportlog.New()
+	l.SetLevel(logrus.ErrorLevel)
+	return l
+}
+
+// writeSourcePack materializes a source ledger pack for chunkID under
+// root/ledgers (the tree --pack-dir points at), containing numLedgers ledgers
+// from the chunk's first sequence: every eventEvery-th one carries a
+// transaction with one contract event, the rest are zero-tx. It returns the
+// ledgers tree root and the number of tx/event-bearing ledgers written.
+func writeSourcePack(t *testing.T, root string, chunkID chunk.ID, numLedgers uint32) (string, int) {
+	t.Helper()
+	layout := geometry.NewLayout(root)
+	packPath := layout.LedgerPackPath(chunkID)
+	require.NoError(t, os.MkdirAll(filepath.Dir(packPath), 0o755))
+
+	w, err := ledger.NewColdWriter(packPath, chunkID.FirstLedger(), ledger.ColdWriterOptions{})
+	require.NoError(t, err)
+	defer func() { _ = w.Close() }()
+
+	txLedgers := 0
+	first := chunkID.FirstLedger()
+	for seq := first; seq < first+numLedgers; seq++ {
+		var raw []byte
+		if (seq-first)%eventEvery == 0 {
+			raw = fhtest.EventLCMBytes(t, seq)
+			txLedgers++
+		} else {
+			raw = fhtest.ZeroTxLCMBytes(t, seq)
+		}
+		require.NoError(t, w.AppendLedger(seq, raw))
+	}
+	require.NoError(t, w.Commit())
+	return layout.LedgersRoot(), txLedgers
+}
+
+// readCSV parses one report file into rows keyed by stage name; each row maps
+// the header column name to its integer value.
+func readCSV(t *testing.T, path string) map[string]map[string]int64 {
+	t.Helper()
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+	records, err := csv.NewReader(f).ReadAll()
+	require.NoError(t, err)
+	require.NotEmpty(t, records)
+	header := records[0]
+	rows := make(map[string]map[string]int64, len(records)-1)
+	for _, rec := range records[1:] {
+		row := make(map[string]int64, len(header)-1)
+		for i := 1; i < len(header); i++ {
+			v, perr := strconv.ParseInt(rec[i], 10, 64)
+			require.NoError(t, perr)
+			row[header[i]] = v
+		}
+		rows[rec[0]] = row
+	}
+	return rows
+}
+
+// txhashIndexPath resolves where a backfill over [lo, hi] freezes its txhash
+// index .idx (both chunks inside one window, as every test range here is).
+func txhashIndexPath(t *testing.T, layout geometry.Layout, lo, hi chunk.ID) string {
+	t.Helper()
+	txLayout, err := geometry.NewTxHashIndexLayout(geometry.ChunksPerTxhashIndex)
+	require.NoError(t, err)
+	w := txLayout.TxHashIndexID(lo)
+	require.Equal(t, w, txLayout.TxHashIndexID(hi), "test range must stay inside one index window")
+	return layout.TxHashIndexFilePath(geometry.TxHashIndexCoverage{Index: w, Lo: lo, Hi: hi})
+}
+
+// TestRunColdFromPack is the end-to-end cold path: fabricate a full chunk's
+// source pack, run the production backfill (RunBackfill: chunk freeze + txhash
+// index build) through runCold, and check the CSV report and the cold
+// artifacts.
+func TestRunColdFromPack(t *testing.T) {
+	chunkID := chunk.ID(0)
+	packDir, txLedgers := writeSourcePack(t, t.TempDir(), chunkID, chunk.LedgersPerChunk)
+	outRoot := t.TempDir()
+	csvDir := filepath.Join(t.TempDir(), "csv")
+
+	err := runCold(context.Background(), testLogger(), coldOptions{
+		Source:     sourceConfig{Kind: sourcePack, PackDir: packDir},
+		StartChunk: chunkID,
+		NumChunks:  1,
+		Workers:    1,
+		ColdRoot:   outRoot,
+		OutDir:     csvDir,
+	})
+	require.NoError(t, err)
+
+	// Ledger writes are µs-scale (zstd), so every ledger lands in the write
+	// row; finalize runs once per chunk.
+	ledgers := readCSV(t, filepath.Join(csvDir, "ledgers.csv"))
+	require.Contains(t, ledgers, "write")
+	assert.EqualValues(t, chunk.LedgersPerChunk, ledgers["write"]["n"])
+	assert.EqualValues(t, chunk.LedgersPerChunk, ledgers["write"]["n_items"])
+	require.Contains(t, ledgers, "finalize")
+	assert.EqualValues(t, 1, ledgers["finalize"]["n"])
+
+	// Sub-tick (zero-duration) samples are excluded from n / n_items, so
+	// per-ledger events rows only bound loosely; the finalize rows are
+	// per-chunk and deterministic (txhash finalize items = total hashes).
+	txhash := readCSV(t, filepath.Join(csvDir, "txhash.csv"))
+	require.Contains(t, txhash, "finalize")
+	assert.EqualValues(t, 1, txhash["finalize"]["n"])
+	assert.EqualValues(t, txLedgers, txhash["finalize"]["n_items"])
+
+	events := readCSV(t, filepath.Join(csvDir, "events.csv"))
+	require.Contains(t, events, "write")
+	require.Contains(t, events, "finalize")
+	assert.EqualValues(t, 1, events["finalize"]["n"])
+
+	// The driver rows: the engine's per-chunk aggregates (one sample each,
+	// with the per-type ColdIngest item totals independent of timer
+	// granularity) plus the scheduler's whole-run backfill wall and the one
+	// index build the range plans.
+	driver := readCSV(t, filepath.Join(csvDir, "driver.csv"))
+	for _, name := range []string{
+		"backfill_wall", "index_rebuild", "chunk_total", "ledgers_total", "txhash_total", "events_total",
+	} {
+		require.Contains(t, driver, name)
+		assert.EqualValues(t, 1, driver[name]["n"], name)
+	}
+	assert.EqualValues(t, chunk.LedgersPerChunk, driver["ledgers_total"]["n_items"])
+	assert.EqualValues(t, txLedgers, driver["txhash_total"]["n_items"])
+	assert.EqualValues(t, txLedgers, driver["events_total"]["n_items"])
+
+	// The shared per-ledger ExtractLedgerEvents walk is ledger-scoped (no data
+	// type), so it reports as its own driver row; per-ledger samples bound
+	// loosely (sub-tick walks are excluded).
+	require.Contains(t, driver, "cold_extract")
+
+	// The cold artifacts landed at the Layout-resolved paths — including the
+	// cross-chunk txhash index the backfill builds beyond WriteColdChunk. The
+	// window is partial (chunk 0 of a ChunksPerTxhashIndex-chunk window), so
+	// the .bin inputs are NOT swept.
+	layout := geometry.NewLayout(outRoot)
+	assert.FileExists(t, layout.LedgerPackPath(chunkID))
+	assert.FileExists(t, layout.TxHashBinPath(chunkID))
+	for _, p := range layout.EventsPaths(chunkID) {
+		assert.FileExists(t, p)
+	}
+	assert.FileExists(t, txhashIndexPath(t, layout, chunkID, chunkID))
+}
+
+// TestRunColdMultiChunk exercises the scheduler fan-out: two chunks backfilled
+// with a two-slot worker pool against one shared sink, and one index build
+// covering both.
+func TestRunColdMultiChunk(t *testing.T) {
+	srcRoot := t.TempDir()
+	packDir, _ := writeSourcePack(t, srcRoot, chunk.ID(0), chunk.LedgersPerChunk)
+	_, _ = writeSourcePack(t, srcRoot, chunk.ID(1), chunk.LedgersPerChunk)
+	outRoot := t.TempDir()
+	csvDir := filepath.Join(t.TempDir(), "csv")
+
+	err := runCold(context.Background(), testLogger(), coldOptions{
+		Source:     sourceConfig{Kind: sourcePack, PackDir: packDir},
+		StartChunk: chunk.ID(0),
+		NumChunks:  2,
+		Workers:    2,
+		ColdRoot:   outRoot,
+		OutDir:     csvDir,
+	})
+	require.NoError(t, err)
+
+	driver := readCSV(t, filepath.Join(csvDir, "driver.csv"))
+	assert.EqualValues(t, 2, driver["chunk_total"]["n"])
+	assert.EqualValues(t, 2, driver["ledgers_total"]["n"])
+	assert.Equal(t, 2*int64(chunk.LedgersPerChunk), driver["ledgers_total"]["n_items"])
+	assert.EqualValues(t, 1, driver["backfill_wall"]["n"])
+	assert.EqualValues(t, 1, driver["index_rebuild"]["n"])
+
+	layout := geometry.NewLayout(outRoot)
+	for c := chunk.ID(0); c <= chunk.ID(1); c++ {
+		assert.FileExists(t, layout.LedgerPackPath(c))
+		assert.FileExists(t, layout.TxHashBinPath(c))
+	}
+	assert.FileExists(t, txhashIndexPath(t, layout, chunk.ID(0), chunk.ID(1)))
+}
+
+// TestRunColdRefusesInPlaceRepack asserts the source/destination collision
+// guard.
+func TestRunColdRefusesInPlaceRepack(t *testing.T) {
+	root := t.TempDir()
+	err := runCold(context.Background(), testLogger(), coldOptions{
+		Source:     sourceConfig{Kind: sourcePack, PackDir: geometry.NewLayout(root).LedgersRoot()},
+		StartChunk: chunk.ID(0),
+		NumChunks:  1,
+		Workers:    1,
+		ColdRoot:   root,
+		OutDir:     t.TempDir(),
+	})
+	require.ErrorContains(t, err, "must differ from --pack-dir")
+}
+
+// TestPackBackendMultiChunkRange exercises the pack source's chunk routing: one
+// bounded RawLedgers call spanning two packs streams both, in order — what the
+// hot driver relies on when a run crosses a chunk boundary.
+func TestPackBackendMultiChunkRange(t *testing.T) {
+	srcRoot := t.TempDir()
+	packDir, _ := writeSourcePack(t, srcRoot, chunk.ID(0), chunk.LedgersPerChunk)
+	_, _ = writeSourcePack(t, srcRoot, chunk.ID(1), chunk.LedgersPerChunk)
+
+	first := chunk.ID(0).LastLedger() - 2
+	last := chunk.ID(1).FirstLedger() + 2
+	next := first
+	for raw, err := range (packBackend{root: packDir}).RawLedgers(
+		context.Background(), ledgerbackend.BoundedRange(first, last),
+	) {
+		require.NoError(t, err)
+		require.NotEmpty(t, raw)
+		next++
+	}
+	require.Equal(t, last+1, next, "stream must cover the whole cross-chunk range")
+
+	// A chunk with no pack fails fast with a clear error.
+	for _, err := range (packBackend{root: packDir}).RawLedgers(
+		context.Background(), ledgerbackend.BoundedRange(chunk.ID(2).FirstLedger(), chunk.ID(2).FirstLedger()),
+	) {
+		require.ErrorContains(t, err, "stat source pack")
+	}
+}
+
+// TestRunHotFromPack is the end-to-end hot path: a capped run over a fixture
+// pack through the production ingestion loop into a fresh hot RocksDB,
+// checking the per-phase report and the fixed-starting-state semantics.
+func TestRunHotFromPack(t *testing.T) {
+	const numLedgers = 200
+	chunkID := chunk.ID(0)
+	packDir, _ := writeSourcePack(t, t.TempDir(), chunkID, numLedgers)
+	hotRoot := t.TempDir()
+	csvDir := filepath.Join(t.TempDir(), "csv")
+
+	opts := hotOptions{
+		Source:     sourceConfig{Kind: sourcePack, PackDir: packDir},
+		StartChunk: chunkID,
+		NumChunks:  1,
+		NumLedgers: numLedgers,
+		HotRoot:    hotRoot,
+		OutDir:     csvDir,
+	}
+	require.NoError(t, runHot(context.Background(), testLogger(), opts))
+
+	// The commit phase (WAL append + fsync) is far above timer granularity,
+	// so every ledger contributes a sample; extract likewise.
+	hot := readCSV(t, filepath.Join(csvDir, "hot.csv"))
+	require.Contains(t, hot, "extract")
+	require.Contains(t, hot, "commit")
+	assert.EqualValues(t, numLedgers, hot["commit"]["n"])
+	require.Contains(t, hot, "apply")
+
+	// The loop pulls the stream itself, so run_wall is the only row the driver
+	// times directly; ingest_total is reconstructed inside the sink from each
+	// ledger's HotPhase burst — one sample per ledger (items=1), giving the
+	// per-ledger end-to-end latency the per-phase rows can't be summed into.
+	// Every sample includes the fsync'd commit, so none is sub-tick: n counts
+	// all numLedgers. (read_blocked was a bench-loop artifact and stays gone.)
+	driver := readCSV(t, filepath.Join(csvDir, "driver.csv"))
+	require.Contains(t, driver, "run_wall")
+	assert.EqualValues(t, 1, driver["run_wall"]["n"])
+	assert.EqualValues(t, numLedgers, driver["run_wall"]["n_items"])
+	require.Contains(t, driver, "ingest_total")
+	assert.EqualValues(t, numLedgers, driver["ingest_total"]["n"])
+	assert.EqualValues(t, numLedgers, driver["ingest_total"]["n_items"])
+	assert.NotContains(t, driver, "read_blocked")
+
+	// A second run against the same hot root succeeds from a fixed (empty)
+	// starting state: the production create bracket wipes the leftover DB.
+	require.NoError(t, runHot(context.Background(), testLogger(), opts))
+}
+
+// TestRunHotIncompleteStream asserts an undersized source is a hard error, not
+// a silently short report. A pack holding 50 ledgers covers seqs [2, 51]; asking
+// for 60 makes runHot request [2, 61]. The pack stream requires the whole
+// requested range to fall within its coverage, so it refuses the overshoot up
+// front (stores.ErrOutOfRange, no ledgers streamed at all) and the loop surfaces
+// that wrapped as "ingestion stream: ...". So it is that stream-error path that
+// fires here, NOT runHot's own post-loop completion check (last-committed !=
+// requested last): the loop returns the error before ingesting anything, so the
+// completion check is never reached. Pin the exact refusal so an unrelated
+// failure (pack-open error, config mistake) can't masquerade as this assertion.
+func TestRunHotIncompleteStream(t *testing.T) {
+	const packed = 50
+	chunkID := chunk.ID(0)
+	packDir, _ := writeSourcePack(t, t.TempDir(), chunkID, packed)
+
+	err := runHot(context.Background(), testLogger(), hotOptions{
+		Source:     sourceConfig{Kind: sourcePack, PackDir: packDir},
+		StartChunk: chunkID,
+		NumChunks:  1,
+		NumLedgers: packed + 10, // asks for more than the pack holds
+		HotRoot:    t.TempDir(),
+		OutDir:     filepath.Join(t.TempDir(), "csv"),
+	})
+	// Seqs are fixture-determined: 50 ledgers from chunk 0 → coverage [2, 51];
+	// packed+10 requested → [2, 61]. Both bounds are deterministic, so pinning
+	// them is exact rather than volatile.
+	require.ErrorContains(t, err, "ingestion stream: stores: out of range: "+
+		"requested [2, 61] outside store coverage [2, 51]")
+}

--- a/cmd/stellar-rpc/internal/fullhistory/bench/cold.go
+++ b/cmd/stellar-rpc/internal/fullhistory/bench/cold.go
@@ -1,0 +1,177 @@
+package bench
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"time"
+
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/backfill"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/config"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/geometry"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+)
+
+// maxChunkID is the last chunk ID whose LastLedger fits in a uint32 ledger
+// sequence (see chunk.ID.LastLedger).
+const maxChunkID = chunk.ID(math.MaxUint32/chunk.LedgersPerChunk - 1)
+
+// coldOptions configures one cold-ingest benchmark run.
+type coldOptions struct {
+	// Source is the ledger source the backfill reads from: a local pack tree
+	// or a BSB datastore.
+	Source sourceConfig
+
+	// StartChunk and NumChunks give the chunk range to backfill,
+	// [StartChunk, StartChunk+NumChunks). The run materializes that range's
+	// full artifact set: ledger packs, txhash .bins, events segments, and the
+	// cross-chunk txhash index.
+	StartChunk chunk.ID
+	NumChunks  int
+
+	// Workers sizes the backfill worker pool, shared by chunk freezes and
+	// index builds.
+	Workers int
+
+	// ColdRoot is the output root the artifacts land under, laid out by
+	// geometry.NewLayout. It is scratch: a re-run over the same range
+	// overwrites freely, but artifacts from other ranges are left in place and
+	// can look valid to later tooling, so point each run at a fresh dir.
+	ColdRoot string
+
+	// CatalogDir is the base dir the run-scoped scratch catalog is created
+	// under. Empty means ColdRoot.
+	CatalogDir string
+
+	// OutDir receives the CSV report.
+	OutDir string
+}
+
+// validate checks the flags and chunk range before runCold touches the
+// filesystem.
+func (o coldOptions) validate() error {
+	if o.NumChunks < 1 {
+		return fmt.Errorf("--num-chunks must be >= 1, got %d", o.NumChunks)
+	}
+	if o.Workers < 1 {
+		return fmt.Errorf("--workers must be >= 1, got %d", o.Workers)
+	}
+	// uint64 so StartChunk+NumChunks-1 cannot itself wrap before the compare.
+	if end := uint64(o.StartChunk) + uint64(o.NumChunks) - 1; end > uint64(maxChunkID) {
+		return fmt.Errorf("--start-chunk=%d with --num-chunks=%d ends at chunk %d, past the last valid chunk ID %d",
+			uint32(o.StartChunk), o.NumChunks, end, uint32(maxChunkID))
+	}
+	if o.ColdRoot == "" {
+		return errors.New("--cold-out-dir is required")
+	}
+	// Refuse re-packing a source pack tree in place: the backfill always
+	// materializes ledger packs, the cold ledger writer overwrites its
+	// destination, and destination == source would corrupt the pack mid-read.
+	if o.Source.Kind == sourcePack {
+		outLedgers := geometry.NewLayout(o.ColdRoot).LedgersRoot()
+		if samePath(o.Source.PackDir, outLedgers) {
+			return fmt.Errorf("--cold-out-dir's ledgers tree (%s) must differ from --pack-dir", outLedgers)
+		}
+	}
+	return nil
+}
+
+// runCold benchmarks the cold path: one backfill.RunBackfill over the
+// requested chunk range, against a fresh scratch catalog so the run is a clean
+// backfill from empty. As the backfill runs, the sink collects its per-stage
+// MetricSink timings and the scheduler's observability metrics. On success
+// runCold writes the CSV report and logs a summary, including the effective
+// chunk concurrency for multi-chunk runs.
+func runCold(ctx context.Context, logger *supportlog.Entry, opts coldOptions) error {
+	if err := opts.validate(); err != nil {
+		return err
+	}
+	// Surface an unwritable --out before the run.
+	if err := os.MkdirAll(opts.OutDir, 0o755); err != nil {
+		return fmt.Errorf("create --out dir %s: %w", opts.OutDir, err)
+	}
+	// Create and fsync the write roots up front — the daemon's own root prep.
+	layout := geometry.NewLayout(opts.ColdRoot)
+	if err := config.PrepareRoots(
+		layout.LedgersRoot(), layout.EventsRoot(), layout.TxHashRawRoot(), layout.TxHashIndexRoot(),
+	); err != nil {
+		return fmt.Errorf("prepare --cold-out-dir write roots: %w", err)
+	}
+
+	catalogBase := opts.CatalogDir
+	if catalogBase == "" {
+		catalogBase = opts.ColdRoot
+	}
+	cat, releaseCat, err := openScratchCatalog(catalogBase, layout, logger)
+	if err != nil {
+		return err
+	}
+	defer releaseCat()
+
+	backend, release, err := openSource(ctx, opts.Source)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	sink := newCSVSink()
+	//nolint:gosec // validate() proved StartChunk+NumChunks-1 <= maxChunkID
+	end := opts.StartChunk + chunk.ID(uint32(opts.NumChunks-1))
+
+	start := time.Now()
+	err = backfill.RunBackfill(ctx, backfill.ExecConfig{
+		Catalog: cat,
+		Logger:  logger,
+		Metrics: sink,
+		Process: backfill.ProcessConfig{Sink: sink, Backend: backend},
+		Workers: opts.Workers,
+		// Benchmarks measure one clean attempt; retries would fold failure +
+		// backoff time into the samples.
+		MaxRetries: 0,
+	}, opts.StartChunk, end)
+	if err != nil {
+		writePartialCSVs(logger, sink, opts.OutDir)
+		return fmt.Errorf("backfill [%s,%s]: %w", opts.StartChunk, end, err)
+	}
+	totalWall := time.Since(start)
+
+	sink.logSummary(logger)
+	logColdWall(logger, sink, opts.NumChunks, totalWall)
+	written, err := sink.writeCSVs(opts.OutDir)
+	if err != nil {
+		return err
+	}
+	logger.Infof("wrote %d CSVs to %s", len(written), opts.OutDir)
+	return nil
+}
+
+// logColdWall logs the run's total wall-clock and, for multi-chunk runs, the
+// effective chunk concurrency (sum of the engine's per-chunk totals over the
+// total wall).
+func logColdWall(logger *supportlog.Entry, sink *csvSink, numChunks int, totalWall time.Duration) {
+	if numChunks > 1 && totalWall > 0 {
+		sumChunkTotal := sink.sumDriver(driverChunkTotal)
+		logger.Infof("total wall = %s (sum(chunk_total)/total = %.2fx effective concurrency)",
+			totalWall.Round(time.Millisecond), float64(sumChunkTotal)/float64(totalWall))
+		return
+	}
+	logger.Infof("total wall = %s", totalWall.Round(time.Millisecond))
+}
+
+// samePath reports whether a and b resolve to the same directory. Falls back
+// to an abs-path compare when either does not exist yet.
+func samePath(a, b string) bool {
+	ai, aerr := os.Stat(a)
+	bi, berr := os.Stat(b)
+	if aerr == nil && berr == nil {
+		return os.SameFile(ai, bi)
+	}
+	absA, _ := filepath.Abs(a)
+	absB, _ := filepath.Abs(b)
+	return absA == absB
+}

--- a/cmd/stellar-rpc/internal/fullhistory/bench/command.go
+++ b/cmd/stellar-rpc/internal/fullhistory/bench/command.go
@@ -1,0 +1,208 @@
+package bench
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+)
+
+// NewCommand returns the `bench-ingest` command tree: `cold` benchmarks the
+// daemon's backfill (backfill.RunBackfill), `hot` benchmarks the daemon's live
+// ingestion loop.
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bench-ingest",
+		Short: "Benchmark full-history ingestion",
+	}
+	cmd.AddCommand(newColdCommand(), newHotCommand())
+	return cmd
+}
+
+// sourceFlags is the ledger-source flag set shared by both subcommands.
+type sourceFlags struct {
+	source        string
+	packDir       string
+	bucketPath    string
+	bsbBufferSize uint32
+	bsbNumWorkers uint32
+	retryLimit    uint32
+	retryWait     time.Duration
+	datastoreType string
+	region        string
+}
+
+func (f *sourceFlags) bind(cmd *cobra.Command) {
+	fs := cmd.Flags()
+	fs.StringVar(&f.source, "source", sourcePack, "ledger source: pack | bsb")
+	fs.StringVar(&f.packDir, "pack-dir", "",
+		"source ledgers tree root holding {bucket:05d}/{chunk:08d}.pack (required iff --source=pack)")
+	fs.StringVar(&f.bucketPath, "bucket-path", "sdf-ledger-close-meta/v1/ledgers/pubnet",
+		"datastore destination_bucket_path, or the lake's local directory for "+
+			"--datastore-type=Filesystem (used iff --source=bsb)")
+	fs.Uint32Var(&f.bsbBufferSize, "bsb-buffer-size", 0,
+		"BSB prefetch buffer depth PER worker (0 = backfill default)")
+	fs.Uint32Var(&f.bsbNumWorkers, "bsb-num-workers", 0,
+		"BSB download workers PER worker (0 = backfill default)")
+	fs.Uint32Var(&f.retryLimit, "retry-limit", 0, "BSB retry attempts on transient failure (0 = backfill default)")
+	fs.DurationVar(&f.retryWait, "retry-wait", 0, "BSB delay between retries (0 = backfill default)")
+	fs.StringVar(&f.datastoreType, "datastore-type", "GCS",
+		"BSB datastore type: GCS | S3 | Filesystem (used iff --source=bsb)")
+	fs.StringVar(&f.region, "region", "", "bucket region for --datastore-type=S3, e.g. us-east-2")
+}
+
+func (f *sourceFlags) config() sourceConfig {
+	return sourceConfig{
+		Kind:          f.source,
+		PackDir:       f.packDir,
+		BucketPath:    f.bucketPath,
+		BufferSize:    f.bsbBufferSize,
+		NumWorkers:    f.bsbNumWorkers,
+		RetryLimit:    f.retryLimit,
+		RetryWait:     f.retryWait,
+		DatastoreType: f.datastoreType,
+		Region:        f.region,
+	}
+}
+
+// benchContext returns the run context (canceled on SIGINT/SIGTERM) and an
+// Info-level logger (supportlog defaults to Warn, which would swallow the
+// summary report).
+func benchContext() (context.Context, context.CancelFunc, *supportlog.Entry) {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	logger := supportlog.New()
+	logger.SetLevel(logrus.InfoLevel)
+	return ctx, stop, logger
+}
+
+// writePartialCSVs best-effort persists whatever the sink has collected when a
+// run fails or is interrupted, so a long run's finished chunks survive. Write
+// errors are logged, never returned — the run's own error must surface — and
+// the report is logged as PARTIAL: its rows cover only work that completed.
+func writePartialCSVs(logger *supportlog.Entry, sink *csvSink, outDir string) {
+	written, err := sink.writeCSVs(outDir)
+	if err != nil {
+		logger.Warnf("writing partial CSVs: %v", err)
+	}
+	if len(written) > 0 {
+		logger.Warnf("run incomplete: wrote %d PARTIAL CSVs to %s (rows cover only completed work)", len(written), outDir)
+	}
+}
+
+// newBenchCommand builds one bench-ingest subcommand skeleton — no positional
+// args, SIGINT-canceled context, Info-level logger, profiling around run —
+// with the source and profile flag sets bound.
+func newBenchCommand(
+	use, short string, src *sourceFlags, prof *profileFlags,
+	run func(ctx context.Context, logger *supportlog.Entry) error,
+) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: short,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmd.SilenceUsage = true
+			ctx, stop, logger := benchContext()
+			defer stop()
+			return prof.around(logger, func() error { return run(ctx, logger) })
+		},
+	}
+	src.bind(cmd)
+	prof.bind(cmd)
+	return cmd
+}
+
+func newColdCommand() *cobra.Command {
+	var (
+		src        sourceFlags
+		startChunk uint32
+		numChunks  int
+		workers    int
+		coldOutDir string
+		catalogDir string
+		outDir     string
+		prof       profileFlags
+	)
+	cmd := newBenchCommand("cold",
+		"Benchmark cold ingestion: the daemon's backfill (chunk freezes + txhash index builds) over a chunk range",
+		&src, &prof,
+		func(ctx context.Context, logger *supportlog.Entry) error {
+			return runCold(ctx, logger, coldOptions{
+				Source:     src.config(),
+				StartChunk: chunk.ID(startChunk),
+				NumChunks:  numChunks,
+				Workers:    workers,
+				ColdRoot:   coldOutDir,
+				CatalogDir: catalogDir,
+				OutDir:     outDir,
+			})
+		})
+	fs := cmd.Flags()
+	fs.Uint32Var(&startChunk, "start-chunk", 0, "first chunk ID to backfill (required)")
+	fs.IntVar(&numChunks, "num-chunks", 1, "how many consecutive chunks to backfill starting at --start-chunk")
+	fs.IntVar(&workers, "workers", 1, "backfill worker-pool size, shared by chunk freezes and index builds")
+	fs.StringVar(&coldOutDir, "cold-out-dir", "",
+		"output root for cold artifacts (required; use a fresh dir — same-range "+
+			"re-runs overwrite, but leftovers from other ranges are never swept)")
+	fs.StringVar(&catalogDir, "catalog-dir", "",
+		"base dir for the run's scratch catalog; default: --cold-out-dir")
+	fs.StringVar(&outDir, "out", "bench-out", "CSV output dir")
+	markRequired(cmd, "start-chunk", "cold-out-dir")
+	return cmd
+}
+
+func newHotCommand() *cobra.Command {
+	var (
+		src        sourceFlags
+		startChunk uint32
+		numChunks  int
+		numLedgers uint32
+		hotDir     string
+		catalogDir string
+		outDir     string
+		prof       profileFlags
+	)
+	cmd := newBenchCommand("hot",
+		"Benchmark hot ingestion: the daemon's live ingestion loop over a chunk range",
+		&src, &prof,
+		func(ctx context.Context, logger *supportlog.Entry) error {
+			return runHot(ctx, logger, hotOptions{
+				Source:     src.config(),
+				StartChunk: chunk.ID(startChunk),
+				NumChunks:  numChunks,
+				NumLedgers: numLedgers,
+				HotRoot:    hotDir,
+				CatalogDir: catalogDir,
+				OutDir:     outDir,
+			})
+		})
+	fs := cmd.Flags()
+	fs.Uint32Var(&startChunk, "start-chunk", 0, "first chunk ID to ingest (required)")
+	fs.IntVar(&numChunks, "num-chunks", 1,
+		"how many consecutive chunks to ingest starting at --start-chunk (>1 exercises the hot DB rotation)")
+	fs.Uint32Var(&numLedgers, "num-ledgers", 0, "cap on ledgers ingested from the range's start (0 = whole range)")
+	fs.StringVar(&hotDir, "hot-dir", "",
+		"scratch root for the hot RocksDBs (required; leftover chunk DBs are wiped for a fixed starting state)")
+	fs.StringVar(&catalogDir, "catalog-dir", "",
+		"base dir for the run's scratch catalog; default: --hot-dir")
+	fs.StringVar(&outDir, "out", "bench-out", "CSV output dir")
+	markRequired(cmd, "start-chunk", "hot-dir")
+	return cmd
+}
+
+// markRequired marks flags required, panicking on a nonexistent name — a
+// programming error caught by any test that builds the command.
+func markRequired(cmd *cobra.Command, names ...string) {
+	for _, n := range names {
+		if err := cmd.MarkFlagRequired(n); err != nil {
+			panic(err)
+		}
+	}
+}

--- a/cmd/stellar-rpc/internal/fullhistory/bench/command_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/bench/command_test.go
@@ -1,0 +1,36 @@
+package bench
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewCommand builds the full command tree — executing every markRequired
+// call, whose panic on a bad flag name this test exists to catch (main.go
+// calls NewCommand unconditionally at startup) — and pins each subcommand's
+// required flags.
+func TestNewCommand(t *testing.T) {
+	cmd := NewCommand()
+	require.Equal(t, "bench-ingest", cmd.Use)
+
+	requiredBySubcommand := map[string][]string{
+		"cold": {"start-chunk", "cold-out-dir"},
+		"hot":  {"start-chunk", "hot-dir"},
+	}
+	subs := make(map[string]*cobra.Command, len(cmd.Commands()))
+	for _, sub := range cmd.Commands() {
+		subs[sub.Use] = sub
+	}
+	for name, flags := range requiredBySubcommand {
+		sub := subs[name]
+		require.NotNil(t, sub, "subcommand %q missing", name)
+		for _, fn := range flags {
+			f := sub.Flags().Lookup(fn)
+			require.NotNil(t, f, "%s: flag --%s missing", name, fn)
+			require.Contains(t, f.Annotations, cobra.BashCompOneRequiredFlag,
+				"%s: flag --%s not marked required", name, fn)
+		}
+	}
+}

--- a/cmd/stellar-rpc/internal/fullhistory/bench/csvsink.go
+++ b/cmd/stellar-rpc/internal/fullhistory/bench/csvsink.go
@@ -1,0 +1,476 @@
+package bench
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/ingest"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/observability"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk"
+)
+
+// This file is the bench CSV reporter, in three layers: the report schema
+// (fileSpecs — which CSV files exist and their fixed row orders), recording
+// (csvSink, the ingest.MetricSink that stores every signal as a raw sample on
+// a (file, row) key), and reporting (aggregation into percentile rows, then
+// CSV/log rendering).
+
+// csvHeader is every report CSV's header row.
+const csvHeader = "stage,n,n_items,total_ns,p50_ns,p90_ns,p99_ns,max_ns"
+
+// CSV file basenames not named after a cold data type.
+const (
+	fileHot    = "hot"    // hot.csv: per-phase rows
+	fileDriver = "driver" // driver.csv: per-chunk aggregate rows
+)
+
+// Driver-report row labels. run_wall is recorded by the hot bench driver
+// itself via observe; backfill_wall and index_rebuild arrive through the
+// observability.Metrics signals the backfill scheduler emits; ingest_total is
+// reconstructed in HotPhase from each ledger's phase burst; the rest arrive
+// through the MetricSink cold signals.
+const (
+	driverBackfillWall = "backfill_wall" // cold only: RunBackfill's whole plan-and-execute wall (Metrics.Freeze)
+	driverIndexRebuild = "index_rebuild" // cold only: one txhash index build incl. eager sweep (Metrics.Rebuild)
+	driverChunkTotal   = "chunk_total"   // ColdChunkTotal: per-chunk ColdService lifetime
+	driverTotalSuffix  = "_total"        // ColdIngest per data type: "<type>_total"
+	// cold only: the shared per-ledger ExtractLedgerEvents walk (ColdExtract),
+	// ledger-scoped and belonging to no single data type, so it lands in
+	// driver.csv.
+	driverColdExtract = "cold_extract"
+	// hot only: per-ledger end-to-end ingest time, reconstructed as the sum of
+	// one ledger's HotPhase burst (per-phase percentiles can't be summed).
+	driverIngestTotal = "ingest_total"
+	driverRunWall     = "run_wall" // hot only: whole-run wall-clock, seen by the driver
+)
+
+// Cold data-type and stage report labels, fixing the file/row order of the cold
+// CSVs (see fileSpecs). They MUST equal the strings the ingest engine emits
+// through MetricSink (ColdIngest's data_type, IngestStage's data_type/stage) —
+// they set the report ORDER. A label that drifts from the engine's is not dropped:
+// withUnknown appends any unrecognized row after the known ones; it only loses
+// its curated position.
+const (
+	coldTypeLedgers = "ledgers"
+	coldTypeTxhash  = "txhash"
+	coldTypeEvents  = "events"
+
+	coldStageTermIndex = "term_index"
+	coldStageWrite     = "write"
+	coldStageFinalize  = "finalize"
+)
+
+// fileSpec is one CSV file of the report: its basename (without .csv) and the
+// fixed top-to-bottom order of its rows.
+type fileSpec struct {
+	name     string
+	rowOrder []string
+}
+
+// fileSpecs is the whole report schema, in file emission order:
+//
+//   - one CSV per cold data type the ingest engine reports (ledgers.csv,
+//     txhash.csv, events.csv), one row per cold pipeline stage (term_index →
+//     write → finalize) as reported via MetricSink.IngestStage;
+//   - hot.csv, one row per hot ingest phase, in hotchunk.Phase order;
+//   - driver.csv, the run-level aggregates: the cold scheduler's backfill wall
+//     and per-index-build rebuild rows (observability.Metrics), the engine's
+//     ColdChunkTotal, one "<type>_total" row per cold data type (ColdIngest),
+//     the shared per-ledger cold extract walk (ColdExtract), the hot
+//     per-ledger end-to-end ingest_total (reconstructed from each ledger's
+//     phase burst in HotPhase), and the hot bench's driver-observed run
+//     wall-clock.
+//
+// A label recorded outside this vocabulary is still reported: withUnknown
+// appends it after the known rows (or files), so nothing is silently dropped.
+//
+//nolint:gochecknoglobals // fixed report schema, read-only
+var fileSpecs = func() []fileSpec {
+	coldTypes := []string{coldTypeLedgers, coldTypeTxhash, coldTypeEvents}
+	coldStages := []string{coldStageTermIndex, coldStageWrite, coldStageFinalize}
+
+	hotRows := make([]string, hotchunk.NumPhases)
+	for p := range hotchunk.NumPhases {
+		hotRows[p] = p.String()
+	}
+
+	driverRows := make([]string, 0, len(coldTypes)+6)
+	driverRows = append(driverRows, driverBackfillWall, driverIndexRebuild, driverChunkTotal)
+	for _, dt := range coldTypes {
+		driverRows = append(driverRows, dt+driverTotalSuffix)
+	}
+	// cold_extract closes the cold rows; ingest_total then run_wall keep the
+	// two hot rows grouped at the end.
+	driverRows = append(driverRows, driverColdExtract, driverIngestTotal, driverRunWall)
+
+	specs := make([]fileSpec, 0, len(coldTypes)+2)
+	for _, dt := range coldTypes {
+		specs = append(specs, fileSpec{name: dt, rowOrder: coldStages})
+	}
+	return append(specs,
+		fileSpec{name: fileHot, rowOrder: hotRows},
+		fileSpec{name: fileDriver, rowOrder: driverRows},
+	)
+}()
+
+// sample is one observed (duration, item-count) pair.
+type sample struct {
+	d     time.Duration
+	items int
+}
+
+// series accumulates samples for one CSV row.
+type series struct {
+	samples []sample
+}
+
+func (s *series) observe(d time.Duration, items int) {
+	s.samples = append(s.samples, sample{d: d, items: items})
+}
+
+// rowKey locates one CSV row: the file basename it lands in and its row label.
+type rowKey struct {
+	file, row string
+}
+
+// csvSink is an ingest.MetricSink AND an observability.Metrics that records
+// every signal in memory and, on writeCSVs, aggregates them into percentile
+// CSVs (stage,n,n_items,total_ns,p50_ns,p90_ns,p99_ns,max_ns) laid out per
+// fileSpecs. n counts only non-zero-duration samples (an empty ledger's
+// zero-duration stage does not skew percentiles) and n_items sums each
+// included sample's natural item count. Rows with no included samples — and
+// files with no rows — are suppressed. Most signals map one-to-one onto a
+// sample; HotPhase additionally reconstructs the per-ledger ingest_total row
+// from each ledger's phase burst (see HotPhase).
+//
+// Of the observability signals only the durations a bench run produces are
+// recorded (Freeze — the backfill wall — and Rebuild — one index build each);
+// LastCommitted is tracked as a gauge for the hot driver's completion check,
+// and the rest carry no bench signal so they are dropped — Prune does fire
+// from each index build's eager sweep, but its wall is already inside Rebuild
+// and a fresh scratch run sweeps ~nothing; the others never fire.
+//
+// All methods are safe for concurrent use (one mutex), as the MetricSink
+// contract requires: the backfill scheduler runs several chunk freezes against
+// one sink.
+type csvSink struct {
+	mu   sync.Mutex
+	rows map[rowKey]*series // every signal is one sample on a (file, row) key
+
+	// hotBurst accumulates the current hot ledger's HotPhase durations so
+	// HotPhase can reconstruct the per-ledger end-to-end ingest_total (the
+	// phases partition the per-ledger total). Guarded by mu.
+	hotBurst time.Duration
+
+	// lastSeq mirrors the loop's last-committed gauge (Metrics.LastCommitted,
+	// set once per ingested ledger) so the hot driver can verify the bounded
+	// run reached its final ledger.
+	lastSeq atomic.Uint32
+}
+
+var (
+	_ ingest.MetricSink     = (*csvSink)(nil)
+	_ observability.Metrics = (*csvSink)(nil)
+)
+
+// newCSVSink returns an empty recorder.
+func newCSVSink() *csvSink {
+	return &csvSink{rows: make(map[rowKey]*series)}
+}
+
+// HotPhase records one phase of one hot ledger ingest into hot.csv, and
+// reconstructs the per-ledger end-to-end ingest_total for driver.csv from the
+// phase burst.
+//
+// The production hot loop (runIngestionLoop) is a SINGLE goroutine, so HotPhase
+// signals arrive as strict per-ledger bursts in hotchunk.Phase order:
+// extract → ledgers → txhash → events → commit → apply, one burst per ledger.
+// The phases partition the per-ledger IngestLedger wall-clock, so their sum IS
+// the per-ledger total — a number per-phase percentiles can't recover
+// (percentiles don't sum). PhaseExtract (always first) resets the accumulator
+// for a new ledger; PhaseApply (terminal, emitted on the success path only —
+// never the failed phase) records one ingest_total sample with items=1. A
+// failed ledger never reaches PhaseApply, so it contributes nothing (the run
+// aborts and partial CSVs are written anyway).
+//
+// The accumulator is mutex-guarded so the sink stays safe under the MetricSink
+// contract regardless; only the production single-writer pattern yields
+// meaningful sums (interleaved bursts would sum across ledgers, never race).
+func (s *csvSink) HotPhase(phase hotchunk.Phase, d time.Duration, items int, _ error) {
+	s.observe(fileHot, phase.String(), d, items)
+
+	// Accumulator under its own critical section, released before the observe
+	// below so the two locks are sequential, never nested.
+	s.mu.Lock()
+	if phase == hotchunk.PhaseExtract {
+		s.hotBurst = 0
+	}
+	s.hotBurst += d
+	total := s.hotBurst
+	s.mu.Unlock()
+
+	if phase == hotchunk.PhaseApply {
+		s.observe(fileDriver, driverIngestTotal, total, 1)
+	}
+}
+
+// ColdIngest records one cold ingester's per-chunk total.
+func (s *csvSink) ColdIngest(dataType string, d time.Duration, items int, _ error) {
+	s.observe(fileDriver, dataType+driverTotalSuffix, d, items)
+}
+
+// ColdChunkTotal records the per-chunk aggregate wall-clock.
+func (s *csvSink) ColdChunkTotal(d time.Duration) {
+	s.observe(fileDriver, driverChunkTotal, d, 0)
+}
+
+// ColdExtract records the shared per-ledger ExtractLedgerEvents walk —
+// ledger-scoped and type-less, so it lands in driver.csv (see
+// driverColdExtract).
+func (s *csvSink) ColdExtract(d time.Duration, items int, _ error) {
+	s.observe(fileDriver, driverColdExtract, d, items)
+}
+
+// IngestStage records one cold ingester's per-stage wall-clock.
+func (s *csvSink) IngestStage(dataType, stage string, d time.Duration, items int) {
+	s.observe(dataType, stage, d, items)
+}
+
+// Freeze records one backfill pass's whole plan-and-execute wall-clock.
+func (s *csvSink) Freeze(d time.Duration) {
+	s.observe(fileDriver, driverBackfillWall, d, 0)
+}
+
+// Rebuild records one txhash index build's wall-clock (including its eager
+// post-build sweep).
+func (s *csvSink) Rebuild(d time.Duration) {
+	s.observe(fileDriver, driverIndexRebuild, d, 0)
+}
+
+// LastCommitted tracks the hot loop's per-ledger committed gauge (see lastSeq).
+func (s *csvSink) LastCommitted(lastCommitted uint32) {
+	s.lastSeq.Store(lastCommitted)
+}
+
+// The remaining observability signals carry no useful bench signal and are
+// accepted and dropped — Prune does fire (from each index build's eager
+// sweep) but its wall is already inside Rebuild; the others never fire.
+
+func (s *csvSink) RetentionFloor(uint32) {}
+
+func (s *csvSink) ChunkBoundary() {}
+
+func (s *csvSink) LiveHotChunks(int) {}
+
+func (s *csvSink) BackfillPass(time.Duration) {}
+
+func (s *csvSink) Discard(int, time.Duration) {}
+
+func (s *csvSink) Prune(int, time.Duration) {}
+
+// observe appends one sample to the (file, row) series, creating it on first
+// use. Every recording method lands here. (funcorder pins it below the
+// exported methods it serves.)
+func (s *csvSink) observe(fileName, rowName string, d time.Duration, items int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	k := rowKey{file: fileName, row: rowName}
+	sr := s.rows[k]
+	if sr == nil {
+		sr = &series{}
+		s.rows[k] = sr
+	}
+	sr.observe(d, items)
+}
+
+// lastCommittedSeq returns the highest ledger the hot loop reported committed.
+func (s *csvSink) lastCommittedSeq() uint32 {
+	return s.lastSeq.Load()
+}
+
+// sumDriver returns the summed duration of a driver row's samples — the
+// numerator of the cold driver's effective-concurrency summary.
+func (s *csvSink) sumDriver(name string) time.Duration {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var total time.Duration
+	if sr := s.rows[rowKey{file: fileDriver, row: name}]; sr != nil {
+		for _, sm := range sr.samples {
+			total += sm.d
+		}
+	}
+	return total
+}
+
+// row is one aggregated CSV row.
+type row struct {
+	name  string
+	n     int
+	items int
+	total time.Duration
+	p50   time.Duration
+	p90   time.Duration
+	p99   time.Duration
+	maxv  time.Duration
+}
+
+// aggregate reduces a series to a row, filtering out zero-duration samples so
+// work too fast for the timer (an empty ledger's stage) doesn't skew the
+// percentiles. ok is false when no sample survives the filter — the row is
+// suppressed.
+func aggregate(name string, s *series) (row, bool) {
+	durs := make([]time.Duration, 0, len(s.samples))
+	items := 0
+	for _, sm := range s.samples {
+		if sm.d > 0 {
+			durs = append(durs, sm.d)
+			items += sm.items
+		}
+	}
+	if len(durs) == 0 {
+		return row{}, false
+	}
+	slices.Sort(durs)
+	var total time.Duration
+	for _, d := range durs {
+		total += d
+	}
+	pick := func(p float64) time.Duration {
+		i := int(p * float64(len(durs)))
+		if i >= len(durs) {
+			i = len(durs) - 1
+		}
+		return durs[i]
+	}
+	return row{
+		name: name, n: len(durs), items: items, total: total,
+		p50: pick(0.50), p90: pick(0.90), p99: pick(0.99), maxv: durs[len(durs)-1],
+	}, true
+}
+
+// withUnknown returns order plus any keys of m not already in it, sorted and
+// appended after the known order, so a recorded label outside the known
+// vocabulary still appears, after the known rows.
+func withUnknown[V any](order []string, m map[string]V) []string {
+	var extra []string
+	for k := range m {
+		if !slices.Contains(order, k) {
+			extra = append(extra, k)
+		}
+	}
+	if len(extra) == 0 {
+		return order
+	}
+	slices.Sort(extra)
+	return append(slices.Clone(order), extra...)
+}
+
+// file is one aggregated CSV file: its basename (without .csv) and its rows.
+type file struct {
+	name string
+	rows []row
+}
+
+// files aggregates every recorded series into the report's CSV files, in
+// fileSpecs order (a file outside the schema is appended after, sorted, its
+// rows ordered by sorted label).
+func (s *csvSink) files() []file {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	byFile := make(map[string]map[string]*series)
+	for k, sr := range s.rows {
+		if byFile[k.file] == nil {
+			byFile[k.file] = make(map[string]*series)
+		}
+		byFile[k.file][k.row] = sr
+	}
+
+	names := make([]string, len(fileSpecs))
+	rowOrders := make(map[string][]string, len(fileSpecs))
+	for i, spec := range fileSpecs {
+		names[i] = spec.name
+		rowOrders[spec.name] = spec.rowOrder
+	}
+
+	var out []file
+	for _, name := range withUnknown(names, byFile) {
+		byRow := byFile[name]
+		var rows []row
+		for _, label := range withUnknown(rowOrders[name], byRow) {
+			if sr := byRow[label]; sr != nil {
+				if r, ok := aggregate(label, sr); ok {
+					rows = append(rows, r)
+				}
+			}
+		}
+		if len(rows) > 0 {
+			out = append(out, file{name: name, rows: rows})
+		}
+	}
+	return out
+}
+
+// writeCSVs writes every non-empty aggregated CSV under outDir (created if
+// missing) and returns the files it wrote.
+func (s *csvSink) writeCSVs(outDir string) ([]string, error) {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir %s: %w", outDir, err)
+	}
+	var written []string
+	for _, f := range s.files() {
+		path := filepath.Join(outDir, f.name+".csv")
+		if err := writeCSV(path, f.rows); err != nil {
+			return written, err
+		}
+		written = append(written, path)
+	}
+	return written, nil
+}
+
+func writeCSV(path string, rows []row) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := fmt.Fprintln(f, csvHeader); err != nil {
+		return fmt.Errorf("write header: %w", err)
+	}
+	for _, r := range rows {
+		if _, err := fmt.Fprintf(f, "%s,%d,%d,%d,%d,%d,%d,%d\n",
+			r.name, r.n, r.items, r.total.Nanoseconds(),
+			r.p50.Nanoseconds(), r.p90.Nanoseconds(), r.p99.Nanoseconds(), r.maxv.Nanoseconds(),
+		); err != nil {
+			return fmt.Errorf("write row %s: %w", r.name, err)
+		}
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", path, err)
+	}
+	return nil
+}
+
+// logSummary logs one percentile line per aggregated row, through the logger
+// (forbidigo bans fmt.Print*).
+func (s *csvSink) logSummary(logger *supportlog.Entry) {
+	for _, f := range s.files() {
+		for _, r := range f.rows {
+			logger.Infof("%-10s %-12s n=%-7d items=%-9d total=%-12s p50=%-10s p90=%-10s p99=%-10s max=%s",
+				f.name, r.name, r.n, r.items,
+				r.total.Round(time.Microsecond),
+				r.p50.Round(time.Microsecond),
+				r.p90.Round(time.Microsecond),
+				r.p99.Round(time.Microsecond),
+				r.maxv.Round(time.Microsecond))
+		}
+	}
+}

--- a/cmd/stellar-rpc/internal/fullhistory/bench/csvsink_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/bench/csvsink_test.go
@@ -1,0 +1,153 @@
+package bench
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk"
+)
+
+// TestCSVSinkExactOutput replays a fixed signal sequence from two goroutines
+// and asserts the exact CSV bytes: aggregation is order-independent (sorted
+// percentiles, summed totals), so the concurrent interleaving must not change
+// the report. Covers both sink interfaces (ingest.MetricSink and the
+// observability.Metrics signals RunBackfill emits), the zero-duration
+// exclusion rule, row suppression, file suppression (no per-type txhash or
+// events stage signals → no txhash.csv / events.csv), and the fixed row
+// orders.
+func TestCSVSinkExactOutput(t *testing.T) {
+	sink := newCSVSink()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		sink.ColdExtract(10, 1, nil)
+		sink.ColdExtract(20, 2, nil)
+		sink.ColdExtract(0, 5, nil) // zero duration: excluded, items dropped
+		sink.IngestStage("ledgers", "write", 5, 1)
+		sink.IngestStage("ledgers", "finalize", 7, 0)
+		sink.ColdIngest("ledgers", 100, 10000, nil)
+		sink.HotPhase(hotchunk.PhaseExtract, 10, 0, nil)
+		sink.Freeze(300)
+	}()
+	go func() {
+		defer wg.Done()
+		sink.ColdExtract(30, 3, nil)
+		sink.ColdExtract(40, 4, nil)
+		sink.IngestStage("ledgers", "write", 5, 1)
+		sink.ColdIngest("events", 50, 20, nil)
+		sink.ColdChunkTotal(200)
+		sink.Rebuild(40)
+		sink.HotPhase(hotchunk.PhaseCommit, 50, 0, nil)
+		sink.HotPhase(hotchunk.PhaseCommit, 60, 3, nil)
+	}()
+	wg.Wait()
+
+	outDir := t.TempDir()
+	written, err := sink.writeCSVs(outDir)
+	require.NoError(t, err)
+	require.Len(t, written, 3)
+
+	want := map[string]string{
+		"ledgers.csv": csvHeader + "\n" +
+			"write,2,2,10,5,5,5,5\n" +
+			"finalize,1,0,7,7,7,7,7\n",
+		"hot.csv": csvHeader + "\n" +
+			"extract,1,0,10,10,10,10,10\n" +
+			"commit,2,3,110,60,60,60,60\n",
+		"driver.csv": csvHeader + "\n" +
+			"backfill_wall,1,0,300,300,300,300,300\n" +
+			"index_rebuild,1,0,40,40,40,40,40\n" +
+			"chunk_total,1,0,200,200,200,200,200\n" +
+			"ledgers_total,1,10000,100,100,100,100,100\n" +
+			"events_total,1,20,50,50,50,50,50\n" +
+			"cold_extract,4,10,100,30,40,40,40\n",
+	}
+	for name, content := range want {
+		got, rerr := os.ReadFile(filepath.Join(outDir, name))
+		require.NoError(t, rerr, name)
+		assert.Equal(t, content, string(got), name)
+	}
+	assert.NoFileExists(t, filepath.Join(outDir, "txhash.csv"))
+	assert.NoFileExists(t, filepath.Join(outDir, "events.csv"))
+}
+
+// TestCSVSinkHotIngestTotal drives the ingest_total reconstruction directly:
+// two complete per-ledger HotPhase bursts (extract→ledgers→txhash→events→
+// commit→apply) plus one FAILED burst (extract, then a phase carrying an error,
+// no apply). Only PhaseApply — the terminal, success-only phase — emits an
+// ingest_total sample, so the failed burst contributes nothing; each complete
+// burst contributes one sample (items=1) whose duration is the sum of that
+// burst's phases.
+func TestCSVSinkHotIngestTotal(t *testing.T) {
+	sink := newCSVSink()
+
+	// burst plays one complete per-ledger phase burst, each phase 1ns longer
+	// than the last, so its six phases sum to base*6+21ns.
+	burst := func(base time.Duration) {
+		sink.HotPhase(hotchunk.PhaseExtract, base+1, 0, nil)
+		sink.HotPhase(hotchunk.PhaseLedgers, base+2, 1, nil)
+		sink.HotPhase(hotchunk.PhaseTxhash, base+3, 4, nil)
+		sink.HotPhase(hotchunk.PhaseEvents, base+4, 2, nil)
+		sink.HotPhase(hotchunk.PhaseCommit, base+5, 0, nil)
+		sink.HotPhase(hotchunk.PhaseApply, base+6, 0, nil)
+	}
+	burst(100) // 6*100 + 21 = 621
+	burst(200) // 6*200 + 21 = 1221
+
+	// A failed ledger: extract ran, then PhaseCommit failed — no apply, so no
+	// ingest_total sample.
+	sink.HotPhase(hotchunk.PhaseExtract, 10, 0, nil)
+	sink.HotPhase(hotchunk.PhaseCommit, 20, 0, errors.New("commit failed"))
+
+	outDir := t.TempDir()
+	_, err := sink.writeCSVs(outDir)
+	require.NoError(t, err)
+
+	driver := readCSV(t, filepath.Join(outDir, "driver.csv"))
+	require.Contains(t, driver, "ingest_total")
+	assert.EqualValues(t, 2, driver["ingest_total"]["n"])
+	assert.EqualValues(t, 2, driver["ingest_total"]["n_items"])
+	assert.EqualValues(t, 621+1221, driver["ingest_total"]["total_ns"])
+}
+
+// TestCSVSinkEmpty asserts a sink with no signals writes no files.
+func TestCSVSinkEmpty(t *testing.T) {
+	outDir := t.TempDir()
+	written, err := newCSVSink().writeCSVs(outDir)
+	require.NoError(t, err)
+	assert.Empty(t, written)
+	entries, err := os.ReadDir(outDir)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+// TestCSVSinkLastCommitted pins the gauge semantics the hot driver's
+// completion check relies on: latest value wins, and dropped observability
+// signals stay dropped.
+func TestCSVSinkLastCommitted(t *testing.T) {
+	sink := newCSVSink()
+	assert.Zero(t, sink.lastCommittedSeq())
+	sink.LastCommitted(41)
+	sink.LastCommitted(42)
+	assert.EqualValues(t, 42, sink.lastCommittedSeq())
+
+	// Dropped signals must not fabricate CSV rows.
+	sink.RetentionFloor(7)
+	sink.ChunkBoundary()
+	sink.LiveHotChunks(3)
+	sink.BackfillPass(10)
+	sink.Discard(1, 10)
+	sink.Prune(2, 10)
+	written, err := sink.writeCSVs(t.TempDir())
+	require.NoError(t, err)
+	assert.Empty(t, written)
+}

--- a/cmd/stellar-rpc/internal/fullhistory/bench/doc.go
+++ b/cmd/stellar-rpc/internal/fullhistory/bench/doc.go
@@ -1,0 +1,11 @@
+// Package bench benchmarks full-history ingestion: the cold backfill that
+// bulk-materializes past ledgers at startup, and the hot loop that ingests the
+// live stream as it advances.
+//
+// A run drives the daemon's production ingestion code over a
+// benchmark-controlled ledger source and times it: cold calls
+// backfill.RunBackfill, hot calls the production ingestion loop. Both report
+// their per-stage timings through the MetricSink and observability.Metrics
+// interfaces; a csvSink implements those interfaces, collects the signals, and
+// aggregates each run into percentile CSV reports.
+package bench

--- a/cmd/stellar-rpc/internal/fullhistory/bench/hot.go
+++ b/cmd/stellar-rpc/internal/fullhistory/bench/hot.go
@@ -1,0 +1,165 @@
+package bench
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"os"
+	"time"
+
+	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/config"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/geometry"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+)
+
+// hotOptions configures one hot-ingest benchmark run.
+type hotOptions struct {
+	// Source is the ledger source the loop reads from: a local pack tree or a
+	// BSB datastore.
+	Source sourceConfig
+
+	// StartChunk and NumChunks give the chunk range to ingest,
+	// [StartChunk, StartChunk+NumChunks). A range spanning more than one chunk
+	// crosses a chunk boundary, exercising the loop's hot-DB rotation.
+	StartChunk chunk.ID
+	NumChunks  int
+
+	// NumLedgers caps how many ledgers are ingested from the range's start
+	// (0 = the whole range). fsync-per-ledger makes full runs slow, so a cap
+	// gives a cheap smoke run without changing what is measured per ledger; a
+	// cap below one chunk never reaches a boundary.
+	NumLedgers uint32
+
+	// HotRoot is the scratch root the hot RocksDBs are created under, at
+	// geometry.NewLayout(HotRoot).HotChunkPath(chunk). Each chunk's DB is
+	// opened through the production create bracket, which wipes any leftover
+	// dir, so every run starts from an empty DB (hot timings are only
+	// comparable from a fixed starting state).
+	HotRoot string
+
+	// CatalogDir is the base dir the run-scoped scratch catalog is created
+	// under. Empty means HotRoot.
+	CatalogDir string
+
+	// OutDir receives the CSV report.
+	OutDir string
+}
+
+// validate checks the flags and chunk range before runHot touches the
+// filesystem.
+func (o hotOptions) validate() error {
+	if o.HotRoot == "" {
+		return errors.New("--hot-dir is required")
+	}
+	if o.NumChunks < 1 {
+		return fmt.Errorf("--num-chunks must be >= 1, got %d", o.NumChunks)
+	}
+	if end := uint64(o.StartChunk) + uint64(o.NumChunks) - 1; end > uint64(maxChunkID) {
+		return fmt.Errorf("--start-chunk=%d with --num-chunks=%d ends at chunk %d, past the last valid chunk ID %d",
+			uint32(o.StartChunk), o.NumChunks, end, uint32(maxChunkID))
+	}
+	return nil
+}
+
+// runHot benchmarks the hot path: the daemon's ingestion loop (via
+// fullhistory.RunBoundedIngestionLoop) over the range's ledgers, into fresh hot
+// DBs opened through a scratch catalog. A no-op boundary discards completed
+// chunks so no cold-path freeze runs, isolating the hot measurement. The sink
+// collects the loop's per-phase HotPhase timings; on success runHot records the
+// whole-run wall-clock and writes the CSV report.
+func runHot(ctx context.Context, logger *supportlog.Entry, opts hotOptions) error {
+	if err := opts.validate(); err != nil {
+		return err
+	}
+	// Surface an unwritable --out before the expensive run, not after it.
+	if err := os.MkdirAll(opts.OutDir, 0o755); err != nil {
+		return fmt.Errorf("create --out dir %s: %w", opts.OutDir, err)
+	}
+	layout := geometry.NewLayout(opts.HotRoot)
+	// Create + fsync the hot root up front — the daemon's own root prep.
+	if err := config.PrepareRoots(layout.HotRoot()); err != nil {
+		return fmt.Errorf("prepare --hot-dir hot root: %w", err)
+	}
+	catalogBase := opts.CatalogDir
+	if catalogBase == "" {
+		catalogBase = opts.HotRoot
+	}
+	cat, releaseCat, err := openScratchCatalog(catalogBase, layout, logger)
+	if err != nil {
+		return err
+	}
+	defer releaseCat()
+
+	backend, release, err := openSource(ctx, opts.Source)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	first := opts.StartChunk.FirstLedger()
+	//nolint:gosec // validate() proved StartChunk+NumChunks-1 <= maxChunkID
+	last := (opts.StartChunk + chunk.ID(uint32(opts.NumChunks-1))).LastLedger()
+	// Overflow-safe cap: compare against the range's span rather than adding
+	// a flag-supplied count to a ledger sequence.
+	if span := last - first + 1; opts.NumLedgers > 0 && opts.NumLedgers < span {
+		last = first + opts.NumLedgers - 1
+	}
+
+	sink := newCSVSink()
+	start := time.Now()
+	err = fullhistory.RunBoundedIngestionLoop(ctx, fullhistory.BoundedIngestConfig{
+		Stream:   boundedStream{inner: backend, first: first, last: last},
+		Resume:   first,
+		Catalog:  cat,
+		Boundary: nopBoundary{},
+		Logger:   logger,
+		Metrics:  sink,
+		Sink:     sink,
+	})
+	// The loop cannot tell a complete bounded stream from one that ran dry;
+	// the sink's last-committed gauge (set once per ingested ledger) can.
+	if err == nil && sink.lastCommittedSeq() != last {
+		err = fmt.Errorf("stream ended at seq %d, expected through %d", sink.lastCommittedSeq(), last)
+	}
+	if err != nil {
+		writePartialCSVs(logger, sink, opts.OutDir)
+		return err
+	}
+	sink.observe(fileDriver, driverRunWall, time.Since(start), int(last-first+1))
+
+	sink.logSummary(logger)
+	written, err := sink.writeCSVs(opts.OutDir)
+	if err != nil {
+		return err
+	}
+	logger.Infof("wrote %d CSVs to %s", len(written), opts.OutDir)
+	return nil
+}
+
+// boundedStream pins the range a LedgerStream serves. The ingestion loop always
+// requests an unbounded range, so the bench wraps its source to serve only
+// [first, last]; the stream then ends after last, which is what stops the loop.
+type boundedStream struct {
+	inner       ledgerbackend.LedgerStream
+	first, last uint32
+}
+
+// RawLedgers serves inner's ledgers clamped to [first, last], ignoring the
+// range the loop asks for.
+func (b boundedStream) RawLedgers(
+	ctx context.Context, _ ledgerbackend.Range, opts ...ledgerbackend.StreamOption,
+) iter.Seq2[[]byte, error] {
+	return b.inner.RawLedgers(ctx, ledgerbackend.BoundedRange(b.first, b.last), opts...)
+}
+
+// nopBoundary discards the ingestion loop's boundary publications: a bounded
+// bench run has no lifecycle to hand completed chunks to, so nothing is handed
+// off to a freeze — keeping the hot measurement isolated from the cold path.
+type nopBoundary struct{}
+
+func (nopBoundary) Publish(chunk.ID) {}

--- a/cmd/stellar-rpc/internal/fullhistory/bench/profile.go
+++ b/cmd/stellar-rpc/internal/fullhistory/bench/profile.go
@@ -1,0 +1,72 @@
+package bench
+
+import (
+	"fmt"
+	"os"
+	"runtime/pprof"
+
+	"github.com/spf13/cobra"
+
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+)
+
+// profileFlags is the optional Go-profiling flag pair shared by both
+// subcommands.
+type profileFlags struct {
+	cpuProfile string
+	memProfile string
+}
+
+func (p *profileFlags) bind(cmd *cobra.Command) {
+	fs := cmd.Flags()
+	fs.StringVar(&p.cpuProfile, "cpuprofile", "", "write a Go CPU profile to PATH")
+	fs.StringVar(&p.memProfile, "memprofile", "",
+		"write a Go allocation profile to PATH (read it with `go tool pprof -alloc_space`)")
+}
+
+// around runs fn under the optional profiles: the CPU profile spans the whole
+// run; the heap profile is written once fn returns (see writeHeapProfile).
+func (p *profileFlags) around(logger *supportlog.Entry, fn func() error) error {
+	if p.cpuProfile != "" {
+		f, err := os.Create(p.cpuProfile)
+		if err != nil {
+			return fmt.Errorf("create %s: %w", p.cpuProfile, err)
+		}
+		if err := pprof.StartCPUProfile(f); err != nil {
+			_ = f.Close()
+			return fmt.Errorf("start CPU profile: %w", err)
+		}
+		defer func() {
+			pprof.StopCPUProfile()
+			_ = f.Close()
+			logger.Infof("wrote CPU profile to %s", p.cpuProfile)
+		}()
+	}
+	err := fn()
+	if p.memProfile != "" {
+		p.writeHeapProfile(logger)
+	}
+	return err
+}
+
+// writeHeapProfile writes the heap profile to --memprofile. Read it as an
+// ALLOCATION profile (`go tool pprof -alloc_space`): that view is cumulative —
+// every byte the run allocated, whether or not it was later freed — so writing
+// it here, after the run's stores have closed, still captures the full picture.
+// The default `-inuse_space` view is a live snapshot taken after teardown and
+// under-reports, so it is not what this profile is for. No GC is forced:
+// alloc_space is unaffected by collection, so there is nothing to gain by
+// perturbing the run.
+func (p *profileFlags) writeHeapProfile(logger *supportlog.Entry) {
+	f, err := os.Create(p.memProfile)
+	if err != nil {
+		logger.Errorf("create %s: %v", p.memProfile, err)
+		return
+	}
+	defer func() { _ = f.Close() }()
+	if err := pprof.WriteHeapProfile(f); err != nil {
+		logger.Errorf("write heap profile: %v", err)
+		return
+	}
+	logger.Infof("wrote heap profile to %s", p.memProfile)
+}

--- a/cmd/stellar-rpc/internal/fullhistory/bench/scratch.go
+++ b/cmd/stellar-rpc/internal/fullhistory/bench/scratch.go
@@ -1,0 +1,42 @@
+package bench
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/catalog"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/geometry"
+)
+
+const catalogBaseDirPerm os.FileMode = 0o755 // owner rwx, group/others rx
+
+// openScratchCatalog creates a fresh catalog in a temp dir under catalogBase
+// and returns a release func that closes it and removes that temp dir.
+func openScratchCatalog(
+	catalogBase string, layout geometry.Layout, logger *supportlog.Entry,
+) (*catalog.Catalog, func(), error) {
+	if err := os.MkdirAll(catalogBase, catalogBaseDirPerm); err != nil {
+		return nil, nil, fmt.Errorf("create catalog base dir %s: %w", catalogBase, err)
+	}
+	dir, err := os.MkdirTemp(catalogBase, "bench-ingest-catalog-")
+	if err != nil {
+		return nil, nil, fmt.Errorf("create scratch catalog dir: %w", err)
+	}
+	txLayout, err := geometry.NewTxHashIndexLayout(geometry.ChunksPerTxhashIndex)
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, nil, err
+	}
+	cat, err := catalog.Open(filepath.Join(dir, "catalog"), layout, txLayout, logger)
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, nil, fmt.Errorf("open scratch catalog: %w", err)
+	}
+	return cat, func() {
+		_ = cat.Close()
+		_ = os.RemoveAll(dir)
+	}, nil
+}

--- a/cmd/stellar-rpc/internal/fullhistory/bench/sources.go
+++ b/cmd/stellar-rpc/internal/fullhistory/bench/sources.go
@@ -1,0 +1,173 @@
+package bench
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"math"
+	"os"
+	"time"
+
+	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
+	"github.com/stellar/go-stellar-sdk/support/datastore"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/backfill"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/geometry"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/ledger"
+)
+
+// Source identifiers accepted by the --source flag.
+const (
+	sourcePack = "pack"
+	sourceBSB  = "bsb"
+)
+
+// sourceConfig selects and configures the benchmark ledger source. Both
+// implementations satisfy backfill.Backend, the source interface the production
+// backfill reads through, so the drivers behave the same whichever source they
+// get.
+type sourceConfig struct {
+	// Kind selects the source implementation: sourcePack or sourceBSB.
+	Kind string
+
+	// PackDir is the pack source's ledgers tree root — the directory holding
+	// {bucket:05d}/{chunk:08d}.pack, i.e. geometry.Layout's ledgers root of an
+	// existing full-history deployment. Required when Kind is sourcePack.
+	PackDir string
+
+	// BucketPath is the BSB source's datastore bucket
+	// (destination_bucket_path), e.g. sdf-ledger-close-meta/v1/ledgers/pubnet.
+	// For --datastore-type=Filesystem it is the lake's local directory
+	// (destination_path). Required when Kind is sourceBSB.
+	BucketPath string
+
+	// BufferSize is the BSB prefetch buffer depth PER WORKER: total prefetch
+	// multiplies by the cold driver's Workers. Zero falls back to the backfill
+	// package's benchmarked default.
+	BufferSize uint32
+
+	// NumWorkers is the BSB download concurrency PER WORKER: total downloads
+	// in flight multiply by the cold driver's Workers. Zero falls back to the
+	// backfill package's benchmarked default.
+	NumWorkers uint32
+
+	// RetryLimit caps BSB download retries on transient datastore errors.
+	// Zero falls back to the backfill package's default — retries cannot be
+	// disabled.
+	RetryLimit uint32
+
+	// RetryWait is the pause between BSB download retries. Zero falls back to
+	// the backfill package's default.
+	RetryWait time.Duration
+
+	// DatastoreType selects the SDK datastore backing the BSB source:
+	// "GCS", "S3", or "Filesystem" (a local lake directory, for deterministic
+	// runs without network).
+	DatastoreType string
+
+	// Region is the bucket region handed to the SDK datastore. The S3
+	// datastore requires it; the others ignore it.
+	Region string
+}
+
+// openSource resolves cfg into a backfill.Backend — the LedgerStream + frontier
+// Tip pair the production freeze path fetches from — plus a release func for any
+// run-long resources (the BSB Tip datastore handle).
+//
+//   - pack: a packBackend over the frozen ledgers tree under PackDir. Local and
+//     fully repeatable.
+//   - bsb: the production BSB source (backfill.NewBSBBackendFromConfig) over a
+//     GCS, S3, or Filesystem datastore, with its benchmarked default tuning.
+//     Each RawLedgers call owns an independent datastore + prefetch lifecycle,
+//     so concurrent workers do not contend on shared cursor state.
+func openSource(ctx context.Context, cfg sourceConfig) (backfill.Backend, func(), error) {
+	noop := func() {}
+	switch cfg.Kind {
+	case sourcePack:
+		if cfg.PackDir == "" {
+			return nil, noop, errors.New("--pack-dir is required when --source=pack")
+		}
+		return packBackend{root: cfg.PackDir}, noop, nil
+	case sourceBSB:
+		if cfg.BucketPath == "" {
+			return nil, noop, errors.New("--bucket-path is required when --source=bsb")
+		}
+		// GCS/S3 name their bucket via destination_bucket_path; the Filesystem
+		// datastore names its local root via destination_path.
+		pathKey := "destination_bucket_path"
+		if cfg.DatastoreType == "Filesystem" {
+			pathKey = "destination_path"
+		}
+		params := map[string]string{pathKey: cfg.BucketPath}
+		if cfg.Region != "" {
+			params["region"] = cfg.Region
+		}
+		backend, release, err := backfill.NewBSBBackendFromConfig(ctx,
+			datastore.DataStoreConfig{Type: cfg.DatastoreType, Params: params},
+			ledgerbackend.BufferedStorageBackendConfig{
+				BufferSize: cfg.BufferSize,
+				NumWorkers: cfg.NumWorkers,
+				RetryLimit: cfg.RetryLimit,
+				RetryWait:  cfg.RetryWait,
+			})
+		if err != nil {
+			return nil, noop, fmt.Errorf("open BSB backend: %w", err)
+		}
+		return backend, release, nil
+	default:
+		return nil, noop, fmt.Errorf("--source=%s; expected %s|%s", cfg.Kind, sourcePack, sourceBSB)
+	}
+}
+
+// packBackend adapts a frozen local ledgers tree (--pack-dir) to
+// backfill.Backend: RawLedgers routes each requested range to the per-chunk
+// .pack files it spans (in order, so a multi-chunk range concatenates their
+// packs), and Tip reports no frontier to wait on — a local pack is either
+// present (the stream opens) or missing (a fast, clear error), so there is
+// nothing for the freeze path's coverage wait to poll.
+type packBackend struct {
+	// root is the source ledgers tree holding {bucket:05d}/{chunk:08d}.pack.
+	root string
+}
+
+var _ backfill.Backend = packBackend{}
+
+// RawLedgers streams [rng.From(), rng.To()] by walking the chunks the range
+// spans and delegating each chunk's sub-range to its pack's own stream. Pack
+// paths are derived through geometry.LedgerPackPath — the single home of the
+// path formula — never composed by hand.
+func (p packBackend) RawLedgers(
+	ctx context.Context, rng ledgerbackend.Range, _ ...ledgerbackend.StreamOption,
+) iter.Seq2[[]byte, error] {
+	return func(yield func([]byte, error) bool) {
+		if !rng.Bounded() {
+			yield(nil, fmt.Errorf("pack source requires a bounded range, got %s", rng))
+			return
+		}
+		for c := chunk.IDFromLedger(rng.From()); c <= chunk.IDFromLedger(rng.To()); c++ {
+			path := geometry.LedgerPackPath(p.root, c)
+			if _, err := os.Stat(path); err != nil {
+				yield(nil, fmt.Errorf("stat source pack %s: %w", path, err))
+				return
+			}
+			sub := ledgerbackend.BoundedRange(max(rng.From(), c.FirstLedger()), min(rng.To(), c.LastLedger()))
+			for raw, err := range ledger.NewPackStream(path).RawLedgers(ctx, sub) {
+				if !yield(raw, err) {
+					return
+				}
+				if err != nil {
+					return
+				}
+			}
+		}
+	}
+}
+
+// Tip reports the maximum ledger. Local packs have no advancing frontier, so
+// the freeze path's coverage wait always passes immediately; a missing pack
+// then surfaces through RawLedgers as a clear open error.
+func (p packBackend) Tip(context.Context) (uint32, error) {
+	return math.MaxUint32, nil
+}

--- a/cmd/stellar-rpc/internal/fullhistory/config/config.go
+++ b/cmd/stellar-rpc/internal/fullhistory/config/config.go
@@ -34,6 +34,26 @@ type Config struct {
 	Backfill  BackfillConfig  `toml:"backfill"`
 	Ingestion IngestionConfig `toml:"ingestion"`
 	Logging   LoggingConfig   `toml:"logging"`
+	Serve     ServeConfig     `toml:"serve"`
+}
+
+// ServeConfig is [serve] — the read-side JSON-RPC server (query POC). An empty
+// endpoint disables serving (the default), so a pure ingestion/backfill daemon
+// needs no [serve] section at all. The per-endpoint limits mirror the v1 RPC
+// getLedgers/getTransactions/getEvents caps; they are pointers so an absent key
+// is distinguishable from an explicit zero, with the v1 defaults filled in
+// WithDefaults.
+type ServeConfig struct {
+	// Endpoint is the host:port the JSON-RPC server listens on; "" disables
+	// serving. Use host:0 to bind an OS-assigned port (benchmark harness).
+	Endpoint string `toml:"endpoint"`
+
+	MaxLedgersLimit          *uint `toml:"max_ledgers_limit"`          // v1 default 200
+	DefaultLedgersLimit      *uint `toml:"default_ledgers_limit"`      // v1 default 50
+	MaxTransactionsLimit     *uint `toml:"max_transactions_limit"`     // v1 default 200
+	DefaultTransactionsLimit *uint `toml:"default_transactions_limit"` // v1 default 50
+	MaxEventsLimit           *uint `toml:"max_events_limit"`           // v1 default 10000
+	DefaultEventsLimit       *uint `toml:"default_events_limit"`       // v1 default 100
 }
 
 // ServiceConfig is [service].
@@ -138,6 +158,19 @@ const (
 	DefaultEarliestLedger = EarliestGenesis
 )
 
+// [serve] per-endpoint limit defaults, copied verbatim from the v1 RPC config
+// (cmd/stellar-rpc/internal/config/options.go: max/default ledgers 200/50,
+// transactions 200/50, events 10000/100). Filled by WithDefaults so the server
+// mounts identically whether or not [serve] pins them.
+const (
+	DefaultServeMaxLedgersLimit          uint = 200
+	DefaultServeDefaultLedgersLimit      uint = 50
+	DefaultServeMaxTransactionsLimit     uint = 200
+	DefaultServeDefaultTransactionsLimit uint = 50
+	DefaultServeMaxEventsLimit           uint = 10000
+	DefaultServeDefaultEventsLimit       uint = 100
+)
+
 // LoadConfig reads and parses the TOML config at path. It applies defaults but
 // does NOT validate semantics or touch any pin — that is validateConfig's job.
 // See ParseConfig.
@@ -190,7 +223,23 @@ func (cfg Config) WithDefaults() Config {
 	if cfg.Logging.Format == "" {
 		cfg.Logging.Format = DefaultLogFormat
 	}
+	fillUint(&cfg.Serve.MaxLedgersLimit, DefaultServeMaxLedgersLimit)
+	fillUint(&cfg.Serve.DefaultLedgersLimit, DefaultServeDefaultLedgersLimit)
+	fillUint(&cfg.Serve.MaxTransactionsLimit, DefaultServeMaxTransactionsLimit)
+	fillUint(&cfg.Serve.DefaultTransactionsLimit, DefaultServeDefaultTransactionsLimit)
+	fillUint(&cfg.Serve.MaxEventsLimit, DefaultServeMaxEventsLimit)
+	fillUint(&cfg.Serve.DefaultEventsLimit, DefaultServeDefaultEventsLimit)
 	return cfg
+}
+
+// fillUint sets *p to def when the key was absent (nil pointer). An explicit
+// zero is preserved, matching the pointer-defaulting contract of the other
+// optional scalars above.
+func fillUint(p **uint, def uint) {
+	if *p == nil {
+		v := def
+		*p = &v
+	}
 }
 
 // Paths is the resolved set of on-disk paths the daemon uses — the single place

--- a/cmd/stellar-rpc/internal/fullhistory/config/config_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/config/config_test.go
@@ -48,6 +48,15 @@ captive_core_config = "/etc/captive-core.toml"
 [logging]
 level = "debug"
 format = "json"
+
+[serve]
+endpoint = "127.0.0.1:8100"
+max_ledgers_limit = 300
+default_ledgers_limit = 75
+max_transactions_limit = 400
+default_transactions_limit = 80
+max_events_limit = 20000
+default_events_limit = 250
 `
 
 // A minimal config: only the required keys, everything else defaulted.
@@ -87,6 +96,13 @@ func TestParseConfig_FullDocument(t *testing.T) {
 	assert.Equal(t, "/etc/captive-core.toml", cfg.Ingestion.CaptiveCoreConfig)
 	assert.Equal(t, "debug", cfg.Logging.Level)
 	assert.Equal(t, "json", cfg.Logging.Format)
+	assert.Equal(t, "127.0.0.1:8100", cfg.Serve.Endpoint)
+	assert.Equal(t, uint(300), *cfg.Serve.MaxLedgersLimit)
+	assert.Equal(t, uint(75), *cfg.Serve.DefaultLedgersLimit)
+	assert.Equal(t, uint(400), *cfg.Serve.MaxTransactionsLimit)
+	assert.Equal(t, uint(80), *cfg.Serve.DefaultTransactionsLimit)
+	assert.Equal(t, uint(20000), *cfg.Serve.MaxEventsLimit)
+	assert.Equal(t, uint(250), *cfg.Serve.DefaultEventsLimit)
 }
 
 func TestParseConfig_MinimalAppliesDefaults(t *testing.T) {
@@ -105,6 +121,17 @@ func TestParseConfig_MinimalAppliesDefaults(t *testing.T) {
 	assert.Equal(t, DefaultEarliestLedger, cfg.Retention.EarliestLedger)
 	assert.Equal(t, DefaultLogLevel, cfg.Logging.Level)
 	assert.Equal(t, DefaultLogFormat, cfg.Logging.Format)
+
+	// Serving is disabled by default (empty endpoint), but the per-endpoint
+	// limits are always filled to the v1 defaults so the server can mount its
+	// handlers without a nil deref regardless of whether [serve] is present.
+	assert.Equal(t, "", cfg.Serve.Endpoint)
+	assert.Equal(t, DefaultServeMaxLedgersLimit, *cfg.Serve.MaxLedgersLimit)
+	assert.Equal(t, DefaultServeDefaultLedgersLimit, *cfg.Serve.DefaultLedgersLimit)
+	assert.Equal(t, DefaultServeMaxTransactionsLimit, *cfg.Serve.MaxTransactionsLimit)
+	assert.Equal(t, DefaultServeDefaultTransactionsLimit, *cfg.Serve.DefaultTransactionsLimit)
+	assert.Equal(t, DefaultServeMaxEventsLimit, *cfg.Serve.MaxEventsLimit)
+	assert.Equal(t, DefaultServeDefaultEventsLimit, *cfg.Serve.DefaultEventsLimit)
 }
 
 func TestParseConfig_ExplicitZeroPreserved(t *testing.T) {
@@ -194,6 +221,18 @@ default_data_dir = "/d"
 [backfill.bsb]
 bucket_path = "b/p"
 bufer_size = 10
+[ingestion]
+captive_core_config = "/cc"
+`,
+		},
+		{
+			name: "unknown key under [serve]",
+			text: `
+[service]
+default_data_dir = "/d"
+[serve]
+endpoint = "127.0.0.1:8100"
+max_ledger_limit = 100
 [ingestion]
 captive_core_config = "/cc"
 `,

--- a/cmd/stellar-rpc/internal/fullhistory/config/config_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/config/config_test.go
@@ -125,7 +125,7 @@ func TestParseConfig_MinimalAppliesDefaults(t *testing.T) {
 	// Serving is disabled by default (empty endpoint), but the per-endpoint
 	// limits are always filled to the v1 defaults so the server can mount its
 	// handlers without a nil deref regardless of whether [serve] is present.
-	assert.Equal(t, "", cfg.Serve.Endpoint)
+	assert.Empty(t, cfg.Serve.Endpoint)
 	assert.Equal(t, DefaultServeMaxLedgersLimit, *cfg.Serve.MaxLedgersLimit)
 	assert.Equal(t, DefaultServeDefaultLedgersLimit, *cfg.Serve.DefaultLedgersLimit)
 	assert.Equal(t, DefaultServeMaxTransactionsLimit, *cfg.Serve.MaxTransactionsLimit)

--- a/cmd/stellar-rpc/internal/fullhistory/daemon.go
+++ b/cmd/stellar-rpc/internal/fullhistory/daemon.go
@@ -210,12 +210,18 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 			servingReg = serve.NewRegistry(cat, retention, logger)
 			layout := config.NewLayoutFromPaths(paths)
 			serveReads = func(serveCtx context.Context) error {
-				// serveCtx is the daemon run ctx — cancellable — so StartServer's
-				// ctx-cancel watcher shuts the server down at daemon shutdown (no leak).
-				// POC: on a supervised restart the previous server is torn down only
-				// when the daemon ctx cancels; a fixed-port restart would rebind-fail
-				// until then. Acceptable for the query POC (host:0 benchmark binds a
-				// fresh port; serving restarts are out of scope).
+				// serveCtx is the daemon run ctx — it cancels only at daemon shutdown,
+				// so StartServer's ctx-cancel watcher tears the server down then (no leak
+				// on clean shutdown).
+				// POC: supervise re-invokes ServeReads on every restartable error while
+				// the daemon ctx is still live, so the prior server keeps its listener.
+				// StartServer now registers its histogram tolerantly (reusing the existing
+				// collector) instead of panicking, and binds BEFORE it registers — so a
+				// fixed-port restart cleanly rebind-fails ("address already in use") and
+				// the daemon crash-loops on the bind until the daemon ctx tears the prior
+				// server down. Acceptable for the query POC: the host:0 benchmark binds a
+				// fresh ephemeral port each attempt (the prior server lingers but does not
+				// block the restart), and serving restarts are out of scope.
 				addr, _, serr := serve.StartServer(serveCtx, serve.ServerParams{
 					Registry:   servingReg,
 					Layout:     layout,

--- a/cmd/stellar-rpc/internal/fullhistory/daemon.go
+++ b/cmd/stellar-rpc/internal/fullhistory/daemon.go
@@ -193,6 +193,7 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	// placeholder (reads still come from the v1 SQLite daemon). ---
 	serveReads := opts.ServeReads
 	var servingReg *serve.Registry
+	//nolint:nestif // POC read-path resolution kept inline with the lifecycle wiring it feeds
 	if serveReads == nil {
 		if cfg.Serve.Endpoint != "" {
 			// The read server verifies by-hash lookups with the network passphrase;

--- a/cmd/stellar-rpc/internal/fullhistory/daemon.go
+++ b/cmd/stellar-rpc/internal/fullhistory/daemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -25,6 +26,7 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/geometry"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/ingest"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/observability"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/serve"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
 )
 
@@ -68,6 +70,17 @@ type daemonOptions struct {
 	// fixed geometry.ChunksPerTxhashIndex. Tests set it to 1 so a single chunk's
 	// freeze is a terminal index (exercising the index rebuild + prune path cheaply).
 	chunksPerTxhashIndex uint32
+
+	// serveAddr, when set, is invoked with the read server's bound address once
+	// StartServer returns (test-only): a host:0 endpoint yields the OS-assigned
+	// port here so the e2e can dial it. nil in production.
+	serveAddr func(net.Addr)
+
+	// passphrase overrides the network passphrase the read server verifies tx
+	// hashes with (test-only): the e2e injects a fake Core (bypassing the
+	// captive-core peek), so it supplies the passphrase here. "" ⇒ production
+	// reads it from the captive-core config peek.
+	passphrase string
 }
 
 const defaultRestartBackoff = 5 * time.Second
@@ -119,7 +132,7 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	// ingestion loop, and the no-lake backfill source is built from its stream. A
 	// bad [ingestion] config therefore surfaces before validateConfig's errors —
 	// cosmetic, both are fatal startup errors. ---
-	core, err := resolveCore(opts, cfg, logger)
+	core, corePassphrase, err := resolveCore(opts, cfg, logger)
 	if err != nil {
 		return err
 	}
@@ -157,12 +170,6 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 			"or [ingestion].history_archive_urls")
 	}
 
-	serveReads := opts.ServeReads
-	if serveReads == nil {
-		// TODO(#772): wire the full-history RPC read server; no-op until the cutover.
-		serveReads = func(context.Context) error { return nil }
-	}
-
 	// --- validateConfig: pin/confirm the layout, resolve the earliest floor. ---
 	earliest, err := validateConfig(ctx, cfg, cat, backend.Tip)
 	if err != nil {
@@ -179,9 +186,61 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	registry := prometheus.NewRegistry()
 	metrics, sink := buildSinks(opts, registry)
 
+	// --- Resolve the read path (query POC). When an injected ServeReads is
+	// present (existing ingestion/backfill tests) it wins unchanged. Otherwise a
+	// non-empty [serve].endpoint builds the serving Registry and a ServeReads that
+	// launches the JSON-RPC read server on it; an empty endpoint keeps the no-op
+	// placeholder (reads still come from the v1 SQLite daemon). ---
+	serveReads := opts.ServeReads
+	var servingReg *serve.Registry
+	if serveReads == nil {
+		if cfg.Serve.Endpoint != "" {
+			// The read server verifies by-hash lookups with the network passphrase;
+			// serving with the wrong (or empty) one would silently miss every tx, so
+			// refuse to start.
+			passphrase := opts.passphrase
+			if passphrase == "" {
+				passphrase = corePassphrase
+			}
+			if passphrase == "" {
+				return errors.New("[serve].endpoint is set but the network passphrase is empty; " +
+					"it is read from [ingestion].captive_core_config's NETWORK_PASSPHRASE")
+			}
+			servingReg = serve.NewRegistry(cat, retention, logger)
+			layout := config.NewLayoutFromPaths(paths)
+			serveReads = func(serveCtx context.Context) error {
+				// serveCtx is the daemon run ctx — cancellable — so StartServer's
+				// ctx-cancel watcher shuts the server down at daemon shutdown (no leak).
+				// POC: on a supervised restart the previous server is torn down only
+				// when the daemon ctx cancels; a fixed-port restart would rebind-fail
+				// until then. Acceptable for the query POC (host:0 benchmark binds a
+				// fresh port; serving restarts are out of scope).
+				addr, _, serr := serve.StartServer(serveCtx, serve.ServerParams{
+					Registry:   servingReg,
+					Layout:     layout,
+					Passphrase: passphrase,
+					Health:     hs,
+					Metrics:    registry,
+					Logger:     logger,
+					Cfg:        cfg.Serve,
+				})
+				if serr != nil {
+					return serr
+				}
+				if opts.serveAddr != nil {
+					opts.serveAddr(addr)
+				}
+				return nil
+			}
+		} else {
+			serveReads = func(context.Context) error { return nil }
+		}
+	}
+
 	// --- Assemble the StartConfig and run the supervised run loop. ---
 	start := startConfig(
-		cfg, cat, logger, backend, core, serveReads, metrics, sink, hs, retention)
+		cfg, cat, logger, backend, core, serveReads, metrics, sink, hs, retention, servingReg,
+	)
 
 	backoff := opts.RestartBackoff
 	if backoff <= 0 {
@@ -209,16 +268,19 @@ func openCatalog(paths config.Paths, opts daemonOptions, logger *supportlog.Entr
 }
 
 // resolveCore returns the injected CoreOpener (tests) or a production captive-core
-// opener built from [ingestion].
-func resolveCore(opts daemonOptions, cfg config.Config, logger *supportlog.Entry) (CoreOpener, error) {
+// opener built from [ingestion], plus the network passphrase the read server
+// verifies tx hashes with. The passphrase is the one the captive-core peek read
+// back from the config file (empty for an injected Core — the test supplies it
+// via daemonOptions.passphrase instead).
+func resolveCore(opts daemonOptions, cfg config.Config, logger *supportlog.Entry) (CoreOpener, string, error) {
 	if opts.Core != nil {
-		return opts.Core, nil
+		return opts.Core, "", nil
 	}
 	built, err := newCaptiveCoreOpener(cfg.Ingestion, cfg.Service.DefaultDataDir, logger)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	return built, nil
+	return built, built.config.NetworkPassphrase, nil
 }
 
 // startConfig assembles the StartConfig run consumes. run() builds the
@@ -228,6 +290,7 @@ func startConfig(
 	cfg config.Config, cat *catalog.Catalog, logger *supportlog.Entry,
 	backend backfill.Backend, core CoreOpener, serveReads func(context.Context) error,
 	metrics observability.Metrics, sink ingest.MetricSink, hs *healthState, retention geometry.Retention,
+	serving *serve.Registry,
 ) StartConfig {
 	exec := backfill.ExecConfig{
 		Catalog:    cat,
@@ -246,6 +309,7 @@ func startConfig(
 		Core:       core,
 		ServeReads: serveReads,
 		health:     hs,
+		serving:    serving,
 	}
 }
 
@@ -425,7 +489,8 @@ func newCaptiveCoreOpener(
 		found, lerr := exec.LookPath("stellar-core")
 		if lerr != nil {
 			return nil, fmt.Errorf(
-				"[ingestion].stellar_core_binary_path unset and stellar-core not found on PATH: %w", lerr)
+				"[ingestion].stellar_core_binary_path unset and stellar-core not found on PATH: %w", lerr,
+			)
 		}
 		binaryPath = found
 	}

--- a/cmd/stellar-rpc/internal/fullhistory/e2e_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/e2e_test.go
@@ -68,6 +68,13 @@ type e2eCore struct {
 	fromSeen  atomic.Uint32
 	delivered atomic.Uint32
 	opens     atomic.Int32
+
+	// Optional test hooks (default nil/0, so existing callers are unaffected).
+	// onYield timestamps each frame as it enters ingestion; yieldDelay paces
+	// frame delivery so a query poller can stay ahead of commits. Used by the
+	// ingest→query latency test.
+	onYield    func(seq uint32)
+	yieldDelay time.Duration
 }
 
 func (c *e2eCore) OpenCore(context.Context) (ledgerbackend.LedgerStream, error) {
@@ -102,8 +109,19 @@ func (s *e2eStream) RawLedgers(
 			}
 			if raw, ok := s.core.frames[seq]; ok {
 				s.core.delivered.Store(seq)
+				if s.core.onYield != nil {
+					s.core.onYield(seq)
+				}
 				if !yield(raw, nil) {
 					return
+				}
+				if s.core.yieldDelay > 0 {
+					select {
+					case <-ctx.Done():
+						yield(nil, ctx.Err())
+						return
+					case <-time.After(s.core.yieldDelay):
+					}
 				}
 				continue
 			}

--- a/cmd/stellar-rpc/internal/fullhistory/fhtest/fhtest.go
+++ b/cmd/stellar-rpc/internal/fullhistory/fhtest/fhtest.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stellar/go-stellar-sdk/network"
 	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/catalog"
@@ -52,6 +54,87 @@ func ZeroTxLCMBytes(t *testing.T, seq uint32) []byte {
 				V1TxSet: &xdr.TransactionSetV1{Phases: nil},
 			},
 			TxProcessing: nil,
+		},
+	}
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	return raw
+}
+
+// EventLCMBytes returns the marshaled bytes of a single-transaction
+// LedgerCloseMeta (V2) for ledger seq whose transaction carries one
+// operation-level contract event — the fixture for tests that need ledgers
+// with tx-hash and event payloads to extract. The random source account gives
+// each call a distinct, valid pubnet transaction hash.
+func EventLCMBytes(t *testing.T, seq uint32) []byte {
+	t.Helper()
+	var contractID xdr.ContractId
+	contractID[0] = 0xab
+	sym := xdr.ScSymbol("fhtest")
+	ev := xdr.ContractEvent{
+		ContractId: &contractID,
+		Type:       xdr.ContractEventTypeContract,
+		Body: xdr.ContractEventBody{
+			V: 0,
+			V0: &xdr.ContractEventV0{
+				Topics: []xdr.ScVal{{Type: xdr.ScValTypeScvSymbol, Sym: &sym}},
+				Data:   xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &sym},
+			},
+		},
+	}
+	meta := xdr.TransactionMeta{
+		V:  4,
+		V4: &xdr.TransactionMetaV4{Operations: []xdr.OperationMetaV2{{Events: []xdr.ContractEvent{ev}}}},
+	}
+
+	envelope := xdr.TransactionEnvelope{
+		Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+		V1: &xdr.TransactionV1Envelope{
+			Tx: xdr.Transaction{
+				SourceAccount: xdr.MustMuxedAddress(keypair.MustRandom().Address()),
+				Ext: xdr.TransactionExt{
+					V:           1,
+					SorobanData: &xdr.SorobanTransactionData{},
+				},
+			},
+		},
+	}
+	hash, err := network.HashTransactionInEnvelope(envelope, network.PublicNetworkPassphrase)
+	require.NoError(t, err)
+
+	opResults := []xdr.OperationResult{}
+	comp := []xdr.TxSetComponent{{
+		Type: xdr.TxSetComponentTypeTxsetCompTxsMaybeDiscountedFee,
+		TxsMaybeDiscountedFee: &xdr.TxSetComponentTxsMaybeDiscountedFee{
+			Txs: []xdr.TransactionEnvelope{envelope},
+		},
+	}}
+	lcm := xdr.LedgerCloseMeta{
+		V: 2,
+		V2: &xdr.LedgerCloseMetaV2{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+				Header: xdr.LedgerHeader{
+					ScpValue:  xdr.StellarValue{CloseTime: xdr.TimePoint(0)},
+					LedgerSeq: xdr.Uint32(seq),
+				},
+			},
+			TxSet: xdr.GeneralizedTransactionSet{
+				V:       1,
+				V1TxSet: &xdr.TransactionSetV1{Phases: []xdr.TransactionPhase{{V: 0, V0Components: &comp}}},
+			},
+			TxProcessing: []xdr.TransactionResultMetaV1{{
+				TxApplyProcessing: meta,
+				Result: xdr.TransactionResultPair{
+					TransactionHash: hash,
+					Result: xdr.TransactionResult{
+						FeeCharged: 100,
+						Result: xdr.TransactionResultResult{
+							Code:    xdr.TransactionResultCodeTxSuccess,
+							Results: &opResults,
+						},
+					},
+				},
+			}},
 		},
 	}
 	raw, err := lcm.MarshalBinary()

--- a/cmd/stellar-rpc/internal/fullhistory/geometry/keys_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/geometry/keys_test.go
@@ -47,6 +47,7 @@ func TestKeyToPathBijection(t *testing.T) {
 
 	// The doc's directory-layout examples.
 	require.Equal(t, "/data/ledgers/00005/00005350.pack", l.LedgerPackPath(5350))
+	require.Equal(t, l.LedgerPackPath(5350), LedgerPackPath("/data/ledgers", 5350))
 	require.Equal(t, "/data/txhash/raw/00005/00005350.bin", l.TxHashBinPath(5350))
 	require.Equal(t, []string{
 		"/data/events/00005/00005350-events.pack",

--- a/cmd/stellar-rpc/internal/fullhistory/geometry/paths.go
+++ b/cmd/stellar-rpc/internal/fullhistory/geometry/paths.go
@@ -77,7 +77,15 @@ func (l Layout) HotChunkPath(c chunk.ID) string {
 // leaf is owned by ledger.PackName (shared with the cold writer and reader).
 // EventsPaths/TxHashBinPath follow the same split.
 func (l Layout) LedgerPackPath(c chunk.ID) string {
-	return filepath.Join(l.ledgersRoot, c.BucketID(), ledger.PackName(c))
+	return LedgerPackPath(l.ledgersRoot, c)
+}
+
+// LedgerPackPath composes a chunk's ledger pack path under an explicit ledgers
+// root, for callers that hold only that one tree (a full Layout would carry
+// five unused roots). Layout.LedgerPackPath delegates here so the formula has
+// one home.
+func LedgerPackPath(ledgersRoot string, c chunk.ID) string {
+	return filepath.Join(ledgersRoot, c.BucketID(), ledger.PackName(c))
 }
 
 // EventsBucketDir is a chunk's events cold-segment directory — the bucket dir the

--- a/cmd/stellar-rpc/internal/fullhistory/hotloop.go
+++ b/cmd/stellar-rpc/internal/fullhistory/hotloop.go
@@ -77,6 +77,27 @@ type boundaryPublisher interface {
 	Publish(c chunk.ID)
 }
 
+// servingHooks is the write-side coupling to the read-server's serve.Registry
+// (query POC): the ingestion loop calls it as the true committed watermark and
+// the hot map change as it commits, boundary-closes, and opens chunks.
+// *serve.Registry satisfies it; the daemon leaves it nil (nopServingHooks) when
+// [serve] is disabled, so every non-serving test compiles unchanged. All three
+// hooks are cheap and non-blocking (atomic store / map clone-publish).
+type servingHooks interface {
+	LedgerCommitted(seq uint32)
+	HotOpened(c chunk.ID, db *hotchunk.DB)
+	ChunkClosed(c chunk.ID)
+}
+
+// nopServingHooks is the no-serve default: every hook is a no-op, so the
+// ingestion loop drives the same call sites whether or not a read server is
+// wired.
+type nopServingHooks struct{}
+
+func (nopServingHooks) LedgerCommitted(uint32)           {}
+func (nopServingHooks) HotOpened(chunk.ID, *hotchunk.DB) {}
+func (nopServingHooks) ChunkClosed(chunk.ID)             {}
+
 // ingestionLoopConfig bundles the ingestion loop's dependencies. run() opens the
 // resume chunk's hot DB (HotDB) BEFORE serving reads — so a broken hot tier fails
 // startup instead of serving behind a crash-looping loop — and hands the open
@@ -92,6 +113,11 @@ type ingestionLoopConfig struct {
 	Metrics  observability.Metrics
 	Sink     ingest.MetricSink
 	Health   *healthState
+
+	// Serving is the read-server registry's write-side hook surface (query POC);
+	// nil ⇒ nopServingHooks (no read server). Normalized in runIngestionLoop so
+	// the hook call sites below need no nil guard.
+	Serving servingHooks
 }
 
 // runIngestionLoop is the hot tier's OWNER: the single goroutine that opens,
@@ -116,6 +142,10 @@ type ingestionLoopConfig struct {
 // rely on.
 func runIngestionLoop(ctx context.Context, cfg ingestionLoopConfig) error {
 	metrics := observability.MetricsOrNop(cfg.Metrics)
+	// Normalize the serving hooks once so every call site below is guard-free.
+	if cfg.Serving == nil {
+		cfg.Serving = nopServingHooks{}
+	}
 
 	// Take ownership of the resume hot DB run() opened (before serving reads) as the
 	// loop's FIRST statement, so the deferred close sits ahead of any early return —
@@ -155,6 +185,10 @@ func runIngestionLoop(ctx context.Context, cfg ingestionLoopConfig) error {
 		// committed ledger (mid-chunk included), one atomic gauge set per ledger.
 		// The tick must not touch it — its chunk-aligned value would regress it.
 		metrics.LastCommitted(seq)
+		// Advance the read server's `latest` watermark AFTER the commit is durable,
+		// so a query never admits a ledger the View cannot yet serve (design:
+		// "latest advances last"). No-op when serving is disabled.
+		cfg.Serving.LedgerCommitted(seq)
 
 		// Feed the readiness/health signal from the SAME commit: the first commit
 		// latches readiness, and the close time drives the health staleness check.
@@ -173,12 +207,23 @@ func runIngestionLoop(ctx context.Context, cfg ingestionLoopConfig) error {
 			_ = hotDB.Close() // Close never fails; flush errors are logged inside
 			hotDB = nil       // released; reopen below republishes it for the defer
 
+			// The write handle is closed; hand the closed chunk to the read server so
+			// it reopens a full-facade read view (OpenReadView) and keeps serving it
+			// until freeze covers it from cold. Must follow the Close above (the fence)
+			// and precede Publish below. No-op when serving is disabled.
+			cfg.Serving.ChunkClosed(closed)
+
 			nextDB, oerr := openHotDBForChunk(cfg.Catalog, next, cfg.Logger)
 			if oerr != nil {
 				return fmt.Errorf("open hot DB for chunk %s at boundary: %w", next, oerr)
 			}
 			hotDB = nextDB
 			hotService = ingest.NewHotService(hotDB, cfg.Sink)
+			// Publish the new live chunk's shared write handle to the read server
+			// BEFORE Boundary.Publish (and thus before any LedgerCommitted can advance
+			// latest into it), so the View serves the new chunk the instant latest can
+			// reach it (design ordering rule). No-op when serving is disabled.
+			cfg.Serving.HotOpened(next, nextDB)
 			// next's key (created inside openHotDBForChunk) moved the partition; only
 			// now publish the completed chunk to the lifecycle.
 			cfg.Boundary.Publish(closed)

--- a/cmd/stellar-rpc/internal/fullhistory/hotloop.go
+++ b/cmd/stellar-rpc/internal/fullhistory/hotloop.go
@@ -245,5 +245,55 @@ func runIngestionLoop(ctx context.Context, cfg ingestionLoopConfig) error {
 	// means the source stopped WITHOUT an error while the daemon ctx is still live —
 	// abnormal; surface a restartable error. (run()'s guard owns the clean-vs-restart
 	// classification.)
-	return errors.New("ingestion stream ended unexpectedly (source stopped with no error)")
+	return errStreamEnded
+}
+
+// errStreamEnded reports the stream stopping with no error while ctx is still
+// live.
+var errStreamEnded = errors.New("ingestion stream ended unexpectedly (source stopped with no error)")
+
+// BoundedIngestConfig configures RunBoundedIngestionLoop. Catalog must be bound
+// to the layout whose hot root the run writes; every hot DB the loop touches is
+// opened through it (the create bracket wipes any leftover chunk dir, so runs
+// always start from an empty DB).
+type BoundedIngestConfig struct {
+	// Stream must be bounded to the range to ingest: its end is what terminates
+	// the loop (the loop itself always requests an unbounded range).
+	Stream ledgerbackend.LedgerStream
+	// Resume is the first ledger to ingest; its chunk's hot DB is opened fresh.
+	Resume  uint32
+	Catalog *catalog.Catalog
+	// Boundary receives the id of each chunk the loop completes, as in the
+	// daemon's loop.
+	Boundary boundaryPublisher
+	Logger   *supportlog.Entry
+	Metrics  observability.Metrics
+	Sink     ingest.MetricSink
+}
+
+// RunBoundedIngestionLoop runs the ingestion loop over a bounded stream: it
+// opens the resume chunk's hot DB through openHotDBForChunk and runs
+// runIngestionLoop until the stream ends. A bounded stream ending is the
+// expected termination (errStreamEnded), so unlike the daemon's unbounded run
+// it is remapped to a nil error rather than surfaced as a restartable failure.
+func RunBoundedIngestionLoop(ctx context.Context, cfg BoundedIngestConfig) error {
+	hotDB, err := openHotDBForChunk(cfg.Catalog, chunk.IDFromLedger(cfg.Resume), cfg.Logger)
+	if err != nil {
+		return fmt.Errorf("open hot DB for resume ledger %d: %w", cfg.Resume, err)
+	}
+	// The loop's first deferred statement takes ownership of the close.
+	err = runIngestionLoop(ctx, ingestionLoopConfig{
+		Stream:   cfg.Stream,
+		Resume:   cfg.Resume,
+		HotDB:    hotDB,
+		Catalog:  cfg.Catalog,
+		Boundary: cfg.Boundary,
+		Logger:   cfg.Logger,
+		Metrics:  cfg.Metrics,
+		Sink:     cfg.Sink,
+	})
+	if errors.Is(err, errStreamEnded) {
+		return nil
+	}
+	return err
 }

--- a/cmd/stellar-rpc/internal/fullhistory/hotloop.go
+++ b/cmd/stellar-rpc/internal/fullhistory/hotloop.go
@@ -81,8 +81,11 @@ type boundaryPublisher interface {
 // (query POC): the ingestion loop calls it as the true committed watermark and
 // the hot map change as it commits, boundary-closes, and opens chunks.
 // *serve.Registry satisfies it; the daemon leaves it nil (nopServingHooks) when
-// [serve] is disabled, so every non-serving test compiles unchanged. All three
-// hooks are cheap and non-blocking (atomic store / map clone-publish).
+// [serve] is disabled, so every non-serving test compiles unchanged.
+// LedgerCommitted and HotOpened are cheap (atomic store / map clone-publish), but
+// ChunkClosed is NOT non-blocking: it synchronously opens a full-facade read view
+// (RocksDB open + mandatory eventstore warmup) on the ingestion goroutine, so it
+// stalls ingestion for the warmup's duration once per chunk boundary.
 type servingHooks interface {
 	LedgerCommitted(seq uint32)
 	HotOpened(c chunk.ID, db *hotchunk.DB)

--- a/cmd/stellar-rpc/internal/fullhistory/lifecycle/lifecycle.go
+++ b/cmd/stellar-rpc/internal/fullhistory/lifecycle/lifecycle.go
@@ -44,6 +44,20 @@ type Config struct {
 	// WithLifecycleDefaults.
 	opRetryAttempts int
 	opRetryBackoff  time.Duration
+
+	// TickObserver is notified after each SUCCESSFUL tick (query POC): the read
+	// server's serve.Registry rescans the catalog and republishes its serving
+	// View so freeze/discard/prune become visible to queries. nil ⇒ no observer
+	// (the no-serve daemon). The observer defined as an interface here keeps
+	// lifecycle free of any read-server dependency.
+	TickObserver TickObserver
+}
+
+// TickObserver observes completed lifecycle ticks. *serve.Registry satisfies it
+// (its TickCompleted rescans + republishes); the interface lives here so
+// lifecycle does not import the serve package.
+type TickObserver interface {
+	TickCompleted()
 }
 
 const (
@@ -176,6 +190,14 @@ func runLifecycle(ctx context.Context, cfg Config, cat *catalog.Catalog, lastChu
 	}
 	if prunedArtifacts > 0 {
 		logger.WithField("pruned", prunedArtifacts).Info("lifecycle prune stage complete")
+	}
+
+	// End of a fully successful tick: the durable state just changed (freeze /
+	// discard / prune), so let the read server's serving View rescan and
+	// republish. A mid-tick error returns above WITHOUT notifying — the next tick
+	// (which subsumes it) republishes then. No-op when no observer is wired.
+	if cfg.TickObserver != nil {
+		cfg.TickObserver.TickCompleted()
 	}
 	return nil
 }

--- a/cmd/stellar-rpc/internal/fullhistory/serve/events_handler.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/events_handler.go
@@ -3,6 +3,7 @@ package serve
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -60,7 +61,7 @@ type foundEvent struct {
 	ledgerClosedAt int64
 }
 
-//nolint:cyclop,funlen // mirrors v1 getEvents' validate→scan→format→cursor shape
+//nolint:cyclop // mirrors v1 getEvents' validate→scan→format→cursor shape
 func (h eventsHandler) getEvents(
 	ctx context.Context, request protocol.GetEventsRequest,
 ) (protocol.GetEventsResponse, error) {
@@ -235,7 +236,7 @@ func (h eventsHandler) scanChunk(
 		// MaxEvents cap (QueryOptions doc: "Pagers MUST NOT treat len(result) <
 		// limit as exhausted"), so a false positive inside the capped prefix can
 		// shrink the result while real matches remain past the cap.
-		windowSize := int(rng.End - rng.Start) //nolint:gosec // chunk event-id space (~10M today) fits int
+		windowSize := int(rng.End - rng.Start) // chunk event-id space (~10M today) fits int
 		if len(matches) == remaining || queryCap >= windowSize {
 			*found = append(*found, matches...)
 			return nil
@@ -352,7 +353,7 @@ func topicFilterSets(topics []protocol.TopicFilter) ([][protocol.MaxTopicCount][
 			if err != nil {
 				return nil, fmt.Errorf("marshal topic segment: %w", err)
 			}
-			set[i] = encoded
+			set[i] = encoded //nolint:gosec // i < MaxTopicCount, guarded by the break above (G602 false positive)
 		}
 		out = append(out, set)
 	}
@@ -368,7 +369,7 @@ func eventInfoForEvent(
 ) (protocol.EventInfo, error) {
 	v0, ok := event.Event.Body.GetV0()
 	if !ok {
-		return protocol.EventInfo{}, fmt.Errorf("unknown event version")
+		return protocol.EventInfo{}, errors.New("unknown event version")
 	}
 
 	eventType, ok := protocol.GetEventTypeFromEventTypeXDR()[event.Event.Type]

--- a/cmd/stellar-rpc/internal/fullhistory/serve/events_handler.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/events_handler.go
@@ -172,10 +172,13 @@ func (h eventsHandler) getEvents(
 // The eventstore index is a coarse pre-filter, so eventstore.Query results are
 // re-checked against request.Matches (event type, exact contract, full topic
 // semantics incl. wildcards/length) and the resume cursor. Because that exact
-// post-filter — and the resume drop — can discard index candidates, MaxEvents:
+// post-filter — and the resume drop, and Query's OWN collision post-filter
+// (applied after MaxEvents) — can discard index candidates, MaxEvents:
 // remaining could return a capped page that yields fewer than `remaining`
-// matches while the chunk still holds more. When that happens the cap is doubled
-// and the chunk re-queried, so the seam between chunks never skips a match.
+// matches while the chunk still holds more. The cap is doubled and the chunk
+// re-queried until the page fills or the cap covers the whole event-ID window
+// (the only reliable exhaustion proof), so the seam between chunks never skips
+// a match.
 //
 // POC: the chunk is re-queried from scratch on underfill rather than advancing a
 // pinned event-ID cursor; correct but re-fetches. A streaming pager that threads
@@ -226,14 +229,19 @@ func (h eventsHandler) scanChunk(
 		if err != nil {
 			return err
 		}
-		// Enough to fill the page, or the whole window is exhausted (Query returned
-		// fewer than the cap): take what matched and move on.
-		if len(matches) == remaining || len(payloads) < queryCap {
+		// Done when the page fills, or when the cap covered the whole event-ID
+		// window — only then is the chunk provably exhausted. A short result alone
+		// is NOT exhaustion: Query applies its collision post-filter AFTER the
+		// MaxEvents cap (QueryOptions doc: "Pagers MUST NOT treat len(result) <
+		// limit as exhausted"), so a false positive inside the capped prefix can
+		// shrink the result while real matches remain past the cap.
+		windowSize := int(rng.End - rng.Start) //nolint:gosec // chunk event-id space (~10M today) fits int
+		if len(matches) == remaining || queryCap >= windowSize {
 			*found = append(*found, matches...)
 			return nil
 		}
-		// Cap hit but the page is still short after the exact post-filter: the
-		// window holds more candidates — widen the cap and re-scan this chunk.
+		// Page still short and the cap did not cover the window: more candidates
+		// may remain — widen the cap and re-scan this chunk.
 	}
 }
 

--- a/cmd/stellar-rpc/internal/fullhistory/serve/events_handler.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/events_handler.go
@@ -1,0 +1,423 @@
+package serve
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/creachadair/jrpc2"
+
+	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
+	"github.com/stellar/go-stellar-sdk/strkey"
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/events"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/geometry"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/methods"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/xdr2json"
+)
+
+// eventsLedgerScanLimit caps a single page's ledger span, matching v1's
+// methods.LedgerScanLimit (get_events.go:24) so the two backends page identically.
+const eventsLedgerScanLimit = 10000
+
+// eventsHandler serves getEvents over the serve Registry + eventstore.Query
+// instead of v1's SQL-shaped db.EventReader. It is wire-compatible with v1
+// getEvents: same validation, cursor/limit semantics, filter model, and response
+// shape (see methods/get_events.go). The eventstore index is the coarse
+// pre-filter (contract ID + topic equality); protocol.GetEventsRequest.Matches is
+// the authoritative post-filter, exactly as v1 layers request.Matches over its SQL
+// column pre-filter.
+type eventsHandler struct {
+	logger       *supportlog.Entry
+	reg          *Registry
+	layout       geometry.Layout
+	maxLimit     uint
+	defaultLimit uint
+}
+
+// NewGetEventsHandler returns a jrpc2 handler for getEvents backed by the serve
+// Registry. maxLimit/defaultLimit copy v1's getEvents bounds (10000/100).
+func NewGetEventsHandler(
+	logger *supportlog.Entry, reg *Registry, layout geometry.Layout, maxLimit, defaultLimit uint,
+) jrpc2.Handler {
+	h := eventsHandler{logger: logger, reg: reg, layout: layout, maxLimit: maxLimit, defaultLimit: defaultLimit}
+	return methods.NewHandler(h.getEvents)
+}
+
+// foundEvent is one matched event pending format conversion — the decoded event,
+// its cursor, tx hash, and close time. Kept until the whole page is scanned so
+// format conversion (xdr2json / base64) happens once at the end, mirroring v1.
+type foundEvent struct {
+	cursor         protocol.Cursor
+	event          xdr.DiagnosticEvent
+	txHash         string
+	ledgerClosedAt int64
+}
+
+//nolint:cyclop,funlen // mirrors v1 getEvents' validate→scan→format→cursor shape
+func (h eventsHandler) getEvents(
+	ctx context.Context, request protocol.GetEventsRequest,
+) (protocol.GetEventsResponse, error) {
+	if err := request.Valid(h.maxLimit); err != nil {
+		return protocol.GetEventsResponse{}, &jrpc2.Error{Code: jrpc2.InvalidParams, Message: err.Error()}
+	}
+
+	// Admit once per page (design §Admission) and pin (latest, view) for the whole
+	// request. The ledger range comes from the same snapshot via a readTx literal,
+	// so validation, scanning, and the response all observe one immutable View.
+	latest, v := h.reg.Admit()
+	tx := &readTx{view: v, layout: h.layout, latest: latest, first: max(v.Floor.FirstLedger(), v.Earliest)}
+	ledgerRange, err := tx.GetLedgerRange(ctx)
+	if err != nil {
+		return protocol.GetEventsResponse{}, &jrpc2.Error{Code: jrpc2.InternalError, Message: err.Error()}
+	}
+
+	start := protocol.Cursor{Ledger: request.StartLedger}
+	limit := h.defaultLimit
+	if request.Pagination != nil {
+		if request.Pagination.Cursor != nil {
+			start = *request.Pagination.Cursor
+			// Resume exclusive: begin at the event right after the cursor.
+			start.Event++
+		}
+		if request.Pagination.Limit > 0 {
+			limit = request.Pagination.Limit
+		}
+	}
+	// endLedger is the exclusive upper ledger bound, capped by the scan limit and
+	// the served range, then by an explicit request.EndLedger (v1 get_events.go).
+	endLedger := start.Ledger + eventsLedgerScanLimit
+	endLedger = min(ledgerRange.LastLedger.Sequence+1, endLedger)
+	if request.EndLedger != 0 {
+		endLedger = min(request.EndLedger, endLedger)
+	}
+
+	if start.Ledger < ledgerRange.FirstLedger.Sequence || start.Ledger > ledgerRange.LastLedger.Sequence {
+		return protocol.GetEventsResponse{}, &jrpc2.Error{
+			Code: jrpc2.InvalidRequest,
+			Message: fmt.Sprintf(
+				"startLedger must be within the ledger range: %d - %d",
+				ledgerRange.FirstLedger.Sequence, ledgerRange.LastLedger.Sequence,
+			),
+		}
+	}
+
+	filters, err := translateFilters(request.Filters)
+	if err != nil {
+		return protocol.GetEventsResponse{}, &jrpc2.Error{Code: jrpc2.InvalidParams, Message: err.Error()}
+	}
+
+	found := make([]foundEvent, 0, limit)
+	// scanHi is the inclusive last ledger to scan; endLedger is exclusive. When
+	// the window is empty (endLedger <= start.Ledger, e.g. a tight request.EndLedger)
+	// no chunk is visited and the empty-page cursor logic below still applies.
+	if scanHi := endLedger - 1; scanHi >= start.Ledger {
+		for c := chunk.IDFromLedger(start.Ledger); c <= chunk.IDFromLedger(scanHi) && uint(len(found)) < limit; c++ {
+			lo := max(start.Ledger, c.FirstLedger())
+			hi := min(scanHi, c.LastLedger())
+			if lo > hi {
+				continue
+			}
+			if err := h.scanChunk(ctx, v, c, filters, lo, hi, start, &request, &found, limit); err != nil {
+				return protocol.GetEventsResponse{}, &jrpc2.Error{Code: jrpc2.InternalError, Message: err.Error()}
+			}
+		}
+	}
+
+	results := make([]protocol.EventInfo, 0, len(found))
+	for i := range found {
+		info, err := eventInfoForEvent(
+			found[i].event,
+			found[i].cursor,
+			time.Unix(found[i].ledgerClosedAt, 0).UTC().Format(time.RFC3339),
+			found[i].txHash,
+			request.Format,
+		)
+		if err != nil {
+			return protocol.GetEventsResponse{}, fmt.Errorf("could not parse event: %w", err)
+		}
+		results = append(results, info)
+	}
+
+	var cursor string
+	if uint(len(results)) == limit {
+		cursor = results[len(results)-1].ID
+	} else {
+		// The page did not fill: the cursor is the end of the search window
+		// (endLedger is exclusive, so the last scanned ledger is endLedger-1).
+		maxCursor := protocol.MaxCursor
+		maxCursor.Ledger = endLedger - 1
+		cursor = maxCursor.String()
+	}
+
+	return protocol.GetEventsResponse{
+		Events:                results,
+		Cursor:                cursor,
+		LatestLedger:          ledgerRange.LastLedger.Sequence,
+		OldestLedger:          ledgerRange.FirstLedger.Sequence,
+		LatestLedgerCloseTime: ledgerRange.LastLedger.CloseTime,
+		OldestLedgerCloseTime: ledgerRange.FirstLedger.CloseTime,
+	}, nil
+}
+
+// scanChunk resolves chunk c's events reader and appends the matching events in
+// [lo, hi] (cursor-ascending) to found, up to the page limit.
+//
+// The eventstore index is a coarse pre-filter, so eventstore.Query results are
+// re-checked against request.Matches (event type, exact contract, full topic
+// semantics incl. wildcards/length) and the resume cursor. Because that exact
+// post-filter — and the resume drop — can discard index candidates, MaxEvents:
+// remaining could return a capped page that yields fewer than `remaining`
+// matches while the chunk still holds more. When that happens the cap is doubled
+// and the chunk re-queried, so the seam between chunks never skips a match.
+//
+// POC: the chunk is re-queried from scratch on underfill rather than advancing a
+// pinned event-ID cursor; correct but re-fetches. A streaming pager that threads
+// a chunk-relative event-ID position is the productionization path.
+func (h eventsHandler) scanChunk(
+	ctx context.Context, v *View, c chunk.ID, filters []eventstore.Filter,
+	lo, hi uint32, start protocol.Cursor, request *protocol.GetEventsRequest,
+	found *[]foundEvent, limit uint,
+) error {
+	remaining := int(limit) - len(*found) //nolint:gosec // limit is bounded by maxLimit (validated by request.Valid)
+	if remaining <= 0 {
+		return nil
+	}
+
+	ec, err := v.ResolveEvents(c, h.layout)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = ec.Close() }()
+	reader := ec.Reader()
+
+	// Pin the chunk's offsets snapshot once and reuse the derived range across
+	// re-queries (eventstore.EventIDRange snapshot-isolation contract).
+	ofs, err := reader.Offsets()
+	if err != nil {
+		return err
+	}
+	rng, err := eventstore.EventIDRangeForLedgers(ofs, lo, hi)
+	if err != nil {
+		return err
+	}
+	if rng.Start == rng.End {
+		return nil // no events in this ledger window
+	}
+
+	for queryCap := remaining; ; queryCap *= 2 {
+		payloads, err := eventstore.Query(ctx, reader, filters, eventstore.QueryOptions{
+			// POC: getEvents is ascending-only — protocol.GetEventsRequest exposes
+			// no order field, so Descending stays false. eventstore.Query supports
+			// descending; wiring it needs a protocol/cursor extension first.
+			MaxEvents: queryCap,
+			Range:     rng,
+		})
+		if err != nil {
+			return err
+		}
+		matches, err := collectMatches(payloads, start, request, remaining)
+		if err != nil {
+			return err
+		}
+		// Enough to fill the page, or the whole window is exhausted (Query returned
+		// fewer than the cap): take what matched and move on.
+		if len(matches) == remaining || len(payloads) < queryCap {
+			*found = append(*found, matches...)
+			return nil
+		}
+		// Cap hit but the page is still short after the exact post-filter: the
+		// window holds more candidates — widen the cap and re-scan this chunk.
+	}
+}
+
+// collectMatches turns Query payloads into foundEvents, keeping at most `limit`,
+// dropping events at or before the resume cursor and any the coarse index let
+// through that request.Matches rejects (event type / exact topic semantics).
+// Payloads arrive in ascending event-ID (== cursor) order, so the output is too.
+func collectMatches(
+	payloads []events.Payload, start protocol.Cursor, request *protocol.GetEventsRequest, limit int,
+) ([]foundEvent, error) {
+	out := make([]foundEvent, 0, min(len(payloads), limit))
+	for i := range payloads {
+		p := &payloads[i]
+		cur := protocol.Cursor{Ledger: p.LedgerSequence, Tx: p.TxIdx, Op: p.OpIdx, Event: p.EventIdx}
+		// Resume is exclusive: skip everything at or before the (incremented) start
+		// cursor. For a fresh startLedger request, start sits at the ledger head so
+		// nothing is dropped.
+		if cur.Cmp(start) < 0 {
+			continue
+		}
+		var ce xdr.ContractEvent
+		if err := ce.UnmarshalBinary(p.ContractEventBytes); err != nil {
+			return nil, fmt.Errorf("decode contract event: %w", err)
+		}
+		// POC: the stored payload has no InSuccessfulContractCall flag (dropped at
+		// freeze); default true. It feeds only the deprecated EventInfo field and
+		// never request.Matches, which reads event type/contract/topics.
+		ev := xdr.DiagnosticEvent{InSuccessfulContractCall: true, Event: ce}
+		if !request.Matches(ev) {
+			continue
+		}
+		out = append(out, foundEvent{
+			cursor:         cur,
+			event:          ev,
+			txHash:         p.TxHash.HexString(),
+			ledgerClosedAt: p.LedgerClosedAt,
+		})
+		if len(out) == limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+// translateFilters maps protocol event filters to the eventstore filter union.
+// Each protocol filter is a conjunction (contract IDs OR'd, topics OR'd) that
+// expands to the cartesian product of its contract IDs × topic filters — one
+// eventstore.Filter per combination, since an eventstore.Filter AND's a single
+// contract ID with per-position topic equality. The mapping is a deliberate
+// superset: only exact ScVal segments are indexed; "*"/"**" wildcards and the
+// event-type constraint leave the position (or filter) unconstrained, and
+// request.Matches enforces the exact semantics afterward. An empty request
+// filter list stays nil — eventstore.Query treats that as match-all.
+func translateFilters(filters []protocol.EventFilter) ([]eventstore.Filter, error) {
+	if len(filters) == 0 {
+		return nil, nil
+	}
+	var out []eventstore.Filter
+	for fi := range filters {
+		f := &filters[fi]
+
+		contractIDs := make([][]byte, 0, len(f.ContractIDs))
+		for _, id := range f.ContractIDs {
+			decoded, err := strkey.Decode(strkey.VersionByteContract, id)
+			if err != nil {
+				return nil, fmt.Errorf("invalid contract ID: %v", id)
+			}
+			contractIDs = append(contractIDs, decoded)
+		}
+		if len(contractIDs) == 0 {
+			contractIDs = [][]byte{nil} // no contract constraint (wildcard)
+		}
+
+		topicSets, err := topicFilterSets(f.Topics)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, cid := range contractIDs {
+			for _, topics := range topicSets {
+				out = append(out, eventstore.Filter{ContractID: cid, Topics: topics})
+			}
+		}
+	}
+	return out, nil
+}
+
+// topicFilterSets maps a protocol filter's topic clauses (OR'd) to per-position
+// eventstore topic constraints. No topics → one all-wildcard set. Each TopicFilter
+// becomes one set where exact-ScVal segments fix their position (via
+// ScVal.MarshalBinary, the same encoding the events index terms on) and wildcard
+// segments stay nil. Segments past protocol.MaxTopicCount are not indexed.
+func topicFilterSets(topics []protocol.TopicFilter) ([][protocol.MaxTopicCount][]byte, error) {
+	if len(topics) == 0 {
+		return [][protocol.MaxTopicCount][]byte{{}}, nil
+	}
+	out := make([][protocol.MaxTopicCount][]byte, 0, len(topics))
+	for _, tf := range topics {
+		var set [protocol.MaxTopicCount][]byte
+		for i, seg := range tf {
+			if i >= protocol.MaxTopicCount {
+				break
+			}
+			if seg.ScVal == nil {
+				continue // wildcard segment: leave the position unconstrained
+			}
+			encoded, err := seg.ScVal.MarshalBinary()
+			if err != nil {
+				return nil, fmt.Errorf("marshal topic segment: %w", err)
+			}
+			set[i] = encoded
+		}
+		out = append(out, set)
+	}
+	return out, nil
+}
+
+// eventInfoForEvent renders one matched event into the wire EventInfo, in either
+// base64-XDR (default) or decoded-JSON form. Byte-identical to v1's
+// methods.eventInfoForEvent (get_events.go:243-319); duplicated because that
+// helper is unexported.
+func eventInfoForEvent(
+	event xdr.DiagnosticEvent, cursor protocol.Cursor, ledgerClosedAt, txHash, format string,
+) (protocol.EventInfo, error) {
+	v0, ok := event.Event.Body.GetV0()
+	if !ok {
+		return protocol.EventInfo{}, fmt.Errorf("unknown event version")
+	}
+
+	eventType, ok := protocol.GetEventTypeFromEventTypeXDR()[event.Event.Type]
+	if !ok {
+		return protocol.EventInfo{}, fmt.Errorf("unknown XDR ContractEventType type: %d", event.Event.Type)
+	}
+
+	ledger, err := strconv.ParseInt(strconv.FormatUint(uint64(cursor.Ledger), 10), 10, 32)
+	if err != nil {
+		return protocol.EventInfo{}, fmt.Errorf("ledger sequence %d exceeds supported range", cursor.Ledger)
+	}
+
+	info := protocol.EventInfo{
+		EventType:                eventType,
+		Ledger:                   int32(ledger),
+		LedgerClosedAt:           ledgerClosedAt,
+		ID:                       cursor.String(),
+		InSuccessfulContractCall: event.InSuccessfulContractCall,
+		TransactionHash:          txHash,
+		OpIndex:                  cursor.Op,
+		TxIndex:                  cursor.Tx,
+	}
+
+	switch format {
+	case protocol.FormatJSON:
+		info.TopicJSON = make([]json.RawMessage, 0, protocol.MaxTopicCount)
+		for _, topic := range v0.Topics {
+			converted, err := xdr2json.ConvertInterface(topic)
+			if err != nil {
+				return protocol.EventInfo{}, err
+			}
+			info.TopicJSON = append(info.TopicJSON, converted)
+		}
+		var convErr error
+		info.ValueJSON, convErr = xdr2json.ConvertInterface(v0.Data)
+		if convErr != nil {
+			return protocol.EventInfo{}, convErr
+		}
+	default:
+		topic := make([]string, 0, protocol.MaxTopicCount)
+		for _, segment := range v0.Topics {
+			seg, err := xdr.MarshalBase64(segment)
+			if err != nil {
+				return protocol.EventInfo{}, err
+			}
+			topic = append(topic, seg)
+		}
+		data, err := xdr.MarshalBase64(v0.Data)
+		if err != nil {
+			return protocol.EventInfo{}, err
+		}
+		info.TopicXDR = topic
+		info.ValueXDR = data
+	}
+
+	if event.Event.ContractId != nil {
+		info.ContractID = strkey.MustEncode(strkey.VersionByteContract, (*event.Event.ContractId)[:])
+	}
+	return info, nil
+}

--- a/cmd/stellar-rpc/internal/fullhistory/serve/events_handler_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/events_handler_test.go
@@ -51,11 +51,11 @@ func buildEventsSeamFixture(t *testing.T) eventsFixture {
 	require.NoError(t, cat.PinEarliestLedger(coldFirst))
 
 	cA, cB := contractID(0xAA), contractID(0xBB)
-	evA1, _ := contractEventXDR(t, cA, "topic-a", "a1")
-	evB, _ := contractEventXDR(t, cB, "topic-b", "b1")
-	evA2, _ := contractEventXDR(t, cA, "topic-a", "a2")
-	evA3, _ := contractEventXDR(t, cA, "topic-a", "a3")
-	evB2, _ := contractEventXDR(t, cB, "topic-b", "b2")
+	evA1 := contractEventXDR(t, cA, "topic-a", "a1")
+	evB := contractEventXDR(t, cB, "topic-b", "b1")
+	evA2 := contractEventXDR(t, cA, "topic-a", "a2")
+	evA3 := contractEventXDR(t, cA, "topic-a", "a3")
+	evB2 := contractEventXDR(t, cB, "topic-b", "b2")
 
 	// Cold chunk 0: A@coldFirst, B@coldFirst+1, A@coldLast.
 	coldSeqs := []uint32{coldFirst, coldFirst + 1, coldLast}
@@ -180,9 +180,8 @@ func TestGetEvents_OutOfRangeStartErrors(t *testing.T) {
 
 	_, err := h(t.Context(), getEventsRequest(t,
 		`{"startLedger":`+itoa(coldFirst-1)+`,"pagination":{"limit":10}}`))
-	require.Error(t, err)
-	rpcErr, ok := err.(*jrpc2.Error)
-	require.True(t, ok, "a jrpc2.Error carrying the range")
+	var rpcErr *jrpc2.Error
+	require.ErrorAs(t, err, &rpcErr, "a jrpc2.Error carrying the range")
 	assert.Contains(t, rpcErr.Message, "ledger range")
 }
 
@@ -234,10 +233,10 @@ func TestGetEvents_CollisionUnderfillDoesNotSkip(t *testing.T) {
 	require.NoError(t, cat.PinEarliestLedger(first))
 
 	cA, cB := contractID(0xAA), contractID(0xBB)
-	evA, _ := contractEventXDR(t, cA, "topic-a", "a")
-	evB, _ := contractEventXDR(t, cB, "topic-b", "b")
+	evA := contractEventXDR(t, cA, "topic-a", "a")
+	evB := contractEventXDR(t, cB, "topic-b", "b")
 
-	// One event per ledger: B, B, A, A → event IDs 0..3.
+	// One event per ledger: B, then B, then A, then A → event IDs 0..3.
 	seqs := []uint32{first, first + 1, first + 2, coldLast}
 	ledgerEvents := map[uint32][]xdr.ContractEvent{
 		first:     {evB},
@@ -245,7 +244,7 @@ func TestGetEvents_CollisionUnderfillDoesNotSkip(t *testing.T) {
 		first + 2: {evA},
 		coldLast:  {evA},
 	}
-	var raws [][]byte
+	raws := make([][]byte, 0, len(seqs))
 	for _, seq := range seqs {
 		raws = append(raws, lcmWithCloseTime(t, seq, int64(seq)*10))
 	}

--- a/cmd/stellar-rpc/internal/fullhistory/serve/events_handler_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/events_handler_test.go
@@ -1,0 +1,220 @@
+package serve
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/creachadair/jrpc2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
+	"github.com/stellar/go-stellar-sdk/strkey"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/fhtest"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/geometry"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+)
+
+// The events seam fixture reuses the ledger seam constants (coldFirst..hotLast in
+// ledger_reader_test.go): a frozen cold chunk 0 covering ledgers
+// [coldFirst, coldLast] and a live hot chunk 1 covering [hotFirst, hotLast].
+// Contract A emits an event at coldFirst, coldLast (cold) and hotFirst (hot);
+// contract B at coldFirst+1 (cold) and hotLast (hot). A contract-A filter thus
+// matches 3 events straddling the cold→hot seam.
+func contractID(b byte) xdr.ContractId {
+	var c xdr.ContractId
+	c[0] = b
+	return c
+}
+
+func contractStrkey(t *testing.T, c xdr.ContractId) string {
+	t.Helper()
+	s, err := strkey.Encode(strkey.VersionByteContract, c[:])
+	require.NoError(t, err)
+	return s
+}
+
+type eventsFixture struct {
+	reg       *Registry
+	layout    geometry.Layout
+	contractA string
+	contractB string
+	contractC string // never emitted — the empty-match case
+}
+
+func buildEventsSeamFixture(t *testing.T) eventsFixture {
+	t.Helper()
+	cat, layout := newTestCatalog(t)
+	require.NoError(t, cat.PinEarliestLedger(coldFirst))
+
+	cA, cB := contractID(0xAA), contractID(0xBB)
+	evA1, _ := contractEventXDR(t, cA, "topic-a", "a1")
+	evB, _ := contractEventXDR(t, cB, "topic-b", "b1")
+	evA2, _ := contractEventXDR(t, cA, "topic-a", "a2")
+	evA3, _ := contractEventXDR(t, cA, "topic-a", "a3")
+	evB2, _ := contractEventXDR(t, cB, "topic-b", "b2")
+
+	// Cold chunk 0: A@coldFirst, B@coldFirst+1, A@coldLast.
+	coldSeqs := []uint32{coldFirst, coldFirst + 1, coldLast}
+	coldEvents := map[uint32][]xdr.ContractEvent{
+		coldFirst:     {evA1},
+		coldFirst + 1: {evB},
+		coldLast:      {evA2},
+	}
+	// A cold ledger pack + cold events pack for chunk 0, both frozen.
+	var raws [][]byte
+	for seq := uint32(coldFirst); seq <= coldLast; seq++ {
+		raws = append(raws, lcmWithCloseTime(t, seq, int64(seq)*10))
+	}
+	writeColdLedgerRun(t, layout, chunk.ID(0), coldFirst, raws)
+	freezeLedgers(t, cat, chunk.ID(0))
+	writeColdEventsChunk(t, layout, chunk.ID(0), coldFirst, coldSeqs, coldEvents)
+	freezeEvents(t, cat, chunk.ID(0))
+
+	// Hot chunk 1: A@hotFirst, B@hotLast.
+	hotSeqs := []uint32{hotFirst, hotLast}
+	hotEvents := map[uint32][]xdr.ContractEvent{
+		hotFirst: {evA3},
+		hotLast:  {evB2},
+	}
+	db1 := openHotEventChunk(t, cat, layout, chunk.ID(1), hotSeqs, hotEvents)
+	t.Cleanup(func() { _ = db1.Close() })
+
+	r := NewRegistry(cat, fhtest.RetentionFor(t, cat, 0), silentLogger())
+	require.NoError(t, r.BuildInitial(hotLast))
+	r.HotOpened(chunk.ID(1), db1)
+
+	return eventsFixture{
+		reg:       r,
+		layout:    layout,
+		contractA: contractStrkey(t, cA),
+		contractB: contractStrkey(t, cB),
+		contractC: contractStrkey(t, contractID(0xCC)),
+	}
+}
+
+func getEventsRequest(t *testing.T, params string) *jrpc2.Request {
+	t.Helper()
+	requests, err := jrpc2.ParseRequests([]byte(
+		`{"jsonrpc":"2.0","id":1,"method":"getEvents","params":` + params + `}`,
+	))
+	require.NoError(t, err)
+	require.Len(t, requests, 1)
+	return requests[0].ToRequest()
+}
+
+func callGetEvents(t *testing.T, fx eventsFixture, params string) protocol.GetEventsResponse {
+	t.Helper()
+	h := NewGetEventsHandler(silentLogger(), fx.reg, fx.layout, 10000, 100)
+	res, err := h(t.Context(), getEventsRequest(t, params))
+	require.NoError(t, err)
+	resp, ok := res.(protocol.GetEventsResponse)
+	require.True(t, ok, "handler returns a GetEventsResponse")
+	return resp
+}
+
+// A contract-A filter matches all three A events across the cold→hot seam in one
+// page, in ascending cursor order.
+func TestGetEvents_FilterAcrossSeam(t *testing.T) {
+	fx := buildEventsSeamFixture(t)
+	resp := callGetEvents(t, fx, `{"startLedger":`+itoa(coldFirst)+
+		`,"filters":[{"contractIds":["`+fx.contractA+`"]}],"pagination":{"limit":10}}`)
+
+	require.Len(t, resp.Events, 3, "all three contract-A events across the seam")
+	assert.EqualValues(t, coldFirst, resp.Events[0].Ledger)
+	assert.EqualValues(t, coldLast, resp.Events[1].Ledger)
+	assert.EqualValues(t, hotFirst, resp.Events[2].Ledger)
+	for _, e := range resp.Events {
+		assert.Equal(t, fx.contractA, e.ContractID, "only contract-A events matched")
+		assert.Equal(t, protocol.EventTypeContract, e.EventType)
+		assert.NotEmpty(t, e.TopicXDR, "base64 topic encoding by default")
+		assert.NotEmpty(t, e.ValueXDR)
+	}
+	assert.EqualValues(t, hotLast, resp.LatestLedger)
+	assert.EqualValues(t, coldFirst, resp.OldestLedger)
+}
+
+// A limited page truncates to the limit and sets the cursor to the last returned
+// event; the follow-up cursor page resumes exclusively.
+func TestGetEvents_PaginationResumesExclusively(t *testing.T) {
+	fx := buildEventsSeamFixture(t)
+
+	page1 := callGetEvents(t, fx, `{"startLedger":`+itoa(coldFirst)+
+		`,"filters":[{"contractIds":["`+fx.contractA+`"]}],"pagination":{"limit":2}}`)
+	require.Len(t, page1.Events, 2, "limit truncates the page")
+	assert.EqualValues(t, coldFirst, page1.Events[0].Ledger)
+	assert.EqualValues(t, coldLast, page1.Events[1].Ledger)
+	assert.Equal(t, page1.Events[1].ID, page1.Cursor, "cursor is the last returned event when limit reached")
+
+	page2 := callGetEvents(t, fx, `{"filters":[{"contractIds":["`+fx.contractA+
+		`"]}],"pagination":{"cursor":"`+page1.Cursor+`","limit":2}}`)
+	require.Len(t, page2.Events, 1, "the remaining A event resumes after the cursor")
+	assert.EqualValues(t, hotFirst, page2.Events[0].Ledger)
+	assert.NotEqual(t, page1.Cursor, page2.Events[0].ID, "resume is exclusive of the prior cursor")
+}
+
+// A filter matching nothing returns an empty page whose cursor advances to the
+// end of the scan window (endLedger-1), so the client makes forward progress.
+func TestGetEvents_EmptyMatchAdvancesCursor(t *testing.T) {
+	fx := buildEventsSeamFixture(t)
+	resp := callGetEvents(t, fx, `{"startLedger":`+itoa(coldFirst)+
+		`,"filters":[{"contractIds":["`+fx.contractC+`"]}],"pagination":{"limit":10}}`)
+
+	assert.Empty(t, resp.Events, "contract C never emitted")
+	// endLedger = min(latest+1, startLedger+scanLimit); here latest+1 = hotLast+1.
+	wantCursor := protocol.MaxCursor
+	wantCursor.Ledger = hotLast // endLedger-1
+	assert.Equal(t, wantCursor.String(), resp.Cursor, "empty page advances the cursor to the window end")
+	assert.EqualValues(t, hotLast, resp.LatestLedger)
+	assert.EqualValues(t, coldFirst, resp.OldestLedger)
+}
+
+// A startLedger below the oldest served ledger is rejected with the available
+// range surfaced (mirrors v1's InvalidRequest).
+func TestGetEvents_OutOfRangeStartErrors(t *testing.T) {
+	fx := buildEventsSeamFixture(t)
+	h := NewGetEventsHandler(silentLogger(), fx.reg, fx.layout, 10000, 100)
+
+	_, err := h(t.Context(), getEventsRequest(t,
+		`{"startLedger":`+itoa(coldFirst-1)+`,"pagination":{"limit":10}}`))
+	require.Error(t, err)
+	rpcErr, ok := err.(*jrpc2.Error)
+	require.True(t, ok, "a jrpc2.Error carrying the range")
+	assert.Contains(t, rpcErr.Message, "ledger range")
+}
+
+// The json format renders topics/value as decoded JSON instead of base64 XDR.
+func TestGetEvents_JSONFormat(t *testing.T) {
+	fx := buildEventsSeamFixture(t)
+	resp := callGetEvents(t, fx, `{"startLedger":`+itoa(coldFirst)+
+		`,"filters":[{"contractIds":["`+fx.contractA+`"]}],"xdrFormat":"json","pagination":{"limit":10}}`)
+
+	require.NotEmpty(t, resp.Events)
+	for _, e := range resp.Events {
+		assert.NotEmpty(t, e.TopicJSON, "json topic encoding")
+		assert.NotEmpty(t, e.ValueJSON)
+		assert.Empty(t, e.TopicXDR, "no base64 topics in json mode")
+	}
+}
+
+// A match-all page (no filters) returns every event across both tiers in cursor
+// order.
+func TestGetEvents_NoFilterMatchesAll(t *testing.T) {
+	fx := buildEventsSeamFixture(t)
+	resp := callGetEvents(t, fx, `{"startLedger":`+itoa(coldFirst)+`,"pagination":{"limit":10}}`)
+
+	require.Len(t, resp.Events, 5, "all five events across cold+hot")
+	ledgers := make([]uint32, len(resp.Events))
+	for i, e := range resp.Events {
+		ledgers[i] = uint32(e.Ledger)
+	}
+	assert.Equal(t, []uint32{coldFirst, coldFirst + 1, coldLast, hotFirst, hotLast}, ledgers,
+		"ascending cursor order across the seam")
+}
+
+// itoa is a tiny helper so the JSON request literals stay readable.
+func itoa(v int) string {
+	return strconv.Itoa(v)
+}

--- a/cmd/stellar-rpc/internal/fullhistory/serve/events_handler_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/events_handler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stellar/go-stellar-sdk/strkey"
 	"github.com/stellar/go-stellar-sdk/xdr"
 
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/events"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/fhtest"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/geometry"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
@@ -70,7 +71,7 @@ func buildEventsSeamFixture(t *testing.T) eventsFixture {
 	}
 	writeColdLedgerRun(t, layout, chunk.ID(0), coldFirst, raws)
 	freezeLedgers(t, cat, chunk.ID(0))
-	writeColdEventsChunk(t, layout, chunk.ID(0), coldFirst, coldSeqs, coldEvents)
+	writeColdEventsChunk(t, layout, chunk.ID(0), coldFirst, coldSeqs, coldEvents, nil)
 	freezeEvents(t, cat, chunk.ID(0))
 
 	// Hot chunk 1: A@hotFirst, B@hotLast.
@@ -212,6 +213,64 @@ func TestGetEvents_NoFilterMatchesAll(t *testing.T) {
 	}
 	assert.Equal(t, []uint32{coldFirst, coldFirst + 1, coldLast, hotFirst, hotLast}, ledgers,
 		"ascending cursor order across the seam")
+}
+
+// Regression for review finding I1: eventstore.Query applies its collision
+// post-filter AFTER the MaxEvents cap, so a short result does NOT mean the
+// window is exhausted (QueryOptions.MaxEvents contract). If scanChunk treats a
+// capped-but-underfilled query as exhaustion, real matches past the cap are
+// skipped permanently (the short page's cursor advances past them).
+//
+// The fixture simulates an xxh3_128 term collision by poisoning contract A's
+// term bitmap with the IDs of contract B's events (0, 1): with limit 2, the
+// first Query(MaxEvents=2) fetches only the two false positives, Query's own
+// post-filter drops both, and a `len(payloads) < cap` exhaustion gate would
+// stop before ever fetching the real A events at IDs 2, 3.
+func TestGetEvents_CollisionUnderfillDoesNotSkip(t *testing.T) {
+	cat, layout := newTestCatalog(t)
+	// Four cold ledgers ending at chunk 0's last ledger, so the whole run stays
+	// inside one chunk.
+	first := uint32(coldLast - 3)
+	require.NoError(t, cat.PinEarliestLedger(first))
+
+	cA, cB := contractID(0xAA), contractID(0xBB)
+	evA, _ := contractEventXDR(t, cA, "topic-a", "a")
+	evB, _ := contractEventXDR(t, cB, "topic-b", "b")
+
+	// One event per ledger: B, B, A, A → event IDs 0..3.
+	seqs := []uint32{first, first + 1, first + 2, coldLast}
+	ledgerEvents := map[uint32][]xdr.ContractEvent{
+		first:     {evB},
+		first + 1: {evB},
+		first + 2: {evA},
+		coldLast:  {evA},
+	}
+	var raws [][]byte
+	for _, seq := range seqs {
+		raws = append(raws, lcmWithCloseTime(t, seq, int64(seq)*10))
+	}
+	writeColdLedgerRun(t, layout, chunk.ID(0), first, raws)
+	freezeLedgers(t, cat, chunk.ID(0))
+
+	// Poison contract A's term bitmap with B's event IDs — the collision stand-in.
+	poison := func(idx events.Bitmaps) {
+		key := events.ComputeTermKey(cA[:], events.FieldContractID)
+		idx.AddTo(key, 0, 1)
+	}
+	writeColdEventsChunk(t, layout, chunk.ID(0), first, seqs, ledgerEvents, poison)
+	freezeEvents(t, cat, chunk.ID(0))
+
+	r := NewRegistry(cat, fhtest.RetentionFor(t, cat, 0), silentLogger())
+	require.NoError(t, r.BuildInitial(coldLast))
+	fx := eventsFixture{reg: r, layout: layout, contractA: contractStrkey(t, cA)}
+
+	resp := callGetEvents(t, fx, `{"startLedger":`+itoa(int(first))+
+		`,"filters":[{"contractIds":["`+fx.contractA+`"]}],"pagination":{"limit":2}}`)
+
+	require.Len(t, resp.Events, 2, "both real A events found despite the collision-capped first query")
+	assert.EqualValues(t, first+2, resp.Events[0].Ledger)
+	assert.EqualValues(t, coldLast, resp.Events[1].Ledger)
+	assert.Equal(t, resp.Events[1].ID, resp.Cursor, "page filled: cursor is the last real match")
 }
 
 // itoa is a tiny helper so the JSON request literals stay readable.

--- a/cmd/stellar-rpc/internal/fullhistory/serve/fixtures_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/fixtures_test.go
@@ -1,0 +1,190 @@
+package serve
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stellar/go-stellar-sdk/network"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/events"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/catalog"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/geometry"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk"
+)
+
+// contractEventXDR builds a contract-type ContractEvent for the given contract
+// ID with a single symbol topic and symbol data — the minimal shape the events
+// index and the protocol filter both key off (mirror of the eventstore and
+// ingest test fixtures). It returns the event and its marshaled bytes.
+func contractEventXDR(t *testing.T, contractID xdr.ContractId, topic, data string) (xdr.ContractEvent, []byte) {
+	t.Helper()
+	topicSym := xdr.ScSymbol(topic)
+	dataSym := xdr.ScSymbol(data)
+	cid := contractID
+	ev := xdr.ContractEvent{
+		ContractId: &cid,
+		Type:       xdr.ContractEventTypeContract,
+		Body: xdr.ContractEventBody{
+			V: 0,
+			V0: &xdr.ContractEventV0{
+				Topics: []xdr.ScVal{{Type: xdr.ScValTypeScvSymbol, Sym: &topicSym}},
+				Data:   xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &dataSym},
+			},
+		},
+	}
+	raw, err := ev.MarshalBinary()
+	require.NoError(t, err)
+	return ev, raw
+}
+
+// eventLedgerLCM builds a V2 LedgerCloseMeta carrying one transaction whose sole
+// operation emits evs (operation-level contract events). It is the hot-ingest
+// counterpart of writeColdEventsChunk: IngestLedger runs ExtractLedgerEvents over
+// this LCM, so the events land in the chunk's events store in cursor order. The
+// header close time is seq*10 so a test can prove the served close time came from
+// the ingested bytes.
+func eventLedgerLCM(t *testing.T, seq uint32, evs []xdr.ContractEvent) []byte {
+	t.Helper()
+	meta := xdr.TransactionMeta{
+		V:  4,
+		V4: &xdr.TransactionMetaV4{Operations: []xdr.OperationMetaV2{{Events: evs}}},
+	}
+	src := xdr.MustMuxedAddress(keypair.MustRandom().Address())
+	envelope := xdr.TransactionEnvelope{
+		Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+		V1: &xdr.TransactionV1Envelope{
+			Tx: xdr.Transaction{
+				SourceAccount: src,
+				SeqNum:        xdr.SequenceNumber(seq),
+				Ext:           xdr.TransactionExt{V: 1, SorobanData: &xdr.SorobanTransactionData{}},
+			},
+		},
+	}
+	hash, err := network.HashTransactionInEnvelope(envelope, network.PublicNetworkPassphrase)
+	require.NoError(t, err)
+	comp := []xdr.TxSetComponent{{
+		Type: xdr.TxSetComponentTypeTxsetCompTxsMaybeDiscountedFee,
+		TxsMaybeDiscountedFee: &xdr.TxSetComponentTxsMaybeDiscountedFee{
+			Txs: []xdr.TransactionEnvelope{envelope},
+		},
+	}}
+	lcm := xdr.LedgerCloseMeta{
+		V: 2,
+		V2: &xdr.LedgerCloseMetaV2{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+				Header: xdr.LedgerHeader{
+					ScpValue:  xdr.StellarValue{CloseTime: xdr.TimePoint(uint64(seq) * 10)},
+					LedgerSeq: xdr.Uint32(seq),
+				},
+			},
+			TxSet: xdr.GeneralizedTransactionSet{
+				V:       1,
+				V1TxSet: &xdr.TransactionSetV1{Phases: []xdr.TransactionPhase{{V: 0, V0Components: &comp}}},
+			},
+			TxProcessing: []xdr.TransactionResultMetaV1{{
+				TxApplyProcessing: meta,
+				Result: xdr.TransactionResultPair{
+					TransactionHash: hash,
+					Result: xdr.TransactionResult{
+						FeeCharged: 100,
+						Result: xdr.TransactionResultResult{
+							Code:    xdr.TransactionResultCodeTxSuccess,
+							Results: &[]xdr.OperationResult{},
+						},
+					},
+				},
+			}},
+		},
+	}
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	return raw
+}
+
+// openHotEventChunk runs the real create bracket for chunk c and ingests one
+// event-bearing ledger per entry in ledgerEvents (keyed by sequence), returning
+// the live write handle. Mirrors registry_test's openHotChunk but drives
+// event-carrying LCMs so the chunk's events store is populated.
+func openHotEventChunk(
+	t *testing.T, cat *catalog.Catalog, layout geometry.Layout, c chunk.ID,
+	seqs []uint32, ledgerEvents map[uint32][]xdr.ContractEvent,
+) *hotchunk.DB {
+	t.Helper()
+	require.NoError(t, cat.BeginHotCreate(c))
+	db, err := hotchunk.Open(layout.HotChunkPath(c), c, silentLogger())
+	require.NoError(t, err)
+	for _, s := range seqs {
+		raw := eventLedgerLCM(t, s, ledgerEvents[s])
+		_, err := db.IngestLedger(s, xdr.LedgerCloseMetaView(raw))
+		require.NoError(t, err)
+	}
+	require.NoError(t, cat.FinishHotCreate(c))
+	return db
+}
+
+// writeColdEventsChunk materializes cold events artifacts (events.pack + index)
+// for chunk c at layout.EventsBucketDir(c), holding the contract events in
+// ledgerEvents. offsets start at startLedger and cover the contiguous run
+// [startLedger, startLedger+len(seqs)-1] (a partial-chunk pack — the POC fixture
+// keeps cold artifacts tiny, like writeColdLedgerRun). Payloads carry a
+// deterministic close time (seq*10) matching the hot path's header close time.
+func writeColdEventsChunk(
+	t *testing.T, layout geometry.Layout, c chunk.ID,
+	startLedger uint32, seqs []uint32, ledgerEvents map[uint32][]xdr.ContractEvent,
+) {
+	t.Helper()
+	dir := layout.EventsBucketDir(c)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	cw, err := eventstore.NewColdWriter(c, dir, eventstore.ColdWriterOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cw.Close() })
+
+	offsets := events.NewLedgerOffsets(startLedger)
+	idx := events.NewBitmaps()
+	eventID := uint32(0)
+	for _, seq := range seqs {
+		evs := ledgerEvents[seq]
+		require.NoError(t, offsets.Append(seq, uint32(len(evs))))
+		var txHash xdr.Hash
+		txHash[0] = byte(seq)
+		txHash[1] = byte(seq >> 8)
+		for evIdx, ev := range evs {
+			raw, err := ev.MarshalBinary()
+			require.NoError(t, err)
+			p := events.Payload{
+				TxHash:             txHash,
+				LedgerSequence:     seq,
+				TxIdx:              1,
+				OpIdx:              0,
+				LedgerClosedAt:     int64(seq) * 10,
+				EventIdx:           uint32(evIdx),
+				ContractEventBytes: raw,
+			}
+			require.NoError(t, cw.Append(p))
+			keys, err := events.TermsForBytes(raw)
+			require.NoError(t, err)
+			for _, k := range keys {
+				idx.AddTo(k, eventID)
+			}
+			eventID++
+		}
+	}
+	require.NoError(t, cw.Finish(offsets))
+	require.NoError(t, eventstore.WriteColdIndex(context.Background(), c, idx, dir))
+}
+
+// freezeEvents marks chunk c's events artifact frozen in the catalog, so the
+// View resolves it to the cold events reader (cold wins over the hot handle).
+func freezeEvents(t *testing.T, cat *catalog.Catalog, c chunk.ID) {
+	t.Helper()
+	require.NoError(t, cat.MarkChunkFreezing(c, geometry.KindEvents))
+	require.NoError(t, cat.FlipChunkFrozen(c, geometry.KindEvents))
+}

--- a/cmd/stellar-rpc/internal/fullhistory/serve/fixtures_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/fixtures_test.go
@@ -135,9 +135,15 @@ func openHotEventChunk(
 // [startLedger, startLedger+len(seqs)-1] (a partial-chunk pack — the POC fixture
 // keeps cold artifacts tiny, like writeColdLedgerRun). Payloads carry a
 // deterministic close time (seq*10) matching the hot path's header close time.
+//
+// poison, when non-nil, runs over the term bitmaps just before the index is
+// written — a test hook to inject false-positive event IDs, simulating what an
+// xxh3_128 term collision would produce (mirror of eventstore's
+// TestQuery_PostFilterRejectsTermHashCollision technique on the cold side).
 func writeColdEventsChunk(
 	t *testing.T, layout geometry.Layout, c chunk.ID,
 	startLedger uint32, seqs []uint32, ledgerEvents map[uint32][]xdr.ContractEvent,
+	poison func(events.Bitmaps),
 ) {
 	t.Helper()
 	dir := layout.EventsBucketDir(c)
@@ -178,6 +184,9 @@ func writeColdEventsChunk(
 		}
 	}
 	require.NoError(t, cw.Finish(offsets))
+	if poison != nil {
+		poison(idx)
+	}
 	require.NoError(t, eventstore.WriteColdIndex(context.Background(), c, idx, dir))
 }
 

--- a/cmd/stellar-rpc/internal/fullhistory/serve/fixtures_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/fixtures_test.go
@@ -22,8 +22,8 @@ import (
 // contractEventXDR builds a contract-type ContractEvent for the given contract
 // ID with a single symbol topic and symbol data — the minimal shape the events
 // index and the protocol filter both key off (mirror of the eventstore and
-// ingest test fixtures). It returns the event and its marshaled bytes.
-func contractEventXDR(t *testing.T, contractID xdr.ContractId, topic, data string) (xdr.ContractEvent, []byte) {
+// ingest test fixtures).
+func contractEventXDR(t *testing.T, contractID xdr.ContractId, topic, data string) xdr.ContractEvent {
 	t.Helper()
 	topicSym := xdr.ScSymbol(topic)
 	dataSym := xdr.ScSymbol(data)
@@ -39,9 +39,7 @@ func contractEventXDR(t *testing.T, contractID xdr.ContractId, topic, data strin
 			},
 		},
 	}
-	raw, err := ev.MarshalBinary()
-	require.NoError(t, err)
-	return ev, raw
+	return ev
 }
 
 // eventLedgerLCM builds a V2 LedgerCloseMeta carrying one transaction whose sole

--- a/cmd/stellar-rpc/internal/fullhistory/serve/ledger_reader.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/ledger_reader.go
@@ -119,7 +119,11 @@ func (tx *readTx) GetLedger(_ context.Context, sequence uint32) (xdr.LedgerClose
 }
 
 func (tx *readTx) GetLedgerRange(_ context.Context) (ledgerbucketwindow.LedgerRange, error) {
-	if tx.latest == 0 {
+	// Not-yet-servable watermark: 0 before the first View is built, and the
+	// FirstLedgerSeq-1 sentinel that startup seeds ("nothing committed yet")
+	// until the first ledger commits. Guard both — a sub-genesis latest would
+	// panic chunk.IDFromLedger in closeTime below.
+	if tx.latest < chunk.FirstLedgerSeq {
 		return ledgerbucketwindow.LedgerRange{}, db.ErrEmptyDB
 	}
 	firstCloseTime, err := tx.closeTime(tx.first)

--- a/cmd/stellar-rpc/internal/fullhistory/serve/ledger_reader.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/ledger_reader.go
@@ -1,0 +1,225 @@
+package serve
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/db"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/geometry"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/ledgerbucketwindow"
+)
+
+// errPOCUnsupported is returned by the read-path methods none of the four query
+// handlers reach in the POC (the daemon serves only getLedgers / getTransaction
+// / getTransactions).
+var errPOCUnsupported = errors.New("not supported by full-history POC read path")
+
+// ledgerReader adapts the serve Registry to the db.LedgerReader interface the v1
+// query handlers consume, so methods.NewGetLedgersHandler and
+// methods.NewGetTransactionsHandler run verbatim over full-history storage.
+type ledgerReader struct {
+	reg    *Registry
+	layout geometry.Layout
+}
+
+// NewLedgerReader returns a db.LedgerReader backed by the serve Registry.
+func NewLedgerReader(reg *Registry, layout geometry.Layout) db.LedgerReader {
+	return ledgerReader{reg: reg, layout: layout}
+}
+
+func (r ledgerReader) NewTx(_ context.Context) (db.LedgerReaderTx, error) {
+	// Admit exactly once and pin (latest, view) for the whole tx (design
+	// §Admission) — every method below reads that one immutable snapshot.
+	latest, v := r.reg.Admit()
+	return &readTx{
+		view:   v,
+		layout: r.layout,
+		latest: latest,
+		first:  max(v.Floor.FirstLedger(), v.Earliest),
+	}, nil
+}
+
+// GetLedger and GetLedgerRange are cheap one-shot transactions (the single-
+// transaction getTransaction path calls GetLedgerRange on the reader directly).
+func (r ledgerReader) GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, bool, error) {
+	tx, err := r.NewTx(ctx)
+	if err != nil {
+		return xdr.LedgerCloseMeta{}, false, err
+	}
+	defer func() { _ = tx.Done() }()
+	return tx.GetLedger(ctx, sequence)
+}
+
+func (r ledgerReader) GetLedgerRange(ctx context.Context) (ledgerbucketwindow.LedgerRange, error) {
+	tx, err := r.NewTx(ctx)
+	if err != nil {
+		return ledgerbucketwindow.LedgerRange{}, err
+	}
+	defer func() { _ = tx.Done() }()
+	return tx.GetLedgerRange(ctx)
+}
+
+func (r ledgerReader) GetLatestLedgerSequence(_ context.Context) (uint32, error) {
+	latest, _ := r.reg.Admit()
+	if latest == 0 {
+		return 0, db.ErrEmptyDB
+	}
+	return latest, nil
+}
+
+// POC: the daemon's read path never streams or counts ledger ranges.
+func (r ledgerReader) StreamAllLedgers(_ context.Context, _ db.StreamLedgerFn) error {
+	return errPOCUnsupported
+}
+
+// POC: unused by the four query handlers.
+func (r ledgerReader) GetLedgerCountInRange(_ context.Context, _, _ uint32) (uint32, uint32, uint32, error) {
+	return 0, 0, 0, errPOCUnsupported
+}
+
+// POC: unused by the four query handlers.
+func (r ledgerReader) StreamLedgerRange(_ context.Context, _, _ uint32, _ db.StreamLedgerFn) error {
+	return errPOCUnsupported
+}
+
+// readTx is one query's pinned snapshot: a fixed (latest, view) pair and the
+// derived servable floor. Done() is a no-op release — nothing is held open
+// between calls (per-chunk cold readers are opened and closed within each call).
+type readTx struct {
+	view   *View
+	layout geometry.Layout
+	latest uint32
+	first  uint32
+}
+
+func (tx *readTx) Done() error { return nil }
+
+func (tx *readTx) GetLedger(_ context.Context, sequence uint32) (xdr.LedgerCloseMeta, bool, error) {
+	if sequence < tx.first || sequence > tx.latest {
+		return xdr.LedgerCloseMeta{}, false, nil
+	}
+	raw, err := tx.getRaw(sequence)
+	switch {
+	case errors.Is(err, stores.ErrNotFound), errors.Is(err, stores.ErrOutOfRange):
+		return xdr.LedgerCloseMeta{}, false, nil
+	case err != nil:
+		return xdr.LedgerCloseMeta{}, false, err
+	}
+	var lcm xdr.LedgerCloseMeta
+	if err := lcm.UnmarshalBinary(raw); err != nil {
+		return xdr.LedgerCloseMeta{}, false, err
+	}
+	return lcm, true, nil
+}
+
+func (tx *readTx) GetLedgerRange(_ context.Context) (ledgerbucketwindow.LedgerRange, error) {
+	if tx.latest == 0 {
+		return ledgerbucketwindow.LedgerRange{}, db.ErrEmptyDB
+	}
+	firstCloseTime, err := tx.closeTime(tx.first)
+	if err != nil {
+		return ledgerbucketwindow.LedgerRange{}, err
+	}
+	lastCloseTime, err := tx.closeTime(tx.latest)
+	if err != nil {
+		return ledgerbucketwindow.LedgerRange{}, err
+	}
+	return ledgerbucketwindow.LedgerRange{
+		FirstLedger: ledgerbucketwindow.LedgerInfo{Sequence: tx.first, CloseTime: firstCloseTime},
+		LastLedger:  ledgerbucketwindow.LedgerInfo{Sequence: tx.latest, CloseTime: lastCloseTime},
+	}, nil
+}
+
+func (tx *readTx) BatchGetLedgers(_ context.Context, start, end uint32) ([]db.LedgerMetadataChunk, error) {
+	if end > tx.latest {
+		end = tx.latest
+	}
+	if start < tx.first {
+		return nil, fmt.Errorf("%w: batch start %d below retention floor %d", stores.ErrOutOfRange, start, tx.first)
+	}
+	if start > end {
+		return nil, nil
+	}
+
+	out := make([]db.LedgerMetadataChunk, 0, end-start+1)
+	for c := chunk.IDFromLedger(start); c <= chunk.IDFromLedger(end); c++ {
+		lo := max(start, c.FirstLedger())
+		hi := min(end, c.LastLedger())
+		if err := tx.appendChunk(c, lo, hi, &out); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+// appendChunk resolves chunk c, appends its ledgers in [lo, hi], and closes the
+// handle before returning. Each borrowed iterator buffer is copied so the
+// retained Lcm outlives the iteration step.
+func (tx *readTx) appendChunk(c chunk.ID, lo, hi uint32, out *[]db.LedgerMetadataChunk) error {
+	lc, err := tx.view.ResolveLedgers(c, tx.layout)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = lc.Close() }()
+
+	for e, err := range lc.Iterate(lo, hi) {
+		if err != nil {
+			return err
+		}
+		raw := bytes.Clone(e.Bytes)
+		header, err := decodeLedgerHeader(raw)
+		if err != nil {
+			return err
+		}
+		*out = append(*out, db.LedgerMetadataChunk{Header: header, Lcm: raw})
+	}
+	return nil
+}
+
+// getRaw resolves seq's chunk, reads its raw ledger bytes, and closes the handle.
+func (tx *readTx) getRaw(seq uint32) ([]byte, error) {
+	lc, err := tx.view.ResolveLedgers(chunk.IDFromLedger(seq), tx.layout)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = lc.Close() }()
+	return lc.Get(seq)
+}
+
+// closeTime decodes just the close time of the ledger at seq via the zero-copy
+// LedgerCloseMetaView (no full-body XDR decode).
+func (tx *readTx) closeTime(seq uint32) (int64, error) {
+	raw, err := tx.getRaw(seq)
+	if err != nil {
+		return 0, err
+	}
+	return xdr.LedgerCloseMetaView(raw).LedgerCloseTime()
+}
+
+// decodeLedgerHeader extracts the concrete LedgerHeaderHistoryEntry from raw
+// LedgerCloseMeta bytes without decoding the (potentially large) transaction
+// body — the same header-only skip v1's db.BatchGetLedgers uses.
+func decodeLedgerHeader(raw []byte) (xdr.LedgerHeaderHistoryEntry, error) {
+	var header xdr.LedgerHeaderHistoryEntry
+	var version xdr.Int32
+	rd := bytes.NewReader(raw)
+	if _, err := xdr.Unmarshal(rd, &version); err != nil {
+		return header, err
+	}
+	if version > 0 { // V0 has no extension
+		var ext xdr.LedgerCloseMetaExt
+		if _, err := xdr.Unmarshal(rd, &ext); err != nil {
+			return header, err
+		}
+	}
+	if _, err := xdr.Unmarshal(rd, &header); err != nil {
+		return header, err
+	}
+	return header, nil
+}

--- a/cmd/stellar-rpc/internal/fullhistory/serve/ledger_reader_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/ledger_reader_test.go
@@ -198,6 +198,19 @@ func TestLedgerReader_GetLedgerRange_EmptyIsErrEmptyDB(t *testing.T) {
 	require.ErrorIs(t, err, db.ErrEmptyDB)
 }
 
+// A watermark of FirstLedgerSeq-1 is the startup "nothing committed yet" sentinel
+// (BuildInitial seeds it before the first commit). GetLedgerRange must report
+// ErrEmptyDB, not panic in chunk.IDFromLedger on the sub-genesis close-time read.
+func TestLedgerReader_GetLedgerRange_SentinelWatermarkIsErrEmptyDB(t *testing.T) {
+	cat, layout := newTestCatalog(t)
+	r := NewRegistry(cat, fhtest.RetentionFor(t, cat, 0), silentLogger())
+	require.NoError(t, r.BuildInitial(chunk.FirstLedgerSeq-1))
+	lr := NewLedgerReader(r, layout)
+
+	_, err := lr.GetLedgerRange(t.Context())
+	require.ErrorIs(t, err, db.ErrEmptyDB)
+}
+
 func TestLedgerReader_UnsupportedPOCMethods(t *testing.T) {
 	lr, _ := buildSeamReader(t)
 	require.Error(t, lr.StreamAllLedgers(t.Context(), nil))

--- a/cmd/stellar-rpc/internal/fullhistory/serve/ledger_reader_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/ledger_reader_test.go
@@ -1,0 +1,233 @@
+package serve
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/creachadair/jrpc2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/db"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/fhtest"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/geometry"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/ledger"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/methods"
+)
+
+// The seam fixture: a frozen cold chunk 0 covering ledgers [coldFirst, coldLast]
+// and a live hot chunk 1 covering [hotFirst, hotLast], contiguous across the
+// chunk-0/chunk-1 boundary. earliest_ledger is pinned to coldFirst so the
+// servable floor lands inside the (partial) cold pack — a real frozen chunk
+// spans its whole range, but the POC fixture keeps packs tiny.
+const (
+	coldFirst = 9999
+	coldLast  = 10001 // chunk 0's last ledger
+	hotFirst  = 10002 // chunk 1's first ledger
+	hotLast   = 10003
+)
+
+// lcmWithCloseTime is ZeroTxLCMBytes with a caller-chosen close time, so a
+// GetLedgerRange test can prove the close time was decoded from the served bytes.
+func lcmWithCloseTime(t *testing.T, seq uint32, closeTime int64) []byte {
+	t.Helper()
+	lcm := xdr.LedgerCloseMeta{
+		V: 2,
+		V2: &xdr.LedgerCloseMetaV2{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+				Header: xdr.LedgerHeader{
+					ScpValue:  xdr.StellarValue{CloseTime: xdr.TimePoint(closeTime)}, //nolint:gosec
+					LedgerSeq: xdr.Uint32(seq),
+				},
+			},
+			TxSet: xdr.GeneralizedTransactionSet{
+				V:       1,
+				V1TxSet: &xdr.TransactionSetV1{Phases: nil},
+			},
+		},
+	}
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	return raw
+}
+
+// writeColdLedgerRun writes a real cold ledger pack at c's layout path holding
+// the contiguous run raws[i] at firstSeq+i.
+func writeColdLedgerRun(t *testing.T, layout geometry.Layout, c chunk.ID, firstSeq uint32, raws [][]byte) {
+	t.Helper()
+	path := layout.LedgerPackPath(c)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	w, err := ledger.NewColdWriter(path, firstSeq, ledger.ColdWriterOptions{})
+	require.NoError(t, err)
+	for i, raw := range raws {
+		require.NoError(t, w.AppendLedger(firstSeq+uint32(i), raw)) //nolint:gosec
+	}
+	require.NoError(t, w.Commit())
+	require.NoError(t, w.Close())
+}
+
+// buildSeamReader wires the cold+hot seam fixture and returns a reader over it
+// plus the exact cold bytes keyed by sequence (so a read can be proven to have
+// come from the cold pack, byte-for-byte).
+func buildSeamReader(t *testing.T) (db.LedgerReader, map[uint32][]byte) {
+	t.Helper()
+	cat, layout := newTestCatalog(t)
+	require.NoError(t, cat.PinEarliestLedger(coldFirst))
+
+	cold := map[uint32][]byte{}
+	var raws [][]byte
+	for seq := uint32(coldFirst); seq <= coldLast; seq++ {
+		b := lcmWithCloseTime(t, seq, int64(seq)*10)
+		cold[seq] = b
+		raws = append(raws, b)
+	}
+	writeColdLedgerRun(t, layout, chunk.ID(0), coldFirst, raws)
+	freezeLedgers(t, cat, chunk.ID(0))
+
+	db1 := openHotChunk(t, cat, layout, chunk.ID(1), hotFirst, hotLast)
+	t.Cleanup(func() { _ = db1.Close() })
+
+	r := NewRegistry(cat, fhtest.RetentionFor(t, cat, 0), silentLogger())
+	require.NoError(t, r.BuildInitial(hotLast))
+	r.HotOpened(chunk.ID(1), db1)
+
+	return NewLedgerReader(r, layout), cold
+}
+
+func TestLedgerReader_BatchGetLedgers_ColdHotSeam(t *testing.T) {
+	lr, cold := buildSeamReader(t)
+	tx, err := lr.NewTx(t.Context())
+	require.NoError(t, err)
+	defer func() { _ = tx.Done() }()
+
+	got, err := tx.BatchGetLedgers(t.Context(), coldFirst, hotLast)
+	require.NoError(t, err)
+	require.Len(t, got, hotLast-coldFirst+1, "full contiguous run across the seam")
+
+	for i, mc := range got {
+		wantSeq := uint32(coldFirst + i) //nolint:gosec
+		assert.EqualValues(t, wantSeq, mc.Header.Header.LedgerSeq, "header sequence in order")
+
+		// Decode the retained Lcm bytes independently: catches a missing copy of
+		// the borrowed iterator buffer (which would alias every entry to the last).
+		var lcm xdr.LedgerCloseMeta
+		require.NoError(t, lcm.UnmarshalBinary(mc.Lcm))
+		assert.Equal(t, wantSeq, lcm.LedgerSequence(), "retained Lcm decodes to its own sequence")
+
+		if want, ok := cold[wantSeq]; ok {
+			assert.Equal(t, want, mc.Lcm, "cold ledgers served byte-for-byte from the pack")
+		}
+	}
+}
+
+func TestLedgerReader_BatchGetLedgers_BelowFloorErrors(t *testing.T) {
+	lr, _ := buildSeamReader(t)
+	tx, err := lr.NewTx(t.Context())
+	require.NoError(t, err)
+	defer func() { _ = tx.Done() }()
+
+	_, err = tx.BatchGetLedgers(t.Context(), coldFirst-1, hotLast)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, stores.ErrOutOfRange)
+}
+
+func TestLedgerReader_BatchGetLedgers_EndClampsToLatest(t *testing.T) {
+	lr, _ := buildSeamReader(t)
+	tx, err := lr.NewTx(t.Context())
+	require.NoError(t, err)
+	defer func() { _ = tx.Done() }()
+
+	got, err := tx.BatchGetLedgers(t.Context(), coldFirst, hotLast+50_000)
+	require.NoError(t, err)
+	require.Len(t, got, hotLast-coldFirst+1, "end clamps to latest")
+	assert.EqualValues(t, hotLast, got[len(got)-1].Header.Header.LedgerSeq)
+}
+
+func TestLedgerReader_GetLedgerRange_EndpointsAndCloseTimes(t *testing.T) {
+	lr, _ := buildSeamReader(t)
+
+	lrange, err := lr.GetLedgerRange(t.Context())
+	require.NoError(t, err)
+
+	assert.EqualValues(t, coldFirst, lrange.FirstLedger.Sequence)
+	assert.EqualValues(t, int64(coldFirst)*10, lrange.FirstLedger.CloseTime, "first close time decoded from cold bytes")
+	assert.EqualValues(t, hotLast, lrange.LastLedger.Sequence)
+	assert.EqualValues(t, 0, lrange.LastLedger.CloseTime, "hot ZeroTx ledgers carry close time 0")
+}
+
+func TestLedgerReader_GetLedger_BoundsAndFound(t *testing.T) {
+	lr, _ := buildSeamReader(t)
+	tx, err := lr.NewTx(t.Context())
+	require.NoError(t, err)
+	defer func() { _ = tx.Done() }()
+
+	// Below the floor is a not-found, not an error (matches v1 GetLedger).
+	_, found, err := tx.GetLedger(t.Context(), coldFirst-1)
+	require.NoError(t, err)
+	assert.False(t, found, "below floor is not-found")
+
+	// Above latest is likewise a not-found.
+	_, found, err = tx.GetLedger(t.Context(), hotLast+1)
+	require.NoError(t, err)
+	assert.False(t, found, "above latest is not-found")
+
+	// A cold-backed and a hot-backed hit both resolve.
+	for _, seq := range []uint32{coldFirst, coldLast, hotFirst, hotLast} {
+		lcm, found, err := tx.GetLedger(t.Context(), seq)
+		require.NoError(t, err)
+		require.True(t, found, "seq %d found", seq)
+		assert.Equal(t, seq, lcm.LedgerSequence())
+	}
+}
+
+func TestLedgerReader_GetLedgerRange_EmptyIsErrEmptyDB(t *testing.T) {
+	cat, layout := newTestCatalog(t)
+	r := NewRegistry(cat, fhtest.RetentionFor(t, cat, 0), silentLogger())
+	require.NoError(t, r.BuildInitial(0))
+	lr := NewLedgerReader(r, layout)
+
+	_, err := lr.GetLedgerRange(t.Context())
+	assert.ErrorIs(t, err, db.ErrEmptyDB)
+
+	_, err = lr.GetLatestLedgerSequence(t.Context())
+	assert.ErrorIs(t, err, db.ErrEmptyDB)
+}
+
+func TestLedgerReader_UnsupportedPOCMethods(t *testing.T) {
+	lr, _ := buildSeamReader(t)
+	assert.Error(t, lr.StreamAllLedgers(t.Context(), nil))
+	assert.Error(t, lr.StreamLedgerRange(t.Context(), coldFirst, hotLast, nil))
+	_, _, _, err := lr.GetLedgerCountInRange(t.Context(), coldFirst, hotLast)
+	assert.Error(t, err)
+}
+
+// Step 4 integration: the real getLedgers handler, mounted over the adapter,
+// returns a contiguous GetLedgersResponse across the cold->hot seam.
+func TestLedgerReader_GetLedgersHandler_AcrossSeam(t *testing.T) {
+	lr, _ := buildSeamReader(t)
+	h := methods.NewGetLedgersHandler(lr, 200, 50, nil, silentLogger())
+
+	requests, err := jrpc2.ParseRequests([]byte(
+		`{"jsonrpc":"2.0","id":1,"method":"getLedgers","params":{"startLedger":9999,"pagination":{"limit":10}}}`,
+	))
+	require.NoError(t, err)
+	require.Len(t, requests, 1)
+
+	res, err := h(t.Context(), requests[0].ToRequest())
+	require.NoError(t, err)
+
+	resp, ok := res.(protocol.GetLedgersResponse)
+	require.True(t, ok, "handler returns a GetLedgersResponse")
+	assert.EqualValues(t, hotLast, resp.LatestLedger)
+	assert.EqualValues(t, coldFirst, resp.OldestLedger)
+	require.Len(t, resp.Ledgers, hotLast-coldFirst+1)
+	for i, li := range resp.Ledgers {
+		assert.EqualValues(t, coldFirst+i, li.Sequence, "contiguous across the seam")
+	}
+}

--- a/cmd/stellar-rpc/internal/fullhistory/serve/ledger_reader_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/ledger_reader_test.go
@@ -42,7 +42,7 @@ func lcmWithCloseTime(t *testing.T, seq uint32, closeTime int64) []byte {
 		V2: &xdr.LedgerCloseMetaV2{
 			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
 				Header: xdr.LedgerHeader{
-					ScpValue:  xdr.StellarValue{CloseTime: xdr.TimePoint(closeTime)}, //nolint:gosec
+					ScpValue:  xdr.StellarValue{CloseTime: xdr.TimePoint(closeTime)},
 					LedgerSeq: xdr.Uint32(seq),
 				},
 			},
@@ -66,7 +66,7 @@ func writeColdLedgerRun(t *testing.T, layout geometry.Layout, c chunk.ID, firstS
 	w, err := ledger.NewColdWriter(path, firstSeq, ledger.ColdWriterOptions{})
 	require.NoError(t, err)
 	for i, raw := range raws {
-		require.NoError(t, w.AppendLedger(firstSeq+uint32(i), raw)) //nolint:gosec
+		require.NoError(t, w.AppendLedger(firstSeq+uint32(i), raw))
 	}
 	require.NoError(t, w.Commit())
 	require.NoError(t, w.Close())
@@ -111,7 +111,7 @@ func TestLedgerReader_BatchGetLedgers_ColdHotSeam(t *testing.T) {
 	require.Len(t, got, hotLast-coldFirst+1, "full contiguous run across the seam")
 
 	for i, mc := range got {
-		wantSeq := uint32(coldFirst + i) //nolint:gosec
+		wantSeq := uint32(coldFirst + i)
 		assert.EqualValues(t, wantSeq, mc.Header.Header.LedgerSeq, "header sequence in order")
 
 		// Decode the retained Lcm bytes independently: catches a missing copy of
@@ -133,8 +133,7 @@ func TestLedgerReader_BatchGetLedgers_BelowFloorErrors(t *testing.T) {
 	defer func() { _ = tx.Done() }()
 
 	_, err = tx.BatchGetLedgers(t.Context(), coldFirst-1, hotLast)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, stores.ErrOutOfRange)
+	require.ErrorIs(t, err, stores.ErrOutOfRange)
 }
 
 func TestLedgerReader_BatchGetLedgers_EndClampsToLatest(t *testing.T) {
@@ -156,7 +155,7 @@ func TestLedgerReader_GetLedgerRange_EndpointsAndCloseTimes(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.EqualValues(t, coldFirst, lrange.FirstLedger.Sequence)
-	assert.EqualValues(t, int64(coldFirst)*10, lrange.FirstLedger.CloseTime, "first close time decoded from cold bytes")
+	assert.Equal(t, int64(coldFirst)*10, lrange.FirstLedger.CloseTime, "first close time decoded from cold bytes")
 	assert.EqualValues(t, hotLast, lrange.LastLedger.Sequence)
 	assert.EqualValues(t, 0, lrange.LastLedger.CloseTime, "hot ZeroTx ledgers carry close time 0")
 }
@@ -193,18 +192,18 @@ func TestLedgerReader_GetLedgerRange_EmptyIsErrEmptyDB(t *testing.T) {
 	lr := NewLedgerReader(r, layout)
 
 	_, err := lr.GetLedgerRange(t.Context())
-	assert.ErrorIs(t, err, db.ErrEmptyDB)
+	require.ErrorIs(t, err, db.ErrEmptyDB)
 
 	_, err = lr.GetLatestLedgerSequence(t.Context())
-	assert.ErrorIs(t, err, db.ErrEmptyDB)
+	require.ErrorIs(t, err, db.ErrEmptyDB)
 }
 
 func TestLedgerReader_UnsupportedPOCMethods(t *testing.T) {
 	lr, _ := buildSeamReader(t)
-	assert.Error(t, lr.StreamAllLedgers(t.Context(), nil))
-	assert.Error(t, lr.StreamLedgerRange(t.Context(), coldFirst, hotLast, nil))
+	require.Error(t, lr.StreamAllLedgers(t.Context(), nil))
+	require.Error(t, lr.StreamLedgerRange(t.Context(), coldFirst, hotLast, nil))
 	_, _, _, err := lr.GetLedgerCountInRange(t.Context(), coldFirst, hotLast)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 // Step 4 integration: the real getLedgers handler, mounted over the adapter,

--- a/cmd/stellar-rpc/internal/fullhistory/serve/registry.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/registry.go
@@ -182,7 +182,9 @@ func (r *Registry) BuildInitial(lastCommitted uint32) error {
 // TickCompleted rescans the catalog and republishes: it recomputes Cold, TxIdx,
 // and Floor from durable state, keeps existing hot handles, closes handles for
 // chunks that vanished (discarded) and swaps in fresh tx-hash readers for
-// superseded coverages. Fallible catalog work runs before the lock; on error it
+// superseded coverages. Cold/TxIdx rescans run before the lock; the hot-key scan
+// and the clone-and-store run UNDER mu (so a chunk going live via HotOpened can
+// never be misread as discarded — see the in-body note). On any scan error it
 // logs and leaves the current View in place (lifecycle re-runs the next tick).
 func (r *Registry) TickCompleted() {
 	if r == nil {
@@ -196,8 +198,26 @@ func (r *Registry) TickCompleted() {
 		return
 	}
 
+	txidx, err := r.rescanTxIdx(r.current.Load().TxIdx)
+	if err != nil {
+		r.logger.WithError(err).Error("serve: tick tx-hash rescan failed")
+		return
+	}
+
+	// The hot-key scan, the delete-set, and the clone-and-store MUST run together
+	// under mu. openHotDBForChunk creates a chunk's hot:chunk key BEFORE HotOpened
+	// publishes its live write handle, and HotOpened serializes on this same mu.
+	// So a scan taken under the lock can never miss a chunk whose handle is already
+	// in the View: either HotOpened has run (handle in Hot AND key in the scan) or
+	// it has not (neither). Scanning outside the lock reopened that gap — a chunk
+	// that went live between an unlocked scan and the publish would be absent from
+	// the stale scan set and get deleted-and-closed while live, ErrStoreClosed-ing
+	// the next Ingest.
+	var toClose []*hotchunk.DB
+	r.mu.Lock()
 	hotKeys, err := r.cat.HotChunkKeys()
 	if err != nil {
+		r.mu.Unlock()
 		r.logger.WithError(err).Error("serve: tick hot-key scan failed")
 		return
 	}
@@ -205,29 +225,22 @@ func (r *Registry) TickCompleted() {
 	for _, c := range hotKeys {
 		present[c] = struct{}{}
 	}
-
-	txidx, err := r.rescanTxIdx(r.current.Load().TxIdx)
-	if err != nil {
-		r.logger.WithError(err).Error("serve: tick tx-hash rescan failed")
-		return
-	}
-
-	var toClose []*hotchunk.DB
-	r.publish(func(v *View) {
-		v.Floor = floor
-		v.Cold = cold
-		v.TxIdx = txidx
-		for c, db := range v.Hot {
-			if _, ok := present[c]; ok {
-				continue
-			}
-			// Discarded: remove from the serving map, then close the handle.
-			// rocksdb Store.Close is lifecycle-guarded — an in-flight read on an
-			// older View gets stores.ErrStoreClosed, memory-safe.
-			delete(v.Hot, c)
-			toClose = append(toClose, db)
+	next := r.current.Load().clone()
+	next.Floor = floor
+	next.Cold = cold
+	next.TxIdx = txidx
+	for c, db := range next.Hot {
+		if _, ok := present[c]; ok {
+			continue
 		}
-	})
+		// Discarded: remove from the serving map, then close the handle.
+		// rocksdb Store.Close is lifecycle-guarded — an in-flight read on an
+		// older View gets stores.ErrStoreClosed, memory-safe.
+		delete(next.Hot, c)
+		toClose = append(toClose, db)
+	}
+	r.current.Store(next)
+	r.mu.Unlock()
 
 	for _, db := range toClose {
 		if err := db.Close(); err != nil {

--- a/cmd/stellar-rpc/internal/fullhistory/serve/registry.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/registry.go
@@ -100,9 +100,9 @@ func NewRegistry(cat *catalog.Catalog, retention geometry.Retention, logger *sup
 // every ledger <= the admitted latest has a serving home in the loaded View. A
 // chunk boundary between the loads could otherwise let latest point into a
 // chunk the older View does not serve.
-func (r *Registry) Admit() (latest uint32, v *View) {
-	latest = r.latest.Load()
-	v = r.current.Load()
+func (r *Registry) Admit() (uint32, *View) {
+	latest := r.latest.Load()
+	v := r.current.Load()
 	return latest, v
 }
 
@@ -254,6 +254,9 @@ func (r *Registry) scanCold() (map[chunk.ID]ColdFlags, error) {
 			f.Ledgers = true
 		case geometry.KindEvents:
 			f.Events = true
+		case geometry.KindTxHash:
+			// txhash .bin is a transient index artifact, never a cold serving
+			// artifact — see the doc comment above.
 		}
 		cold[ref.Chunk] = f
 	}

--- a/cmd/stellar-rpc/internal/fullhistory/serve/registry.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/registry.go
@@ -1,0 +1,418 @@
+// Package serve is the read-side registry/View for the full-history query POC.
+// It projects the durable catalog into an in-memory serving map that queries
+// admit against, following design-docs/query-routing-design.md (Registry /
+// View / Admission / View-update-points), simplified for the POC.
+//
+// A query admits by loading `latest` then the current View (order is
+// load-bearing — see Admit). It then routes each chunk to a hot handle or a
+// per-request cold reader against that one immutable View for its whole
+// lifetime. Storage-side hooks (LedgerCommitted, HotOpened, ChunkClosed,
+// TickCompleted) publish new Views as the serving map changes.
+//
+// The package must not import the fullhistory root (the root imports serve).
+package serve
+
+import (
+	"cmp"
+	"errors"
+	"iter"
+	"maps"
+	"slices"
+	"sync"
+	"sync/atomic"
+
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/catalog"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/geometry"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/eventstore"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/ledger"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash"
+)
+
+// ErrUnavailable is returned by the View resolvers when a chunk has no serving
+// home (neither a cold flag nor a hot handle).
+var ErrUnavailable = errors.New("no serving home for chunk")
+
+// Kind names a per-chunk serving data type. Defined for the downstream query
+// handlers (Tasks 3-7); the resolvers below expose one method per kind.
+type Kind int
+
+const (
+	KindLedgers Kind = iota
+	KindEvents
+)
+
+// ColdFlags records which cold artifacts are frozen and servable for a chunk.
+// It holds flags, not open readers — cold readers are opened per request (see
+// the View resolvers).
+type ColdFlags struct{ Ledgers, Events bool }
+
+// TxIndexCoverage is one window's frozen tx-hash index reader and the chunk
+// range it covers. The slice on a View is ascending by Lo.
+type TxIndexCoverage struct {
+	Lo, Hi chunk.ID
+	Reader *txhash.ColdReader
+}
+
+// View is one immutable snapshot of the serving map. A query keeps its admitted
+// View pointer for its whole lifetime; publishers clone-and-replace rather than
+// mutate in place, so a live query never observes a half-applied change.
+type View struct {
+	Floor    chunk.ID                  // chunk-aligned retention floor
+	Earliest uint32                    // catalog earliest_ledger (genesis clamp)
+	Hot      map[chunk.ID]*hotchunk.DB // live chunk: shared write handle; closed ready chunks: OpenReadView handle
+	Cold     map[chunk.ID]ColdFlags
+	TxIdx    []TxIndexCoverage
+}
+
+func emptyView() *View {
+	return &View{
+		Hot:  map[chunk.ID]*hotchunk.DB{},
+		Cold: map[chunk.ID]ColdFlags{},
+	}
+}
+
+// Registry owns the serving map: the current immutable View plus the `latest`
+// watermark, rebuilt from the catalog at startup and updated by the hooks. All
+// hooks are safe on a nil *Registry, so the no-serve path needs no guards.
+type Registry struct {
+	mu        sync.Mutex
+	current   atomic.Pointer[View]
+	latest    atomic.Uint32
+	cat       *catalog.Catalog
+	retention geometry.Retention
+	logger    *supportlog.Entry
+}
+
+// NewRegistry returns a registry seeded with an empty View (so Admit before
+// BuildInitial is safe and publish never dereferences nil).
+func NewRegistry(cat *catalog.Catalog, retention geometry.Retention, logger *supportlog.Entry) *Registry {
+	r := &Registry{cat: cat, retention: retention, logger: logger}
+	r.current.Store(emptyView())
+	return r
+}
+
+// Admit performs the two atomic loads a query needs, latest FIRST. The order is
+// load-bearing (design §Admission): reading latest before the View guarantees
+// every ledger <= the admitted latest has a serving home in the loaded View. A
+// chunk boundary between the loads could otherwise let latest point into a
+// chunk the older View does not serve.
+func (r *Registry) Admit() (latest uint32, v *View) {
+	latest = r.latest.Load()
+	v = r.current.Load()
+	return latest, v
+}
+
+// LedgerCommitted advances `latest`. Called only after hotService.Ingest
+// returned, so latest advances last (design: "latest advances last").
+func (r *Registry) LedgerCommitted(seq uint32) {
+	if r == nil {
+		return
+	}
+	r.latest.Store(seq)
+}
+
+// HotOpened publishes a chunk's shared write handle — the hotloop/startup hook
+// for openHotDBForChunk flipping the chunk "ready".
+func (r *Registry) HotOpened(c chunk.ID, db *hotchunk.DB) {
+	if r == nil {
+		return
+	}
+	r.publish(func(v *View) { v.Hot[c] = db })
+}
+
+// ChunkClosed reopens a boundary-fenced chunk as a read-only full-facade view
+// and republishes it, replacing the (now write-fenced) handle. On open failure
+// it removes the entry — the next freeze/tick covers the chunk from cold. The
+// old write handle is owned and closed by ingestion, never here.
+func (r *Registry) ChunkClosed(c chunk.ID) {
+	if r == nil {
+		return
+	}
+	db, err := hotchunk.OpenReadView(geometry.HotReady, r.cat.Layout().HotChunkPath(c), c, r.logger)
+	if err != nil {
+		r.logger.WithError(err).WithField("chunk", c).Warn("serve: reopen closed chunk as read view failed; removing")
+		r.publish(func(v *View) { delete(v.Hot, c) })
+		return
+	}
+	r.publish(func(v *View) { v.Hot[c] = db })
+}
+
+// BuildInitial rebuilds the whole View from a fresh catalog scan at startup,
+// before ServeReads begins (design: startup serveReads row). It seeds `latest`,
+// the retention floor, cold flags, frozen tx-hash readers, and read views for
+// every ready hot chunk EXCEPT the resume (highest) chunk — that one is
+// published by HotOpened once ingestion opens its write handle.
+func (r *Registry) BuildInitial(lastCommitted uint32) error {
+	if r == nil {
+		return nil
+	}
+	r.latest.Store(lastCommitted)
+
+	v := emptyView()
+	v.Floor = r.retention.FloorAt(geometry.LastCompleteChunkAt(lastCommitted))
+	earliest, pinned, err := r.cat.EarliestLedger()
+	if err != nil {
+		return err
+	}
+	if pinned {
+		v.Earliest = earliest
+	}
+	if v.Cold, err = r.scanCold(); err != nil {
+		return err
+	}
+	txidx, err := r.rescanTxIdx(nil)
+	if err != nil {
+		return err
+	}
+	v.TxIdx = txidx
+	if err := r.openInitialHot(v); err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	r.current.Store(v)
+	r.mu.Unlock()
+	return nil
+}
+
+// TickCompleted rescans the catalog and republishes: it recomputes Cold, TxIdx,
+// and Floor from durable state, keeps existing hot handles, closes handles for
+// chunks that vanished (discarded) and swaps in fresh tx-hash readers for
+// superseded coverages. Fallible catalog work runs before the lock; on error it
+// logs and leaves the current View in place (lifecycle re-runs the next tick).
+func (r *Registry) TickCompleted() {
+	if r == nil {
+		return
+	}
+	floor := r.retention.FloorAt(geometry.LastCompleteChunkAt(r.latest.Load()))
+
+	cold, err := r.scanCold()
+	if err != nil {
+		r.logger.WithError(err).Error("serve: tick cold rescan failed")
+		return
+	}
+
+	hotKeys, err := r.cat.HotChunkKeys()
+	if err != nil {
+		r.logger.WithError(err).Error("serve: tick hot-key scan failed")
+		return
+	}
+	present := make(map[chunk.ID]struct{}, len(hotKeys))
+	for _, c := range hotKeys {
+		present[c] = struct{}{}
+	}
+
+	txidx, err := r.rescanTxIdx(r.current.Load().TxIdx)
+	if err != nil {
+		r.logger.WithError(err).Error("serve: tick tx-hash rescan failed")
+		return
+	}
+
+	var toClose []*hotchunk.DB
+	r.publish(func(v *View) {
+		v.Floor = floor
+		v.Cold = cold
+		v.TxIdx = txidx
+		for c, db := range v.Hot {
+			if _, ok := present[c]; ok {
+				continue
+			}
+			// Discarded: remove from the serving map, then close the handle.
+			// rocksdb Store.Close is lifecycle-guarded — an in-flight read on an
+			// older View gets stores.ErrStoreClosed, memory-safe.
+			delete(v.Hot, c)
+			toClose = append(toClose, db)
+		}
+	})
+
+	for _, db := range toClose {
+		if err := db.Close(); err != nil {
+			r.logger.WithError(err).Warn("serve: closing discarded hot handle")
+		}
+	}
+}
+
+// scanCold builds the Cold map from the frozen per-chunk ledger/events artifact
+// keys. The transient txhash .bin kind is never a cold serving artifact.
+func (r *Registry) scanCold() (map[chunk.ID]ColdFlags, error) {
+	refs, err := r.cat.ChunkArtifactKeys()
+	if err != nil {
+		return nil, err
+	}
+	cold := map[chunk.ID]ColdFlags{}
+	for _, ref := range refs {
+		if ref.State != geometry.StateFrozen {
+			continue
+		}
+		f := cold[ref.Chunk]
+		switch ref.Kind {
+		case geometry.KindLedgers:
+			f.Ledgers = true
+		case geometry.KindEvents:
+			f.Events = true
+		}
+		cold[ref.Chunk] = f
+	}
+	return cold, nil
+}
+
+// rescanTxIdx builds the ascending TxIndexCoverage slice from the frozen
+// coverage keys, reusing a reader from prev when the exact [Lo, Hi] coverage is
+// unchanged (so a steady tick opens nothing new).
+//
+// POC: superseded .idx readers leak (bounded by coverage swaps per run) — a
+// dropped coverage's reader is never closed, because streamhash Close unmaps and
+// a racing read on an older View would fault; reaper at productionization.
+func (r *Registry) rescanTxIdx(prev []TxIndexCoverage) ([]TxIndexCoverage, error) {
+	covs, err := r.cat.AllTxHashIndexKeys()
+	if err != nil {
+		return nil, err
+	}
+	reuse := make(map[[2]chunk.ID]*txhash.ColdReader, len(prev))
+	for _, p := range prev {
+		reuse[[2]chunk.ID{p.Lo, p.Hi}] = p.Reader
+	}
+	layout := r.cat.Layout()
+	var out []TxIndexCoverage
+	for _, cov := range covs {
+		if cov.State != geometry.StateFrozen {
+			continue
+		}
+		reader, ok := reuse[[2]chunk.ID{cov.Lo, cov.Hi}]
+		if !ok {
+			reader, err = txhash.OpenColdReader(layout.TxHashIndexFilePath(cov))
+			if err != nil {
+				return nil, err
+			}
+		}
+		out = append(out, TxIndexCoverage{Lo: cov.Lo, Hi: cov.Hi, Reader: reader})
+	}
+	slices.SortFunc(out, func(a, b TxIndexCoverage) int { return cmp.Compare(a.Lo, b.Lo) })
+	return out, nil
+}
+
+// openInitialHot opens a read view for every ready hot chunk except the highest
+// (the resume chunk, published by HotOpened).
+func (r *Registry) openInitialHot(v *View) error {
+	ready, err := r.cat.ReadyHotChunkKeys()
+	if err != nil {
+		return err
+	}
+	layout := r.cat.Layout()
+	for i, c := range ready {
+		if i == len(ready)-1 {
+			continue // resume chunk: ingestion publishes it via HotOpened
+		}
+		db, err := hotchunk.OpenReadView(geometry.HotReady, layout.HotChunkPath(c), c, r.logger)
+		if err != nil {
+			return err
+		}
+		v.Hot[c] = db
+	}
+	return nil
+}
+
+// publish serializes View updates: clone the current View, apply mutate, and
+// atomically store the result (design §Publishing View updates).
+func (r *Registry) publish(mutate func(*View)) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	next := r.current.Load().clone()
+	mutate(next)
+	r.current.Store(next)
+}
+
+// LedgerChunk is a per-chunk ledger handle the caller must Close(). Hot-backed
+// handles have a no-op Close; cold-backed ones own and close the cold reader.
+type LedgerChunk struct {
+	src     ledgerSource
+	closeFn func() error
+}
+
+// ledgerSource is the read surface shared by ledger.HotStore and
+// ledger.ColdReader — the two things a LedgerChunk can front.
+type ledgerSource interface {
+	GetLedgerRaw(seq uint32) ([]byte, error)
+	IterateLedgers(start, end uint32) iter.Seq2[ledger.Entry, error]
+}
+
+func (lc LedgerChunk) Get(seq uint32) ([]byte, error) { return lc.src.GetLedgerRaw(seq) }
+
+func (lc LedgerChunk) Iterate(start, end uint32) iter.Seq2[ledger.Entry, error] {
+	return lc.src.IterateLedgers(start, end)
+}
+
+func (lc LedgerChunk) Close() error {
+	if lc.closeFn == nil {
+		return nil
+	}
+	return lc.closeFn()
+}
+
+// EventsChunk is a per-chunk events handle the caller must Close(). Same Close
+// contract as LedgerChunk.
+type EventsChunk struct {
+	reader  eventstore.Reader
+	closeFn func() error
+}
+
+func (ec EventsChunk) Reader() eventstore.Reader { return ec.reader }
+
+func (ec EventsChunk) Close() error {
+	if ec.closeFn == nil {
+		return nil
+	}
+	return ec.closeFn()
+}
+
+// ResolveLedgers routes chunk c to its ledger store: cold wins over hot (design
+// §Chunk resolution), else the hot handle, else ErrUnavailable.
+//
+// POC: no LRU — cold readers are opened per request and closed by the caller.
+func (v *View) ResolveLedgers(c chunk.ID, layout geometry.Layout) (LedgerChunk, error) {
+	if v.Cold[c].Ledgers {
+		cr, err := ledger.OpenColdReader(layout.LedgerPackPath(c))
+		if err != nil {
+			return LedgerChunk{}, err
+		}
+		return LedgerChunk{src: cr, closeFn: cr.Close}, nil
+	}
+	if db, ok := v.Hot[c]; ok {
+		return LedgerChunk{src: db.Ledgers()}, nil
+	}
+	return LedgerChunk{}, ErrUnavailable
+}
+
+// ResolveEvents routes chunk c to its events store: cold wins over hot, else the
+// hot handle, else ErrUnavailable.
+//
+// POC: no LRU — cold readers are opened per request and closed by the caller.
+func (v *View) ResolveEvents(c chunk.ID, layout geometry.Layout) (EventsChunk, error) {
+	if v.Cold[c].Events {
+		cr, err := eventstore.OpenColdReader(c, layout.EventsBucketDir(c), eventstore.ColdReaderOptions{})
+		if err != nil {
+			return EventsChunk{}, err
+		}
+		return EventsChunk{reader: cr, closeFn: cr.Close}, nil
+	}
+	if db, ok := v.Hot[c]; ok {
+		return EventsChunk{reader: db.Events()}, nil
+	}
+	return EventsChunk{}, ErrUnavailable
+}
+
+// clone shallow-copies the maps and slice so a publisher can mutate the copy
+// without disturbing the View live queries still hold.
+func (v *View) clone() *View {
+	return &View{
+		Floor:    v.Floor,
+		Earliest: v.Earliest,
+		Hot:      maps.Clone(v.Hot),
+		Cold:     maps.Clone(v.Cold),
+		TxIdx:    slices.Clone(v.TxIdx),
+	}
+}

--- a/cmd/stellar-rpc/internal/fullhistory/serve/registry_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/registry_test.go
@@ -1,0 +1,234 @@
+package serve
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/catalog"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/fhtest"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/geometry"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/ledger"
+)
+
+func silentLogger() *supportlog.Entry {
+	log := supportlog.New()
+	log.SetLevel(logrus.ErrorLevel)
+	return log
+}
+
+// newTestCatalog opens a temp catalog with a one-chunk-per-index window layout
+// (keeps index arithmetic trivial: every chunk is its own window).
+func newTestCatalog(t *testing.T) (*catalog.Catalog, geometry.Layout) {
+	t.Helper()
+	layout := geometry.NewLayout(t.TempDir())
+	windows, err := geometry.NewTxHashIndexLayout(1)
+	require.NoError(t, err)
+	cat, err := catalog.Open(layout.CatalogPath(), layout, windows, silentLogger())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cat.Close() })
+	return cat, layout
+}
+
+// openHotChunk runs the real create bracket (BeginHotCreate → Open → ingest →
+// FinishHotCreate) so the chunk has a "ready" hot key AND a live write DB, then
+// returns the write handle. Seqs are ingested as zero-tx ledgers.
+func openHotChunk(t *testing.T, cat *catalog.Catalog, layout geometry.Layout, c chunk.ID, seqs ...uint32) *hotchunk.DB {
+	t.Helper()
+	require.NoError(t, cat.BeginHotCreate(c))
+	db, err := hotchunk.Open(layout.HotChunkPath(c), c, silentLogger())
+	require.NoError(t, err)
+	for _, s := range seqs {
+		_, err := db.IngestLedger(s, xdr.LedgerCloseMetaView(fhtest.ZeroTxLCMBytes(t, s)))
+		require.NoError(t, err)
+	}
+	require.NoError(t, cat.FinishHotCreate(c))
+	return db
+}
+
+// freezeLedgers marks chunk c's ledger artifact frozen in the catalog.
+func freezeLedgers(t *testing.T, cat *catalog.Catalog, c chunk.ID) {
+	t.Helper()
+	require.NoError(t, cat.MarkChunkFreezing(c, geometry.KindLedgers))
+	require.NoError(t, cat.FlipChunkFrozen(c, geometry.KindLedgers))
+}
+
+// writeColdLedgerPack writes a real cold ledger pack at c's layout path holding
+// one ledger at seq with the given raw bytes (the cold store persists the bytes
+// verbatim, so a distinctive payload lets a test prove the COLD reader served).
+func writeColdLedgerPack(t *testing.T, layout geometry.Layout, c chunk.ID, seq uint32, raw []byte) {
+	t.Helper()
+	path := layout.LedgerPackPath(c)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	w, err := ledger.NewColdWriter(path, seq, ledger.ColdWriterOptions{})
+	require.NoError(t, err)
+	require.NoError(t, w.AppendLedger(seq, raw))
+	require.NoError(t, w.Commit())
+	require.NoError(t, w.Close())
+}
+
+// (a) Admit returns the seeded latest and an initial View with a frozen chunk in
+// Cold and a (non-resume) ready chunk in Hot.
+func TestAdmit_InitialView(t *testing.T) {
+	cat, layout := newTestCatalog(t)
+
+	// Two ready hot chunks: 0 (completed/fenced) + 1 (resume). BuildInitial opens
+	// a read view for 0 and leaves 1 for HotOpened.
+	db0 := openHotChunk(t, cat, layout, chunk.ID(0), 2)
+	require.NoError(t, db0.Close()) // fenced completed chunk: write handle closed
+	db1 := openHotChunk(t, cat, layout, chunk.ID(1))
+	t.Cleanup(func() { _ = db1.Close() })
+
+	// A frozen cold chunk with no hot key.
+	freezeLedgers(t, cat, chunk.ID(3))
+
+	r := NewRegistry(cat, fhtest.RetentionFor(t, cat, 0), silentLogger())
+	const lastCommitted = 12345
+	require.NoError(t, r.BuildInitial(lastCommitted))
+
+	latest, v := r.Admit()
+	assert.EqualValues(t, lastCommitted, latest)
+	require.NotNil(t, v)
+
+	// chunk 0 was opened as a read view; chunk 1 (resume) is NOT in Hot yet.
+	assert.Contains(t, v.Hot, chunk.ID(0), "completed ready chunk opened as read view")
+	assert.NotContains(t, v.Hot, chunk.ID(1), "resume chunk is published via HotOpened, not BuildInitial")
+	// chunk 3 is frozen cold ledgers.
+	assert.True(t, v.Cold[chunk.ID(3)].Ledgers, "frozen chunk is in Cold")
+}
+
+// (b) Admission order: LedgerCommitted advances latest but must NOT churn the
+// View pointer — a query admitting after LedgerCommitted still sees the same
+// immutable View until a real publish.
+func TestAdmit_LatestAdvancesWithoutViewChurn(t *testing.T) {
+	cat, _ := newTestCatalog(t)
+	r := NewRegistry(cat, fhtest.RetentionFor(t, cat, 0), silentLogger())
+	require.NoError(t, r.BuildInitial(100))
+
+	latest0, v0 := r.Admit()
+	assert.EqualValues(t, 100, latest0)
+
+	r.LedgerCommitted(101)
+	latest1, v1 := r.Admit()
+	assert.EqualValues(t, 101, latest1, "latest advanced")
+	assert.Same(t, v0, v1, "View pointer unchanged by LedgerCommitted")
+
+	// A real publish DOES swap the pointer.
+	r.HotOpened(chunk.ID(0), nil)
+	_, v2 := r.Admit()
+	assert.NotSame(t, v1, v2, "HotOpened publishes a new View")
+}
+
+// (c) Resolution: cold wins when both a cold flag and a hot handle exist;
+// unknown chunk is ErrUnavailable; hot-only serves from the hot handle.
+func TestResolveLedgers_ColdWinsAndUnavailable(t *testing.T) {
+	cat, layout := newTestCatalog(t)
+	r := NewRegistry(cat, fhtest.RetentionFor(t, cat, 0), silentLogger())
+	require.NoError(t, r.BuildInitial(0))
+
+	// hot-only chunk 1 with a real ledger.
+	seq1 := chunk.ID(1).FirstLedger()
+	db1 := openHotChunk(t, cat, layout, chunk.ID(1), seq1)
+	t.Cleanup(func() { _ = db1.Close() })
+	r.HotOpened(chunk.ID(1), db1)
+
+	// chunk 0: both a hot handle AND frozen cold ledgers. Hot and cold both hold
+	// seq 2, but the cold pack stores a distinctive payload — so a read returning
+	// those bytes proves the COLD reader was chosen over the hot handle.
+	db0 := openHotChunk(t, cat, layout, chunk.ID(0), 2)
+	t.Cleanup(func() { _ = db0.Close() })
+	r.HotOpened(chunk.ID(0), db0)
+	coldBytes := []byte("cold-copy-of-seq-2")
+	writeColdLedgerPack(t, layout, chunk.ID(0), 2, coldBytes)
+	freezeLedgers(t, cat, chunk.ID(0))
+	r.TickCompleted() // picks up Cold[0].Ledgers
+
+	_, v := r.Admit()
+
+	// hot-only resolves and serves.
+	hotChunk, err := v.ResolveLedgers(chunk.ID(1), layout)
+	require.NoError(t, err)
+	got, err := hotChunk.Get(seq1)
+	require.NoError(t, err, "hot handle serves the ledger")
+	assert.NotEmpty(t, got)
+	require.NoError(t, hotChunk.Close())
+
+	// chunk 0 has both flags → cold wins. seq 2 lives only in the cold pack, so a
+	// successful read returning the cold bytes proves the cold reader was used.
+	bothChunk, err := v.ResolveLedgers(chunk.ID(0), layout)
+	require.NoError(t, err)
+	gotCold, err := bothChunk.Get(2)
+	require.NoError(t, err, "cold reader serves seq 2 (chosen over the hot handle)")
+	assert.Equal(t, coldBytes, gotCold, "served the cold copy")
+	require.NoError(t, bothChunk.Close())
+
+	// unknown chunk → ErrUnavailable.
+	_, err = v.ResolveLedgers(chunk.ID(99), layout)
+	assert.ErrorIs(t, err, ErrUnavailable)
+}
+
+// (d) TickCompleted moves a frozen chunk hot→cold (keeping its hot handle) and
+// closes a discarded chunk's handle — a read on the stale View then returns
+// stores.ErrStoreClosed rather than crashing.
+func TestTickCompleted_FreezeAndDiscard(t *testing.T) {
+	cat, layout := newTestCatalog(t)
+	r := NewRegistry(cat, fhtest.RetentionFor(t, cat, 0), silentLogger())
+	require.NoError(t, r.BuildInitial(0))
+
+	// chunk A (0): stays hot, will be frozen (hot→cold overlap).
+	dbA := openHotChunk(t, cat, layout, chunk.ID(0), 2)
+	t.Cleanup(func() { _ = dbA.Close() })
+	r.HotOpened(chunk.ID(0), dbA)
+
+	// chunk B (1): a read-view handle we then discard.
+	seqB := chunk.ID(1).FirstLedger()
+	dbBWrite := openHotChunk(t, cat, layout, chunk.ID(1), seqB)
+	require.NoError(t, dbBWrite.Close()) // fence the write handle before reopening read-only
+	r.ChunkClosed(chunk.ID(1))           // registry opens + publishes a read-view handle
+
+	_, staleView := r.Admit()
+	bReader, err := staleView.ResolveLedgers(chunk.ID(1), layout)
+	require.NoError(t, err)
+	_, err = bReader.Get(seqB)
+	require.NoError(t, err, "chunk B read view serves before discard")
+
+	// Freeze A; discard B.
+	freezeLedgers(t, cat, chunk.ID(0))
+	require.NoError(t, cat.DiscardHotChunk(chunk.ID(1)))
+
+	r.TickCompleted()
+
+	_, v := r.Admit()
+	// A moved hot→cold: still hot AND now cold.
+	assert.Contains(t, v.Hot, chunk.ID(0), "frozen chunk keeps its hot handle during overlap")
+	assert.True(t, v.Cold[chunk.ID(0)].Ledgers, "frozen chunk is now cold")
+	// B was discarded: gone from the new View.
+	assert.NotContains(t, v.Hot, chunk.ID(1), "discarded chunk removed from View")
+
+	// The stale View's handle was closed by the tick: a read now returns
+	// ErrStoreClosed (memory-safe), not a crash.
+	_, err = bReader.Get(seqB)
+	assert.ErrorIs(t, err, stores.ErrStoreClosed, "discarded handle closed; stale read is store-closed")
+}
+
+// (e) Every hook is safe on a nil *Registry (the no-serve path needs no guards).
+func TestNilRegistry_HooksAreNoOps(t *testing.T) {
+	var r *Registry
+	assert.NotPanics(t, func() {
+		r.LedgerCommitted(1)
+		r.HotOpened(chunk.ID(0), nil)
+		r.ChunkClosed(chunk.ID(0))
+		r.TickCompleted()
+		assert.NoError(t, r.BuildInitial(0))
+	})
+}

--- a/cmd/stellar-rpc/internal/fullhistory/serve/registry_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/registry_test.go
@@ -243,6 +243,46 @@ func TestTickCompleted_FreezeAndDiscard(t *testing.T) {
 	assert.ErrorIs(t, err, stores.ErrStoreClosed, "discarded handle closed; stale read is store-closed")
 }
 
+// (regression, I-2) TickCompleted must never delete-and-close a chunk whose live
+// write handle is in the current View. openHotDBForChunk creates the hot:chunk
+// key BEFORE HotOpened publishes the handle, and HotOpened serializes on the same
+// mu the tick's hot-key scan now takes — so a chunk in Hot is always in the scan
+// set, and the live handle survives the tick (and stays open: it still reads and
+// still ingests). Before the fix the scan ran outside the publish lock, so a
+// chunk that went live between a stale scan and the publish was closed while live.
+func TestTickCompleted_DoesNotCloseLiveChunk(t *testing.T) {
+	cat, layout := newTestCatalog(t)
+	r := NewRegistry(cat, fhtest.RetentionFor(t, cat, 0), silentLogger())
+	require.NoError(t, r.BuildInitial(0))
+
+	// A completed chunk 0 kept hot as a read-view stand-in, plus the LIVE write
+	// handle for chunk 1 published via HotOpened. openHotChunk runs the real create
+	// bracket, so both chunks have a "ready" hot:chunk key exactly as the ingestion
+	// loop leaves them at a boundary.
+	db0 := openHotChunk(t, cat, layout, chunk.ID(0), 2)
+	t.Cleanup(func() { _ = db0.Close() })
+	r.HotOpened(chunk.ID(0), db0)
+
+	seq1 := chunk.ID(1).FirstLedger()
+	liveDB := openHotChunk(t, cat, layout, chunk.ID(1), seq1)
+	t.Cleanup(func() { _ = liveDB.Close() })
+	r.HotOpened(chunk.ID(1), liveDB)
+
+	r.TickCompleted()
+
+	_, v := r.Admit()
+	require.Contains(t, v.Hot, chunk.ID(1), "live chunk survives the tick")
+	assert.Same(t, liveDB, v.Hot[chunk.ID(1)], "live write handle is un-swapped")
+
+	// The handle was NOT closed by the tick: it still serves reads and still
+	// accepts writes (a closed store would ErrStoreClosed both).
+	got, err := v.Hot[chunk.ID(1)].Ledgers().GetLedgerRaw(seq1)
+	require.NoError(t, err, "live handle still serves reads after the tick")
+	require.NotEmpty(t, got)
+	_, err = liveDB.IngestLedger(seq1+1, xdr.LedgerCloseMetaView(fhtest.ZeroTxLCMBytes(t, seq1+1)))
+	require.NoError(t, err, "live write handle still ingests after the tick")
+}
+
 // TxIdx: BuildInitial opens a frozen window's .idx into a usable reader, and a
 // steady tick reuses the same *ColdReader when the coverage is unchanged.
 func TestTxIdx_BuildProbeAndReuse(t *testing.T) {

--- a/cmd/stellar-rpc/internal/fullhistory/serve/registry_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/registry_test.go
@@ -1,6 +1,7 @@
 package serve
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,6 +20,7 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/ledger"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash"
 )
 
 func silentLogger() *supportlog.Entry {
@@ -75,6 +77,26 @@ func writeColdLedgerPack(t *testing.T, layout geometry.Layout, c chunk.ID, seq u
 	require.NoError(t, w.AppendLedger(seq, raw))
 	require.NoError(t, w.Commit())
 	require.NoError(t, w.Close())
+}
+
+// freezeTxIndex builds a real frozen tx-hash index for window w covering chunks
+// [lo, hi] over ledgers [minLedger, maxLedger] and holding entries: writes a
+// .bin, runs BuildColdIndex to the layout's .idx path, then marks + commits it
+// frozen in the catalog (the backfill build path, minus the daemon).
+func freezeTxIndex(
+	t *testing.T, cat *catalog.Catalog, layout geometry.Layout,
+	w geometry.TxHashIndexID, lo, hi chunk.ID, minLedger, maxLedger uint32, entries []txhash.ColdEntry,
+) {
+	t.Helper()
+	binPath := filepath.Join(t.TempDir(), "index.bin")
+	require.NoError(t, txhash.WriteColdBin(binPath, entries))
+
+	cov, err := cat.MarkTxHashIndexFreezing(w, lo, hi)
+	require.NoError(t, err)
+	idxPath := layout.TxHashIndexFilePath(cov)
+	require.NoError(t, os.MkdirAll(filepath.Dir(idxPath), 0o755))
+	require.NoError(t, txhash.BuildColdIndex(context.Background(), []string{binPath}, idxPath, minLedger, maxLedger))
+	require.NoError(t, cat.CommitTxHashIndex(cov))
 }
 
 // (a) Admit returns the seeded latest and an initial View with a frozen chunk in
@@ -219,6 +241,65 @@ func TestTickCompleted_FreezeAndDiscard(t *testing.T) {
 	// ErrStoreClosed (memory-safe), not a crash.
 	_, err = bReader.Get(seqB)
 	assert.ErrorIs(t, err, stores.ErrStoreClosed, "discarded handle closed; stale read is store-closed")
+}
+
+// TxIdx: BuildInitial opens a frozen window's .idx into a usable reader, and a
+// steady tick reuses the same *ColdReader when the coverage is unchanged.
+func TestTxIdx_BuildProbeAndReuse(t *testing.T) {
+	cat, layout := newTestCatalog(t)
+
+	// A known hash resolving to seq 5, in window 0 / chunk 0 (cpi=1).
+	var hash [32]byte
+	for i := range hash {
+		hash[i] = byte(i + 1)
+	}
+	var entry txhash.ColdEntry
+	copy(entry.Key[:], hash[:])
+	entry.Seq = 5
+	freezeTxIndex(t, cat, layout, geometry.TxHashIndexID(0), chunk.ID(0), chunk.ID(0),
+		chunk.ID(0).FirstLedger(), chunk.ID(0).LastLedger(), []txhash.ColdEntry{entry})
+
+	r := NewRegistry(cat, fhtest.RetentionFor(t, cat, 0), silentLogger())
+	require.NoError(t, r.BuildInitial(chunk.ID(0).LastLedger()))
+
+	_, v := r.Admit()
+	require.Len(t, v.TxIdx, 1)
+	assert.Equal(t, chunk.ID(0), v.TxIdx[0].Lo)
+	assert.Equal(t, chunk.ID(0), v.TxIdx[0].Hi)
+	require.NotNil(t, v.TxIdx[0].Reader)
+	got, err := v.TxIdx[0].Reader.Get(hash)
+	require.NoError(t, err, "the frozen .idx reader resolves the known hash")
+	assert.EqualValues(t, 5, got)
+
+	// A steady tick (coverage unchanged) reuses the same reader — no reopen/leak.
+	before := v.TxIdx[0].Reader
+	r.TickCompleted()
+	_, v2 := r.Admit()
+	require.Len(t, v2.TxIdx, 1)
+	assert.Same(t, before, v2.TxIdx[0].Reader, "unchanged coverage reuses the reader")
+}
+
+// ResolveEvents: hot handle serves when no cold flag; unknown chunk is
+// ErrUnavailable.
+func TestResolveEvents_HotAndUnavailable(t *testing.T) {
+	cat, layout := newTestCatalog(t)
+	r := NewRegistry(cat, fhtest.RetentionFor(t, cat, 0), silentLogger())
+	require.NoError(t, r.BuildInitial(0))
+
+	db0 := openHotChunk(t, cat, layout, chunk.ID(0), 2)
+	t.Cleanup(func() { _ = db0.Close() })
+	r.HotOpened(chunk.ID(0), db0)
+
+	_, v := r.Admit()
+	ev, err := v.ResolveEvents(chunk.ID(0), layout)
+	require.NoError(t, err)
+	require.NotNil(t, ev.Reader())
+	_, err = ev.Reader().EventCount()
+	require.NoError(t, err, "hot events reader is usable")
+	require.NoError(t, ev.Close())
+
+	_, err = v.ResolveEvents(chunk.ID(99), layout)
+	assert.ErrorIs(t, err, ErrUnavailable)
 }
 
 // (e) Every hook is safe on a nil *Registry (the no-serve path needs no guards).

--- a/cmd/stellar-rpc/internal/fullhistory/serve/server.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/server.go
@@ -3,6 +3,7 @@ package serve
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
 	"sync"
@@ -52,6 +53,19 @@ type ServerParams struct {
 // benchmark client controls load and the server is not internet-facing. v1's
 // jsonrpc.go stacks all of those; add them at productionization.
 func StartServer(ctx context.Context, p ServerParams) (net.Addr, func(), error) {
+	// Bind FIRST — before touching prometheus. Two reasons: a host:0 endpoint must
+	// resolve to a real port before we return, and (load-bearing for restarts) the
+	// daemon builds ONE process registry but supervise re-invokes StartServer on
+	// every restartable error, so a transient bind failure must return before any
+	// collector is registered — otherwise a lingering registration would trip the
+	// retry. A fixed-port restart fails cleanly here (address already in use) until
+	// the prior server's daemon-ctx teardown frees the port; see daemon.go.
+	var lc net.ListenConfig
+	ln, err := lc.Listen(ctx, "tcp", p.Cfg.Endpoint)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	// requestDurationBuckets spans 100µs to 10s — the benchmark's latency dynamic
 	// range (a cold multi-chunk scan can reach seconds; a hot single-ledger hit is
 	// sub-millisecond). This is THE instrument the fhbench harness reads.
@@ -64,7 +78,21 @@ func StartServer(ctx context.Context, p ServerParams) (net.Addr, func(), error) 
 		Help:    "Per-endpoint JSON-RPC request latency for the full-history read server.",
 		Buckets: requestDurationBuckets,
 	}, []string{"endpoint", "status"})
-	p.Metrics.MustRegister(durations)
+	// Register tolerantly, NOT MustRegister: a supervised restart re-enters
+	// StartServer against the same process registry, so the second registration of
+	// this histogram is expected. Reuse the already-registered collector so restarts
+	// re-observe into the SAME series instead of panicking.
+	if regErr := p.Metrics.Register(durations); regErr != nil {
+		var already prometheus.AlreadyRegisteredError
+		if errors.As(regErr, &already) {
+			if existing, ok := already.ExistingCollector.(*prometheus.HistogramVec); ok {
+				durations = existing
+			}
+		} else {
+			_ = ln.Close()
+			return nil, nil, regErr
+		}
+	}
 
 	lr := NewLedgerReader(p.Registry, p.Layout)
 	txr := NewTransactionReader(p.Registry, p.Layout, p.Passphrase)
@@ -97,14 +125,6 @@ func StartServer(ctx context.Context, p ServerParams) (net.Addr, func(), error) 
 	httpMux.Handle("/metrics", promhttp.HandlerFor(p.Metrics, promhttp.HandlerOpts{}))
 	httpMux.HandleFunc("/health", healthProbe(p.Health))
 	httpMux.HandleFunc("/ready", readyProbe(p.Health))
-
-	// Listen first so a host:0 endpoint resolves to a real port before we return.
-	var lc net.ListenConfig
-	ln, err := lc.Listen(ctx, "tcp", p.Cfg.Endpoint)
-	if err != nil {
-		_ = bridge.Close()
-		return nil, nil, err
-	}
 
 	srv := &http.Server{
 		Handler: httpMux,

--- a/cmd/stellar-rpc/internal/fullhistory/serve/server.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/server.go
@@ -1,0 +1,206 @@
+package serve
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/creachadair/jrpc2"
+	"github.com/creachadair/jrpc2/handler"
+	"github.com/creachadair/jrpc2/jhttp"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/config"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/geometry"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/methods"
+)
+
+// HealthLike is the tiny read side of the daemon's health signal the server's
+// /health + /ready probes consume. It is the shape of fullhistory.HealthSignal,
+// declared locally because serve must NOT import the fullhistory root (the root
+// imports serve — the reverse edge would be an import cycle).
+type HealthLike interface {
+	Ready() bool
+	LastCommitClose() (time.Time, bool)
+}
+
+// ServerParams is everything StartServer needs to mount the read-side JSON-RPC
+// server over one serve Registry.
+type ServerParams struct {
+	Registry   *Registry
+	Layout     geometry.Layout
+	Passphrase string
+	Health     HealthLike
+	Metrics    *prometheus.Registry
+	Logger     *supportlog.Entry
+	Cfg        config.ServeConfig
+}
+
+// requestDurationBuckets spans 100µs to 10s — the benchmark's latency dynamic
+// range (a cold multi-chunk scan can reach seconds; a hot single-ledger hit is
+// sub-millisecond). This is THE instrument the fhbench harness reads.
+var requestDurationBuckets = []float64{
+	0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025,
+	0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
+}
+
+// StartServer binds the JSON-RPC server on p.Cfg.Endpoint and starts serving in
+// a background goroutine. It returns the bound address (so an endpoint of
+// host:0 yields the real OS-assigned port), a shutdown func, and any bind error.
+// The server also shuts down when ctx is cancelled.
+//
+// POC: no CORS, no backlog/duration limiters, no request-size cap — the
+// benchmark client controls load and the server is not internet-facing. v1's
+// jsonrpc.go stacks all of those; add them at productionization.
+func StartServer(ctx context.Context, p ServerParams) (net.Addr, func(), error) {
+	durations := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "fullhistory_rpc_request_duration_seconds",
+		Help:    "Per-endpoint JSON-RPC request latency for the full-history read server.",
+		Buckets: requestDurationBuckets,
+	}, []string{"endpoint", "status"})
+	p.Metrics.MustRegister(durations)
+
+	lr := NewLedgerReader(p.Registry, p.Layout)
+	txr := NewTransactionReader(p.Registry, p.Layout, p.Passphrase)
+
+	mux := handler.Map{
+		protocol.GetLedgersMethodName: instrument(protocol.GetLedgersMethodName, durations,
+			methods.NewGetLedgersHandler(lr,
+				derefUint(p.Cfg.MaxLedgersLimit, config.DefaultServeMaxLedgersLimit),
+				derefUint(p.Cfg.DefaultLedgersLimit, config.DefaultServeDefaultLedgersLimit),
+				nil /* POC: no datastore fallback */, p.Logger)),
+		protocol.GetTransactionsMethodName: instrument(protocol.GetTransactionsMethodName, durations,
+			methods.NewGetTransactionsHandler(p.Logger, lr,
+				derefUint(p.Cfg.MaxTransactionsLimit, config.DefaultServeMaxTransactionsLimit),
+				derefUint(p.Cfg.DefaultTransactionsLimit, config.DefaultServeDefaultTransactionsLimit),
+				p.Passphrase)),
+		protocol.GetTransactionMethodName: instrument(protocol.GetTransactionMethodName, durations,
+			methods.NewGetTransactionHandler(p.Logger, txr, lr)),
+		protocol.GetEventsMethodName: instrument(protocol.GetEventsMethodName, durations,
+			NewGetEventsHandler(p.Logger, p.Registry, p.Layout,
+				derefUint(p.Cfg.MaxEventsLimit, config.DefaultServeMaxEventsLimit),
+				derefUint(p.Cfg.DefaultEventsLimit, config.DefaultServeDefaultEventsLimit))),
+	}
+
+	bridge := jhttp.NewBridge(mux, &jhttp.BridgeOptions{
+		Server: &jrpc2.ServerOptions{Logger: func(text string) { p.Logger.Debug(text) }},
+	})
+
+	httpMux := http.NewServeMux()
+	httpMux.Handle("/", bridge)
+	httpMux.Handle("/metrics", promhttp.HandlerFor(p.Metrics, promhttp.HandlerOpts{}))
+	httpMux.HandleFunc("/health", healthProbe(p.Health))
+	httpMux.HandleFunc("/ready", readyProbe(p.Health))
+
+	// Listen first so a host:0 endpoint resolves to a real port before we return.
+	ln, err := net.Listen("tcp", p.Cfg.Endpoint)
+	if err != nil {
+		_ = bridge.Close()
+		return nil, nil, err
+	}
+
+	srv := &http.Server{
+		Handler: httpMux,
+		// ReadHeaderTimeout guards against a slow-loris even in the POC (cheap,
+		// keeps gosec quiet); every other limiter is deliberately omitted.
+		ReadHeaderTimeout: 30 * time.Second,
+	}
+
+	go func() {
+		if serveErr := srv.Serve(ln); serveErr != nil && serveErr != http.ErrServerClosed {
+			p.Logger.WithError(serveErr).Error("fullhistory serve: http server stopped")
+		}
+	}()
+
+	var once sync.Once
+	shutdown := func() {
+		once.Do(func() {
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_ = srv.Shutdown(shutdownCtx)
+			_ = bridge.Close()
+		})
+	}
+	// Shut down on ctx cancel too, so the daemon's lifecycle owns the server's
+	// lifetime without the caller having to plumb the shutdown func everywhere.
+	go func() {
+		<-ctx.Done()
+		shutdown()
+	}()
+
+	return ln.Addr(), shutdown, nil
+}
+
+// instrument wraps a jrpc2.Handler to record its wall-clock latency into the
+// per-endpoint histogram, labelled by method and ok/error status.
+func instrument(endpoint string, vec *prometheus.HistogramVec, h jrpc2.Handler) jrpc2.Handler {
+	return func(ctx context.Context, req *jrpc2.Request) (any, error) {
+		start := time.Now()
+		res, err := h(ctx, req)
+		status := "ok"
+		if err != nil {
+			status = "error"
+		}
+		vec.WithLabelValues(endpoint, status).Observe(time.Since(start).Seconds())
+		return res, err
+	}
+}
+
+// healthProbe reports liveness: 200 once at least one ledger has been committed
+// (carrying its close time), 503 while the daemon is still starting up. The
+// staleness judgment (close-time age vs a latency threshold) is left to the
+// scraper — the POC probe keeps the raw signal trivial.
+func healthProbe(h HealthLike) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		closeTime, committed := lastCommit(h)
+		if !committed {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]any{"status": "starting"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status":                "healthy",
+			"latestLedgerCloseTime": closeTime.Unix(),
+		})
+	}
+}
+
+// readyProbe reflects the latched readiness signal: 200 when the ingestion loop
+// has proven itself (committed a ledger), 503 otherwise — the deploy-gate probe.
+func readyProbe(h HealthLike) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		if h != nil && h.Ready() {
+			writeJSON(w, http.StatusOK, map[string]any{"ready": true})
+			return
+		}
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{"ready": false})
+	}
+}
+
+func lastCommit(h HealthLike) (time.Time, bool) {
+	if h == nil {
+		return time.Time{}, false
+	}
+	return h.LastCommitClose()
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// derefUint returns *p, or def when the key was absent (nil). StartServer accepts
+// a bare config.ServeConfig (unpinned limits) and still mounts at the v1 caps.
+func derefUint(p *uint, def uint) uint {
+	if p == nil {
+		return def
+	}
+	return *p
+}

--- a/cmd/stellar-rpc/internal/fullhistory/serve/server.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/server.go
@@ -43,23 +43,22 @@ type ServerParams struct {
 	Cfg        config.ServeConfig
 }
 
-// requestDurationBuckets spans 100µs to 10s — the benchmark's latency dynamic
-// range (a cold multi-chunk scan can reach seconds; a hot single-ledger hit is
-// sub-millisecond). This is THE instrument the fhbench harness reads.
-var requestDurationBuckets = []float64{
-	0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025,
-	0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
-}
-
 // StartServer binds the JSON-RPC server on p.Cfg.Endpoint and starts serving in
 // a background goroutine. It returns the bound address (so an endpoint of
 // host:0 yields the real OS-assigned port), a shutdown func, and any bind error.
-// The server also shuts down when ctx is cancelled.
+// The server also shuts down when ctx is canceled.
 //
 // POC: no CORS, no backlog/duration limiters, no request-size cap — the
 // benchmark client controls load and the server is not internet-facing. v1's
 // jsonrpc.go stacks all of those; add them at productionization.
 func StartServer(ctx context.Context, p ServerParams) (net.Addr, func(), error) {
+	// requestDurationBuckets spans 100µs to 10s — the benchmark's latency dynamic
+	// range (a cold multi-chunk scan can reach seconds; a hot single-ledger hit is
+	// sub-millisecond). This is THE instrument the fhbench harness reads.
+	requestDurationBuckets := []float64{
+		0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025,
+		0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
+	}
 	durations := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "fullhistory_rpc_request_duration_seconds",
 		Help:    "Per-endpoint JSON-RPC request latency for the full-history read server.",
@@ -100,7 +99,8 @@ func StartServer(ctx context.Context, p ServerParams) (net.Addr, func(), error) 
 	httpMux.HandleFunc("/ready", readyProbe(p.Health))
 
 	// Listen first so a host:0 endpoint resolves to a real port before we return.
-	ln, err := net.Listen("tcp", p.Cfg.Endpoint)
+	var lc net.ListenConfig
+	ln, err := lc.Listen(ctx, "tcp", p.Cfg.Endpoint)
 	if err != nil {
 		_ = bridge.Close()
 		return nil, nil, err
@@ -120,6 +120,7 @@ func StartServer(ctx context.Context, p ServerParams) (net.Addr, func(), error) 
 	}()
 
 	var once sync.Once
+	//nolint:contextcheck // uses a fresh Background ctx so graceful drain runs after the run ctx is canceled
 	shutdown := func() {
 		once.Do(func() {
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -139,7 +140,7 @@ func StartServer(ctx context.Context, p ServerParams) (net.Addr, func(), error) 
 }
 
 // instrument wraps a jrpc2.Handler to record its wall-clock latency into the
-// per-endpoint histogram, labelled by method and ok/error status.
+// per-endpoint histogram, labeled by method and ok/error status.
 func instrument(endpoint string, vec *prometheus.HistogramVec, h jrpc2.Handler) jrpc2.Handler {
 	return func(ctx context.Context, req *jrpc2.Request) (any, error) {
 		start := time.Now()
@@ -193,6 +194,7 @@ func lastCommit(h HealthLike) (time.Time, bool) {
 func writeJSON(w http.ResponseWriter, status int, body any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
+	//nolint:errchkjson // body is always a JSON-safe map[string]any built in this file
 	_ = json.NewEncoder(w).Encode(body)
 }
 

--- a/cmd/stellar-rpc/internal/fullhistory/serve/server_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/server_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -17,8 +18,6 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/fhtest"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/geometry"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
-
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // fakeHealth is a mutable HealthLike for the server probes: Ready() and the last
@@ -58,8 +57,8 @@ func buildServerRegistry(t *testing.T) (*Registry, geometry.Layout, uint32, uint
 }
 
 // startTestServer boots a server over the tiny hot fixture and returns its base
-// URL, the metrics registry, and the fixture's first/last served ledger.
-func startTestServer(t *testing.T, health HealthLike) (string, *prometheus.Registry, uint32, uint32) {
+// URL and the fixture's first/last served ledger.
+func startTestServer(t *testing.T, health HealthLike) (string, uint32, uint32) {
 	t.Helper()
 	reg, layout, first, last := buildServerRegistry(t)
 	metrics := prometheus.NewRegistry()
@@ -78,12 +77,15 @@ func startTestServer(t *testing.T, health HealthLike) (string, *prometheus.Regis
 	})
 	require.NoError(t, err)
 	t.Cleanup(shutdown)
-	return "http://" + addr.String(), metrics, first, last
+	return "http://" + addr.String(), first, last
 }
 
 func postJSON(t *testing.T, url, body string) map[string]any {
 	t.Helper()
-	resp, err := http.Post(url, "application/json", bytes.NewReader([]byte(body)))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, url, bytes.NewReader([]byte(body)))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
 	raw, err := io.ReadAll(resp.Body)
@@ -93,10 +95,21 @@ func postJSON(t *testing.T, url, body string) map[string]any {
 	return out
 }
 
+// httpGet issues a context-carrying GET (noctx) and returns the response; the
+// caller closes the body.
+func httpGet(t *testing.T, url string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
 func TestStartServer_GetLedgersOverHTTP(t *testing.T) {
 	h := &fakeHealth{}
 	h.ready.Store(true)
-	base, _, first, last := startTestServer(t, h)
+	base, first, last := startTestServer(t, h)
 
 	req := `{"jsonrpc":"2.0","id":1,"method":"getLedgers","params":{"startLedger":` +
 		itoa(int(first)) + `,"pagination":{"limit":10}}}`
@@ -114,52 +127,47 @@ func TestStartServer_GetLedgersOverHTTP(t *testing.T) {
 func TestStartServer_MetricsExposeLatencyHistogram(t *testing.T) {
 	h := &fakeHealth{}
 	h.ready.Store(true)
-	base, _, first, _ := startTestServer(t, h)
+	base, first, _ := startTestServer(t, h)
 
 	req := `{"jsonrpc":"2.0","id":1,"method":"getLedgers","params":{"startLedger":` +
 		itoa(int(first)) + `,"pagination":{"limit":10}}}`
 	postJSON(t, base+"/", req)
 
-	resp, err := http.Get(base + "/metrics")
-	require.NoError(t, err)
+	resp := httpGet(t, base+"/metrics")
 	defer func() { _ = resp.Body.Close() }()
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	assert.Contains(t, string(body), "fullhistory_rpc_request_duration_seconds",
 		"the benchmark latency histogram must be exposed after a request")
 	assert.Contains(t, string(body), `endpoint="getLedgers"`,
-		"the histogram must be labelled per endpoint")
+		"the histogram must be labeled per endpoint")
 }
 
 func TestStartServer_ReadyReflectsHealth(t *testing.T) {
 	h := &fakeHealth{} // not ready yet
-	base, _, _, _ := startTestServer(t, h)
+	base, _, _ := startTestServer(t, h)
 
-	resp, err := http.Get(base + "/ready")
-	require.NoError(t, err)
+	resp := httpGet(t, base+"/ready")
 	_ = resp.Body.Close()
 	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode, "not ready -> 503")
 
 	h.ready.Store(true)
-	resp, err = http.Get(base + "/ready")
-	require.NoError(t, err)
+	resp = httpGet(t, base+"/ready")
 	_ = resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode, "ready -> 200")
 }
 
 func TestStartServer_HealthReportsCommit(t *testing.T) {
 	h := &fakeHealth{}
-	base, _, _, _ := startTestServer(t, h)
+	base, _, _ := startTestServer(t, h)
 
-	resp, err := http.Get(base + "/health")
-	require.NoError(t, err)
+	resp := httpGet(t, base+"/health")
 	_ = resp.Body.Close()
 	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode, "no commit -> 503")
 
 	h.haveCommit.Store(true)
 	h.closeUnix.Store(1234567890)
-	resp, err = http.Get(base + "/health")
-	require.NoError(t, err)
+	resp = httpGet(t, base+"/health")
 	defer func() { _ = resp.Body.Close() }()
 	assert.Equal(t, http.StatusOK, resp.StatusCode, "committed -> 200")
 }

--- a/cmd/stellar-rpc/internal/fullhistory/serve/server_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/server_test.go
@@ -1,0 +1,165 @@
+package serve
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/config"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/fhtest"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/geometry"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// fakeHealth is a mutable HealthLike for the server probes: Ready() and the last
+// commit close time are both flipped by the test to prove /ready and /health
+// reflect the live signal.
+type fakeHealth struct {
+	ready      atomic.Bool
+	closeUnix  atomic.Int64
+	haveCommit atomic.Bool
+}
+
+func (f *fakeHealth) Ready() bool { return f.ready.Load() }
+
+func (f *fakeHealth) LastCommitClose() (time.Time, bool) {
+	if !f.haveCommit.Load() {
+		return time.Time{}, false
+	}
+	return time.Unix(f.closeUnix.Load(), 0), true
+}
+
+// buildServerRegistry wires a tiny live-hot registry (one chunk, two zero-tx
+// ledgers) so StartServer has a real getLedgers path to serve.
+func buildServerRegistry(t *testing.T) (*Registry, geometry.Layout, uint32, uint32) {
+	t.Helper()
+	cat, layout := newTestCatalog(t)
+	first := chunk.ID(0).FirstLedger()
+	last := first + 1
+	require.NoError(t, cat.PinEarliestLedger(first))
+
+	db0 := openHotChunk(t, cat, layout, chunk.ID(0), first, last)
+	t.Cleanup(func() { _ = db0.Close() })
+
+	r := NewRegistry(cat, fhtest.RetentionFor(t, cat, 0), silentLogger())
+	require.NoError(t, r.BuildInitial(last))
+	r.HotOpened(chunk.ID(0), db0)
+	return r, layout, first, last
+}
+
+// startTestServer boots a server over the tiny hot fixture and returns its base
+// URL, the metrics registry, and the fixture's first/last served ledger.
+func startTestServer(t *testing.T, health HealthLike) (string, *prometheus.Registry, uint32, uint32) {
+	t.Helper()
+	reg, layout, first, last := buildServerRegistry(t)
+	metrics := prometheus.NewRegistry()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	addr, shutdown, err := StartServer(ctx, ServerParams{
+		Registry:   reg,
+		Layout:     layout,
+		Passphrase: "Test SDF Network ; September 2015",
+		Health:     health,
+		Metrics:    metrics,
+		Logger:     silentLogger(),
+		Cfg:        config.ServeConfig{Endpoint: "127.0.0.1:0"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(shutdown)
+	return "http://" + addr.String(), metrics, first, last
+}
+
+func postJSON(t *testing.T, url, body string) map[string]any {
+	t.Helper()
+	resp, err := http.Post(url, "application/json", bytes.NewReader([]byte(body)))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(raw, &out), "response: %s", raw)
+	return out
+}
+
+func TestStartServer_GetLedgersOverHTTP(t *testing.T) {
+	h := &fakeHealth{}
+	h.ready.Store(true)
+	base, _, first, last := startTestServer(t, h)
+
+	req := `{"jsonrpc":"2.0","id":1,"method":"getLedgers","params":{"startLedger":` +
+		itoa(int(first)) + `,"pagination":{"limit":10}}}`
+	got := postJSON(t, base+"/", req)
+
+	require.Nil(t, got["error"], "getLedgers must not error: %v", got["error"])
+	result, ok := got["result"].(map[string]any)
+	require.True(t, ok, "result present: %v", got)
+	assert.EqualValues(t, last, result["latestLedger"])
+	ledgers, ok := result["ledgers"].([]any)
+	require.True(t, ok)
+	assert.Len(t, ledgers, int(last-first+1))
+}
+
+func TestStartServer_MetricsExposeLatencyHistogram(t *testing.T) {
+	h := &fakeHealth{}
+	h.ready.Store(true)
+	base, _, first, _ := startTestServer(t, h)
+
+	req := `{"jsonrpc":"2.0","id":1,"method":"getLedgers","params":{"startLedger":` +
+		itoa(int(first)) + `,"pagination":{"limit":10}}}`
+	postJSON(t, base+"/", req)
+
+	resp, err := http.Get(base + "/metrics")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "fullhistory_rpc_request_duration_seconds",
+		"the benchmark latency histogram must be exposed after a request")
+	assert.Contains(t, string(body), `endpoint="getLedgers"`,
+		"the histogram must be labelled per endpoint")
+}
+
+func TestStartServer_ReadyReflectsHealth(t *testing.T) {
+	h := &fakeHealth{} // not ready yet
+	base, _, _, _ := startTestServer(t, h)
+
+	resp, err := http.Get(base + "/ready")
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode, "not ready -> 503")
+
+	h.ready.Store(true)
+	resp, err = http.Get(base + "/ready")
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "ready -> 200")
+}
+
+func TestStartServer_HealthReportsCommit(t *testing.T) {
+	h := &fakeHealth{}
+	base, _, _, _ := startTestServer(t, h)
+
+	resp, err := http.Get(base + "/health")
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode, "no commit -> 503")
+
+	h.haveCommit.Store(true)
+	h.closeUnix.Store(1234567890)
+	resp, err = http.Get(base + "/health")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "committed -> 200")
+}

--- a/cmd/stellar-rpc/internal/fullhistory/serve/tx_reader.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/tx_reader.go
@@ -47,17 +47,16 @@ func (r txReader) GetTransaction(_ context.Context, hash xdr.Hash) (db.Transacti
 	for i := len(hotIDs) - 1; i >= 0; i-- {
 		hot = append(hot, v.Hot[hotIDs[i]].Txhash())
 	}
-	// Cold windows newest first (TxIdx is ascending by Lo).
+	// Cold windows newest first (TxIdx is ascending by Lo), each floor-gated: a
+	// window index may keep naming ledgers prune has removed (design R2), so a
+	// below-floor candidate is a clean index miss, not an unverifiable probe.
+	floor := max(v.Floor.FirstLedger(), v.Earliest)
 	cold := make([]txhash.HashIndex, 0, len(v.TxIdx))
 	for i := len(v.TxIdx) - 1; i >= 0; i-- {
-		cold = append(cold, v.TxIdx[i].Reader)
+		cold = append(cold, floorGatedIndex{inner: v.TxIdx[i].Reader, floor: floor})
 	}
 
-	src := txLedgerSource{
-		view:   v,
-		layout: r.layout,
-		floor:  max(v.Floor.FirstLedger(), v.Earliest),
-	}
+	src := txLedgerSource{view: v, layout: r.layout}
 	tr, err := txhash.NewTxReader(hot, cold, src, r.passphrase)
 	if err != nil {
 		return db.Transaction{}, err
@@ -73,21 +72,36 @@ func (r txReader) GetTransaction(_ context.Context, hash xdr.Hash) (db.Transacti
 	return viewToTransaction(txv), nil
 }
 
+// floorGatedIndex drops a cold candidate whose ledger sits below the retention
+// floor. A window index legitimately keeps naming ledgers prune has already
+// removed (design R2), so a below-floor hit is a clean index miss — not a
+// candidate the ledger source must then fail to verify.
+type floorGatedIndex struct {
+	inner txhash.HashIndex
+	floor uint32
+}
+
+func (g floorGatedIndex) Get(hash [32]byte) (uint32, error) {
+	seq, err := g.inner.Get(hash)
+	if err != nil {
+		return 0, err
+	}
+	if seq < g.floor {
+		return 0, stores.ErrNotFound
+	}
+	return seq, nil
+}
+
 // txLedgerSource resolves a ledger's raw bytes for the txhash reader over one
-// pinned View, opening/closing the per-chunk reader per call. It returns
-// not-found for a seq below the retention floor so a cold fingerprint candidate
-// naming pruned history is skipped rather than served (design: R2 for by-hash
-// lookups).
+// pinned View, opening/closing the per-chunk reader per call. A genuine
+// resolution failure stays an error (the reader's "never a false not-found"
+// path); below-floor filtering happens at the index layer above.
 type txLedgerSource struct {
 	view   *View
 	layout geometry.Layout
-	floor  uint32
 }
 
 func (s txLedgerSource) GetLedgerRaw(seq uint32) ([]byte, error) {
-	if seq < s.floor {
-		return nil, stores.ErrNotFound
-	}
 	lc, err := s.view.ResolveLedgers(chunk.IDFromLedger(seq), s.layout)
 	if err != nil {
 		return nil, err

--- a/cmd/stellar-rpc/internal/fullhistory/serve/tx_reader.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/tx_reader.go
@@ -41,6 +41,18 @@ func NewTransactionReader(reg *Registry, layout geometry.Layout, passphrase stri
 func (r txReader) GetTransaction(_ context.Context, hash xdr.Hash) (db.Transaction, error) {
 	_, v := r.reg.Admit()
 
+	// POC: this probe chain finds a fee-bump transaction by its OUTER hash only,
+	// never its inner hash — a v1 parity gap. v1 indexes a fee-bump under both
+	// hashes (db/transaction.go: transactions[tx.Result.InnerHash()] = tx), but the
+	// full-history write path stores exactly ONE key per tx — the outer TxProcessing
+	// result hash — in BOTH tiers (the cold .bin/.idx build in ingest/txhash.go and
+	// the hot txhash CF in hot_store.go), and the SDK verify chain
+	// (ingest.LedgerTransactionViewByHash) matches that outer hash only. So
+	// GetTransaction(innerHash) returns a clean NOT_FOUND where v1 returns the
+	// fee-bump tx. Not fixable at this read layer. Productionization requires
+	// inner-hash index entries at build time (hot CF + .bin codec + .idx build +
+	// backfill) or an inner-hash fallback in the SDK extractor.
+
 	// Hot indexes newest chunk first (higher ID = newer).
 	hotIDs := slices.Sorted(maps.Keys(v.Hot))
 	hot := make([]txhash.HashIndex, 0, len(hotIDs))

--- a/cmd/stellar-rpc/internal/fullhistory/serve/tx_reader.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/tx_reader.go
@@ -1,0 +1,122 @@
+package serve
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"maps"
+	"slices"
+
+	"github.com/stellar/go-stellar-sdk/ingest"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/db"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/geometry"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/ledgerbucketwindow"
+)
+
+// txReader adapts the serve Registry to the db.TransactionReader interface the
+// v1 getTransaction handler consumes, so methods.NewGetTransactionHandler runs
+// verbatim over full-history storage: a by-hash lookup probes the hot tx-hash
+// CFs (exact, newest first), then the cold window indexes (fingerprinted,
+// newest first), verifying every candidate against the resolved ledger.
+type txReader struct {
+	reg        *Registry
+	layout     geometry.Layout
+	passphrase string
+}
+
+// NewTransactionReader returns a db.TransactionReader backed by the serve Registry.
+func NewTransactionReader(reg *Registry, layout geometry.Layout, passphrase string) db.TransactionReader {
+	return txReader{reg: reg, layout: layout, passphrase: passphrase}
+}
+
+// GetTransaction admits once, assembles the hot/cold probe chain against that
+// one immutable View, and runs the shared txhash reader. A miss is
+// db.ErrNoTransaction; the view's raw byte fields (which alias the per-call
+// ledger buffer the LedgerSource cloned) become the returned Transaction.
+func (r txReader) GetTransaction(_ context.Context, hash xdr.Hash) (db.Transaction, error) {
+	_, v := r.reg.Admit()
+
+	// Hot indexes newest chunk first (higher ID = newer).
+	hotIDs := slices.Sorted(maps.Keys(v.Hot))
+	hot := make([]txhash.HashIndex, 0, len(hotIDs))
+	for i := len(hotIDs) - 1; i >= 0; i-- {
+		hot = append(hot, v.Hot[hotIDs[i]].Txhash())
+	}
+	// Cold windows newest first (TxIdx is ascending by Lo).
+	cold := make([]txhash.HashIndex, 0, len(v.TxIdx))
+	for i := len(v.TxIdx) - 1; i >= 0; i-- {
+		cold = append(cold, v.TxIdx[i].Reader)
+	}
+
+	src := txLedgerSource{
+		view:   v,
+		layout: r.layout,
+		floor:  max(v.Floor.FirstLedger(), v.Earliest),
+	}
+	tr, err := txhash.NewTxReader(hot, cold, src, r.passphrase)
+	if err != nil {
+		return db.Transaction{}, err
+	}
+
+	txv, found, err := tr.GetTransaction([32]byte(hash))
+	if err != nil {
+		return db.Transaction{}, err
+	}
+	if !found {
+		return db.Transaction{}, db.ErrNoTransaction
+	}
+	return viewToTransaction(txv), nil
+}
+
+// txLedgerSource resolves a ledger's raw bytes for the txhash reader over one
+// pinned View, opening/closing the per-chunk reader per call. It returns
+// not-found for a seq below the retention floor so a cold fingerprint candidate
+// naming pruned history is skipped rather than served (design: R2 for by-hash
+// lookups).
+type txLedgerSource struct {
+	view   *View
+	layout geometry.Layout
+	floor  uint32
+}
+
+func (s txLedgerSource) GetLedgerRaw(seq uint32) ([]byte, error) {
+	if seq < s.floor {
+		return nil, stores.ErrNotFound
+	}
+	lc, err := s.view.ResolveLedgers(chunk.IDFromLedger(seq), s.layout)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = lc.Close() }()
+	raw, err := lc.Get(seq)
+	if err != nil {
+		return nil, err
+	}
+	// The reader's view aliases these bytes past the call; copy the borrowed buffer.
+	return bytes.Clone(raw), nil
+}
+
+// viewToTransaction maps the raw-bytes LedgerTransactionView field-for-field
+// onto db.Transaction (the view is the view-path parallel of ParseTransaction's
+// output, already holding the same XDR wire bytes). The byte slices alias the
+// buffer txLedgerSource cloned per call, so the returned Transaction owns them.
+func viewToTransaction(v ingest.LedgerTransactionView) db.Transaction {
+	return db.Transaction{
+		TransactionHash:   hex.EncodeToString(v.Hash[:]),
+		Result:            v.Result,
+		Meta:              v.Meta,
+		Envelope:          v.Envelope,
+		Events:            v.DiagnosticEvents,
+		FeeBump:           v.FeeBump,
+		ApplicationOrder:  v.ApplicationOrder,
+		Successful:        v.Successful,
+		Ledger:            ledgerbucketwindow.LedgerInfo{Sequence: v.LedgerSequence, CloseTime: v.LedgerCloseTime},
+		TransactionEvents: v.TransactionEvents,
+		ContractEvents:    v.ContractEvents,
+	}
+}

--- a/cmd/stellar-rpc/internal/fullhistory/serve/tx_reader_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/tx_reader_test.go
@@ -173,18 +173,17 @@ func TestTxReader_Miss(t *testing.T) {
 	assert.ErrorIs(t, err, db.ErrNoTransaction, "an uncommitted hash is a clean not-found")
 }
 
-// A cold candidate below the retention floor must not be served: the floor gate
-// makes the ledger probe not-found even though the pack still holds the bytes,
-// so the tx is not returned (a soft-error incomplete lookup, never pruned data).
+// A cold candidate below the retention floor is skipped at the index seam (a
+// window index may keep naming pruned ledgers, design R2), so it reads as a
+// clean index miss and ends as db.ErrNoTransaction — never pruned data, never
+// an incomplete-lookup error.
 func TestTxReader_BelowFloorSkipped(t *testing.T) {
 	// Pin earliest to chunk 1's first ledger ⇒ floor sits above chunk 0's tx.
 	r, layout, hash, _ := buildColdTxFixture(t, chunk.ID(1).FirstLedger())
 	txr := NewTransactionReader(r, layout, network.PublicNetworkPassphrase)
 
-	got, err := txr.GetTransaction(t.Context(), xdr.Hash(hash))
-	require.Error(t, err, "below-floor candidate is not served")
-	assert.NotErrorIs(t, err, db.ErrNoTransaction, "incomplete lookup, not a false not-found")
-	assert.Empty(t, got.TransactionHash, "no transaction returned")
+	_, err := txr.GetTransaction(t.Context(), xdr.Hash(hash))
+	assert.ErrorIs(t, err, db.ErrNoTransaction, "below-floor candidate skips to a clean not-found")
 }
 
 // Step: the real getTransaction handler, mounted over the adapter, returns a

--- a/cmd/stellar-rpc/internal/fullhistory/serve/tx_reader_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/tx_reader_test.go
@@ -1,0 +1,225 @@
+package serve
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/creachadair/jrpc2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stellar/go-stellar-sdk/network"
+	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/db"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/fhtest"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/geometry"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/txhash"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/methods"
+)
+
+// oneTxLCM is fhtest.ZeroTxLCMBytes plus one network-hashed tx (unique SeqNum ⇒
+// unique hash), so ExtractTxHashes yields exactly one key for seq. Returns the
+// wire bytes and the real tx hash a by-hash lookup resolves. Mirror of
+// daemon_test.go's oneTxLCMBytes, kept here to avoid a _test cross-package dep.
+func oneTxLCM(t *testing.T, seq uint32) ([]byte, [32]byte) {
+	t.Helper()
+	src := xdr.MustMuxedAddress(keypair.MustRandom().Address())
+	envelope := xdr.TransactionEnvelope{
+		Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+		V1: &xdr.TransactionV1Envelope{
+			Tx: xdr.Transaction{
+				SourceAccount: src,
+				SeqNum:        xdr.SequenceNumber(seq),
+				Ext:           xdr.TransactionExt{V: 1, SorobanData: &xdr.SorobanTransactionData{}},
+			},
+		},
+	}
+	hash, err := network.HashTransactionInEnvelope(envelope, network.PublicNetworkPassphrase)
+	require.NoError(t, err)
+	comp := []xdr.TxSetComponent{{
+		Type: xdr.TxSetComponentTypeTxsetCompTxsMaybeDiscountedFee,
+		TxsMaybeDiscountedFee: &xdr.TxSetComponentTxsMaybeDiscountedFee{
+			Txs: []xdr.TransactionEnvelope{envelope},
+		},
+	}}
+	lcm := xdr.LedgerCloseMeta{
+		V: 2,
+		V2: &xdr.LedgerCloseMetaV2{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+				Header: xdr.LedgerHeader{
+					ScpValue:  xdr.StellarValue{CloseTime: xdr.TimePoint(0)},
+					LedgerSeq: xdr.Uint32(seq),
+				},
+			},
+			TxSet: xdr.GeneralizedTransactionSet{
+				V:       1,
+				V1TxSet: &xdr.TransactionSetV1{Phases: []xdr.TransactionPhase{{V: 0, V0Components: &comp}}},
+			},
+			TxProcessing: []xdr.TransactionResultMetaV1{{
+				TxApplyProcessing: xdr.TransactionMeta{V: 4, V4: &xdr.TransactionMetaV4{}},
+				Result: xdr.TransactionResultPair{
+					TransactionHash: hash,
+					Result: xdr.TransactionResult{
+						FeeCharged: 100,
+						Result: xdr.TransactionResultResult{
+							Code:    xdr.TransactionResultCodeTxSuccess,
+							Results: &[]xdr.OperationResult{},
+						},
+					},
+				},
+			}},
+		},
+	}
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	return raw, hash
+}
+
+// unknownHash builds a deterministic 32-byte hash for the never-committed miss.
+func unknownHash(n uint64) [32]byte {
+	var h [32]byte
+	for i := range 8 {
+		h[i] = byte(n >> (8 * i))
+	}
+	return h
+}
+
+// buildHotTxFixture ingests one tx-bearing ledger into a live hot chunk 0 and
+// publishes it, so a by-hash lookup resolves through the hot (exact) probe.
+func buildHotTxFixture(t *testing.T) (*Registry, geometry.Layout, [32]byte, uint32) {
+	t.Helper()
+	cat, layout := newTestCatalog(t)
+	seq := chunk.ID(0).FirstLedger()
+	raw, hash := oneTxLCM(t, seq)
+
+	require.NoError(t, cat.BeginHotCreate(chunk.ID(0)))
+	dbHot, err := hotchunk.Open(layout.HotChunkPath(chunk.ID(0)), chunk.ID(0), silentLogger())
+	require.NoError(t, err)
+	_, err = dbHot.IngestLedger(seq, xdr.LedgerCloseMetaView(raw))
+	require.NoError(t, err)
+	require.NoError(t, cat.FinishHotCreate(chunk.ID(0)))
+	t.Cleanup(func() { _ = dbHot.Close() })
+
+	r := NewRegistry(cat, fhtest.RetentionFor(t, cat, 0), silentLogger())
+	require.NoError(t, r.BuildInitial(seq))
+	r.HotOpened(chunk.ID(0), dbHot) // chunk 0 is the resume chunk
+
+	return r, layout, hash, seq
+}
+
+// buildColdTxFixture freezes one tx-bearing ledger into a cold pack at chunk 0's
+// first ledger AND a matching frozen tx-hash window index, so a by-hash lookup
+// resolves through the cold (fingerprint) probe and is verified against the cold
+// ledger. earliestPin > 0 pins earliest_ledger (used to push the retention floor
+// above the tx's ledger for the below-floor case); 0 leaves full history.
+func buildColdTxFixture(t *testing.T, earliestPin uint32) (*Registry, geometry.Layout, [32]byte, uint32) {
+	t.Helper()
+	cat, layout := newTestCatalog(t)
+	if earliestPin > 0 {
+		require.NoError(t, cat.PinEarliestLedger(earliestPin))
+	}
+	seq := chunk.ID(0).FirstLedger()
+	raw, hash := oneTxLCM(t, seq)
+
+	writeColdLedgerPack(t, layout, chunk.ID(0), seq, raw)
+	freezeLedgers(t, cat, chunk.ID(0))
+
+	var entry txhash.ColdEntry
+	copy(entry.Key[:], hash[:])
+	entry.Seq = seq
+	freezeTxIndex(t, cat, layout, geometry.TxHashIndexID(0), chunk.ID(0), chunk.ID(0),
+		chunk.ID(0).FirstLedger(), chunk.ID(0).LastLedger(), []txhash.ColdEntry{entry})
+
+	r := NewRegistry(cat, fhtest.RetentionFor(t, cat, 0), silentLogger())
+	require.NoError(t, r.BuildInitial(seq))
+	return r, layout, hash, seq
+}
+
+func TestTxReader_HotHit(t *testing.T) {
+	r, layout, hash, seq := buildHotTxFixture(t)
+	txr := NewTransactionReader(r, layout, network.PublicNetworkPassphrase)
+
+	got, err := txr.GetTransaction(t.Context(), xdr.Hash(hash))
+	require.NoError(t, err)
+	assert.EqualValues(t, seq, got.Ledger.Sequence)
+	assert.Equal(t, hex.EncodeToString(hash[:]), got.TransactionHash)
+	assert.True(t, got.Successful)
+	assert.NotEmpty(t, got.Envelope, "envelope XDR carried through")
+	assert.NotEmpty(t, got.Result, "result XDR carried through")
+	assert.NotEmpty(t, got.Meta, "meta XDR carried through")
+}
+
+func TestTxReader_ColdHit(t *testing.T) {
+	r, layout, hash, seq := buildColdTxFixture(t, 0)
+	txr := NewTransactionReader(r, layout, network.PublicNetworkPassphrase)
+
+	got, err := txr.GetTransaction(t.Context(), xdr.Hash(hash))
+	require.NoError(t, err, "the frozen .idx candidate resolves + verifies against the cold ledger")
+	assert.EqualValues(t, seq, got.Ledger.Sequence)
+	assert.Equal(t, hex.EncodeToString(hash[:]), got.TransactionHash)
+	assert.NotEmpty(t, got.Envelope)
+}
+
+func TestTxReader_Miss(t *testing.T) {
+	r, layout, _, _ := buildColdTxFixture(t, 0)
+	txr := NewTransactionReader(r, layout, network.PublicNetworkPassphrase)
+
+	_, err := txr.GetTransaction(t.Context(), xdr.Hash(unknownHash(0xDEADBEEF)))
+	assert.ErrorIs(t, err, db.ErrNoTransaction, "an uncommitted hash is a clean not-found")
+}
+
+// A cold candidate below the retention floor must not be served: the floor gate
+// makes the ledger probe not-found even though the pack still holds the bytes,
+// so the tx is not returned (a soft-error incomplete lookup, never pruned data).
+func TestTxReader_BelowFloorSkipped(t *testing.T) {
+	// Pin earliest to chunk 1's first ledger ⇒ floor sits above chunk 0's tx.
+	r, layout, hash, _ := buildColdTxFixture(t, chunk.ID(1).FirstLedger())
+	txr := NewTransactionReader(r, layout, network.PublicNetworkPassphrase)
+
+	got, err := txr.GetTransaction(t.Context(), xdr.Hash(hash))
+	require.Error(t, err, "below-floor candidate is not served")
+	assert.NotErrorIs(t, err, db.ErrNoTransaction, "incomplete lookup, not a false not-found")
+	assert.Empty(t, got.TransactionHash, "no transaction returned")
+}
+
+// Step: the real getTransaction handler, mounted over the adapter, returns a
+// found tx and a NotFound for an unknown hash.
+func TestTxReader_GetTransactionHandler(t *testing.T) {
+	r, layout, hash, seq := buildColdTxFixture(t, 0)
+	txr := NewTransactionReader(r, layout, network.PublicNetworkPassphrase)
+	lr := NewLedgerReader(r, layout)
+	h := methods.NewGetTransactionHandler(silentLogger(), txr, lr)
+
+	// Found.
+	found := getTxRequest(t, hex.EncodeToString(hash[:]))
+	res, err := h(t.Context(), found)
+	require.NoError(t, err)
+	resp, ok := res.(protocol.GetTransactionResponse)
+	require.True(t, ok)
+	assert.Equal(t, protocol.TransactionStatusSuccess, resp.Status)
+	assert.EqualValues(t, seq, resp.Ledger)
+
+	// NotFound.
+	miss := unknownHash(0x1234)
+	missing := getTxRequest(t, hex.EncodeToString(miss[:]))
+	res, err = h(t.Context(), missing)
+	require.NoError(t, err)
+	resp, ok = res.(protocol.GetTransactionResponse)
+	require.True(t, ok)
+	assert.Equal(t, protocol.TransactionStatusNotFound, resp.Status)
+}
+
+func getTxRequest(t *testing.T, hash string) *jrpc2.Request {
+	t.Helper()
+	requests, err := jrpc2.ParseRequests([]byte(
+		`{"jsonrpc":"2.0","id":1,"method":"getTransaction","params":{"hash":"` + hash + `"}}`,
+	))
+	require.NoError(t, err)
+	require.Len(t, requests, 1)
+	return requests[0].ToRequest()
+}

--- a/cmd/stellar-rpc/internal/fullhistory/serve/tx_reader_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve/tx_reader_test.go
@@ -146,7 +146,7 @@ func TestTxReader_HotHit(t *testing.T) {
 
 	got, err := txr.GetTransaction(t.Context(), xdr.Hash(hash))
 	require.NoError(t, err)
-	assert.EqualValues(t, seq, got.Ledger.Sequence)
+	assert.Equal(t, seq, got.Ledger.Sequence)
 	assert.Equal(t, hex.EncodeToString(hash[:]), got.TransactionHash)
 	assert.True(t, got.Successful)
 	assert.NotEmpty(t, got.Envelope, "envelope XDR carried through")
@@ -160,7 +160,7 @@ func TestTxReader_ColdHit(t *testing.T) {
 
 	got, err := txr.GetTransaction(t.Context(), xdr.Hash(hash))
 	require.NoError(t, err, "the frozen .idx candidate resolves + verifies against the cold ledger")
-	assert.EqualValues(t, seq, got.Ledger.Sequence)
+	assert.Equal(t, seq, got.Ledger.Sequence)
 	assert.Equal(t, hex.EncodeToString(hash[:]), got.TransactionHash)
 	assert.NotEmpty(t, got.Envelope)
 }
@@ -170,7 +170,7 @@ func TestTxReader_Miss(t *testing.T) {
 	txr := NewTransactionReader(r, layout, network.PublicNetworkPassphrase)
 
 	_, err := txr.GetTransaction(t.Context(), xdr.Hash(unknownHash(0xDEADBEEF)))
-	assert.ErrorIs(t, err, db.ErrNoTransaction, "an uncommitted hash is a clean not-found")
+	require.ErrorIs(t, err, db.ErrNoTransaction, "an uncommitted hash is a clean not-found")
 }
 
 // A cold candidate below the retention floor is skipped at the index seam (a
@@ -201,7 +201,7 @@ func TestTxReader_GetTransactionHandler(t *testing.T) {
 	resp, ok := res.(protocol.GetTransactionResponse)
 	require.True(t, ok)
 	assert.Equal(t, protocol.TransactionStatusSuccess, resp.Status)
-	assert.EqualValues(t, seq, resp.Ledger)
+	assert.Equal(t, seq, resp.Ledger)
 
 	// NotFound.
 	miss := unknownHash(0x1234)

--- a/cmd/stellar-rpc/internal/fullhistory/serve_bench_harness_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve_bench_harness_test.go
@@ -20,6 +20,12 @@ package fullhistory
 //     from the post-backfill resume point. They land in the next (unfrozen) chunk
 //     as the HOT tier, give getTransaction/getEvents something to sample there,
 //     and latch /ready (which keys off a live commit).
+//     NOTE: this makes the hot tier SYNTHETIC 1-tx toy ledgers — fhbench hot-tier
+//     rows against this harness are NOT representative of real-profile hot
+//     serving (the profiles' real ledgers are 10-17 MB with thousands of tx).
+//     TestServeE2E_ProfileLatency, which live-ingests the real ledgers into the
+//     hot tier, is the representative hot-path benchmark; this harness's value
+//     is the real COLD tier it freezes.
 //   - cpi=1 so each frozen chunk's one-chunk tx-hash window is terminal the instant
 //     it freezes — the cold .idx a by-hash lookup resolves against exists.
 //

--- a/cmd/stellar-rpc/internal/fullhistory/serve_bench_harness_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve_bench_harness_test.go
@@ -1,0 +1,267 @@
+package fullhistory
+
+// =============================================================================
+// Serve-harness for the full-history QUERY benchmark (tools/fhbench).
+//
+// fhbench is a black-box HTTP load generator: it needs a *running daemon* with a
+// bound [serve] endpoint that serves a profile's data across both tiers. There is
+// no turnkey way to serve the synthetic apply-load profiles (bench-ingest throws
+// its catalog away; the daemon has no local-pack ingest source). This harness
+// bridges that gap using the SAME injected seam the serve e2e uses
+// (runDaemonWith + fake Backend/Core):
+//
+//   - Backend = a pack reader over the profile's frozen ledger tree, with Tip one
+//     ledger into the chunk AFTER the profile's last real chunk. passTarget's
+//     LastCompleteChunkAt(tip) therefore resolves to that last real chunk, so the
+//     daemon's startup backfill FREEZES every real chunk into cold artifacts
+//     (events + txhash regenerated fresh from the ledger packs) — the real cold
+//     serving tier, per profile.
+//   - Core = the fake e2eCore delivering `hotLedgers` synthetic tx+event ledgers
+//     from the post-backfill resume point. They land in the next (unfrozen) chunk
+//     as the HOT tier, give getTransaction/getEvents something to sample there,
+//     and latch /ready (which keys off a live commit).
+//   - cpi=1 so each frozen chunk's one-chunk tx-hash window is terminal the instant
+//     it freezes — the cold .idx a by-hash lookup resolves against exists.
+//
+// It is env-gated (skipped in normal `go test`): set FHBENCH_PROFILE_LEDGERS to a
+// profile's ledgers tree root and it boots the server on FHBENCH_SERVE_ADDR, holds
+// FHBENCH_HOLD_SEC seconds (run fhbench against it in that window), then shuts down
+// cleanly. See tools/bench-suite for the driver.
+// =============================================================================
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"math"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stellar/go-stellar-sdk/network"
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/backfill"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/config"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/geometry"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/ledger"
+)
+
+// profilePackBackend is a backfill.Backend over a profile's frozen ledger tree
+// (FHBENCH_PROFILE_LEDGERS), identical in behavior to bench's packBackend but with
+// a FIXED Tip: the backfill freeze target is LastCompleteChunkAt(Tip), so tip =
+// (lastRealChunk+1).FirstLedger() freezes exactly the real chunks and no more.
+type profilePackBackend struct {
+	root string
+	tip  uint32
+}
+
+var _ backfill.Backend = profilePackBackend{}
+
+func (p profilePackBackend) RawLedgers(
+	ctx context.Context, rng ledgerbackend.Range, _ ...ledgerbackend.StreamOption,
+) iter.Seq2[[]byte, error] {
+	return func(yield func([]byte, error) bool) {
+		if !rng.Bounded() {
+			yield(nil, fmt.Errorf("pack source requires a bounded range, got %s", rng))
+			return
+		}
+		for c := chunk.IDFromLedger(rng.From()); c <= chunk.IDFromLedger(rng.To()); c++ {
+			path := geometry.LedgerPackPath(p.root, c)
+			if _, err := os.Stat(path); err != nil {
+				yield(nil, fmt.Errorf("stat source pack %s: %w", path, err))
+				return
+			}
+			sub := ledgerbackend.BoundedRange(max(rng.From(), c.FirstLedger()), min(rng.To(), c.LastLedger()))
+			for raw, err := range ledger.NewPackStream(path).RawLedgers(ctx, sub) {
+				if !yield(raw, err) {
+					return
+				}
+				if err != nil {
+					return
+				}
+			}
+		}
+	}
+}
+
+func (p profilePackBackend) Tip(context.Context) (uint32, error) { return p.tip, nil }
+
+func fhbenchEnvInt(t *testing.T, key string, def int) int {
+	t.Helper()
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	require.NoError(t, err, "env %s must be an integer, got %q", key, v)
+	return n
+}
+
+// TestServeProfileForBench boots the daemon serving one synthetic profile and
+// holds so an external fhbench run can query it. Skipped unless
+// FHBENCH_PROFILE_LEDGERS is set.
+func TestServeProfileForBench(t *testing.T) {
+	ledgersRoot := os.Getenv("FHBENCH_PROFILE_LEDGERS")
+	if ledgersRoot == "" {
+		t.Skip("set FHBENCH_PROFILE_LEDGERS (a profile ledgers tree root) to run the serve harness")
+	}
+	dataDir := os.Getenv("FHBENCH_DATA_DIR")
+	if dataDir == "" {
+		dataDir = t.TempDir()
+	} else {
+		require.NoError(t, os.MkdirAll(dataDir, 0o755))
+	}
+	serveAddr := os.Getenv("FHBENCH_SERVE_ADDR")
+	if serveAddr == "" {
+		serveAddr = "127.0.0.1:8100"
+	}
+	firstChunk := chunk.ID(fhbenchEnvInt(t, "FHBENCH_FIRST_CHUNK", 1)) //nolint:gosec // small test id
+	lastChunk := chunk.ID(fhbenchEnvInt(t, "FHBENCH_LAST_CHUNK", 1))   //nolint:gosec // small test id
+	hotLedgers := fhbenchEnvInt(t, "FHBENCH_HOT_LEDGERS", 5200)
+	holdSec := fhbenchEnvInt(t, "FHBENCH_HOLD_SEC", 900)
+	passphrase := os.Getenv("FHBENCH_PASSPHRASE")
+	if passphrase == "" {
+		passphrase = network.PublicNetworkPassphrase
+	}
+
+	require.LessOrEqual(t, uint32(lastChunk), uint32(math.MaxUint32/chunk.LedgersPerChunk-2),
+		"lastChunk too large")
+
+	// Tip one ledger into the chunk after the last real chunk ⇒ backfill freezes
+	// [firstChunk..lastChunk] as cold, no more.
+	tip := (lastChunk + 1).FirstLedger()
+	backend := profilePackBackend{root: ledgersRoot, tip: tip}
+
+	// Hot tier: synthetic tx+event ledgers from the post-backfill resume point.
+	resume := lastChunk.LastLedger() + 1
+	src := xdr.MustMuxedAddress(keypair.MustRandom().Address())
+	frames := make(map[uint32][]byte, hotLedgers)
+	for i := 0; i < hotLedgers; i++ {
+		seq := resume + uint32(i) //nolint:gosec // bounded by hotLedgers
+		raw, _ := oneTxEventLCM(t, seq, src, fmt.Sprintf("hot%d", seq))
+		frames[seq] = raw
+	}
+	core := &e2eCore{frames: frames}
+
+	earliest := firstChunk.FirstLedger()
+	cfgPath := serveBenchConfigPath(t, dataDir, serveAddr, earliest)
+
+	addrCh := make(chan net.Addr, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runDaemonWith(ctx, cfgPath, daemonOptions{
+			Backend:              backend,
+			Core:                 core,
+			Logger:               newBenchLogger(t),
+			RestartBackoff:       time.Second,
+			chunksPerTxhashIndex: 1,
+			passphrase:           passphrase,
+			serveAddr:            func(a net.Addr) { addrCh <- a },
+		})
+	}()
+	defer func() {
+		cancel()
+		select {
+		case err := <-errCh:
+			require.NoError(t, err, "ctx cancel is a clean daemon shutdown")
+		case <-time.After(5 * time.Minute):
+			t.Fatal("daemon did not shut down cleanly after ctx cancel")
+		}
+	}()
+
+	// The read server binds only AFTER startup backfill freezes the cold chunk(s)
+	// (run() serves against a populated View), so this wait must exceed the cold
+	// freeze — ~11 min per chunk, so soroswap's two chunks take ~25 min.
+	var addr net.Addr
+	select {
+	case addr = <-addrCh:
+	case err := <-errCh:
+		t.Fatalf("daemon returned before the read server bound: %v", err)
+	case <-time.After(45 * time.Minute):
+		t.Fatal("read server never bound (cold backfill still running?)")
+	}
+	base := "http://" + addr.String()
+	t.Logf("[fhbench-harness] serving profile ledgers=%s on %s (cold chunks %d..%d, %d hot ledgers from %d)",
+		ledgersRoot, addr.String(), firstChunk, lastChunk, hotLedgers, resume)
+
+	// Wait for cold backfill to freeze the chunks AND the hot ledgers to commit:
+	// /ready latches on the first live commit, and both tiers must be queryable
+	// before fhbench probes the served range. 20 min budget absorbs the cold
+	// freeze (events + txhash over a full chunk) on a shared box.
+	require.Eventually(t, func() bool {
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, base+"/ready", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return false
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 20*time.Minute, time.Second, "read server must become ready (cold freeze + first hot commit)")
+
+	// Smoke: cold range head is queryable (proves the frozen chunk serves).
+	require.Eventually(t, func() bool {
+		res, ok := resultMap(tryRPC(ctx, base+"/", ledgersReq(earliest, 1)))
+		if !ok {
+			return false
+		}
+		ls, _ := res["ledgers"].([]any)
+		return len(ls) == 1
+	}, 5*time.Minute, time.Second, "cold chunk head must be served")
+
+	t.Logf("[fhbench-harness] READY on %s — holding %ds for fhbench", addr.String(), holdSec)
+	select {
+	case <-time.After(time.Duration(holdSec) * time.Second):
+		t.Logf("[fhbench-harness] hold elapsed; shutting down")
+	case err := <-errCh:
+		t.Fatalf("daemon exited during hold: %v", err)
+	}
+}
+
+// serveBenchConfigPath writes a daemon TOML pointing default_data_dir at dataDir,
+// binding [serve] to a fixed endpoint, with the retention floor at the profile's
+// first chunk (the packs start at chunk 1, not genesis).
+func serveBenchConfigPath(t *testing.T, dataDir, endpoint string, earliest uint32) string {
+	t.Helper()
+	cfgPath := filepath.Join(t.TempDir(), "daemon.toml")
+	body := fmt.Sprintf(`
+[service]
+default_data_dir = %q
+
+[retention]
+earliest_ledger = "%d"
+retention_chunks = 0
+
+[ingestion]
+captive_core_config = "/dev/null"
+
+[serve]
+endpoint = %q
+
+[logging]
+level = "info"
+format = "text"
+`, dataDir, earliest, endpoint)
+	require.NoError(t, os.WriteFile(cfgPath, []byte(body), 0o644))
+	return cfgPath
+}
+
+// newBenchLogger returns a real (non-silent) logger so the harness's daemon
+// progress is visible in the test output while it holds.
+func newBenchLogger(t *testing.T) *supportlog.Entry {
+	t.Helper()
+	l, err := newLogger(config.LoggingConfig{Level: "info", Format: "text"})
+	require.NoError(t, err)
+	return l
+}

--- a/cmd/stellar-rpc/internal/fullhistory/serve_e2e_cold_latency_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve_e2e_cold_latency_test.go
@@ -206,4 +206,8 @@ func TestServeE2E_ColdQueryLatency(t *testing.T) {
 	} else {
 		t.Logf("  getEvents          (skipped — no contract id harvested from the cold window)")
 	}
+
+	// getEvents OR-union index-term sweep over the same cold window (selective
+	// path), directly comparable to the hot test's sweep on identical ledgers.
+	runEventTermsSweep(ctx, t, base, measure, measureFrom, lastLedger)
 }

--- a/cmd/stellar-rpc/internal/fullhistory/serve_e2e_cold_latency_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve_e2e_cold_latency_test.go
@@ -1,0 +1,209 @@
+package fullhistory
+
+// =============================================================================
+// COLD-tier query latency: the same getLedgers/getTransaction/getEvents pass as
+// TestServeE2E_ProfileLatency, but served from FROZEN cold artifacts (packs +
+// MPHF/bitmap indexes on disk, via ColdReader) instead of hot RocksDB.
+//
+// It boots the daemon against an EXISTING daemon data dir that already has a
+// frozen chunk (catalog marks it StateFrozen; BuildInitial seeds `latest` from
+// the catalog, so the frozen range is queryable with no live ingestion). The
+// Core yields no frames (no new commits) and the backend is young (no backfill /
+// re-freeze), so the daemon simply serves the pre-frozen chunk.
+//
+// Env-gated: FHBENCH_COLD_DATA_DIR must point at a daemon data dir with a frozen
+// chunk; FHBENCH_FIRST_CHUNK (default 1) is that chunk. The query window
+// [first+warmup .. first+warmup+window-1] must fall inside the frozen chunk.
+// Other knobs match the hot test (FHBENCH_WINDOW_LEDGERS, FHBENCH_WARMUP_LEDGERS,
+// FHBENCH_QUERY_REPS, FHBENCH_PROFILE_NAME, FHBENCH_PASSPHRASE, FHBENCH_LOG).
+// =============================================================================
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/network"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+)
+
+func TestServeE2E_ColdQueryLatency(t *testing.T) {
+	dataDir := os.Getenv("FHBENCH_COLD_DATA_DIR")
+	if dataDir == "" {
+		t.Skip("set FHBENCH_COLD_DATA_DIR (a daemon data dir with a frozen chunk) to run the cold latency test")
+	}
+	firstChunk := chunk.ID(profileEnvInt(t, "FHBENCH_FIRST_CHUNK", 1)) //nolint:gosec // small test id
+	window := profileEnvInt(t, "FHBENCH_WINDOW_LEDGERS", 20)
+	require.Positive(t, window, "FHBENCH_WINDOW_LEDGERS must be >= 1")
+	warmup := profileEnvInt(t, "FHBENCH_WARMUP_LEDGERS", 200)
+	reps := profileEnvInt(t, "FHBENCH_QUERY_REPS", 500)
+	passphrase := os.Getenv("FHBENCH_PASSPHRASE")
+	if passphrase == "" {
+		passphrase = network.PublicNetworkPassphrase
+	}
+	profileName := os.Getenv("FHBENCH_PROFILE_NAME")
+	if profileName == "" {
+		profileName = "cold"
+	}
+
+	firstLedger := firstChunk.FirstLedger()
+	measureFrom := firstLedger + uint32(warmup)           //nolint:gosec // small positive
+	lastLedger := firstLedger + uint32(warmup+window) - 1 //nolint:gosec // small positive
+	require.Less(t, lastLedger, firstChunk.LastLedger(),
+		"window must stay inside the frozen chunk (%d ledgers/chunk)", chunk.LedgersPerChunk)
+
+	// Config points default_data_dir at the EXISTING frozen dir; earliest_ledger
+	// must match the catalog's pin (the chunk's first ledger).
+	cfgPath := profileLatencyConfig(t, dataDir, firstLedger)
+
+	// Empty Core ⇒ no live ingestion. Young backend (tip at/below last-committed)
+	// ⇒ no backfill/re-freeze. The daemon just serves the pre-frozen chunk.
+	core := &e2eCore{frames: map[uint32][]byte{}}
+	backend := &fakeBackend{tip: firstLedger}
+
+	addrCh := make(chan net.Addr, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runDaemonWith(ctx, cfgPath, daemonOptions{
+			Backend:              backend,
+			Core:                 core,
+			Logger:               profileLogger(t),
+			RestartBackoff:       10 * time.Millisecond,
+			chunksPerTxhashIndex: 1,
+			passphrase:           passphrase,
+			serveAddr:            func(a net.Addr) { addrCh <- a },
+		})
+	}()
+	defer func() {
+		cancel()
+		select {
+		case err := <-errCh:
+			require.NoError(t, err, "ctx cancel is a clean daemon shutdown")
+		case <-time.After(60 * time.Second):
+			t.Fatal("daemon did not shut down cleanly after ctx cancel")
+		}
+	}()
+
+	var addr net.Addr
+	select {
+	case addr = <-addrCh:
+	case err := <-errCh:
+		t.Fatalf("daemon returned before the read server bound: %v", err)
+	case <-time.After(60 * time.Second):
+		t.Fatal("read server never bound")
+	}
+	base := "http://" + addr.String()
+
+	// The frozen range is queryable as soon as the View is built (latest is seeded
+	// from the catalog). Poll the window head to be safe.
+	ledgerVisible := func(seq uint32) bool {
+		res, ok := resultMap(tryRPC(ctx, base+"/", ledgersReq(seq, 1)))
+		if !ok {
+			return false
+		}
+		ls, _ := res["ledgers"].([]any)
+		return len(ls) == 1
+	}
+	deadline := time.Now().Add(60 * time.Second)
+	for !ledgerVisible(measureFrom) {
+		if ctx.Err() != nil || time.Now().After(deadline) {
+			gl, _ := tryRPC(ctx, base+"/", ledgersReq(measureFrom, 1))
+			ls, _ := gl["result"].(map[string]any)
+			t.Fatalf("cold ledger %d never queryable; served oldest=%v latest=%v",
+				measureFrom, ls["oldestLedger"], ls["latestLedger"])
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	txHashes := harvestTxHashes(ctx, base, measureFrom, 200)
+	contractID := harvestContract(ctx, base, measureFrom)
+	t.Logf("COLD query-latency on %q chunk %d, window [%d,%d]: %d reps/endpoint (%d tx hashes, contract=%q)",
+		profileName, firstChunk, measureFrom, lastLedger, reps, len(txHashes), contractID)
+	t.Logf("  %-16s %-8s %-12s %-12s %-12s %-12s %s",
+		"endpoint", "count", "p50", "p90", "p99", "max", "errors")
+
+	const queryTimeout = 10 * time.Second
+	const endpointBudget = 45 * time.Second
+	measure := func(name string, do func(qctx context.Context, n int) bool) {
+		ds := make([]time.Duration, 0, reps)
+		errs := 0
+		loopStart := time.Now()
+		truncated := false
+		for n := 0; n < reps; n++ {
+			if ctx.Err() != nil {
+				break
+			}
+			if time.Since(loopStart) > endpointBudget {
+				truncated = true
+				break
+			}
+			qctx, qcancel := context.WithTimeout(ctx, queryTimeout)
+			start := time.Now()
+			ok := do(qctx, n)
+			elapsed := time.Since(start)
+			qcancel()
+			if ok {
+				ds = append(ds, elapsed)
+			} else {
+				errs++
+			}
+		}
+		sort.Slice(ds, func(i, j int) bool { return ds[i] < ds[j] })
+		note := ""
+		if truncated {
+			note = fmt.Sprintf("  (budget-capped at %s)", endpointBudget)
+		}
+		t.Logf("  %-16s %-8d %-12v %-12v %-12v %-12v %d%s",
+			name, len(ds),
+			pctl(ds, 0.50).Round(time.Microsecond),
+			pctl(ds, 0.90).Round(time.Microsecond),
+			pctl(ds, 0.99).Round(time.Microsecond),
+			pctl(ds, 1.0).Round(time.Microsecond),
+			errs, note)
+	}
+
+	win := uint32(window) //nolint:gosec // small positive
+	measure("getLedgers", func(qctx context.Context, n int) bool {
+		start := measureFrom + uint32(n)%win
+		res, ok := resultMap(tryRPC(qctx, base+"/", ledgersReq(start, 1)))
+		if !ok {
+			return false
+		}
+		_, has := res["ledgers"]
+		return has
+	})
+	if len(txHashes) > 0 {
+		measure("getTransaction", func(qctx context.Context, n int) bool {
+			res, ok := resultMap(tryRPC(qctx, base+"/",
+				fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"getTransaction","params":{"hash":%q}}`,
+					txHashes[n%len(txHashes)])))
+			if !ok {
+				return false
+			}
+			return res["status"] != nil
+		})
+	} else {
+		t.Logf("  getTransaction     (skipped — no tx hashes harvested from the cold window)")
+	}
+	if contractID != "" {
+		measure("getEvents", func(qctx context.Context, n int) bool {
+			start := measureFrom + uint32(n)%win
+			res, ok := resultMap(tryRPC(qctx, base+"/", eventsReq(start, contractID)))
+			if !ok {
+				return false
+			}
+			_, has := res["events"]
+			return has
+		})
+	} else {
+		t.Logf("  getEvents          (skipped — no contract id harvested from the cold window)")
+	}
+}

--- a/cmd/stellar-rpc/internal/fullhistory/serve_e2e_latency_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve_e2e_latency_test.go
@@ -1,0 +1,300 @@
+package fullhistory
+
+// =============================================================================
+// Ingest→query visibility latency of the full-history daemon with [serve].
+//
+// For each of a handful of live ledgers (all inside chunk 0 — no boundary, no
+// freeze, the clean hot-path regime), this measures the wall-clock from when a
+// ledger enters ingestion to when a query can first return it, for all three
+// item kinds against the SAME ledger:
+//
+//	getLedgers(seq)            — the ledger itself
+//	getTransaction(hash∈seq)   — a transaction in that ledger
+//	getEvents(seq, contract)   — a contract event in that ledger
+//
+// Timestamps are taken in-process (no clock skew): the fake core stamps each
+// frame as it enters ingestion (source), latencyMetrics stamps the durable
+// commit, and the poller stamps the first successful query. This yields three
+// spans per sample — full (source→query), ingest (source→commit), and visible
+// (commit→query) — the last of which the design's "latest advances last" rule
+// says should be ~poll-granularity with no staleness window.
+//
+// The source is paced (yieldDelay) so the poller stays ahead of each commit;
+// otherwise ingestion outruns the poller and every sample floors at 0.
+// =============================================================================
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stellar/go-stellar-sdk/network"
+	"github.com/stellar/go-stellar-sdk/strkey"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/observability"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+)
+
+// latencyMetrics records the instant each ledger is durably committed
+// (observability.Metrics.LastCommitted — the last per-ledger step before
+// `latest` advances), so the test can measure commit→query.
+type latencyMetrics struct {
+	observability.NopMetrics
+	mu     sync.Mutex
+	commit map[uint32]time.Time
+}
+
+func (m *latencyMetrics) LastCommitted(seq uint32) {
+	m.mu.Lock()
+	if _, seen := m.commit[seq]; !seen {
+		m.commit[seq] = time.Now()
+	}
+	m.mu.Unlock()
+}
+
+func (m *latencyMetrics) commitAt(seq uint32) (time.Time, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	t, ok := m.commit[seq]
+	return t, ok
+}
+
+// tryRPC POSTs a JSON-RPC body and returns the decoded envelope, or ok=false on
+// any transport/decode failure. Unlike postRPC it never calls t.Fatal, so it is
+// safe to call from the poller goroutines.
+func tryRPC(ctx context.Context, url, body string) (map[string]any, bool) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(body))
+	if err != nil {
+		return nil, false
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, false
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, false
+	}
+	var out map[string]any
+	if json.Unmarshal(raw, &out) != nil {
+		return nil, false
+	}
+	return out, true
+}
+
+func resultMap(env map[string]any, ok bool) (map[string]any, bool) {
+	if !ok {
+		return nil, false
+	}
+	res, isMap := env["result"].(map[string]any)
+	return res, isMap
+}
+
+// TestServeE2E_IngestToQueryLatency measures ingest→query latency for the same
+// ledger/tx/event across a small live window. Fast (a dozen ledgers, no chunk
+// boundary), so it is not -short gated.
+func TestServeE2E_IngestToQueryLatency(t *testing.T) {
+	dataDir := t.TempDir()
+
+	const genesis = chunk.FirstLedgerSeq
+	const firstTarget = genesis + 4
+	const nSamples = 10
+	const lastTarget = firstTarget + nSamples - 1
+	const lastLedger = lastTarget + 2 // a couple past the last target so latest passes it
+
+	// One source account; a per-seq SeqNum makes each tx hash unique. Every ledger
+	// carries a tx and a contract event so all three item kinds share the ledger.
+	src := xdr.MustMuxedAddress(keypair.MustRandom().Address())
+	hashes := make(map[uint32][32]byte, lastLedger)
+	frames := make(map[uint32][]byte, lastLedger)
+	for seq := uint32(genesis); seq <= lastLedger; seq++ {
+		raw, h := oneTxEventLCM(t, seq, src, fmt.Sprintf("l%d", seq))
+		frames[seq] = raw
+		hashes[seq] = h
+	}
+
+	var srcMu sync.Mutex
+	sourceAt := make(map[uint32]time.Time, len(frames))
+	metrics := &latencyMetrics{commit: make(map[uint32]time.Time)}
+
+	core := &e2eCore{
+		frames:     frames,
+		yieldDelay: 15 * time.Millisecond, // pace so the poller stays ahead of commits
+		onYield: func(seq uint32) {
+			srcMu.Lock()
+			if _, ok := sourceAt[seq]; !ok {
+				sourceAt[seq] = time.Now()
+			}
+			srcMu.Unlock()
+		},
+	}
+
+	addrCh := make(chan net.Addr, 1)
+	cfgPath := serveE2EConfigPath(t, dataDir)
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runDaemonWith(ctx, cfgPath, daemonOptions{
+			Backend:              &fakeBackend{tip: chunk.FirstLedgerSeq + 5}, // young ⇒ ingest from genesis
+			Core:                 core,
+			Logger:               silentLogger(),
+			Metrics:              metrics,
+			RestartBackoff:       10 * time.Millisecond,
+			chunksPerTxhashIndex: 1,
+			passphrase:           network.PublicNetworkPassphrase,
+			serveAddr:            func(a net.Addr) { addrCh <- a },
+		})
+	}()
+	defer func() {
+		cancel()
+		select {
+		case err := <-errCh:
+			require.NoError(t, err, "ctx cancel is a clean daemon shutdown")
+		case <-time.After(60 * time.Second):
+			t.Fatal("daemon did not shut down cleanly after ctx cancel")
+		}
+	}()
+
+	var addr net.Addr
+	select {
+	case addr = <-addrCh:
+	case err := <-errCh:
+		t.Fatalf("daemon returned before the read server bound: %v", err)
+	case <-time.After(60 * time.Second):
+		t.Fatal("read server never bound")
+	}
+	base := "http://" + addr.String()
+
+	// Wait for readiness (latches once the first ledger commits) before polling,
+	// so we measure ingest→query on committed ledgers, not the startup window.
+	require.Eventually(t, func() bool {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/ready", nil)
+		if err != nil {
+			return false
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return false
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 60*time.Second, 20*time.Millisecond, "read server must become ready")
+
+	cid := eventContractID()
+	cStrkey, err := strkey.Encode(strkey.VersionByteContract, cid[:])
+	require.NoError(t, err)
+
+	// Per-kind "is seq queryable yet?" predicates (defensive parsing, no t.Fatal).
+	ledgerVisible := func(seq uint32) bool {
+		res, ok := resultMap(tryRPC(ctx, base+"/", ledgersReq(seq, 1)))
+		if !ok {
+			return false
+		}
+		ls, _ := res["ledgers"].([]any)
+		if len(ls) != 1 {
+			return false
+		}
+		l, _ := ls[0].(map[string]any)
+		return fmt.Sprint(l["sequence"]) == fmt.Sprint(seq)
+	}
+	txVisible := func(seq uint32) bool {
+		res, ok := resultMap(tryRPC(ctx, base+"/", txReq(hashes[seq])))
+		if !ok {
+			return false
+		}
+		return res["status"] == "SUCCESS" && fmt.Sprint(res["ledger"]) == fmt.Sprint(seq)
+	}
+	eventVisible := func(seq uint32) bool {
+		res, ok := resultMap(tryRPC(ctx, base+"/", eventsReq(seq, cStrkey)))
+		if !ok {
+			return false
+		}
+		evs, _ := res["events"].([]any)
+		if len(evs) == 0 {
+			return false
+		}
+		e, _ := evs[0].(map[string]any)
+		return fmt.Sprint(e["ledger"]) == fmt.Sprint(seq)
+	}
+
+	type sample struct{ full, ingest, visible time.Duration }
+	kinds := []struct {
+		name    string
+		visible func(uint32) bool
+		out     []sample
+	}{
+		{name: "getLedgers", visible: ledgerVisible},
+		{name: "getTransaction", visible: txVisible},
+		{name: "getEvents", visible: eventVisible},
+	}
+
+	var wg sync.WaitGroup
+	for i := range kinds {
+		k := &kinds[i]
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for seq := uint32(firstTarget); seq <= lastTarget; seq++ {
+				for !k.visible(seq) {
+					if ctx.Err() != nil {
+						return
+					}
+					time.Sleep(300 * time.Microsecond)
+				}
+				tQuery := time.Now()
+				srcMu.Lock()
+				tSrc, okS := sourceAt[seq]
+				srcMu.Unlock()
+				tCommit, okC := metrics.commitAt(seq)
+				if okS && okC {
+					k.out = append(k.out, sample{
+						full:    tQuery.Sub(tSrc),
+						ingest:  tCommit.Sub(tSrc),
+						visible: tQuery.Sub(tCommit),
+					})
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	pick := func(ss []sample, f func(sample) time.Duration) (p50, mx time.Duration) {
+		ds := make([]time.Duration, len(ss))
+		for i, s := range ss {
+			ds[i] = f(s)
+		}
+		sort.Slice(ds, func(i, j int) bool { return ds[i] < ds[j] })
+		return ds[len(ds)/2], ds[len(ds)-1]
+	}
+
+	t.Logf("ingest→query latency (hot path, %d samples/kind, same ledger for all three):", nSamples)
+	t.Logf("  %-15s %-22s %-22s %-22s", "kind", "full(src→query)", "ingest(src→commit)", "visible(commit→query)")
+	for i := range kinds {
+		k := &kinds[i]
+		require.Len(t, k.out, nSamples, "%s: every target ledger must become queryable", k.name)
+		fp50, fmax := pick(k.out, func(s sample) time.Duration { return s.full })
+		ip50, _ := pick(k.out, func(s sample) time.Duration { return s.ingest })
+		vp50, vmax := pick(k.out, func(s sample) time.Duration { return s.visible })
+		t.Logf("  %-15s p50=%-8v max=%-9v p50=%-13v p50=%-8v max=%v",
+			k.name, fp50.Round(time.Microsecond), fmax.Round(time.Microsecond),
+			ip50.Round(time.Microsecond), vp50.Round(time.Microsecond), vmax.Round(time.Microsecond))
+		for _, s := range k.out {
+			require.Positive(t, s.full, "%s: full latency must be positive", k.name)
+			require.Less(t, s.full, 10*time.Second, "%s: full latency sanity bound", k.name)
+		}
+	}
+}

--- a/cmd/stellar-rpc/internal/fullhistory/serve_e2e_profile_latency_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve_e2e_profile_latency_test.go
@@ -52,6 +52,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -184,6 +185,213 @@ func harvestTxHashes(ctx context.Context, base string, startLedger uint32, want 
 		cursor = page.Cursor
 	}
 	return hashes
+}
+
+// fhTerm is one indexed getEvents constraint harvested from real data — a
+// contract ID, or an exact topic value at a position (0..2, leaving room for a
+// trailing "**") — mirroring tools/fhbench's term model so the e2e sweep and the
+// black-box fhbench sweep measure the same thing.
+type fhTerm struct {
+	contractID string // set iff a contract term (strkey)
+	topicPos   int    // topic position (topic terms only)
+	topicVal   string // base64 ScVal (topic terms only)
+}
+
+// termEventsPage is the subset of a getEvents page the term harvest reads.
+type termEventsPage struct {
+	Events []struct {
+		ContractID string   `json:"contractId"`
+		Topic      []string `json:"topic"`
+	} `json:"events"`
+	Cursor string `json:"cursor"`
+}
+
+// fetchTermEventsPage POSTs one unfiltered getEvents page — the first page spans
+// [startLedger, endExclusive), later pages resume from the cursor.
+func fetchTermEventsPage(
+	ctx context.Context, base string, startLedger, endExclusive uint32, cursor string,
+) (termEventsPage, bool) {
+	body := fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"getEvents","params":`+
+		`{"startLedger":%d,"endLedger":%d,"pagination":{"limit":200}}}`, startLedger, endExclusive)
+	if cursor != "" {
+		body = fmt.Sprintf(
+			`{"jsonrpc":"2.0","id":1,"method":"getEvents","params":{"pagination":{"cursor":%q,"limit":200}}}`,
+			cursor)
+	}
+	var page termEventsPage
+	res, ok := resultMap(tryRPC(ctx, base+"/", body))
+	if !ok {
+		return page, false
+	}
+	raw, err := json.Marshal(res)
+	if err != nil {
+		return page, false
+	}
+	return page, json.Unmarshal(raw, &page) == nil
+}
+
+// termHarvest accumulates DISTINCT contract and topic terms from getEvents pages.
+type termHarvest struct {
+	contracts, topics []fhTerm
+	seenC, seenT      map[string]bool
+}
+
+func (h *termHarvest) absorb(page termEventsPage) {
+	for _, ev := range page.Events {
+		if ev.ContractID != "" && !h.seenC[ev.ContractID] {
+			h.seenC[ev.ContractID] = true
+			h.contracts = append(h.contracts, fhTerm{contractID: ev.ContractID})
+		}
+		for pos, val := range ev.Topic {
+			if pos > 2 { // positions 0..2 leave room for the trailing "**"
+				break
+			}
+			if val == "" {
+				continue
+			}
+			key := strconv.Itoa(pos) + ":" + val
+			if !h.seenT[key] {
+				h.seenT[key] = true
+				h.topics = append(h.topics, fhTerm{topicPos: pos, topicVal: val})
+			}
+		}
+	}
+}
+
+// interleaved zips the two pools so any prefix of length N mixes contract and
+// topic terms rather than being all-contract then all-topic.
+func (h *termHarvest) interleaved() []fhTerm {
+	out := make([]fhTerm, 0, len(h.contracts)+len(h.topics))
+	for i := 0; i < len(h.contracts) || i < len(h.topics); i++ {
+		if i < len(h.contracts) {
+			out = append(out, h.contracts[i])
+		}
+		if i < len(h.topics) {
+			out = append(out, h.topics[i])
+		}
+	}
+	return out
+}
+
+// harvestEventTerms pages unfiltered getEvents over [startLedger, endExclusive)
+// and collects up to `want` DISTINCT terms, contract and topic terms interleaved
+// so any prefix of the result mixes both kinds.
+func harvestEventTerms(ctx context.Context, base string, startLedger, endExclusive uint32, want int) []fhTerm {
+	h := termHarvest{seenC: map[string]bool{}, seenT: map[string]bool{}}
+	var cursor string
+	for len(h.contracts)+len(h.topics) < want {
+		page, ok := fetchTermEventsPage(ctx, base, startLedger, endExclusive, cursor)
+		if !ok || len(page.Events) == 0 {
+			break
+		}
+		h.absorb(page)
+		if page.Cursor == "" || page.Cursor == cursor {
+			break
+		}
+		cursor = page.Cursor
+	}
+	return h.interleaved()
+}
+
+// eventsTermsReq builds a getEvents request OR-unioning the first n harvested
+// terms over [start, endExclusive). Terms pack into HOMOGENEOUS filters
+// (contract-only / topic-only, <=5 per filter) so they are OR'd, never AND'd;
+// topic terms become ["*"×pos, value, "**"] — position-anchored, length-flexible.
+func eventsTermsReq(t *testing.T, start, endExclusive uint32, terms []fhTerm, n, limit int) string {
+	t.Helper()
+	n = min(n, len(terms))
+	var (
+		contractIDs  []string
+		topicClauses []any
+	)
+	for _, tm := range terms[:n] {
+		if tm.contractID != "" {
+			contractIDs = append(contractIDs, tm.contractID)
+			continue
+		}
+		segs := make([]any, 0, tm.topicPos+2)
+		for range tm.topicPos {
+			segs = append(segs, "*")
+		}
+		topicClauses = append(topicClauses, append(segs, tm.topicVal, "**"))
+	}
+	var filters []any
+	for i := 0; i < len(contractIDs); i += 5 {
+		filters = append(filters, map[string]any{"contractIds": contractIDs[i:min(i+5, len(contractIDs))]})
+	}
+	for i := 0; i < len(topicClauses); i += 5 {
+		filters = append(filters, map[string]any{"topics": topicClauses[i:min(i+5, len(topicClauses))]})
+	}
+	params, err := json.Marshal(map[string]any{
+		"startLedger": start,
+		"endLedger":   endExclusive,
+		"pagination":  map[string]any{"limit": limit},
+		"filters":     filters,
+	})
+	require.NoError(t, err, "marshal term-sweep getEvents params")
+	return fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"getEvents","params":%s}`, params)
+}
+
+// sweepTermCounts parses FHBENCH_EVENT_TERMS (default "1,4,8,15"; "none"
+// disables the sweep). Counts above 21 are rejected: any contract/topic split of
+// n<=21 packs into <=5 homogeneous filters, the protocol's per-request cap.
+func sweepTermCounts(t *testing.T) []int {
+	t.Helper()
+	v := os.Getenv("FHBENCH_EVENT_TERMS")
+	if v == "" {
+		v = "1,4,8,15"
+	}
+	if v == "none" {
+		return nil
+	}
+	var out []int
+	for part := range strings.SplitSeq(v, ",") {
+		n, err := strconv.Atoi(strings.TrimSpace(part))
+		require.NoError(t, err, "FHBENCH_EVENT_TERMS entry %q", part)
+		require.Positive(t, n, "FHBENCH_EVENT_TERMS entries must be >= 1")
+		require.LessOrEqual(t, n, 21, "FHBENCH_EVENT_TERMS > 21 can overflow the protocol's 5-filter cap")
+		out = append(out, n)
+	}
+	return out
+}
+
+// runEventTermsSweep measures the SELECTIVE getEvents path as a function of
+// OR-union index-term count over the window [measureFrom, lastLedger]: for each
+// requested count it issues the same OR-union of real harvested terms via the
+// caller's measure loop. Contrast with the plain getEvents row (single contract
+// filter) and fhbench's full-chunk sweep (long-span variant of the same model).
+func runEventTermsSweep(
+	ctx context.Context, t *testing.T, base string,
+	measure func(name string, do func(qctx context.Context, n int) bool),
+	measureFrom, lastLedger uint32,
+) {
+	t.Helper()
+	counts := sweepTermCounts(t)
+	if len(counts) == 0 {
+		return
+	}
+	terms := harvestEventTerms(ctx, base, measureFrom, lastLedger+1, 64)
+	if len(terms) == 0 {
+		t.Logf("  getEvents[terms]   (skipped — no event terms harvested from the window)")
+		return
+	}
+	t.Logf("getEvents term sweep over [%d,%d]: %d terms harvested (limit 10/page):",
+		measureFrom, lastLedger, len(terms))
+	for _, n := range counts {
+		eff := min(n, len(terms))
+		if eff < n {
+			t.Logf("  (vocab has only %d terms; running terms=%d instead of %d)", len(terms), eff, n)
+		}
+		body := eventsTermsReq(t, measureFrom, lastLedger+1, terms, eff, 10)
+		measure(fmt.Sprintf("getEvents[t=%d]", eff), func(qctx context.Context, _ int) bool {
+			res, ok := resultMap(tryRPC(qctx, base+"/", body))
+			if !ok {
+				return false
+			}
+			_, has := res["events"]
+			return has
+		})
+	}
 }
 
 // harvestContract pulls one real contract id out of an unfiltered getEvents page
@@ -507,4 +715,7 @@ func TestServeE2E_ProfileLatency(t *testing.T) {
 	} else {
 		t.Logf("  getEvents          (skipped — no contract id harvested from the window)")
 	}
+
+	// ---- Phase 3: getEvents OR-union index-term sweep (selective path) ----
+	runEventTermsSweep(ctx, t, base, measure, measureFrom, lastLedger)
 }

--- a/cmd/stellar-rpc/internal/fullhistory/serve_e2e_profile_latency_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve_e2e_profile_latency_test.go
@@ -1,0 +1,510 @@
+package fullhistory
+
+// =============================================================================
+// Ingest→query latency of the full-history daemon on REAL synthetic-profile
+// ledgers (sac / token / soroswap), as opposed to the 1-tx/1-event toy ledgers
+// TestServeE2E_IngestToQueryLatency uses.
+//
+// It feeds a small window (default 20) of a profile's real frozen ledgers —
+// each carrying the profile's real tx/event load — through the SAME live hot
+// path as the toy latency test (fakeBackend young ⇒ no backfill/freeze, e2eCore
+// delivering the frames), so the numbers reflect realistic per-ledger ingest
+// cost. Two things are measured:
+//
+//  1. Ingest→query VISIBILITY, one sample per ledger, via getLedgers (needs only
+//     the sequence, so no tx-hash/event harvesting is required to time it):
+//       full    = source → first queryable
+//       ingest  = source → durable commit
+//       visible = commit → first queryable   (the "latest advances last" window)
+//
+//  2. Query LATENCY under repetition. A per-ledger visibility span yields only
+//     ONE sample per ledger, so a p99 over a 20-ledger window is just the max
+//     (nearest-rank ceil(0.99*20)=20). To get a MEANINGFUL p99, after the window
+//     commits we harvest real tx hashes + a real contract id from the server and
+//     issue FHBENCH_QUERY_REPS closed-loop queries per endpoint over the committed
+//     window, reporting p50/p90/p99/max of the request latency.
+//
+// Env-gated (skipped in normal `go test`): set FHBENCH_PROFILE_LEDGERS to a
+// profile's ledgers tree root (the dir whose <bucket>/<chunk>.pack tree holds the
+// ledgers). Knobs:
+//   - FHBENCH_FIRST_CHUNK    (default 1)   chunk id to read from
+//   - FHBENCH_WINDOW_LEDGERS (default 20)  ledgers measured
+//   - FHBENCH_WARMUP_LEDGERS (default 0)   ledgers ingested-but-not-measured
+//     BEFORE the window; skip past a profile's light warmup head (contract
+//     deploys / account setup) so the window reflects steady-state load
+//   - FHBENCH_QUERY_REPS     (default 500) closed-loop queries per endpoint
+//   - FHBENCH_PROFILE_NAME   (default: derived from the path) label in the report
+//   - FHBENCH_PASSPHRASE     (default: pubnet)
+//   - FHBENCH_LOG            (unset ⇒ silent) set to surface daemon startup logs
+//
+// Only warmup+window ledgers are read from the pack, so a small partial pack
+// (not a full chunk) is sufficient. See tools/bench-suite/run-e2e-latency-suite.sh
+// for the per-profile driver.
+// =============================================================================
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
+	"github.com/stellar/go-stellar-sdk/network"
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/config"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/geometry"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores/ledger"
+)
+
+// profileLogger returns a visible info logger when FHBENCH_LOG is set (for
+// diagnosing startup), else the silent one used in steady-state runs.
+func profileLogger(t *testing.T) *supportlog.Entry {
+	t.Helper()
+	if os.Getenv("FHBENCH_LOG") == "" {
+		return silentLogger()
+	}
+	l, err := newLogger(config.LoggingConfig{Level: "info", Format: "text"})
+	require.NoError(t, err)
+	return l
+}
+
+func profileEnvInt(t *testing.T, key string, def int) int {
+	t.Helper()
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	require.NoError(t, err, "env %s must be an integer, got %q", key, v)
+	require.GreaterOrEqual(t, n, 0, "env %s must be >= 0", key)
+	return n
+}
+
+// pctl is the nearest-rank quantile (rank = ceil(q*N), value at that 1-based
+// rank) over an already-sorted slice — the same method fhbench reports with.
+func pctl(sorted []time.Duration, q float64) time.Duration {
+	n := len(sorted)
+	if n == 0 {
+		return 0
+	}
+	rank := int(math.Ceil(q * float64(n)))
+	if rank < 1 {
+		rank = 1
+	}
+	if rank > n {
+		rank = n
+	}
+	return sorted[rank-1]
+}
+
+// profileLatencyConfig writes a daemon TOML serving from the profile's first
+// ledger with full-history retention (nothing prunes), binding [serve] to an
+// OS-assigned port surfaced via the serveAddr seam.
+func profileLatencyConfig(t *testing.T, dataDir string, earliest uint32) string {
+	t.Helper()
+	cfgPath := filepath.Join(t.TempDir(), "daemon.toml")
+	body := fmt.Sprintf(`
+[service]
+default_data_dir = %q
+
+[retention]
+earliest_ledger = "%d"
+retention_chunks = 0
+
+[ingestion]
+captive_core_config = "/dev/null"
+
+[serve]
+endpoint = "127.0.0.1:0"
+
+[logging]
+level = "error"
+format = "text"
+`, dataDir, earliest)
+	require.NoError(t, os.WriteFile(cfgPath, []byte(body), 0o644))
+	return cfgPath
+}
+
+// harvestTxHashes pages getTransactions from startLedger, collecting up to `want`
+// real tx hashes so the query-latency pass can exercise getTransaction against
+// data that actually exists in the committed window.
+func harvestTxHashes(ctx context.Context, base string, startLedger uint32, want int) []string {
+	var (
+		hashes []string
+		seen   = map[string]bool{}
+		cursor string
+	)
+	for len(hashes) < want {
+		body := txsReqStart(startLedger, 200)
+		if cursor != "" {
+			body = txsReqCursor(cursor, 200)
+		}
+		env, ok := tryRPC(ctx, base+"/", body)
+		if !ok {
+			break
+		}
+		res, ok := env["result"].(map[string]any)
+		if !ok {
+			break
+		}
+		raw, err := json.Marshal(res)
+		if err != nil {
+			break
+		}
+		var page struct {
+			Transactions []struct {
+				TxHash string `json:"txHash"`
+			} `json:"transactions"`
+			Cursor string `json:"cursor"`
+		}
+		if json.Unmarshal(raw, &page) != nil || len(page.Transactions) == 0 {
+			break
+		}
+		for _, tx := range page.Transactions {
+			if tx.TxHash != "" && !seen[tx.TxHash] {
+				seen[tx.TxHash] = true
+				hashes = append(hashes, tx.TxHash)
+			}
+		}
+		if page.Cursor == "" || page.Cursor == cursor {
+			break
+		}
+		cursor = page.Cursor
+	}
+	return hashes
+}
+
+// harvestContract pulls one real contract id out of an unfiltered getEvents page
+// so the query-latency pass can exercise getEvents with a filter that matches.
+func harvestContract(ctx context.Context, base string, startLedger uint32) string {
+	body := fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":1,"method":"getEvents","params":{"startLedger":%d,"pagination":{"limit":50}}}`,
+		startLedger,
+	)
+	env, ok := tryRPC(ctx, base+"/", body)
+	if !ok {
+		return ""
+	}
+	res, ok := env["result"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	raw, err := json.Marshal(res)
+	if err != nil {
+		return ""
+	}
+	var page struct {
+		Events []struct {
+			ContractID string `json:"contractId"`
+		} `json:"events"`
+	}
+	if json.Unmarshal(raw, &page) != nil {
+		return ""
+	}
+	for _, e := range page.Events {
+		if e.ContractID != "" {
+			return e.ContractID
+		}
+	}
+	return ""
+}
+
+// TestServeE2E_ProfileLatency measures ingest→query latency on a real profile's
+// ledgers. Skipped unless FHBENCH_PROFILE_LEDGERS is set.
+func TestServeE2E_ProfileLatency(t *testing.T) {
+	ledgersRoot := os.Getenv("FHBENCH_PROFILE_LEDGERS")
+	if ledgersRoot == "" {
+		t.Skip("set FHBENCH_PROFILE_LEDGERS (a profile ledgers tree root) to run the profile latency test")
+	}
+	firstChunk := chunk.ID(profileEnvInt(t, "FHBENCH_FIRST_CHUNK", 1)) //nolint:gosec // small test id
+	window := profileEnvInt(t, "FHBENCH_WINDOW_LEDGERS", 20)
+	require.Positive(t, window, "FHBENCH_WINDOW_LEDGERS must be >= 1")
+	// Ledgers ingested-but-not-measured before the window. The head of a synthetic
+	// profile chunk is warmup (contract deploys / account setup) and far lighter
+	// than steady state, so measuring the first ledgers understates ingest cost;
+	// skip past them to sample representative load.
+	warmup := profileEnvInt(t, "FHBENCH_WARMUP_LEDGERS", 0)
+	reps := profileEnvInt(t, "FHBENCH_QUERY_REPS", 500)
+	passphrase := os.Getenv("FHBENCH_PASSPHRASE")
+	if passphrase == "" {
+		passphrase = network.PublicNetworkPassphrase
+	}
+	profileName := os.Getenv("FHBENCH_PROFILE_NAME")
+	if profileName == "" {
+		profileName = filepath.Base(ledgersRoot)
+		if profileName == "ledgers" { // e.g. .../serve-data/sac/ledgers ⇒ "sac"
+			profileName = filepath.Base(filepath.Dir(ledgersRoot))
+		}
+	}
+
+	firstLedger := firstChunk.FirstLedger()
+	measureFrom := firstLedger + uint32(warmup) //nolint:gosec // small positive
+	total := uint32(warmup) + uint32(window)    //nolint:gosec // small positive
+	lastLedger := firstLedger + total - 1       // last ledger INGESTED (warmup + window)
+	require.Less(t, lastLedger, firstChunk.LastLedger(),
+		"warmup+window must stay inside the first chunk's pack (%d ledgers/chunk)", chunk.LedgersPerChunk)
+
+	// Load warmup+window real ledgers from the profile's pack into the frame map.
+	// The pack yields borrowed slices valid only until the next step, so copy each.
+	packPath := geometry.LedgerPackPath(ledgersRoot, firstChunk)
+	_, statErr := os.Stat(packPath)
+	require.NoError(t, statErr, "profile pack not found at %s", packPath)
+
+	frames := make(map[uint32][]byte, total)
+	readCtx, readCancel := context.WithCancel(context.Background())
+	seq := firstLedger
+	for raw, err := range ledger.NewPackStream(packPath).RawLedgers(
+		readCtx, ledgerbackend.BoundedRange(firstLedger, lastLedger),
+	) {
+		require.NoError(t, err, "reading ledger %d from %s", seq, packPath)
+		cp := make([]byte, len(raw))
+		copy(cp, raw)
+		frames[seq] = cp
+		seq++
+	}
+	readCancel()
+	require.Len(t, frames, int(total), "pack must yield exactly warmup+window ledgers")
+
+	var srcMu sync.Mutex
+	sourceAt := make(map[uint32]time.Time, window)
+	metrics := &latencyMetrics{commit: make(map[uint32]time.Time)}
+
+	core := &e2eCore{
+		frames:     frames,
+		yieldDelay: 5 * time.Millisecond, // pace source entry so the poller catches first-visible
+		onYield: func(seq uint32) {
+			srcMu.Lock()
+			if _, ok := sourceAt[seq]; !ok {
+				sourceAt[seq] = time.Now()
+			}
+			srcMu.Unlock()
+		},
+	}
+
+	dataDir := t.TempDir()
+	cfgPath := profileLatencyConfig(t, dataDir, firstLedger)
+
+	// Young backend: tip just past the window (inside the first, incomplete chunk)
+	// ⇒ no complete chunk above the earliest floor to backfill ⇒ the daemon skips
+	// the freeze and live-ingests the frames straight away.
+	backend := &fakeBackend{tip: lastLedger + 1}
+
+	addrCh := make(chan net.Addr, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runDaemonWith(ctx, cfgPath, daemonOptions{
+			Backend:              backend,
+			Core:                 core,
+			Logger:               profileLogger(t),
+			Metrics:              metrics,
+			RestartBackoff:       10 * time.Millisecond,
+			chunksPerTxhashIndex: 1,
+			passphrase:           passphrase,
+			serveAddr:            func(a net.Addr) { addrCh <- a },
+		})
+	}()
+	defer func() {
+		cancel()
+		select {
+		case err := <-errCh:
+			require.NoError(t, err, "ctx cancel is a clean daemon shutdown")
+		case <-time.After(60 * time.Second):
+			t.Fatal("daemon did not shut down cleanly after ctx cancel")
+		}
+	}()
+
+	var addr net.Addr
+	select {
+	case addr = <-addrCh:
+	case err := <-errCh:
+		t.Fatalf("daemon returned before the read server bound: %v", err)
+	case <-time.After(60 * time.Second):
+		t.Fatal("read server never bound")
+	}
+	base := "http://" + addr.String()
+
+	// ---- Phase 1: ingest→query visibility, one sample per ledger via getLedgers ----
+	// A ledger is "visible" at a POSITION once getLedgers(position, 1) returns one
+	// ledger. We deliberately do NOT compare the returned header's `sequence`: the
+	// synthetic apply-load ledgers carry low internal LedgerSeqs (2, 3, …) unrelated
+	// to the chunk position (10002, 10003, …) they were frozen into, and the daemon
+	// keys its served range by position while echoing the real header seq.
+	ledgerVisible := func(seq uint32) bool {
+		res, ok := resultMap(tryRPC(ctx, base+"/", ledgersReq(seq, 1)))
+		if !ok {
+			return false
+		}
+		ls, _ := res["ledgers"].([]any)
+		return len(ls) == 1
+	}
+
+	// Poll from the window start, racing ingestion so each ledger's FIRST-visible
+	// moment is caught near its commit (source pacing via yieldDelay keeps this
+	// poller ahead). A deadline guards against ingestion never delivering.
+	// Budget scales with the ledgers we must ingest (heavy profile ledgers commit
+	// in the tens-to-hundreds of ms), plus slack.
+	deadline := time.Now().Add(time.Duration(total)*time.Second + 60*time.Second)
+	type span struct{ full, ingest, visible time.Duration }
+	var spans []span
+	for seq := firstLedger; seq <= lastLedger; seq++ {
+		for !ledgerVisible(seq) {
+			if ctx.Err() != nil {
+				t.Fatalf("context canceled waiting for ledger %d to become visible", seq)
+			}
+			if time.Now().After(deadline) {
+				gl, _ := tryRPC(ctx, base+"/", ledgersReq(seq, 1))
+				ls, _ := gl["result"].(map[string]any)
+				t.Fatalf("ledger %d never queryable. core: opens=%d fromSeen=%d delivered=%d; frames=[%d..%d]; served oldest=%v latest=%v",
+					seq, core.opens.Load(), core.fromSeen.Load(), core.delivered.Load(), firstLedger, lastLedger,
+					ls["oldestLedger"], ls["latestLedger"])
+			}
+			time.Sleep(300 * time.Microsecond)
+		}
+		// Skip warmup ledgers: they are ingested to reach steady state but not measured.
+		if seq < measureFrom {
+			continue
+		}
+		tQuery := time.Now()
+		srcMu.Lock()
+		tSrc, okS := sourceAt[seq]
+		srcMu.Unlock()
+		tCommit, okC := metrics.commitAt(seq)
+		if okS && okC {
+			spans = append(spans, span{
+				full:    tQuery.Sub(tSrc),
+				ingest:  tCommit.Sub(tSrc),
+				visible: tQuery.Sub(tCommit),
+			})
+		}
+	}
+	require.NotEmpty(t, spans, "at least one measured ledger must yield a visibility sample")
+
+	report := func(label string, f func(span) time.Duration) {
+		ds := make([]time.Duration, len(spans))
+		for i, s := range spans {
+			ds[i] = f(s)
+		}
+		sort.Slice(ds, func(i, j int) bool { return ds[i] < ds[j] })
+		t.Logf("  %-10s p50=%-10v p90=%-10v p99=%-10v max=%v",
+			label,
+			pctl(ds, 0.50).Round(time.Microsecond),
+			pctl(ds, 0.90).Round(time.Microsecond),
+			pctl(ds, 0.99).Round(time.Microsecond),
+			pctl(ds, 1.0).Round(time.Microsecond))
+	}
+	t.Logf("ingest→query visibility on real %q ledgers [%d..%d], warmup=%d (%d samples, one per ledger):",
+		profileName, measureFrom, lastLedger, warmup, len(spans))
+	t.Logf("  %-10s %-14s %-14s %-14s %s", "span", "p50", "p90", "p99", "max")
+	t.Logf("  (NOTE: p90/p99 over %d one-per-ledger samples collapse toward max; "+
+		"see the query-latency pass below for a dense p99)", len(spans))
+	report("full", func(s span) time.Duration { return s.full })
+	report("ingest", func(s span) time.Duration { return s.ingest })
+	report("visible", func(s span) time.Duration { return s.visible })
+
+	// ---- Phase 2: query-latency distribution (dense, real p99) over the window ----
+	txHashes := harvestTxHashes(ctx, base, measureFrom, 200)
+	contractID := harvestContract(ctx, base, measureFrom)
+	t.Logf("query-latency pass: %d reps/endpoint over [%d,%d] (%d tx hashes, contract=%q):",
+		reps, measureFrom, lastLedger, len(txHashes), contractID)
+	t.Logf("  %-16s %-8s %-12s %-12s %-12s %-12s %s",
+		"endpoint", "count", "p50", "p90", "p99", "max", "errors")
+
+	// Per-request timeout + per-endpoint wall budget: getEvents on a profile whose
+	// events all share one contract (e.g. sac) hits the POC's index-unselective
+	// scan cliff and can take ~seconds per query, so an unbounded 500-rep loop
+	// would blow the test timeout. The budget stops an endpoint early (reporting
+	// however many samples it gathered); the per-request timeout counts a hung
+	// query as an error rather than wedging the run.
+	const queryTimeout = 10 * time.Second
+	const endpointBudget = 45 * time.Second
+	measure := func(name string, do func(qctx context.Context, n int) bool) {
+		ds := make([]time.Duration, 0, reps)
+		errs := 0
+		loopStart := time.Now()
+		truncated := false
+		for n := 0; n < reps; n++ {
+			if ctx.Err() != nil {
+				break
+			}
+			if time.Since(loopStart) > endpointBudget {
+				truncated = true
+				break
+			}
+			qctx, qcancel := context.WithTimeout(ctx, queryTimeout)
+			start := time.Now()
+			ok := do(qctx, n)
+			elapsed := time.Since(start)
+			qcancel()
+			if ok {
+				ds = append(ds, elapsed)
+			} else {
+				errs++
+			}
+		}
+		sort.Slice(ds, func(i, j int) bool { return ds[i] < ds[j] })
+		note := ""
+		if truncated {
+			note = fmt.Sprintf("  (budget-capped at %s)", endpointBudget)
+		}
+		t.Logf("  %-16s %-8d %-12v %-12v %-12v %-12v %d%s",
+			name, len(ds),
+			pctl(ds, 0.50).Round(time.Microsecond),
+			pctl(ds, 0.90).Round(time.Microsecond),
+			pctl(ds, 0.99).Round(time.Microsecond),
+			pctl(ds, 1.0).Round(time.Microsecond),
+			errs, note)
+	}
+
+	win := uint32(window) //nolint:gosec // small positive
+	// limit=1: getLedgers returns WHOLE ledgers, so on heavy profiles the response
+	// size (and its XDR→JSON encoding) dominates. One ledger isolates the per-ledger
+	// read cost; bump via the request builder to study how it scales with page size.
+	measure("getLedgers", func(qctx context.Context, n int) bool {
+		start := measureFrom + uint32(n)%win
+		res, ok := resultMap(tryRPC(qctx, base+"/", ledgersReq(start, 1)))
+		if !ok {
+			return false
+		}
+		_, has := res["ledgers"]
+		return has
+	})
+	if len(txHashes) > 0 {
+		measure("getTransaction", func(qctx context.Context, n int) bool {
+			res, ok := resultMap(tryRPC(qctx, base+"/",
+				fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"getTransaction","params":{"hash":%q}}`,
+					txHashes[n%len(txHashes)])))
+			if !ok {
+				return false
+			}
+			return res["status"] != nil
+		})
+	} else {
+		t.Logf("  getTransaction     (skipped — no tx hashes harvested from the window)")
+	}
+	if contractID != "" {
+		measure("getEvents", func(qctx context.Context, n int) bool {
+			start := measureFrom + uint32(n)%win
+			res, ok := resultMap(tryRPC(qctx, base+"/", eventsReq(start, contractID)))
+			if !ok {
+				return false
+			}
+			_, has := res["events"]
+			return has
+		})
+	} else {
+		t.Logf("  getEvents          (skipped — no contract id harvested from the window)")
+	}
+}

--- a/cmd/stellar-rpc/internal/fullhistory/serve_e2e_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve_e2e_test.go
@@ -168,7 +168,10 @@ func oneTxEventLCM(t *testing.T, seq uint32, src xdr.MuxedAccount, data string) 
 // generic map (result/error), mirroring serve/server_test.go's postJSON.
 func postRPC(t *testing.T, url, body string) map[string]any {
 	t.Helper()
-	resp, err := http.Post(url, "application/json", bytes.NewReader([]byte(body)))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, url, bytes.NewReader([]byte(body)))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
 	raw, err := io.ReadAll(resp.Body)
@@ -176,6 +179,30 @@ func postRPC(t *testing.T, url, body string) map[string]any {
 	var out map[string]any
 	require.NoError(t, json.Unmarshal(raw, &out), "response: %s", raw)
 	return out
+}
+
+// asMap/asSlice/asString are checked type-assertion helpers for the decoded
+// JSON-RPC envelopes: they fail the test loudly instead of panicking on a shape
+// mismatch (forcetypeassert), keeping the assertions below readable.
+func asMap(t *testing.T, v any) map[string]any {
+	t.Helper()
+	m, ok := v.(map[string]any)
+	require.True(t, ok, "expected a JSON object, got %T", v)
+	return m
+}
+
+func asSlice(t *testing.T, v any) []any {
+	t.Helper()
+	s, ok := v.([]any)
+	require.True(t, ok, "expected a JSON array, got %T", v)
+	return s
+}
+
+func asString(t *testing.T, v any) string {
+	t.Helper()
+	s, ok := v.(string)
+	require.True(t, ok, "expected a JSON string, got %T", v)
+	return s
 }
 
 // TestServeE2E_QueryHotAndCold is the query POC's end-to-end gate — see the file
@@ -258,7 +285,11 @@ func TestServeE2E_QueryHotAndCold(t *testing.T) {
 
 	// Poll /ready — it latches true once the ingestion loop commits its first ledger.
 	require.Eventually(t, func() bool {
-		resp, err := http.Get(base + "/ready")
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/ready", nil)
+		if err != nil {
+			return false
+		}
+		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			return false
 		}
@@ -295,11 +326,11 @@ func TestServeE2E_QueryHotAndCold(t *testing.T) {
 	}, 60*time.Second, 200*time.Millisecond, "getLedgers must span the cold→hot seam")
 
 	seam := postRPC(t, base+"/", ledgersReq(c0Last-1, 10))
-	seamRes := seam["result"].(map[string]any)
+	seamRes := asMap(t, seam["result"])
 	assert.EqualValues(t, liveLast, seamRes["latestLedger"], "latest is the live tip")
-	seamLedgers := seamRes["ledgers"].([]any)
-	firstSeq := seamLedgers[0].(map[string]any)["sequence"]
-	lastSeq := seamLedgers[len(seamLedgers)-1].(map[string]any)["sequence"]
+	seamLedgers := asSlice(t, seamRes["ledgers"])
+	firstSeq := asMap(t, seamLedgers[0])["sequence"]
+	lastSeq := asMap(t, seamLedgers[len(seamLedgers)-1])["sequence"]
 	assert.EqualValues(t, c0Last-1, firstSeq, "seam page starts in the cold chunk")
 	assert.EqualValues(t, liveLast, lastSeq, "seam page ends in the live chunk")
 
@@ -310,10 +341,10 @@ func TestServeE2E_QueryHotAndCold(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return txStatus(t, base, coldHash) == "SUCCESS"
 	}, 60*time.Second, 200*time.Millisecond, "cold tx must resolve from frozen history")
-	coldTx := postRPC(t, base+"/", txReq(coldHash))["result"].(map[string]any)
+	coldTx := asMap(t, postRPC(t, base+"/", txReq(coldHash))["result"])
 	assert.EqualValues(t, c0Last, coldTx["ledger"], "cold tx is in chunk 0's last ledger")
 
-	hotTx := postRPC(t, base+"/", txReq(hotHash))["result"].(map[string]any)
+	hotTx := asMap(t, postRPC(t, base+"/", txReq(hotHash))["result"])
 	assert.Equal(t, "SUCCESS", hotTx["status"], "live tx must resolve from the hot tier")
 	assert.EqualValues(t, c1First, hotTx["ledger"], "live tx is in chunk 1's first ledger")
 
@@ -322,18 +353,18 @@ func TestServeE2E_QueryHotAndCold(t *testing.T) {
 	// c0Last, limit 1) returns the cold tx; the follow-up cursor page returns the
 	// live tx — proving continuation across the cold→hot boundary.
 	// -------------------------------------------------------------------------
-	page1 := postRPC(t, base+"/", txsReqStart(c0Last, 1))["result"].(map[string]any)
-	p1txs := page1["transactions"].([]any)
+	page1 := asMap(t, postRPC(t, base+"/", txsReqStart(c0Last, 1))["result"])
+	p1txs := asSlice(t, page1["transactions"])
 	require.Len(t, p1txs, 1, "page 1 returns exactly the cold tx (limit 1)")
-	assert.Equal(t, hex.EncodeToString(coldHash[:]), p1txs[0].(map[string]any)["txHash"])
-	cursor1 := page1["cursor"].(string)
+	assert.Equal(t, hex.EncodeToString(coldHash[:]), asMap(t, p1txs[0])["txHash"])
+	cursor1 := asString(t, page1["cursor"])
 
-	page2 := postRPC(t, base+"/", txsReqCursor(cursor1, 5))["result"].(map[string]any)
-	p2txs := page2["transactions"].([]any)
+	page2 := asMap(t, postRPC(t, base+"/", txsReqCursor(cursor1, 5))["result"])
+	p2txs := asSlice(t, page2["transactions"])
 	require.NotEmpty(t, p2txs, "the cursor page resumes past the cold tx")
 	var sawHot bool
 	for _, tx := range p2txs {
-		if tx.(map[string]any)["txHash"] == hex.EncodeToString(hotHash[:]) {
+		if asMap(t, tx)["txHash"] == hex.EncodeToString(hotHash[:]) {
 			sawHot = true
 		}
 	}
@@ -357,13 +388,13 @@ func TestServeE2E_QueryHotAndCold(t *testing.T) {
 		return len(evs) == 2
 	}, 60*time.Second, 200*time.Millisecond, "getEvents must match events in both tiers")
 
-	evResp := postRPC(t, base+"/", eventsReq(c0Last, cStrkey))["result"].(map[string]any)
-	evs := evResp["events"].([]any)
+	evResp := asMap(t, postRPC(t, base+"/", eventsReq(c0Last, cStrkey))["result"])
+	evs := asSlice(t, evResp["events"])
 	require.Len(t, evs, 2)
-	assert.EqualValues(t, c0Last, evs[0].(map[string]any)["ledger"], "first event is cold")
-	assert.EqualValues(t, c1First, evs[1].(map[string]any)["ledger"], "second event is hot")
+	assert.EqualValues(t, c0Last, asMap(t, evs[0])["ledger"], "first event is cold")
+	assert.EqualValues(t, c1First, asMap(t, evs[1])["ledger"], "second event is hot")
 	for _, e := range evs {
-		assert.Equal(t, cStrkey, e.(map[string]any)["contractId"], "only the filtered contract matched")
+		assert.Equal(t, cStrkey, asMap(t, e)["contractId"], "only the filtered contract matched")
 	}
 
 	// -------------------------------------------------------------------------
@@ -372,7 +403,7 @@ func TestServeE2E_QueryHotAndCold(t *testing.T) {
 	// A startLedger below the served floor (genesis) errors with the range surfaced.
 	below := postRPC(t, base+"/", ledgersReq(c0First-1, 5))
 	require.NotNil(t, below["error"], "getLedgers below the floor must error")
-	belowMsg := fmt.Sprint(below["error"].(map[string]any)["message"])
+	belowMsg := fmt.Sprint(asMap(t, below["error"])["message"])
 	assert.Contains(t, belowMsg, "oldest ledger", "the below-floor error surfaces the available range")
 	assert.Contains(t, belowMsg, "latest ledger", "the below-floor error surfaces the available range")
 
@@ -381,7 +412,7 @@ func TestServeE2E_QueryHotAndCold(t *testing.T) {
 	miss[0], miss[31] = 0xDE, 0xAD
 	unknown := postRPC(t, base+"/", txReq(miss))
 	require.Nil(t, unknown["error"], "an unknown hash is a normal NOT_FOUND response, not an error")
-	assert.Equal(t, "NOT_FOUND", unknown["result"].(map[string]any)["status"])
+	assert.Equal(t, "NOT_FOUND", asMap(t, unknown["result"])["status"])
 }
 
 // ---- JSON-RPC request builders (raw wire strings keep the test readable). ----

--- a/cmd/stellar-rpc/internal/fullhistory/serve_e2e_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/serve_e2e_test.go
@@ -1,0 +1,435 @@
+package fullhistory
+
+// =============================================================================
+// End-to-end query integration of the full-history daemon with [serve] enabled.
+//
+// This is the query POC's top-level gate: it boots the REAL daemon
+// (runDaemonWith) with a bound JSON-RPC read server, ingests one FULL chunk plus
+// a few live ledgers through the fake ledger source, lets the real lifecycle
+// freeze chunk 0 into cold artifacts, then drives the four read methods over real
+// HTTP against BOTH tiers:
+//
+//	(a) getLedgers spanning the cold→hot seam,
+//	(b) getTransaction for a hash in the cold chunk AND one in the live chunk,
+//	(c) getTransactions across the seam with cursor continuation,
+//	(d) getEvents with a contract filter matching events in both tiers,
+//	(e) negatives: getLedgers below the floor errors; an unknown tx hash → NOT_FOUND.
+//
+// What is real: everything inside the process (config load, catalog, backfill,
+// the atomic per-ledger hot WriteBatch, the boundary handoff, the lifecycle
+// freeze/discard, the serve Registry + View publishing, and the reused v1
+// handlers behind the db adapters). Faked: only the two injected external
+// boundaries — the ledger source (fake core) and the network passphrase seam
+// (an injected fake Core carries none, so the test supplies PublicNetwork).
+//
+// cpi=1 makes chunk 0's one-chunk tx-hash window terminal the instant it freezes,
+// so the cold .idx the by-hash lookup resolves against exists after one boundary.
+// =============================================================================
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stellar/go-stellar-sdk/network"
+	"github.com/stellar/go-stellar-sdk/strkey"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/fhtest"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+)
+
+// serveE2EConfigPath writes a daemon TOML like e2eConfigPath but with a [serve]
+// section bound to an OS-assigned port (endpoint 127.0.0.1:0). Genesis floor +
+// full-history retention so nothing prunes; the real port is surfaced via the
+// serveAddr test seam, not the config.
+func serveE2EConfigPath(t *testing.T, dataDir string) string {
+	t.Helper()
+	cfgPath := filepath.Join(t.TempDir(), "daemon.toml")
+	body := fmt.Sprintf(`
+[service]
+default_data_dir = %q
+
+[retention]
+earliest_ledger = "genesis"
+retention_chunks = 0
+
+[ingestion]
+captive_core_config = "/dev/null"
+
+[serve]
+endpoint = "127.0.0.1:0"
+
+[logging]
+level = "error"
+format = "text"
+`, dataDir)
+	require.NoError(t, os.WriteFile(cfgPath, []byte(body), 0o644))
+	return cfgPath
+}
+
+// eventContractID is the fixed contract whose events straddle the cold→hot seam.
+func eventContractID() xdr.ContractId {
+	var c xdr.ContractId
+	c[0] = 0xAA
+	return c
+}
+
+// oneTxEventLCM is oneTxLCMBytes plus a single operation-level contract event
+// (contract type, one symbol topic + symbol data) emitted by contract
+// eventContractID. It returns the wire bytes and the network-hashed transaction
+// hash (hashed with PublicNetworkPassphrase, the passphrase the read server is
+// configured with) so the caller can assert both a getTransaction hash lookup
+// and a getEvents contract-filter match against the same ledger.
+func oneTxEventLCM(t *testing.T, seq uint32, src xdr.MuxedAccount, data string) ([]byte, [32]byte) {
+	t.Helper()
+	cid := eventContractID()
+	topicSym := xdr.ScSymbol("seam")
+	dataSym := xdr.ScSymbol(data)
+	ev := xdr.ContractEvent{
+		ContractId: &cid,
+		Type:       xdr.ContractEventTypeContract,
+		Body: xdr.ContractEventBody{
+			V: 0,
+			V0: &xdr.ContractEventV0{
+				Topics: []xdr.ScVal{{Type: xdr.ScValTypeScvSymbol, Sym: &topicSym}},
+				Data:   xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &dataSym},
+			},
+		},
+	}
+	envelope := xdr.TransactionEnvelope{
+		Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+		V1: &xdr.TransactionV1Envelope{
+			Tx: xdr.Transaction{
+				SourceAccount: src,
+				SeqNum:        xdr.SequenceNumber(seq), // unique per ledger ⇒ unique hash
+				Ext:           xdr.TransactionExt{V: 1, SorobanData: &xdr.SorobanTransactionData{}},
+			},
+		},
+	}
+	hash, err := network.HashTransactionInEnvelope(envelope, network.PublicNetworkPassphrase)
+	require.NoError(t, err)
+	comp := []xdr.TxSetComponent{{
+		Type: xdr.TxSetComponentTypeTxsetCompTxsMaybeDiscountedFee,
+		TxsMaybeDiscountedFee: &xdr.TxSetComponentTxsMaybeDiscountedFee{
+			Txs: []xdr.TransactionEnvelope{envelope},
+		},
+	}}
+	lcm := xdr.LedgerCloseMeta{
+		V: 2,
+		V2: &xdr.LedgerCloseMetaV2{
+			LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+				Header: xdr.LedgerHeader{
+					ScpValue:  xdr.StellarValue{CloseTime: xdr.TimePoint(uint64(seq) * 10)},
+					LedgerSeq: xdr.Uint32(seq),
+				},
+			},
+			TxSet: xdr.GeneralizedTransactionSet{
+				V:       1,
+				V1TxSet: &xdr.TransactionSetV1{Phases: []xdr.TransactionPhase{{V: 0, V0Components: &comp}}},
+			},
+			TxProcessing: []xdr.TransactionResultMetaV1{{
+				TxApplyProcessing: xdr.TransactionMeta{
+					V:  4,
+					V4: &xdr.TransactionMetaV4{Operations: []xdr.OperationMetaV2{{Events: []xdr.ContractEvent{ev}}}},
+				},
+				Result: xdr.TransactionResultPair{
+					TransactionHash: hash,
+					Result: xdr.TransactionResult{
+						FeeCharged: 100,
+						Result: xdr.TransactionResultResult{
+							Code:    xdr.TransactionResultCodeTxSuccess,
+							Results: &[]xdr.OperationResult{},
+						},
+					},
+				},
+			}},
+		},
+	}
+	raw, err := lcm.MarshalBinary()
+	require.NoError(t, err)
+	return raw, hash
+}
+
+// postRPC POSTs a JSON-RPC request body and decodes the response envelope into a
+// generic map (result/error), mirroring serve/server_test.go's postJSON.
+func postRPC(t *testing.T, url, body string) map[string]any {
+	t.Helper()
+	resp, err := http.Post(url, "application/json", bytes.NewReader([]byte(body)))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(raw, &out), "response: %s", raw)
+	return out
+}
+
+// TestServeE2E_QueryHotAndCold is the query POC's end-to-end gate — see the file
+// header for the (a)-(e) coverage list. NOT skipped in -short: it is the only
+// test that exercises the wired read path over real HTTP; the generous
+// require.Eventually budgets (matching e2e_test.go) absorb the synced-WriteBatch
+// + freeze cost of one full chunk.
+//
+//nolint:funlen // one linear end-to-end scenario asserted step by step
+func TestServeE2E_QueryHotAndCold(t *testing.T) {
+	dataDir := t.TempDir()
+
+	const c0 = chunk.ID(0)
+	const c1 = chunk.ID(1)
+	c0First := c0.FirstLedger()
+	c0Last := c0.LastLedger() // chunk 0's last ledger — the boundary into chunk 1
+	c1First := c1.FirstLedger()
+	liveLast := c1First + 2 // a few live ledgers past the boundary
+
+	// One shared source account; a per-seq SeqNum makes each tx hash unique.
+	src := xdr.MustMuxedAddress(keypair.MustRandom().Address())
+	coldRaw, coldHash := oneTxEventLCM(t, c0Last, src, "cold") // → frozen cold chunk 0
+	hotRaw, hotHash := oneTxEventLCM(t, c1First, src, "hot")   // → live hot chunk 1
+
+	frames := make(map[uint32][]byte, int(chunk.LedgersPerChunk)+3)
+	for seq := c0First; seq <= c0Last; seq++ {
+		if seq == c0Last {
+			frames[seq] = coldRaw
+		} else {
+			frames[seq] = fhtest.ZeroTxLCMBytes(t, seq)
+		}
+	}
+	frames[c1First] = hotRaw
+	frames[c1First+1] = fhtest.ZeroTxLCMBytes(t, c1First+1)
+	frames[liveLast] = fhtest.ZeroTxLCMBytes(t, liveLast)
+
+	core := &e2eCore{frames: frames}
+	metrics := &e2eMetrics{}
+
+	// Capture the read server's OS-assigned address via the test seam.
+	addrCh := make(chan net.Addr, 1)
+
+	cfgPath := serveE2EConfigPath(t, dataDir)
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runDaemonWith(ctx, cfgPath, daemonOptions{
+			Backend:              &fakeBackend{tip: chunk.FirstLedgerSeq + 5}, // young ⇒ no backfill, ingest from genesis
+			Core:                 core,
+			Logger:               silentLogger(),
+			Metrics:              metrics,
+			RestartBackoff:       10 * time.Millisecond,
+			chunksPerTxhashIndex: 1,
+			passphrase:           network.PublicNetworkPassphrase,
+			serveAddr:            func(a net.Addr) { addrCh <- a },
+		})
+	}()
+	// Clean shutdown: cancel and require the daemon returned nil (ctx cancel is clean).
+	defer func() {
+		cancel()
+		select {
+		case err := <-errCh:
+			require.NoError(t, err, "ctx cancel is a clean daemon shutdown")
+		case <-time.After(60 * time.Second):
+			t.Fatal("daemon did not shut down cleanly after ctx cancel")
+		}
+	}()
+
+	// The wired ServeReads launches StartServer and reports the bound address; a
+	// pre-serve daemon return (a startup failure) surfaces here instead of a hang.
+	var addr net.Addr
+	select {
+	case addr = <-addrCh:
+	case err := <-errCh:
+		t.Fatalf("daemon returned before the read server bound: %v", err)
+	case <-time.After(60 * time.Second):
+		t.Fatal("read server never bound (ServeReads wiring absent?)")
+	}
+	base := "http://" + addr.String()
+
+	// Poll /ready — it latches true once the ingestion loop commits its first ledger.
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(base + "/ready")
+		if err != nil {
+			return false
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 60*time.Second, 100*time.Millisecond, "read server must become ready")
+
+	// Wait until ingestion crosses the chunk-0 boundary and commits the live
+	// ledgers into chunk 1 (proves the boundary handoff + HotOpened fired). 480s
+	// absorbs 10k synced per-ledger WriteBatches on a contended box.
+	require.Eventually(t, func() bool {
+		return core.delivered.Load() >= liveLast
+	}, 480*time.Second, 200*time.Millisecond, "ingestion must cross into chunk 1")
+
+	// Wait for the boundary tick to freeze chunk 0 into cold artifacts and discard
+	// its hot DB — after which TickCompleted republishes chunk 0 as cold.
+	require.Eventually(t, func() bool {
+		return metrics.discardedCount() >= 1
+	}, 120*time.Second, 100*time.Millisecond, "the boundary tick must freeze+discard chunk 0")
+
+	// -------------------------------------------------------------------------
+	// (a) getLedgers spanning the cold→hot seam: [c0Last-1, liveLast] straddles
+	// the frozen chunk 0 and the live chunk 1, returned as one contiguous page.
+	// Wrapped in Eventually to absorb the discard→TickCompleted publish gap.
+	// -------------------------------------------------------------------------
+	require.Eventually(t, func() bool {
+		got := postRPC(t, base+"/", ledgersReq(c0Last-1, 10))
+		res, ok := got["result"].(map[string]any)
+		if !ok {
+			return false
+		}
+		ledgers, _ := res["ledgers"].([]any)
+		return len(ledgers) == int(liveLast-(c0Last-1)+1)
+	}, 60*time.Second, 200*time.Millisecond, "getLedgers must span the cold→hot seam")
+
+	seam := postRPC(t, base+"/", ledgersReq(c0Last-1, 10))
+	seamRes := seam["result"].(map[string]any)
+	assert.EqualValues(t, liveLast, seamRes["latestLedger"], "latest is the live tip")
+	seamLedgers := seamRes["ledgers"].([]any)
+	firstSeq := seamLedgers[0].(map[string]any)["sequence"]
+	lastSeq := seamLedgers[len(seamLedgers)-1].(map[string]any)["sequence"]
+	assert.EqualValues(t, c0Last-1, firstSeq, "seam page starts in the cold chunk")
+	assert.EqualValues(t, liveLast, lastSeq, "seam page ends in the live chunk")
+
+	// -------------------------------------------------------------------------
+	// (b) getTransaction: the cold hash resolves through the frozen .idx + cold
+	// ledger pack; the live hash through the hot txhash CF + hot ledger.
+	// -------------------------------------------------------------------------
+	require.Eventually(t, func() bool {
+		return txStatus(t, base, coldHash) == "SUCCESS"
+	}, 60*time.Second, 200*time.Millisecond, "cold tx must resolve from frozen history")
+	coldTx := postRPC(t, base+"/", txReq(coldHash))["result"].(map[string]any)
+	assert.EqualValues(t, c0Last, coldTx["ledger"], "cold tx is in chunk 0's last ledger")
+
+	hotTx := postRPC(t, base+"/", txReq(hotHash))["result"].(map[string]any)
+	assert.Equal(t, "SUCCESS", hotTx["status"], "live tx must resolve from the hot tier")
+	assert.EqualValues(t, c1First, hotTx["ledger"], "live tx is in chunk 1's first ledger")
+
+	// -------------------------------------------------------------------------
+	// (c) getTransactions across the seam with cursor continuation: page 1 (from
+	// c0Last, limit 1) returns the cold tx; the follow-up cursor page returns the
+	// live tx — proving continuation across the cold→hot boundary.
+	// -------------------------------------------------------------------------
+	page1 := postRPC(t, base+"/", txsReqStart(c0Last, 1))["result"].(map[string]any)
+	p1txs := page1["transactions"].([]any)
+	require.Len(t, p1txs, 1, "page 1 returns exactly the cold tx (limit 1)")
+	assert.Equal(t, hex.EncodeToString(coldHash[:]), p1txs[0].(map[string]any)["txHash"])
+	cursor1 := page1["cursor"].(string)
+
+	page2 := postRPC(t, base+"/", txsReqCursor(cursor1, 5))["result"].(map[string]any)
+	p2txs := page2["transactions"].([]any)
+	require.NotEmpty(t, p2txs, "the cursor page resumes past the cold tx")
+	var sawHot bool
+	for _, tx := range p2txs {
+		if tx.(map[string]any)["txHash"] == hex.EncodeToString(hotHash[:]) {
+			sawHot = true
+		}
+	}
+	assert.True(t, sawHot, "getTransactions cursor continuation reaches the live tx across the seam")
+
+	// -------------------------------------------------------------------------
+	// (d) getEvents with a contract filter matching events in BOTH tiers: contract
+	// eventContractID emitted at c0Last (cold) and c1First (hot); the filter page
+	// returns both in ascending order across the seam.
+	// -------------------------------------------------------------------------
+	evCID := eventContractID()
+	cStrkey, err := strkey.Encode(strkey.VersionByteContract, evCID[:])
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		got := postRPC(t, base+"/", eventsReq(c0Last, cStrkey))
+		res, ok := got["result"].(map[string]any)
+		if !ok {
+			return false
+		}
+		evs, _ := res["events"].([]any)
+		return len(evs) == 2
+	}, 60*time.Second, 200*time.Millisecond, "getEvents must match events in both tiers")
+
+	evResp := postRPC(t, base+"/", eventsReq(c0Last, cStrkey))["result"].(map[string]any)
+	evs := evResp["events"].([]any)
+	require.Len(t, evs, 2)
+	assert.EqualValues(t, c0Last, evs[0].(map[string]any)["ledger"], "first event is cold")
+	assert.EqualValues(t, c1First, evs[1].(map[string]any)["ledger"], "second event is hot")
+	for _, e := range evs {
+		assert.Equal(t, cStrkey, e.(map[string]any)["contractId"], "only the filtered contract matched")
+	}
+
+	// -------------------------------------------------------------------------
+	// (e) negatives.
+	// -------------------------------------------------------------------------
+	// A startLedger below the served floor (genesis) errors with the range surfaced.
+	below := postRPC(t, base+"/", ledgersReq(c0First-1, 5))
+	require.NotNil(t, below["error"], "getLedgers below the floor must error")
+	belowMsg := fmt.Sprint(below["error"].(map[string]any)["message"])
+	assert.Contains(t, belowMsg, "oldest ledger", "the below-floor error surfaces the available range")
+	assert.Contains(t, belowMsg, "latest ledger", "the below-floor error surfaces the available range")
+
+	// An unknown tx hash is NOT_FOUND (a well-formed response, not an error).
+	var miss [32]byte
+	miss[0], miss[31] = 0xDE, 0xAD
+	unknown := postRPC(t, base+"/", txReq(miss))
+	require.Nil(t, unknown["error"], "an unknown hash is a normal NOT_FOUND response, not an error")
+	assert.Equal(t, "NOT_FOUND", unknown["result"].(map[string]any)["status"])
+}
+
+// ---- JSON-RPC request builders (raw wire strings keep the test readable). ----
+
+func ledgersReq(start uint32, limit int) string {
+	return fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":1,"method":"getLedgers","params":{"startLedger":%d,"pagination":{"limit":%d}}}`,
+		start, limit,
+	)
+}
+
+func txReq(hash [32]byte) string {
+	return fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":1,"method":"getTransaction","params":{"hash":%q}}`,
+		hex.EncodeToString(hash[:]),
+	)
+}
+
+func txsReqStart(start uint32, limit int) string {
+	return fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":1,"method":"getTransactions","params":{"startLedger":%d,"pagination":{"limit":%d}}}`,
+		start, limit,
+	)
+}
+
+func txsReqCursor(cursor string, limit int) string {
+	return fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":1,"method":"getTransactions","params":{"pagination":{"cursor":%q,"limit":%d}}}`,
+		cursor, limit,
+	)
+}
+
+func eventsReq(start uint32, contractID string) string {
+	return fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":1,"method":"getEvents","params":{"startLedger":%d,`+
+			`"filters":[{"contractIds":[%q]}],"pagination":{"limit":10}}}`,
+		start, contractID,
+	)
+}
+
+// txStatus POSTs a getTransaction and returns its result.status (or "" on error).
+func txStatus(t *testing.T, base string, hash [32]byte) string {
+	t.Helper()
+	got := postRPC(t, base+"/", txReq(hash))
+	res, ok := got["result"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	s, _ := res["status"].(string)
+	return s
+}

--- a/cmd/stellar-rpc/internal/fullhistory/startup.go
+++ b/cmd/stellar-rpc/internal/fullhistory/startup.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/geometry"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/lifecycle"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/observability"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/serve"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
 )
 
@@ -125,6 +126,24 @@ func run(ctx context.Context, cfg StartConfig) error {
 		ExecConfig: cfg.Exec,
 		Retention:  cfg.Retention,
 	}.WithLifecycleDefaults()
+	// The read server (query POC) rescans + republishes its View after each
+	// successful tick. Set only when serving is enabled so the no-serve daemon
+	// carries no observer.
+	if cfg.serving != nil {
+		lifecycleCfg.TickObserver = cfg.serving
+	}
+
+	// Seed the read server's serving View from durable state, then publish the
+	// live resume chunk's shared write handle. Order is load-bearing: BuildInitial
+	// rebuilds the whole View and deliberately OMITS the resume (highest ready)
+	// chunk, leaving it for HotOpened — so HotOpened MUST follow BuildInitial or
+	// the fresh View would clobber the resume chunk (matching serve's tested
+	// BuildInitial→HotOpened order). Both are no-ops when serving is disabled, and
+	// both precede ServeReads so the server admits against a populated View.
+	if err := cfg.serving.BuildInitial(lastCommitted); err != nil {
+		return fmt.Errorf("startup build initial serving view: %w", err)
+	}
+	cfg.serving.HotOpened(chunk.IDFromLedger(resumeLedger), hotDB)
 
 	// Begin serving reads (injected) BEFORE launching the loops; it must return
 	// promptly (launch, not block).
@@ -153,6 +172,7 @@ func run(ctx context.Context, cfg StartConfig) error {
 			Metrics:  metrics,
 			Sink:     cfg.Exec.Process.Sink,
 			Health:   cfg.health,
+			Serving:  cfg.serving,
 		})
 		if err == nil {
 			// WithContext cancels gctx (unblocking the lifecycle sibling in g.Wait)
@@ -199,7 +219,8 @@ func backfillToTip(ctx context.Context, cfg StartConfig, lastCommitted uint32) (
 		// frontier — and each supervised restart re-samples (a transient outage
 		// self-heals).
 		tip, err := sampleTipWithRetry(
-			ctx, cfg.Exec.Process.Backend.Tip, defaultTipBackoff, defaultTipMaxAttempts)
+			ctx, cfg.Exec.Process.Backend.Tip, defaultTipBackoff, defaultTipMaxAttempts,
+		)
 		if err != nil {
 			return 0, fmt.Errorf("sample network tip: %w", err)
 		}
@@ -315,6 +336,12 @@ type StartConfig struct {
 	// health is the readiness/health signal the ingestion loop feeds per commit;
 	// #772's read server consumes it (as HealthSignal). nil ⇒ observe is a no-op.
 	health *healthState
+
+	// serving is the read server's serve.Registry (query POC): the ingestion loop
+	// drives its write-side hooks and startup seeds its initial View. nil when
+	// [serve] is disabled — every *serve.Registry hook is nil-receiver safe, so the
+	// no-serve path needs no guards.
+	serving *serve.Registry
 }
 
 // withDefaults fills the embedded Exec defaults (Workers -> GOMAXPROCS). The

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk/hotchunk.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk/hotchunk.go
@@ -6,8 +6,9 @@
 // and no per-store frontiers / min-of-three. The three typed facades
 // (ledger/txhash/eventstore HotStore) are composed over the shared store via
 // NewWithStore; their write paths queue Puts into the one shared batch. A
-// read-only open composes a ledgers-only view without the events facade (see
-// OpenReadOnly).
+// read-only open comes in two shapes: a ledgers-only view without the events
+// facade (OpenReadOnly, for freeze/probe) and a full-facade query view that warms
+// and serves all three (OpenReadView).
 package hotchunk
 
 import (
@@ -34,9 +35,9 @@ import (
 )
 
 // DB is one chunk's hot tier: a single multi-CF rocksdb.Store plus the typed
-// facades composed over it — all three on a read-write open; a read-only open
-// leaves events nil (see OpenReadOnly). It owns the store (Close closes it
-// once); the facades wrap it without owning it.
+// facades composed over it — all three on a read-write open or a full read view
+// (OpenReadView); a ledgers-only read-only open leaves events nil (OpenReadOnly).
+// It owns the store (Close closes it once); the facades wrap it without owning it.
 //
 // Concurrency: ingestion is single-writer; IngestLedger is not safe to call
 // concurrently with itself. Reads via the facades follow each facade's own
@@ -103,7 +104,7 @@ func config(path string, logger *supportlog.Entry, readOnly, mustExist bool) roc
 // (ingestion's handle for a NEW chunk) and composes the three facades over it. On
 // any facade-construction failure the shared store is closed before returning.
 func Open(path string, chunkID chunk.ID, logger *supportlog.Entry) (*DB, error) {
-	return open(path, chunkID, logger, false, false)
+	return open(path, chunkID, logger, false, false, true)
 }
 
 // OpenExisting opens an EXISTING hot DB read-WRITE with create-if-missing OFF —
@@ -112,7 +113,7 @@ func Open(path string, chunkID chunk.ID, logger *supportlog.Entry) (*DB, error) 
 // empty one (the "never auto-heal" rule); the caller treats that failure as an
 // ordinary restartable error.
 func OpenExisting(path string, chunkID chunk.ID, logger *supportlog.Entry) (*DB, error) {
-	return open(path, chunkID, logger, false, true)
+	return open(path, chunkID, logger, false, true, true)
 }
 
 // OpenReadOnly opens an EXISTING hot DB read-only — the freeze source's view AND
@@ -130,41 +131,61 @@ func OpenExisting(path string, chunkID chunk.ID, logger *supportlog.Entry) (*DB,
 // index-CF scan plus bitmap/offsets rebuild — discarded unread at Close (#834). The
 // skip is enforced structurally: a read-only DB has no events facade, so Events()
 // panics and IngestLedger errors rather than serving a cold, unwarmed surface.
+//
+// For a read-only handle that DOES serve events (a boundary-closed but not-yet-frozen
+// chunk that must still answer queries), use OpenReadView, which composes all three
+// facades and pays the warmup.
 func OpenReadOnly(path string, chunkID chunk.ID, logger *supportlog.Entry) (*DB, error) {
-	return open(path, chunkID, logger, true, false)
+	return open(path, chunkID, logger, true, false, false)
 }
 
 // OpenReadyWrite opens a "ready" chunk's hot DB read-WRITE — ingestion's handle
 // for a resumed chunk (OpenExisting underneath). openReady enforces the ready-open
 // rule.
 func OpenReadyWrite(state geometry.HotState, path string, chunkID chunk.ID, logger *supportlog.Entry) (*DB, error) {
-	return openReady(state, path, chunkID, logger, false)
+	return openReady(state, path, chunkID, logger, OpenExisting)
 }
 
 // OpenReadyView opens a "ready" chunk's hot DB read-only — the freeze source's
-// and the last-committed refiner's view (OpenReadOnly underneath). openReady
-// enforces the ready-open rule.
+// and the last-committed refiner's LEDGERS-ONLY view (OpenReadOnly underneath).
+// openReady enforces the ready-open rule.
 func OpenReadyView(state geometry.HotState, path string, chunkID chunk.ID, logger *supportlog.Entry) (*DB, error) {
-	return openReady(state, path, chunkID, logger, true)
+	return openReady(state, path, chunkID, logger, OpenReadOnly)
+}
+
+// OpenReadView opens a "ready" chunk's hot DB read-only with the FULL facade union
+// (ledgers + txhash + events, warmup included) — the query view for a chunk whose
+// write handle was fenced at the boundary but whose cold artifacts aren't frozen
+// yet. Unlike OpenReadyView it pays eventstore's warmup so Events() and Txhash()
+// serve. Read-only opens take no RocksDB LOCK, so this coexists with the freeze
+// source's own OpenReadyView. openReady enforces the ready-open rule.
+func OpenReadView(state geometry.HotState, path string, chunkID chunk.ID, logger *supportlog.Entry) (*DB, error) {
+	return openReady(state, path, chunkID, logger, openReadFull)
+}
+
+// openReadFull opens an EXISTING hot DB read-only with all three facades composed
+// (the OpenReadView store open). Split out so it matches openReady's openFn shape.
+func openReadFull(path string, chunkID chunk.ID, logger *supportlog.Entry) (*DB, error) {
+	return open(path, chunkID, logger, true, false, true)
 }
 
 // openReady is the single enforcement site for the "ready key ⇒ must-exist,
-// never-creating open" rule behind the OpenReadyWrite/OpenReadyView pair. It
-// takes the hot-key state the CALLER already read and refuses to open anything
-// not "ready", so no caller can accidentally open a creating handle for a chunk
-// the catalog considers ready. Either way a missing or gutted "ready" DB fails
-// the open — never auto-healed into a fresh empty one — wrapped in the uniform
-// won't-open error so every ready-open site reports it identically.
+// never-creating open" rule behind the OpenReadyWrite/OpenReadyView/OpenReadView
+// trio. It takes the hot-key state the CALLER already read and refuses to open
+// anything not "ready", so no caller can accidentally open a creating handle for a
+// chunk the catalog considers ready. It dispatches to the caller-chosen open
+// (read-write, ledgers-only read, or full read view). Either way a missing or
+// gutted "ready" DB fails the open — never auto-healed into a fresh empty one —
+// wrapped in the uniform won't-open error so every ready-open site reports it
+// identically.
 func openReady(
-	state geometry.HotState, path string, chunkID chunk.ID, logger *supportlog.Entry, readOnly bool,
+	state geometry.HotState, path string, chunkID chunk.ID, logger *supportlog.Entry,
+	openFn func(string, chunk.ID, *supportlog.Entry) (*DB, error),
 ) (*DB, error) {
 	if state != geometry.HotReady {
 		return nil, fmt.Errorf(
-			"hotchunk: ready-open requires chunk %s key %q, got %q", chunkID, geometry.HotReady, state)
-	}
-	openFn := OpenExisting
-	if readOnly {
-		openFn = OpenReadOnly
+			"hotchunk: ready-open requires chunk %s key %q, got %q", chunkID, geometry.HotReady, state,
+		)
 	}
 	db, err := openFn(path, chunkID, logger)
 	if err != nil {
@@ -173,7 +194,7 @@ func openReady(
 	return db, nil
 }
 
-func open(path string, chunkID chunk.ID, logger *supportlog.Entry, readOnly, mustExist bool) (*DB, error) {
+func open(path string, chunkID chunk.ID, logger *supportlog.Entry, readOnly, mustExist, composeEvents bool) (*DB, error) {
 	if path == "" {
 		return nil, stores.ErrInvalidConfig
 	}
@@ -191,11 +212,12 @@ func open(path string, chunkID chunk.ID, logger *supportlog.Entry, readOnly, mus
 		ledger:  ledger.NewWithStore(store),
 		txhash:  txhash.NewWithStore(store),
 	}
-	// A read-only open is a ledgers-only freeze/probe view (see OpenReadOnly): it
-	// never reads events, so skip composing the events facade and its unconditional
-	// warmup scan. Read-WRITE opens (ingestion) MUST warm — the write path assigns
-	// event IDs off the warmed offsets — so they always compose it.
-	if readOnly {
+	// The ledgers-only freeze/probe view (OpenReadOnly) skips the events facade and
+	// its unconditional warmup scan — it never reads events. Everyone else composes
+	// it: read-WRITE opens (ingestion) MUST warm because the write path assigns event
+	// IDs off the warmed offsets, and the full read view (OpenReadView) warms so it
+	// can serve queries.
+	if !composeEvents {
 		return db, nil
 	}
 	es, err := eventstore.NewWithStore(store, chunkID)
@@ -226,10 +248,10 @@ func (d *DB) Txhash() *txhash.HotStore { return d.txhash }
 // Events returns the events read/write facade over the shared store.
 // Same status as Txhash: writes feed ingestion, reads are the #772 seam.
 //
-// Panics on a read-only DB: OpenReadOnly composes a ledgers-only view with no
-// events facade (#834), so reaching for events there is a programming error — a
-// caller that needs a warmed events surface must open read-WRITE (or #772 must
-// add a warmed read-only variant), never silently read a cold, unwarmed store.
+// Panics on a ledgers-only DB: OpenReadOnly composes a view with no events facade
+// (#834), so reaching for events there is a programming error — a caller that needs
+// a warmed events surface must open read-WRITE or use the full read view
+// (OpenReadView), never silently read a cold, unwarmed store.
 func (d *DB) Events() *eventstore.HotStore {
 	if d.events == nil {
 		panic(fmt.Sprintf("hotchunk: Events() on read-only chunk %s: no events facade (ledgers-only view)", d.chunkID))

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk/hotchunk.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk/hotchunk.go
@@ -194,7 +194,9 @@ func openReady(
 	return db, nil
 }
 
-func open(path string, chunkID chunk.ID, logger *supportlog.Entry, readOnly, mustExist, composeEvents bool) (*DB, error) {
+func open(
+	path string, chunkID chunk.ID, logger *supportlog.Entry, readOnly, mustExist, composeEvents bool,
+) (*DB, error) {
 	if path == "" {
 		return nil, stores.ErrInvalidConfig
 	}

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk/hotchunk_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk/hotchunk_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/events"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/geometry"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/rocksdb"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/stores"
@@ -524,6 +525,64 @@ func TestOpenReadOnly_SkipsEventsWarmup(t *testing.T) {
 
 	// Structural safety: the ledgers-only view has no events facade to hand out.
 	assert.Panics(t, func() { ro.Events() }, "Events() on a ledgers-only view must fail loudly")
+}
+
+// TestOpenReadView_ServesAllFacades pins the query POC's full-facade read-only
+// open: unlike OpenReadOnly's ledgers-only view, OpenReadView composes all three
+// facades (ledgers + txhash + events, warmup included) so a boundary-closed but
+// not-yet-frozen chunk stays fully servable. Two concurrent OpenReadView handles
+// must coexist — read-only opens take no RocksDB LOCK.
+func TestOpenReadView_ServesAllFacades(t *testing.T) {
+	chunkID := chunk.ID(0)
+	first := chunkID.FirstLedger()
+	dir := t.TempDir()
+
+	// Writer: ingest two ledgers each carrying one tx + one contract event, then close.
+	db, err := Open(dir, chunkID, silentLogger())
+	require.NoError(t, err)
+	rawA, hashA, termA := lcmWithEvent(t, first)
+	rawB, hashB, _ := lcmWithEvent(t, first+1)
+	_, err = db.IngestLedger(first, xdr.LedgerCloseMetaView(rawA))
+	require.NoError(t, err)
+	_, err = db.IngestLedger(first+1, xdr.LedgerCloseMetaView(rawB))
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	ro, err := OpenReadView(geometry.HotReady, dir, chunkID, silentLogger())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ro.Close()) })
+
+	// Ledgers facade.
+	gotA, err := ro.Ledgers().GetLedgerRaw(first)
+	require.NoError(t, err)
+	assert.Equal(t, rawA, gotA)
+
+	// Txhash facade.
+	seqA, err := ro.Txhash().Get(hashA)
+	require.NoError(t, err)
+	assert.Equal(t, first, seqA)
+	seqB, err := ro.Txhash().Get(hashB)
+	require.NoError(t, err)
+	assert.Equal(t, first+1, seqB)
+
+	// Events facade (warmup ran): count and term lookup both resolve.
+	assert.Equal(t, uint32(2), eventCount(t, ro.Events()))
+	bms, err := ro.Events().LookupKeys(context.Background(), []events.TermKey{termA})
+	require.NoError(t, err)
+	require.NotNil(t, bms[0])
+	assert.Equal(t, uint64(2), bms[0].GetCardinality(), "both ledgers share the event term")
+
+	// A second read-only view opens while the first is live — no LOCK conflict.
+	ro2, err := OpenReadView(geometry.HotReady, dir, chunkID, silentLogger())
+	require.NoError(t, err)
+	require.NoError(t, ro2.Close())
+}
+
+// TestOpenReadView_RejectsNonReadyState confirms OpenReadView routes through the
+// same ready-open enforcement as OpenReadyView: a non-ready state refuses to open.
+func TestOpenReadView_RejectsNonReadyState(t *testing.T) {
+	_, err := OpenReadView(geometry.HotState(""), t.TempDir(), chunk.ID(0), silentLogger())
+	require.Error(t, err)
 }
 
 // TestIngestLedger_ClosedDBFails confirms a closed shared DB rejects ingest. The

--- a/cmd/stellar-rpc/internal/fullhistory/storage/stores/ledger/hot_read_bench_test.go
+++ b/cmd/stellar-rpc/internal/fullhistory/storage/stores/ledger/hot_read_bench_test.go
@@ -1,0 +1,135 @@
+package ledger
+
+// Isolates the DIRECT hot-RocksDB read latency for real profile ledgers — the
+// storage-read component of the daemon's getLedgers cost, with none of the
+// base64 / JSON / HTTP serve overhead. It also reports the raw per-ledger byte
+// sizes (the driver of getLedgers response size).
+//
+// It reads the steady-state window straight from a profile's cold ledger pack,
+// loads it into a fresh hot store (values are zstd-compressed on write, exactly
+// as the daemon stores them), then benchmarks:
+//
+//	store.Get        — RocksDB point read only (returns the compressed value)
+//	GetLedgerRaw     — the full hot read: store.Get + zstd decode + alloc
+//
+// Env-gated (skipped otherwise): FHBENCH_PROFILE_LEDGERS (pack tree root),
+// FHBENCH_FIRST_CHUNK (1), FHBENCH_WARMUP_LEDGERS (200), FHBENCH_WINDOW_LEDGERS (20).
+//
+//	go test ./cmd/stellar-rpc/internal/fullhistory/storage/stores/ledger/ \
+//	  -run '^$' -bench BenchmarkHotGetLedgerRaw -benchtime 2s
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/chunk"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/storage/rocksdb"
+)
+
+func benchEnvU32(b *testing.B, key string, def uint32) uint32 {
+	b.Helper()
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.ParseUint(v, 10, 32)
+	require.NoError(b, err, "env %s", key)
+	return uint32(n)
+}
+
+func BenchmarkHotGetLedgerRaw(b *testing.B) {
+	root := os.Getenv("FHBENCH_PROFILE_LEDGERS")
+	if root == "" {
+		b.Skip("set FHBENCH_PROFILE_LEDGERS (a profile ledgers tree root) to run the hot-read benchmark")
+	}
+	fc := chunk.ID(benchEnvU32(b, "FHBENCH_FIRST_CHUNK", 1))
+	warmup := benchEnvU32(b, "FHBENCH_WARMUP_LEDGERS", 200)
+	window := benchEnvU32(b, "FHBENCH_WINDOW_LEDGERS", 20)
+
+	measureFrom := fc.FirstLedger() + warmup
+	lastLedger := measureFrom + window - 1
+
+	// Read exactly the steady-state window straight from the cold pack (IterateLedgers
+	// seeks to measureFrom, so the warmup head is skipped, not read).
+	packPath := filepath.Join(root, fc.BucketID(), PackName(fc))
+	cr, err := OpenColdReader(packPath)
+	require.NoError(b, err, "open %s", packPath)
+	defer func() { _ = cr.Close() }()
+
+	var entries []Entry
+	total, minB, maxB := 0, 1<<62, 0
+	seq := measureFrom
+	for e, ierr := range cr.IterateLedgers(measureFrom, lastLedger) {
+		require.NoError(b, ierr)
+		cp := make([]byte, len(e.Bytes))
+		copy(cp, e.Bytes)
+		entries = append(entries, Entry{Seq: seq, Bytes: cp})
+		n := len(cp)
+		total += n
+		if n < minB {
+			minB = n
+		}
+		if n > maxB {
+			maxB = n
+		}
+		seq++
+	}
+	require.Len(b, entries, int(window), "pack must yield the whole window")
+	avg := total / len(entries)
+	b.Logf("window [%d..%d]: %d ledgers | raw LCM bytes min=%d avg=%d max=%d | base64≈%d (avg*4/3)",
+		measureFrom, lastLedger, len(entries), minB, avg, maxB, avg*4/3)
+
+	// Fresh hot store (compresses on write, exactly like the daemon).
+	store, err := rocksdb.New(rocksdb.Config{
+		Path:           b.TempDir(),
+		ColumnFamilies: []string{LedgersCF},
+		Logger:         silentLogger(),
+	})
+	require.NoError(b, err)
+	defer func() { _ = store.Close() }()
+	h := NewWithStore(store)
+	require.NoError(b, addLedgers(h, entries...))
+
+	b.Run("store.Get_compressed", func(b *testing.B) {
+		b.SetBytes(int64(avg))
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			s := measureFrom + uint32(i)%window
+			v, found, gerr := h.store.Get(LedgersCF, rocksdb.EncodeUint32(s))
+			if gerr != nil || !found || len(v) == 0 {
+				b.Fatalf("get seq %d: err=%v found=%v", s, gerr, found)
+			}
+		}
+	})
+
+	b.Run("hot_GetLedgerRaw_decoded", func(b *testing.B) {
+		b.SetBytes(int64(avg))
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			s := measureFrom + uint32(i)%window
+			out, gerr := h.GetLedgerRaw(s)
+			if gerr != nil || len(out) == 0 {
+				b.Fatalf("GetLedgerRaw seq %d: err=%v len=%d", s, gerr, len(out))
+			}
+		}
+	})
+
+	// COLD tier: the same ledgers served from the frozen cold pack (index lookup +
+	// seek + zstd block decode) instead of hot RocksDB. This is the read the cold
+	// serving path (View → cold resolver → ColdReader) performs for getLedgers.
+	b.Run("cold_GetLedgerRaw_decoded", func(b *testing.B) {
+		b.SetBytes(int64(avg))
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			s := measureFrom + uint32(i)%window
+			out, gerr := cr.GetLedgerRaw(s)
+			if gerr != nil || len(out) == 0 {
+				b.Fatalf("cold GetLedgerRaw seq %d: err=%v len=%d", s, gerr, len(out))
+			}
+		}
+	})
+}

--- a/cmd/stellar-rpc/main.go
+++ b/cmd/stellar-rpc/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/config"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/daemon"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/fullhistory/bench"
 )
 
 func main() {
@@ -110,6 +111,7 @@ func main() {
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(genConfigFileCmd)
 	rootCmd.AddCommand(fullHistoryCmd)
+	rootCmd.AddCommand(bench.NewCommand())
 
 	if err := cfg.AddFlags(rootCmd); err != nil {
 		fmt.Fprintf(os.Stderr, "could not parse config options: %v\n", err)

--- a/docs/plans/2026-07-15-fullhistory-query-poc-HANDOFF.md
+++ b/docs/plans/2026-07-15-fullhistory-query-poc-HANDOFF.md
@@ -1,15 +1,8 @@
 # Session Handoff — Full-History Query POC (2026-07-15)
 
-> **STATUS: COMPLETE (2026-07-15, second session).** All 9 tasks done; final review verdict: ready for benchmarking. Final HEAD `6e35a7b9`. See "Completion summary" at the bottom. The resume instructions below are retained for the record.
+> **STATUS: COMPLETE (2026-07-15, second session).** All 9 tasks done; final review verdict: ready for benchmarking. Final HEAD `6e35a7b9`. See "Completion summary" at the bottom. The notes below are retained for the record.
 
-Resume document for continuing execution of `2026-07-15-fullhistory-query-poc.md` (same directory) in a fresh Claude Code session on another machine.
-
-## How to resume
-
-1. `git fetch && git checkout poc/fullhistory-query` (branched off `feature/full-history`).
-2. Start a Claude Code session in the repo root and say:
-   > Resume executing docs/superpowers/plans/2026-07-15-fullhistory-query-poc.md with superpowers:subagent-driven-development, per the HANDOFF file next to it. Workers + per-task reviews on opus, final review on fable. Resume at the first task not marked complete below.
-3. Re-create the scratch ledger from the "Progress ledger" section below at `.superpowers/sdd/progress.md` (git-ignored, machine-local). Task briefs are regenerated with the skill's `scripts/task-brief PLAN_FILE N`.
+Companion record for `2026-07-15-fullhistory-query-poc.md` (same directory), the task-by-task implementation plan.
 
 ## Progress ledger (authoritative copy at handoff)
 
@@ -23,23 +16,23 @@ Task 3: complete (commits 6067a677..82098f67, review clean)
   Env note: serve pkg now links Rust libs; build once with RUSTUP_TOOLCHAIN=1.89 make build-libs.
 Task 4: complete (commits 82098f67..a5f32e8d, review clean after floor-gate-at-index-seam fix)
   Minor (deferred to final review): fee-bump inner-hash lookup depends on whether index build stores inner keys (cross-task check); nil-hotDB-guard cut not comment-marked in tx_reader.go.
-Task 5: IN FLIGHT at handoff (getEvents v2 handler) — worker died with the old machine; NO commits/files landed. Restart Task 5 from its plan section.
-Tasks 6-9: not started.
+Task 5: IN FLIGHT at handoff (getEvents v2 handler) — no commits/files landed. Restarted from its plan section.
+Tasks 6-9: not started at handoff.
 ```
 
-## Execution protocol being used
+## Execution protocol used
 
-- One opus implementer subagent per task (fresh context; task brief via `scripts/task-brief`), TDD, one commit per task, report file per task.
-- One opus task-review subagent per task (brief + implementer report + `scripts/review-package BASE..HEAD` diff file). Critical/Important findings go back to the implementer, then focused re-review.
-- Task 9 = whole-branch final review on fable (max effort) over `git merge-base origin/feature/full-history HEAD`..HEAD, plus full-tree `-short` run and repo golangci-lint.
-- Commit messages: `fullhistory: <what> (query POC)`. Never any AI/Claude attribution or Co-authored-by lines (user rule).
+- One implementer per task (fresh context), TDD, one commit per task, report per task.
+- One task-review per task over the task's `BASE..HEAD` diff. Critical/Important findings go back to the implementer, then a focused re-review.
+- Task 9 = whole-branch final review (max effort) over `git merge-base origin/feature/full-history HEAD`..HEAD, plus a full-tree `-short` run and repo golangci-lint.
+- Commit messages: `fullhistory: <what> (query POC)`.
 
 ## Mid-task design decisions already made (binding, not in the plan text)
 
 1. **Task 4 amendment:** the below-floor gate for cold tx-hash candidates lives at the HashIndex seam (`floorGatedIndex` wrapping each `View.TxIdx` reader, returning `stores.ErrNotFound` for candidate seq < max(floor.FirstLedger(), earliest)) — NOT at the LedgerSource — so `txhash.TxReader` sees a clean miss and a below-floor-only hash ends as `db.ErrNoTransaction` (design R2). Landed in a5f32e8d.
 2. Task 2 keeps superseded `.idx` readers open deliberately (mmap close would fault racing reads; no reaper in POC) but DOES close discarded hot handles (rocksdb close is lifecycle-guarded). Both `// POC:`-marked in registry.go.
 
-## Environment prerequisites on the new machine
+## Environment prerequisites
 
 - **RocksDB (macOS):** grocksdb v1.10.7 needs RocksDB 10.9.1; brew's 11.x lacks a required symbol. Build 10.9.1 from source to `~/.rocksdb-1091`, then test with:
   `CGO_CFLAGS="-I$HOME/.rocksdb-1091/include" CGO_LDFLAGS="-L$HOME/.rocksdb-1091/lib -L/opt/homebrew/lib -Wl,-rpath,$HOME/.rocksdb-1091/lib -Wl,-rpath,/opt/homebrew/lib" go test ./cmd/stellar-rpc/internal/fullhistory/... -short -count=1`
@@ -47,20 +40,16 @@ Tasks 6-9: not started.
 - **Rust libs:** the serve package imports `methods`, which links xdr2json/preflight. Build once: `RUSTUP_TOOLCHAIN=1.89 make build-libs` (default cargo 1.84 fails on an edition2024 dep).
 - Gate test success on the command's exit code directly; do not pipe.
 
-## Review-package / task-brief scripts
-
-From the superpowers plugin: `~/.claude/plugins/cache/claude-plugins-official/superpowers/6.1.1/skills/subagent-driven-development/scripts/{task-brief,review-package}` (version dir may differ on the new machine — glob it).
-
 ## Completion summary (second session, Linux box, 2026-07-15)
 
-Tasks 5-9 executed per the protocol above (opus workers + opus per-task reviews, fable max-effort final review).
+Tasks 5-9 executed per the protocol above (per-task implementation + review, max-effort final review).
 
 - Task 5: getEvents handler over eventstore.Query — 68cb0533 + I1 fix 91d05191 (chunk exhaustion gated on window coverage; collision-simulating regression test). Review clean.
 - Task 6: [serve] JSON-RPC server + per-endpoint latency histogram + /metrics /health /ready — 4e502601. Review clean.
 - Task 7: daemon wiring + TestServeE2E_QueryHotAndCold — fc63b4ee. Review clean; plan's BuildInitial/HotOpened prose order was backwards, implementation uses the correct order (review-confirmed).
 - Task 8: tools/fhbench harness + README — 4350e2e6 + structured discovery probe 7ae10abf. Review clean.
 - Lint gate: 846e389c (golangci-lint 0 issues on --new-from-rev origin/feature/full-history).
-- Task 9 final review (fable, max effort): no Critical; 3 CONFIRMED Important fixed in 6e35a7b9 (restart-safe metrics registration; TickCompleted live-handle race closed under r.mu; fee-bump inner-hash v1-parity gap POC-marked). 33 deferred minors adjudicated (21 accepted-POC, 7 rejected). Full record in the executing machine's .superpowers/sdd/ (untracked).
+- Task 9 final review (max effort): no Critical; 3 CONFIRMED Important fixed in 6e35a7b9 (restart-safe metrics registration; TickCompleted live-handle race closed under r.mu; fee-bump inner-hash v1-parity gap POC-marked). 33 deferred minors adjudicated (21 accepted-POC, 7 rejected).
 
 Env notes (Linux): RocksDB 10.9.1 at ~/.rocksdb, zstd 1.5.7 at ~/.zstd (system 1.5.5 too old); CGO_CFLAGS="-I$HOME/.rocksdb/include -I$HOME/.zstd/include" CGO_LDFLAGS="-L$HOME/.rocksdb/lib -L$HOME/.zstd/lib -Wl,-rpath,$HOME/.rocksdb/lib -Wl,-rpath,$HOME/.zstd/lib".
 

--- a/docs/plans/2026-07-15-fullhistory-query-poc.md
+++ b/docs/plans/2026-07-15-fullhistory-query-poc.md
@@ -1,6 +1,6 @@
 # Full-History Query-Support POC Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> Implemented task-by-task; steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** A runnable full-history daemon that serves `getLedgers`, `getTransaction`, `getTransactions`, and `getEvents` over JSON-RPC from both hot RocksDB chunks and sealed cold artifacts, instrumented for ingestion + per-endpoint latency benchmarking, per the query-routing design in PR #843 (`design-docs/query-routing-design.md` on the `docs/query-routing-design` branch).
 
@@ -10,7 +10,7 @@
 
 ## Global Constraints
 
-- Branch: `poc/fullhistory-query` (off `feature/full-history`). Commit after every task; commit messages `fullhistory: <what> (query POC)`. **Never** add AI/Claude attribution or Co-authored-by lines.
+- Branch: `poc/fullhistory-query` (off `feature/full-history`). Commit after every task; commit messages `fullhistory: <what> (query POC)`.
 - This is a POC. Deliberate simplifications are marked `// POC:` with the ceiling and the upgrade path (e.g. `// POC: no reaper — superseded .idx readers leak (bounded by coverage swaps); add grace-period reaper at productionization`).
 - **POC scope cuts (locked, do not re-add):** no LRU reader caches (per-request cold readers), no reaper (see safety rules in Task 2), no datastore fallback (pass `nil`), chunk-aligned retention floor.
 - macOS test invocation (RocksDB 10.9.1 lives at `~/.rocksdb-1091`; brew's 11.x is incompatible):
@@ -316,9 +316,9 @@ func StartServer(ctx context.Context, p ServerParams) (addr net.Addr, shutdown f
 
 ### Task 9: Final review gate
 
-- [ ] Opus-review findings from Tasks 1-8 all addressed (each task got an opus review before merge-forward).
+- [ ] Per-task review findings from Tasks 1-8 all addressed (each task got a review before merge-forward).
 - [ ] Full tree: `go build ./...`, `go vet ./...`, fullhistory tree `-short` green, `golangci-lint` clean on the diff (repo lint: build v2.11.3 with go1.26, `--new-from-rev origin/feature/full-history`, gofumpt).
-- [ ] Fable (max-effort) end-to-end review of the cumulative diff vs this plan + design doc: admission ordering, fence preservation, borrowed-bytes copying, error taxonomy, POC markers present.
+- [ ] Max-effort end-to-end review of the cumulative diff vs this plan + design doc: admission ordering, fence preservation, borrowed-bytes copying, error taxonomy, POC markers present.
 - [ ] Fix anything CONFIRMED; re-run tests; final commit.
 
 ## Self-review notes

--- a/docs/superpowers/plans/2026-07-15-fullhistory-query-poc-HANDOFF.md
+++ b/docs/superpowers/plans/2026-07-15-fullhistory-query-poc-HANDOFF.md
@@ -1,5 +1,7 @@
 # Session Handoff — Full-History Query POC (2026-07-15)
 
+> **STATUS: COMPLETE (2026-07-15, second session).** All 9 tasks done; final review verdict: ready for benchmarking. Final HEAD `6e35a7b9`. See "Completion summary" at the bottom. The resume instructions below are retained for the record.
+
 Resume document for continuing execution of `2026-07-15-fullhistory-query-poc.md` (same directory) in a fresh Claude Code session on another machine.
 
 ## How to resume
@@ -48,3 +50,18 @@ Tasks 6-9: not started.
 ## Review-package / task-brief scripts
 
 From the superpowers plugin: `~/.claude/plugins/cache/claude-plugins-official/superpowers/6.1.1/skills/subagent-driven-development/scripts/{task-brief,review-package}` (version dir may differ on the new machine — glob it).
+
+## Completion summary (second session, Linux box, 2026-07-15)
+
+Tasks 5-9 executed per the protocol above (opus workers + opus per-task reviews, fable max-effort final review).
+
+- Task 5: getEvents handler over eventstore.Query — 68cb0533 + I1 fix 91d05191 (chunk exhaustion gated on window coverage; collision-simulating regression test). Review clean.
+- Task 6: [serve] JSON-RPC server + per-endpoint latency histogram + /metrics /health /ready — 4e502601. Review clean.
+- Task 7: daemon wiring + TestServeE2E_QueryHotAndCold — fc63b4ee. Review clean; plan's BuildInitial/HotOpened prose order was backwards, implementation uses the correct order (review-confirmed).
+- Task 8: tools/fhbench harness + README — 4350e2e6 + structured discovery probe 7ae10abf. Review clean.
+- Lint gate: 846e389c (golangci-lint 0 issues on --new-from-rev origin/feature/full-history).
+- Task 9 final review (fable, max effort): no Critical; 3 CONFIRMED Important fixed in 6e35a7b9 (restart-safe metrics registration; TickCompleted live-handle race closed under r.mu; fee-bump inner-hash v1-parity gap POC-marked). 33 deferred minors adjudicated (21 accepted-POC, 7 rejected). Full record in the executing machine's .superpowers/sdd/ (untracked).
+
+Env notes (Linux): RocksDB 10.9.1 at ~/.rocksdb, zstd 1.5.7 at ~/.zstd (system 1.5.5 too old); CGO_CFLAGS="-I$HOME/.rocksdb/include -I$HOME/.zstd/include" CGO_LDFLAGS="-L$HOME/.rocksdb/lib -L$HOME/.zstd/lib -Wl,-rpath,$HOME/.rocksdb/lib -Wl,-rpath,$HOME/.zstd/lib".
+
+Known accepted gaps for benchmark interpretation: fee-bump inner-hash lookups NOT_FOUND (v1 finds them); cold readers open per-ledger (dominant cold-tier cost); getEvents re-query latency cliff for index-unselective/type-selective filters; error blips at chunk boundaries (fence ErrStoreClosed window); BuildInitial on supervised restart leaks prior View read handles until first tick.

--- a/docs/superpowers/plans/2026-07-15-fullhistory-query-poc-HANDOFF.md
+++ b/docs/superpowers/plans/2026-07-15-fullhistory-query-poc-HANDOFF.md
@@ -1,0 +1,50 @@
+# Session Handoff — Full-History Query POC (2026-07-15)
+
+Resume document for continuing execution of `2026-07-15-fullhistory-query-poc.md` (same directory) in a fresh Claude Code session on another machine.
+
+## How to resume
+
+1. `git fetch && git checkout poc/fullhistory-query` (branched off `feature/full-history`).
+2. Start a Claude Code session in the repo root and say:
+   > Resume executing docs/superpowers/plans/2026-07-15-fullhistory-query-poc.md with superpowers:subagent-driven-development, per the HANDOFF file next to it. Workers + per-task reviews on opus, final review on fable. Resume at the first task not marked complete below.
+3. Re-create the scratch ledger from the "Progress ledger" section below at `.superpowers/sdd/progress.md` (git-ignored, machine-local). Task briefs are regenerated with the skill's `scripts/task-brief PLAN_FILE N`.
+
+## Progress ledger (authoritative copy at handoff)
+
+```
+Task 1: complete (commits 37a75dd1..432e6393, review clean)
+  Minor (deferred to final review): hotchunk.go:248 panic string says "read-only chunk", imprecise now; hotchunk.go:147 note that mustExist is inert under ReadOnly.
+Task 2: complete (commits 432e6393..6067a677, review clean after TxIdx-coverage fix)
+  Minor (deferred to final review): multi-window Lo-sort ordering unasserted (single coverage in test); registry.go 418 lines vs 400 target (comments); golangci-lint not run locally.
+Task 3: complete (commits 6067a677..82098f67, review clean)
+  Minor (deferred to final review): GetLedgerRange fetches computed first as if stored (plan-mandated); BatchGetLedgers start>end returns (nil,nil) vs v1 error (handler-unreachable); mid-range ErrUnavailable fails whole batch, untested.
+  Env note: serve pkg now links Rust libs; build once with RUSTUP_TOOLCHAIN=1.89 make build-libs.
+Task 4: complete (commits 82098f67..a5f32e8d, review clean after floor-gate-at-index-seam fix)
+  Minor (deferred to final review): fee-bump inner-hash lookup depends on whether index build stores inner keys (cross-task check); nil-hotDB-guard cut not comment-marked in tx_reader.go.
+Task 5: IN FLIGHT at handoff (getEvents v2 handler) — worker died with the old machine; NO commits/files landed. Restart Task 5 from its plan section.
+Tasks 6-9: not started.
+```
+
+## Execution protocol being used
+
+- One opus implementer subagent per task (fresh context; task brief via `scripts/task-brief`), TDD, one commit per task, report file per task.
+- One opus task-review subagent per task (brief + implementer report + `scripts/review-package BASE..HEAD` diff file). Critical/Important findings go back to the implementer, then focused re-review.
+- Task 9 = whole-branch final review on fable (max effort) over `git merge-base origin/feature/full-history HEAD`..HEAD, plus full-tree `-short` run and repo golangci-lint.
+- Commit messages: `fullhistory: <what> (query POC)`. Never any AI/Claude attribution or Co-authored-by lines (user rule).
+
+## Mid-task design decisions already made (binding, not in the plan text)
+
+1. **Task 4 amendment:** the below-floor gate for cold tx-hash candidates lives at the HashIndex seam (`floorGatedIndex` wrapping each `View.TxIdx` reader, returning `stores.ErrNotFound` for candidate seq < max(floor.FirstLedger(), earliest)) — NOT at the LedgerSource — so `txhash.TxReader` sees a clean miss and a below-floor-only hash ends as `db.ErrNoTransaction` (design R2). Landed in a5f32e8d.
+2. Task 2 keeps superseded `.idx` readers open deliberately (mmap close would fault racing reads; no reaper in POC) but DOES close discarded hot handles (rocksdb close is lifecycle-guarded). Both `// POC:`-marked in registry.go.
+
+## Environment prerequisites on the new machine
+
+- **RocksDB (macOS):** grocksdb v1.10.7 needs RocksDB 10.9.1; brew's 11.x lacks a required symbol. Build 10.9.1 from source to `~/.rocksdb-1091`, then test with:
+  `CGO_CFLAGS="-I$HOME/.rocksdb-1091/include" CGO_LDFLAGS="-L$HOME/.rocksdb-1091/lib -L/opt/homebrew/lib -Wl,-rpath,$HOME/.rocksdb-1091/lib -Wl,-rpath,/opt/homebrew/lib" go test ./cmd/stellar-rpc/internal/fullhistory/... -short -count=1`
+  (Linux: distro/scripts/install-rocksdb.sh path works as-is.)
+- **Rust libs:** the serve package imports `methods`, which links xdr2json/preflight. Build once: `RUSTUP_TOOLCHAIN=1.89 make build-libs` (default cargo 1.84 fails on an edition2024 dep).
+- Gate test success on the command's exit code directly; do not pipe.
+
+## Review-package / task-brief scripts
+
+From the superpowers plugin: `~/.claude/plugins/cache/claude-plugins-official/superpowers/6.1.1/skills/subagent-driven-development/scripts/{task-brief,review-package}` (version dir may differ on the new machine — glob it).

--- a/docs/superpowers/plans/2026-07-15-fullhistory-query-poc.md
+++ b/docs/superpowers/plans/2026-07-15-fullhistory-query-poc.md
@@ -1,0 +1,327 @@
+# Full-History Query-Support POC Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A runnable full-history daemon that serves `getLedgers`, `getTransaction`, `getTransactions`, and `getEvents` over JSON-RPC from both hot RocksDB chunks and sealed cold artifacts, instrumented for ingestion + per-endpoint latency benchmarking, per the query-routing design in PR #843 (`design-docs/query-routing-design.md` on the `docs/query-routing-design` branch).
+
+**Architecture:** A new `serve` package holds a **Registry** that owns an atomic `latest` watermark and an immutable **View** (floor, hot chunk handles, cold artifact flags, tx-hash window index readers). Queries admit by loading `latest` then the View, and resolve each chunk to cold (preferred) or hot. The v1 JSON-RPC handlers for getLedgers/getTransactions/getTransaction are reused verbatim behind thin `db.LedgerReader`/`db.TransactionReader` adapters; getEvents gets a new lean handler over `eventstore.Query`. The server plugs into the existing `ServeReads` seam.
+
+**Tech Stack:** Go, grocksdb (existing), creachadair/jrpc2 + jhttp (existing), prometheus (existing). **No new dependencies.**
+
+## Global Constraints
+
+- Branch: `poc/fullhistory-query` (off `feature/full-history`). Commit after every task; commit messages `fullhistory: <what> (query POC)`. **Never** add AI/Claude attribution or Co-authored-by lines.
+- This is a POC. Deliberate simplifications are marked `// POC:` with the ceiling and the upgrade path (e.g. `// POC: no reaper — superseded .idx readers leak (bounded by coverage swaps); add grace-period reaper at productionization`).
+- **POC scope cuts (locked, do not re-add):** no LRU reader caches (per-request cold readers), no reaper (see safety rules in Task 2), no datastore fallback (pass `nil`), chunk-aligned retention floor.
+- macOS test invocation (RocksDB 10.9.1 lives at `~/.rocksdb-1091`; brew's 11.x is incompatible):
+  ```
+  CGO_CFLAGS="-I$HOME/.rocksdb-1091/include" CGO_LDFLAGS="-L$HOME/.rocksdb-1091/lib -L/opt/homebrew/lib -Wl,-rpath,$HOME/.rocksdb-1091/lib -Wl,-rpath,/opt/homebrew/lib" go test ./cmd/stellar-rpc/internal/fullhistory/... -short -count=1
+  ```
+  Gate success on the command's exit code directly (`go test ... ; echo $?` is wrong under pipes — do not pipe).
+- Style: gofumpt (not gofmt). Prefer `iter.Seq2[T, error]` range-over-func iterators over callback+sentinel patterns. `errors.Is` against `stores.Err*` sentinels (`storage/stores/errors.go`), never RocksDB/packfile errors.
+- Comment prose in fullhistory intentionally says "window" where it means the tx-index span; do not "fix" it.
+- All catalog access via the `catalog.Catalog` API; never list directories.
+
+## Key file:line anchors (all under `cmd/stellar-rpc/internal/`)
+
+| What | Where |
+| --- | --- |
+| ServeReads seam (no-op default) | `fullhistory/daemon.go:53`, default at `:160-164`, called at `fullhistory/startup.go:131` |
+| Per-ledger commit + LastCommitted gauge | `fullhistory/hotloop.go:151-157` |
+| Chunk boundary (close → open next → Publish) | `fullhistory/hotloop.go:168-192` |
+| Lifecycle tick | `fullhistory/lifecycle/lifecycle.go:106` (runLifecycle), Loop at `:227` |
+| Startup last-committed | `fullhistory/progress.go:33` (`lastCommittedLedger`) |
+| Health signal | `fullhistory/health.go:14` (`HealthSignal`), fed at `hotloop.go:163-165` |
+| Prometheus registry | `fullhistory/daemon.go:179` |
+| Config struct (strict TOML) | `fullhistory/config/config.go:30`, `ResolvePaths` `:215`, `NewLayoutFromPaths` `:273` |
+| Passphrase peek from core TOML | `fullhistory/daemon.go:413-459` |
+| Catalog scans | `catalog/catalog.go`: `ChunkArtifactKeys():96`, `ReadyHotChunkKeys():126`, `FrozenTxHashIndex(w):139`, `AllTxHashIndexKeys():131`, `EarliestLedger():193` |
+| Layout paths | `fullhistory/geometry/paths.go`: `HotChunkPath:72`, `LedgerPackPath:79`, `EventsBucketDir:87`, `TxHashIndexFilePath:128` |
+| hotchunk.DB facades | `storage/stores/hotchunk/hotchunk.go`: `Ledgers():218`, `Txhash():224`, `Events():233` (panics read-only), `MaxCommittedSeq():254`, `OpenReadOnly:133` (ledgers-only) |
+| Ledger stores | hot `GetLedgerRaw` `storage/stores/ledger/hot_store.go:87`, `IterateLedgers:121` (borrowed bytes); cold `OpenColdReader` `cold_reader.go:61`, `GetLedgerRaw:110`, `IterateLedgers:140` (borrowed), `Close:178` |
+| Events | `eventstore.Reader` iface `storage/stores/eventstore/reader.go:56` (hot+cold both implement); `Query(ctx, r, filters, opts)` `query.go:179`; `Filter` `query.go:48`; `QueryOptions` `query.go:147`; `EventIDRangeForLedgers` `query.go:119`; cold open `cold_reader.go:136` |
+| Txhash | hot `Get(hash)` `storage/stores/txhash/hot_store.go:100`; cold window `.idx` `OpenColdReader` `cold_reader.go:33`, `Get:56` (candidate), `MinLedger/MaxLedger:72-76`; verify chain `TxReader` `read_assembly.go:30-50`, `HashIndex` iface `:20`, `LedgerSource` iface `:26` |
+| v1 handlers | `methods/get_ledgers.go:29` (`NewGetLedgersHandler`), `get_transactions.go:289`, `get_transaction.go:160`, `get_events.go` (reference only) |
+| db interfaces | `db/ledger.go:25` (`LedgerReader`), `:35` (`LedgerReaderTx`), `:67` (`LedgerMetadataChunk`); `db/transaction.go:51/29/27` (`TransactionReader`/`Transaction`/`ErrNoTransaction`); `db.ParseTransaction` in `db/transaction.go` |
+| jrpc2 assembly template | `internal/jsonrpc.go:157-363` (bridge, method map, middleware) |
+| E2E harness | `fullhistory/e2e_test.go`: `runDaemonInBackground:209`, `e2eConfigPath:183`, tx-bearing ledger builders `:49-50,253`, cold/hot read pattern `:360-431`; `fhtest/fhtest.go`: `ZeroTxLCMBytes:39` |
+
+---
+
+### Task 1: Full-facade read-only hot open (`hotchunk.OpenReadView`)
+
+**Why:** After the boundary fence closes the write handle (`hotloop.go:173`), the completed chunk must stay servable (ledgers, events, txhash) until its cold artifacts freeze. `OpenReadOnly` is ledgers-only (`Events()` panics). Read-only opens take no RocksDB LOCK (`hotloop.go:111-116`), so a full read-only view can coexist with the freeze source's own `OpenReadyView`.
+
+**Files:**
+- Modify: `cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk/hotchunk.go`
+- Test: `cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk/hotchunk_test.go` (extend)
+
+**Interfaces:**
+- Produces: `func OpenReadView(state geometry.HotState, path string, chunkID chunk.ID, logger *supportlog.Entry) (*DB, error)` — enforces `state == geometry.HotReady` (mirror `OpenReadyView` at hotchunk.go:147), opens the store read-only with the **full CF union** (`ColumnFamilies()` at hotchunk.go:57), and composes **all three facades** including `eventstore.NewWithStore` (which runs its mandatory warmup) so `Events()` and `Txhash()` work. `Close()` closes the store as usual.
+
+- [ ] **Step 1: Write the failing test.** In the existing hotchunk test file, add `TestOpenReadView_ServesAllFacades`: create a DB via `Open`, ingest 2-3 ledgers carrying at least one tx and one contract event (reuse this package's existing ingest-test fixtures — see the `IngestLedger` tests in the same file for how views are built), close it, reopen via `OpenReadView(geometry.HotReady, path, chunkID, logger)`, then assert: `Ledgers().GetLedgerRaw(seq)` returns bytes; `Txhash().Get(hash)` returns the seq; `Events().EventCount()` > 0 and `Events().LookupKeys(...)` finds the ingested event's term. Also assert a second `OpenReadView` while the first is open succeeds (no LOCK conflict).
+- [ ] **Step 2: Run it, confirm it fails** with `OpenReadView` undefined (use the macOS CGO command from Global Constraints, `-run TestOpenReadView`).
+- [ ] **Step 3: Implement.** Follow the structure of `openReady`/`compose` (hotchunk.go:152-210): read-only `rocksdb.Config{ReadOnly: true, MustExist-equivalent}` with full `ColumnFamilies()` + the per-CF options used by the write open, then compose all three facades. Update the doc comments that say read-only views are ledgers-only (hotchunk.go:10,38,118,144-147,194,229) to mention the new full-facade variant — do not weaken the freeze-source docs.
+- [ ] **Step 4: Run the package tests** (`go test ./cmd/stellar-rpc/internal/fullhistory/storage/stores/hotchunk/ -short -count=1` with CGO flags). Expected: PASS.
+- [ ] **Step 5: Commit** `fullhistory: add hotchunk.OpenReadView full-facade read-only open (query POC)`.
+
+---
+
+### Task 2: `serve` package — Registry, View, hooks, resolution
+
+**Files:**
+- Create: `cmd/stellar-rpc/internal/fullhistory/serve/registry.go`
+- Create: `cmd/stellar-rpc/internal/fullhistory/serve/registry_test.go`
+
+**Interfaces:**
+- Consumes: `catalog.Catalog` scan methods, `geometry.Layout`/`Retention`/`TxHashIndexLayout`, `hotchunk.DB`, `hotchunk.OpenReadView` (Task 1), `txhash.OpenColdReader`, `ledger.OpenColdReader`, `eventstore.OpenColdReader`, `stores.Err*`.
+- Produces (used by Tasks 3-7):
+
+```go
+package serve
+
+// View is one immutable snapshot of the serving map (design: PR #843).
+type View struct {
+    Floor    chunk.ID                    // chunk-aligned retention floor
+    Earliest uint32                      // catalog EarliestLedger (genesis clamp)
+    Hot      map[chunk.ID]*hotchunk.DB   // live chunk: shared write handle; closed ready chunks: OpenReadView handle
+    Cold     map[chunk.ID]ColdFlags
+    TxIdx    []TxIndexCoverage           // ascending by window
+}
+
+type ColdFlags struct{ Ledgers, Events bool }
+
+type TxIndexCoverage struct {
+    Lo, Hi chunk.ID
+    Reader *txhash.ColdReader
+}
+
+type Registry struct { /* mu sync.Mutex; current atomic.Pointer[View]; latest atomic.Uint32; cat *catalog.Catalog; retention geometry.Retention; logger *supportlog.Entry */ }
+
+func NewRegistry(cat *catalog.Catalog, retention geometry.Retention, logger *supportlog.Entry) *Registry
+
+// Admit: the two atomic loads, latest FIRST (order is load-bearing, see design §Admission).
+func (r *Registry) Admit() (latest uint32, v *View)
+
+// Hooks (all safe on nil *Registry so the no-serve path needs no guards):
+func (r *Registry) LedgerCommitted(seq uint32)                  // hotloop, after Ingest returns
+func (r *Registry) HotOpened(c chunk.ID, db *hotchunk.DB)      // hotloop + startup: publish shared write handle
+func (r *Registry) ChunkClosed(c chunk.ID)                     // hotloop boundary: reopen via OpenReadView, republish
+func (r *Registry) TickCompleted()                             // lifecycle: rescan catalog, republish
+func (r *Registry) BuildInitial(lastCommitted uint32) error    // startup, before ServeReads returns
+
+// Resolution (design §Chunk resolution: cold wins):
+type Kind int // KindLedgers, KindEvents
+func (v *View) ResolveLedgers(c chunk.ID, layout geometry.Layout) (LedgerChunk, error) // ErrUnavailable if no home
+func (v *View) ResolveEvents(c chunk.ID, layout geometry.Layout) (EventsChunk, error)
+
+// LedgerChunk / EventsChunk are tiny per-chunk handles the caller must Close()
+// (hot-backed ones have a no-op Close; cold-backed ones own the cold reader).
+type LedgerChunk struct{ /* Get(seq) ([]byte, error); Iterate(start, end) iter.Seq2[ledger.Entry, error]; Close() */ }
+type EventsChunk struct{ /* Reader() eventstore.Reader; Close() */ }
+
+var ErrUnavailable = errors.New("no serving home for chunk")
+```
+
+**Semantics (implement exactly):**
+- `publish(mutate func(*View))`: lock mu → clone current View (shallow-copy maps/slice) → mutate → `current.Store` → unlock. Design §Publishing View updates.
+- `BuildInitial`: `latest.Store(lastCommitted)`, then scan: `ChunkArtifactKeys()` filtered `StateFrozen` → `Cold` flags; `AllTxHashIndexKeys()` filtered frozen (or `FrozenTxHashIndex` per window) → open `.idx` readers via `layout.TxHashIndexFilePath(cov)`; `ReadyHotChunkKeys()` → for every ready chunk **except** ones that will be served by the live write handle (the resume chunk is published separately via `HotOpened`), open `OpenReadView`; `EarliestLedger()` → `Earliest`; `Floor = retention.FloorAt(geometry.LastCompleteChunkAt(lastCommitted))`.
+- `TickCompleted` (rescan): recompute Cold/TxIdx/Floor from a fresh catalog scan. Hot map handling: keep existing handles; for a hot chunk that vanished from the catalog (discarded), remove it from the View **then close the handle** (rocksdb `Store.Close` is lifecycle-guarded — an in-flight read on an old View gets `stores.ErrStoreClosed`, memory-safe). For a superseded `.idx` coverage, swap in the new reader but **never close the old one** — streamhash Close unmaps and a racing read would fault. `// POC: superseded .idx readers leak (bounded by coverage swaps per run); reaper at productionization.`
+- `ChunkClosed(c)`: `OpenReadView` the chunk, publish it into `Hot[c]` replacing the (now-closed) write handle entry. If the open fails, log + remove the entry (freeze will cover it after the next tick).
+- `HotOpened(c, db)`: publish `Hot[c] = db`.
+- `LedgerCommitted(seq)`: `latest.Store(seq)` — write-side order note: called only after `hotService.Ingest` returned, matching design "latest advances last".
+- `ResolveLedgers/ResolveEvents`: cold flag wins → open the per-request cold reader (`ledger.OpenColdReader(layout.LedgerPackPath(c))` / `eventstore.OpenColdReader(c, layout.EventsBucketDir(c), eventstore.ColdReaderOptions{})`); else hot handle facade with no-op Close; else `ErrUnavailable`. `// POC: no LRU — cold readers are opened per request and closed by the caller.`
+
+- [ ] **Step 1: Write failing tests** in `registry_test.go`. Build a real temp catalog (see `fullhistory/e2e_test.go:504` `e2eReadCatalog` and lifecycle tests for fixture patterns; `fhtest.RetentionFor` at `fhtest/fhtest.go:25`). Cover: (a) `Admit` returns seeded latest + initial View with frozen chunk in `Cold` and ready chunk in `Hot`; (b) admission order — `LedgerCommitted` then `Admit` observes the new latest with the old View until a publish (assert View pointer identity across `LedgerCommitted`); (c) `ResolveLedgers` prefers cold when both flags exist; returns `ErrUnavailable` for an unknown chunk; (d) `TickCompleted` after a catalog freeze-flip moves the chunk hot→cold and a discarded hot chunk's handle is closed (subsequent read on the stale View returns `stores.ErrStoreClosed`, not a crash); (e) nil-Registry hooks don't panic.
+- [ ] **Step 2: Run, confirm failure** (package doesn't exist yet).
+- [ ] **Step 3: Implement `registry.go`** per the semantics block above. Keep it one file; target ≤400 lines.
+- [ ] **Step 4: Run package tests + `go vet ./...`**. Expected: PASS.
+- [ ] **Step 5: Commit** `fullhistory: serve registry/View with catalog-rescan publishing (query POC)`.
+
+---
+
+### Task 3: `db.LedgerReader` adapter
+
+**Files:**
+- Create: `cmd/stellar-rpc/internal/fullhistory/serve/ledger_reader.go`
+- Create: `cmd/stellar-rpc/internal/fullhistory/serve/ledger_reader_test.go`
+
+**Interfaces:**
+- Consumes: `Registry.Admit`, `View.ResolveLedgers`, `geometry.Layout`.
+- Produces: `func NewLedgerReader(reg *Registry, layout geometry.Layout) db.LedgerReader` (from `db/ledger.go:25`). Handlers reuse it verbatim: `methods.NewGetLedgersHandler(lr, maxLimit, defaultLimit, nil /* POC: no datastore fallback */, logger)` and `methods.NewGetTransactionsHandler(logger, lr, maxLimit, defaultLimit, passphrase)`.
+
+**Method semantics:**
+- `NewTx(ctx)` → a `readTx` that calls `Admit()` **once** and pins `(latest, view)` for its lifetime (this IS the design's admission; `Done()` is a no-op release). All four used methods hang off it.
+- `GetLedgerRange(ctx)`: `first = max(view.Floor.FirstLedger(), view.Earliest)`, `last = latest`. Fill the `ledgerbucketwindow.LedgerRange` sequence+closeTime fields by fetching+decoding those two ledgers through resolution (`xdr.LedgerCloseMetaView` gives cheap header access). If `latest == 0` (nothing ingested) return the same not-found error shape v1 uses for an empty range.
+- `readTx.GetLedger(ctx, seq)`: bounds-check against `[first, latest]` (below floor → `(zero, false, nil)` not-found, matching v1 semantics); resolve `chunk.IDFromLedger(seq)`, `Get`, unmarshal to `xdr.LedgerCloseMeta`, close the chunk handle.
+- `readTx.BatchGetLedgers(ctx, start, end)`: clamp `end` to `latest`; **reject** (error, matching v1's out-of-range error from `get_ledgers.go`) if `start < first` — read how `getLedgers` surfaces range errors and match it. Iterate chunk-by-chunk ascending using `Iterate(start, end)` per chunk, **copying** each borrowed `Entry.Bytes`, building `db.LedgerMetadataChunk{Header, Lcm}` (header via `LedgerCloseMetaView`). Close each chunk handle before moving on.
+- Top-level `GetLedger`/`GetLatestLedgerSequence`: implement via a one-shot internal tx (cheap; getTransaction's helper path uses `GetLedgerRange` on the reader itself — check `get_transaction.go:53` and implement what's called).
+- `StreamAllLedgers`, `GetLedgerCountInRange`, `StreamLedgerRange`: `return errors.New("not supported by full-history POC read path")` — none of the four handlers call them. `// POC:` comment each.
+
+- [ ] **Step 1: Write failing tests.** Fixture: a Registry over a temp catalog with one frozen (cold) chunk and one live hot chunk holding real `fhtest.ZeroTxLCMBytes` ledgers (write the cold pack with the same writer backfill uses — find the `WriteColdChunk`/pack-writer used by `backfill/process.go` and reuse it, or freeze via the backfill helpers the e2e test uses). Cover: `BatchGetLedgers` spanning the cold→hot seam returns the full contiguous run with correct headers; below-floor start errors; end clamps to latest; `GetLedgerRange` endpoints and close times; `GetLedger` miss below floor is not-found not error.
+- [ ] **Step 2: Run, confirm failure.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Integration check:** also add one test that mounts `methods.NewGetLedgersHandler(NewLedgerReader(...), 200, 50, nil, logger)` via `jrpc2` direct handler invocation (see `methods/get_ledgers_test.go` for how v1 tests call handlers without HTTP) and asserts a real `protocol.GetLedgersResponse` across the seam. Run package tests. Expected: PASS.
+- [ ] **Step 5: Commit** `fullhistory: db.LedgerReader adapter over serve views (query POC)`.
+
+---
+
+### Task 4: `db.TransactionReader` adapter
+
+**Files:**
+- Create: `cmd/stellar-rpc/internal/fullhistory/serve/tx_reader.go`
+- Create: `cmd/stellar-rpc/internal/fullhistory/serve/tx_reader_test.go`
+
+**Interfaces:**
+- Consumes: `Registry.Admit`, `View.Hot` (txhash facades), `View.TxIdx`, `View.ResolveLedgers`, `txhash.NewTxReader`/`TxReader.GetTransaction` (`read_assembly.go:37/50`), `db.ParseTransaction`.
+- Produces: `func NewTransactionReader(reg *Registry, layout geometry.Layout, passphrase string) db.TransactionReader` (`db/transaction.go:51`, one method). Handler reuse: `methods.NewGetTransactionHandler(logger, txr, ledgerReader)`.
+
+**Semantics:** Per request: `Admit()` once; assemble `hot []txhash.HashIndex` from every `View.Hot` handle's `Txhash()` facade (**newest chunk first** — design probes hot first, definitive) and `cold []txhash.HashIndex` from `View.TxIdx` readers (**newest window first**); `LedgerSource` = adapter over `View.ResolveLedgers` that opens/closes per call and **skips candidates below the floor** by returning not-found for `seq < max(floor.FirstLedger(), earliest)` (design: R2 for by-hash lookups). Call `txhash.NewTxReader(hot, cold, src, passphrase).GetTransaction(hash)`; `found=false` → `db.ErrNoTransaction`; convert the returned `ingest.LedgerTransactionView` into `db.Transaction` — read `db.ParseTransaction` (`db/transaction.go`) and the `db.Transaction` struct (`:29`) and produce the same fields (result/envelope/meta XDR bytes, events, ledger info with close time).
+
+- [ ] **Step 1: Write failing tests.** Fixture needs tx-bearing ledgers: reuse the e2e tx builders (`e2e_test.go:49-50, 253` — keypair-signed envelopes hashed with the network passphrase; put shared helpers in `serve/fixtures_test.go` if Task 3 didn't already). Cover: hot hit (tx in live hot chunk); cold hit through a window `.idx` (build one with the backfill txindex path or `fhtest.ReadColdBin` fixtures — see how `e2e_test.go:386` opens a real `.idx`); miss → `db.ErrNoTransaction`; a candidate ledger below floor is skipped (probe returns not-found rather than serving pruned data).
+- [ ] **Step 2: Run, confirm failure.**
+- [ ] **Step 3: Implement** (~150 lines).
+- [ ] **Step 4: Run package tests.** Expected: PASS.
+- [ ] **Step 5: Commit** `fullhistory: db.TransactionReader adapter with hot/cold probe chain (query POC)`.
+
+---
+
+### Task 5: getEvents v2 handler
+
+**Files:**
+- Create: `cmd/stellar-rpc/internal/fullhistory/serve/events_handler.go`
+- Create: `cmd/stellar-rpc/internal/fullhistory/serve/events_handler_test.go`
+
+**Interfaces:**
+- Consumes: `Registry.Admit`, `View.ResolveEvents`, `eventstore.Query` (`query.go:179`), `eventstore.Filter` (`query.go:48`), `QueryOptions`/`EventIDRangeForLedgers` (`query.go:147/119`), protocol types `protocol.GetEventsRequest/Response/EventInfo/Cursor`, format helpers used by `methods/get_events.go:274-311` (xdr2json / base64).
+- Produces: `func NewGetEventsHandler(logger *log.Entry, reg *Registry, layout geometry.Layout, maxLimit, defaultLimit uint) jrpc2.Handler` — request/response wire-compatible with v1 `getEvents`.
+
+**Why not reuse v1:** `db.EventReader` is SQL-shaped (column-indexed topic filters, ScanFunction streaming); adapting it would reimplement a coordinator inside the adapter. New handler is smaller.
+
+**Semantics:**
+1. Validate request exactly as v1 does (read `methods/get_events.go:120-232` and mirror: limit bounds, start/cursor exclusivity, filter count limits, out-of-range errors carrying the available range).
+2. Admit once per page. Establish the scan window: from request `startLedger` or cursor+1 (cursor semantics identical to v1: `protocol.Cursor{Ledger,Tx,Op,Event}`, resume exclusive), capped at `LedgerScanLimit = 10000` ledgers (same constant semantics as `get_events.go:24`) and clamped to `[floor, latest]`.
+3. Translate protocol filters → `[]eventstore.Filter`: **first read `eventstore/query.go` filter-matching semantics and its tests** to map contract-ID sets and topic wildcards faithfully; if one protocol filter ORs N contract IDs, expand to N `eventstore.Filter`s. Event-type filtering: check whether `eventstore.Filter` carries type; if not, post-filter decoded payloads by type exactly as v1 does.
+4. Per chunk overlapping the window (ascending): `ResolveEvents` → `eventstore.Query(ctx, chunk.Reader(), filters, QueryOptions{MaxEvents: remaining, Range: EventIDRangeForLedgers(offsets, lo, hi)})`; map each `events.Payload` to `protocol.EventInfo` (cursor id, ledgerSeq, close time, txHash, format encoding via the same helpers v1 uses). Close each chunk handle.
+5. Page termination + response cursor/`latestLedger`/`oldestLedger` fields exactly as v1 (`get_events.go:219-260`).
+6. `// POC:` note that descending order is supported only if `QueryOptions.Descending` composes trivially; otherwise reject descending with a clear error and note it (v1 getEvents is ascending-only — verify against `protocol.GetEventsRequest` before deciding).
+
+- [ ] **Step 1: Write failing tests.** Fixture: hot + cold chunks with contract events (build on Task 2-4 fixtures; cold events artifacts via the same backfill freeze used in Task 3's fixture). Cover: filter match across the cold→hot seam in one page; pagination cursor resumes exclusively; limit truncation sets cursor; empty-match page still advances cursor; out-of-range start errors with available range; base64 and json formats.
+- [ ] **Step 2: Run, confirm failure.**
+- [ ] **Step 3: Implement** (~250 lines target).
+- [ ] **Step 4: Run package tests.** Expected: PASS.
+- [ ] **Step 5: Commit** `fullhistory: getEvents handler over eventstore.Query (query POC)`.
+
+---
+
+### Task 6: JSON-RPC server, config, metrics
+
+**Files:**
+- Create: `cmd/stellar-rpc/internal/fullhistory/serve/server.go`
+- Create: `cmd/stellar-rpc/internal/fullhistory/serve/server_test.go`
+- Modify: `cmd/stellar-rpc/internal/fullhistory/config/config.go` (+ its validate/test files)
+
+**Interfaces:**
+- Consumes: Tasks 3-5 constructors, `methods.NewGetLedgersHandler/NewGetTransactionsHandler/NewGetTransactionHandler`, `fullhistory.HealthSignal` (`health.go:14`), prometheus registry.
+- Produces:
+
+```go
+// config (strict TOML — every key must be declared):
+type ServeConfig struct {
+    Endpoint         string `toml:"endpoint"`           // "" = serving disabled (default)
+    MaxGetLedgersLimit ... // copy v1 defaults: getLedgers 200/50, getTransactions 200/50, getEvents 10000/100
+}
+// added to Config as `Serve ServeConfig `toml:"serve"``, with WithDefaults filling limits.
+
+package serve
+type ServerParams struct {
+    Registry   *Registry
+    Layout     geometry.Layout
+    Passphrase string
+    Health     HealthLike // interface{ Ready() bool; LastCommitClose() (time.Time, bool) } — or import the fullhistory type if no cycle; serve must NOT import the fullhistory root package (it imports serve). Define the tiny interface locally.
+    Metrics    *prometheus.Registry
+    Logger     *supportlog.Entry
+    Cfg        config.ServeConfig
+}
+func StartServer(ctx context.Context, p ServerParams) (addr net.Addr, shutdown func(), err error)
+```
+
+**Semantics:**
+- Mimic `internal/jsonrpc.go` minimally: `handler.Map{ "getLedgers": ..., "getTransactions": ..., "getTransaction": ..., "getEvents": ... }` → `jhttp.NewBridge` → `http.Server` on `cfg.Endpoint` (a `net.Listen` first so port `:0` works and `addr` is real). No CORS/queue-limiters. `// POC: no backlog/duration limiters — benchmark client controls load.`
+- Latency middleware: wrap each method handler recording into `prometheus.HistogramVec{Name: "fullhistory_rpc_request_duration_seconds", Labels: endpoint, status}` registered on `p.Metrics` — this is THE benchmark instrument; use buckets spanning 100µs–10s.
+- Mux: `/` → bridge; `/metrics` → `promhttp.HandlerFor(p.Metrics, ...)` (satisfies daemon.go:178 TODO); `/health` + `/ready` → from `p.Health` (200/503 JSON, same shape as the #839-era probes if any exist — keep trivial).
+- `StartServer` returns promptly; server goroutine exits on ctx cancel via `http.Server.Shutdown`.
+
+- [ ] **Step 1: Write failing tests**: config round-trip (TOML with `[serve]` parses; unknown key still fails strict; defaults fill); `StartServer` on `127.0.0.1:0` → real JSON-RPC `getLedgers` POST over HTTP against a small fixture registry returns a valid response; `/metrics` contains `fullhistory_rpc_request_duration_seconds` after one request; `/ready` flips with a fake HealthLike.
+- [ ] **Step 2: Run, confirm failure.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Run package + config tests.** Expected: PASS.
+- [ ] **Step 5: Commit** `fullhistory: [serve] JSON-RPC server with per-endpoint latency metrics (query POC)`.
+
+---
+
+### Task 7: Daemon wiring + end-to-end test
+
+**Files:**
+- Modify: `cmd/stellar-rpc/internal/fullhistory/hotloop.go` (hooks), `startup.go` (BuildInitial + HotOpened for the resume DB), `lifecycle/lifecycle.go` (post-tick observer in `Config`), `daemon.go` (build Registry when `[serve].endpoint != ""`, wire real ServeReads, pass hooks, plumb passphrase from the peek at daemon.go:413-459 — error out if serving enabled and passphrase empty)
+- Create: `cmd/stellar-rpc/internal/fullhistory/serve_e2e_test.go`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: hook seams —
+  - `ingestionLoopConfig` gains `Serving servingHooks` where `type servingHooks interface { LedgerCommitted(uint32); HotOpened(chunk.ID, *hotchunk.DB); ChunkClosed(chunk.ID) }` defined in package `fullhistory`; `*serve.Registry` satisfies it; nil-safe nop default so every existing test compiles unchanged.
+  - `lifecycle.Config` gains `TickObserver interface{ TickCompleted() }` (defined in `lifecycle`), called after each successful `runLifecycle`.
+  - `daemonOptions` gains a test seam `serveAddr func(net.Addr)` invoked with the bound address.
+
+**Hook call sites (exact):**
+- `hotloop.go:157` (after `metrics.LastCommitted(seq)`): `cfg.Serving.LedgerCommitted(seq)`.
+- `hotloop.go:173` (immediately **after** `hotDB.Close()`, before `openHotDBForChunk`): `cfg.Serving.ChunkClosed(closed)`. Do not reorder the fence.
+- `hotloop.go:180` (after `hotDB = nextDB`): `cfg.Serving.HotOpened(next, nextDB)` — before `Boundary.Publish` so the View serves the new chunk before `latest` can enter it (design ordering rule).
+- `startup.go`: after the resume hot DB opens and before `cfg.ServeReads(ctx)` at `:131`: `registry.HotOpened(resumeChunk, hotDB)` then `registry.BuildInitial(lastCommitted)`; `ServeReads` closure (built in daemon.go) calls `serve.StartServer` and returns.
+- `lifecycle.go` end of successful tick: `cfg.TickObserver.TickCompleted()`.
+
+- [ ] **Step 1: Write the failing e2e test** `TestServeE2E_QueryHotAndCold` modeled on `e2e_test.go:209` `runDaemonInBackground`: config with `[serve] endpoint="127.0.0.1:0"`, tx+event-bearing synthetic ledgers spanning ≥1 full chunk + a partial live chunk (so freeze produces cold artifacts while hot keeps ingesting; reuse `chunksPerTxhashIndex: 1` trick from e2e for a quick `.idx`). Then over real HTTP JSON-RPC: (a) `getLedgers` page spanning the cold→hot seam; (b) `getTransaction` for a hash in the cold chunk AND one in the live chunk; (c) `getTransactions` across the seam with cursor continuation; (d) `getEvents` filter matching events in both tiers; (e) negative: `getLedgers` below the floor errors with available range; unknown tx hash → NotFound. Poll `/ready` before querying. Keep the whole test `-short`-safe within the existing budget patterns (see e2e budget notes — generous `require.Eventually` budgets, no hardcoded tight deadlines).
+- [ ] **Step 2: Run, confirm failure** (hooks/wiring absent).
+- [ ] **Step 3: Implement the wiring.** Keep diffs to `hotloop.go`/`startup.go`/`lifecycle.go` minimal (hook lines only); the invariant comments there are load-bearing — extend, don't rewrite.
+- [ ] **Step 4: Run the FULL fullhistory tree** `-short -count=1` with CGO flags (gate on exit code). Expected: all green including the new e2e.
+- [ ] **Step 5: Commit** `fullhistory: wire serve registry into daemon + query e2e (query POC)`.
+
+---
+
+### Task 8: Benchmark harness + runbook
+
+**Files:**
+- Create: `tools/fhbench/main.go` (single-file CLI, module already covers it via root go.mod — verify; if tools/ isn't in the module, put it at `cmd/stellar-rpc/internal/fullhistory/fhbench/` as `package main` is not allowed under internal for external use — then prefer `tools/`)
+- Create: `tools/fhbench/README.md`
+
+**Interfaces:**
+- Consumes: only the HTTP JSON-RPC API + `/metrics`. Plain `net/http` + `encoding/json`; no new deps.
+- Produces: CLI:
+  ```
+  fhbench --url http://host:port --endpoint getLedgers|getTransaction|getTransactions|getEvents|all \
+          --tier hot|cold|both --concurrency 8 --duration 60s --limit 50
+  ```
+
+**Semantics:**
+- Discovery phase: one `getLedgers` (limit 1) to learn `oldestLedger`/`latestLedger`. Define tiers: **hot** = last `chunk-size/2` ledgers before latest; **cold** = the oldest full chunk ≥ oldest. Sample tx hashes per tier via `getTransactions` pages before timing starts.
+- Load phase: N workers, each a closed loop issuing randomized requests within the tier (random start ledger for range endpoints, random sampled hash for getTransaction, rotating event filters incl. no-filter). Record per-request wall time + status.
+- Report: per endpoint × tier — count, RPS, p50/p90/p99/max (sorted-slice quantiles, no deps), error count. Plain text table.
+- README: how to run the daemon with `[serve]`, how to run fhbench, and the PromQL for ingestion numbers (`rate(fullhistory_streaming_last_committed_ledger[1m])` style — verify metric names from `observability.go`) + per-endpoint latency histograms.
+
+- [ ] **Step 1: Write a failing smoke test** `tools/fhbench/main_test.go`: run the sampler + report path against an `httptest.Server` stubbing the RPC responses; assert quantile math on a known latency set.
+- [ ] **Step 2: Run, confirm failure. Step 3: Implement. Step 4: Test + `go vet`. Expected: PASS.**
+- [ ] **Step 5: Commit** `fullhistory: fhbench query benchmark harness (query POC)`.
+
+---
+
+### Task 9: Final review gate
+
+- [ ] Opus-review findings from Tasks 1-8 all addressed (each task got an opus review before merge-forward).
+- [ ] Full tree: `go build ./...`, `go vet ./...`, fullhistory tree `-short` green, `golangci-lint` clean on the diff (repo lint: build v2.11.3 with go1.26, `--new-from-rev origin/feature/full-history`, gofumpt).
+- [ ] Fable (max-effort) end-to-end review of the cumulative diff vs this plan + design doc: admission ordering, fence preservation, borrowed-bytes copying, error taxonomy, POC markers present.
+- [ ] Fix anything CONFIRMED; re-run tests; final commit.
+
+## Self-review notes
+
+- Spec coverage: registry/View/admission (T2), hot ownership + boundary continuity (T1/T2/T7), all four endpoints (T3-T5), R2 floor gating (T3 ranges, T4 by-hash skip, T5 clamp), server+metrics for benchmarking (T6), ingestion+query benchmark numbers (T8), reaper consciously replaced by close-guard/leak rules (T2, marked). Open design questions resolved for POC: datastore fallback dropped, chunk-aligned floor, sequential probe, no cache sizing.
+- Known intentional gaps (all `// POC:` marked): no reaper grace period (rocksdb close-guard + leaked idx mmaps instead), no request duration limits, no CORS, descending getEvents per T5 note, unused LedgerReader methods stubbed.

--- a/tools/bench-suite/README.md
+++ b/tools/bench-suite/README.md
@@ -1,0 +1,70 @@
+# Full-history benchmark suite
+
+How to reproduce the profile-based ingestion benchmark report (the sac / token /
+soroswap synthetic apply-load run shown at
+<https://stellar-experimental.github.io/stellar-rpc-benchmarks>).
+
+The pipeline is three stages; only stage 2 lives here.
+
+| Stage | What | Where |
+| --- | --- | --- |
+| 1. Generate synthetic apply-load pack trees per profile | `{bucket:05d}/{chunk:08d}.pack` per profile | external apply-load campaign (not in this repo) |
+| 2. Run `bench-ingest cold\|hot` per profile × 5 reps → CSVs | [`run-ingest-suite.sh`](./run-ingest-suite.sh) | **here** |
+| 3. Convert CSVs → report JSON, publish | `make convert` / `ingest.yml` | `stellar-experimental/stellar-rpc-benchmarks` |
+
+## Stage 2 — run the suite
+
+Build the binary, then run the loop against your pack trees:
+
+```sh
+go build -o /usr/local/bin/stellar-rpc ./cmd/stellar-rpc   # needs cgo + RocksDB
+PACKS_ROOT=/data/packs INSTANCE_TYPE=m6id.2xlarge \
+  SAC_CHUNK=<c> TOKEN_CHUNK=<c> SOROSWAP_CHUNK=<c> \
+  ./tools/bench-suite/run-ingest-suite.sh
+```
+
+Set each profile's pack dir + chunk id via `PACKS_ROOT` / `<PROFILE>_CHUNK` (or
+edit the `PROFILES` array in the script). A full run is a multi-hour campaign —
+one hot run ingests a whole 10k-ledger chunk with a synced WriteBatch per ledger.
+For a quick shape check first: `NUM_LEDGERS=500 REPS=1 ./run-ingest-suite.sh`.
+
+The script produces exactly the layout the converter discovers by directory name:
+
+```
+<OUT>/synth-cold-<profile>-run<N>/  driver.csv ledgers.csv txhash.csv events.csv
+<OUT>/synth-hot-<profile>-run<N>/   driver.csv hot.csv
+<OUT>/machine-metadata.txt
+```
+
+Every CSV row is `stage,n,n_items,total_ns,p50_ns,p90_ns,p99_ns,max_ns`:
+
+- **cold** `ledgers`/`txhash`/`events`: per-stage (`term_index`/`write`/`finalize`);
+  `driver`: `backfill_wall`, `index_rebuild`, `chunk_total`, `<type>_total`, `cold_extract`.
+- **hot** `hot.csv`: per-ledger phases (`extract`, `ledgers`, `txhash`, `events`,
+  `commit`, `apply`); `driver`: `ingest_total`, `run_wall`.
+
+## Stage 3 — convert + view
+
+In a checkout of `stellar-rpc-benchmarks`:
+
+```sh
+make convert RESULTS=<OUT> RUN_ID=synthetic-YYYY-MM-DD \
+  RUN_NAME="Synthetic apply-load — sac/token/soroswap" \
+  KIND=synthetic RUN_DATE=YYYY-MM-DD \
+  FACTS=converter/facts/<sidecar>.json
+make serve   # http://localhost:8000
+```
+
+`--unit-facts` is the per-profile sidecar (model / tps / tx-per-ledger / pack size
+/ display order) — the CSVs don't carry it. Copy an existing
+`converter/facts/synthetic-*.json` as a template. Every reported number is the
+median across the 5 reps; percentiles are per-run, never averaged across reps.
+
+## Not covered here
+
+- **Query benchmarks in the report.** The converter's `queries` section consumes a
+  `bench-query cold|hot` subcommand (tracked in #856), which is not on this branch.
+  This branch has the standalone query harness [`tools/fhbench`](../fhbench) and the
+  in-process ingest→query latency test (`TestServeE2E_IngestToQueryLatency`) instead;
+  neither feeds the report format yet.
+- **Stage 1 pack generation** (the apply-load workloads) — external tooling.

--- a/tools/bench-suite/results/fullhistory-latency-2026-07-16/README.md
+++ b/tools/bench-suite/results/fullhistory-latency-2026-07-16/README.md
@@ -1,0 +1,131 @@
+# Full-history ingest + query latency — 2026-07-16
+
+Latency of the `full-history` daemon (branch `poc/fullhistory-query`) on the three
+synthetic apply-load profiles (**sac / token / soroswap**), measured on **real**
+profile ledgers — both the **hot** serving tier (RocksDB) and the **cold** tier
+(frozen `.pack` + MPHF/bitmap index artifacts).
+
+- **Machine:** AWS `c6id.8xlarge` — Intel Xeon Platinum 8375C, 32 vCPU, 64 GiB, local NVMe.
+- **Harness:** `TestServeE2E_ProfileLatency` (hot) and `TestServeE2E_ColdQueryLatency` (cold)
+  in `cmd/stellar-rpc/internal/fullhistory`; direct read via `BenchmarkHotGetLedgerRaw`
+  in `.../storage/stores/ledger`. Driver: [`../../run-e2e-latency-suite.sh`](../../run-e2e-latency-suite.sh).
+- **Window:** 20 steady-state ledgers (chunk 1, ledgers 10202–10221) after a
+  200-ledger warmup skip (the chunk head is contract-deploy warmup, far lighter
+  than steady state). Query pass: 500 reps/endpoint, `getLedgers` at `limit=1`,
+  per-endpoint 45 s wall budget.
+- Raw data: [`latency.csv`](./latency.csv). Report: [`report.html`](./report.html).
+
+## Ledger characteristics (steady-state, per ledger)
+
+These synthetic ledgers are large — thousands of tx + Soroban meta each.
+
+| profile | decompressed LCM | on-disk (zstd) | compression |
+|---|--:|--:|--:|
+| sac | ~17.3 MB | ~2.1 MB | ~8.2× |
+| token | ~16.5 MB | ~1.7 MB | ~9.5× |
+| soroswap | ~10.0 MB | ~0.5 MB | ~19× |
+
+## Ingest → query (source → durable commit), per ledger
+
+| profile | p50 | p90 | p99 |
+|---|--:|--:|--:|
+| sac | 129.3 ms | 138.9 ms | 145.3 ms |
+| token | 129.9 ms | 133.6 ms | 144.7 ms |
+| soroswap | 76.7 ms | 82.6 ms | 85.4 ms |
+
+## Query latency — HOT tier (ms)
+
+`getLedgers` at `limit=1`; getTransaction/getEvents 500 reps. 0 errors throughout.
+`getLedgers` is budget-capped (`count` = reps that fit the 45 s budget).
+
+| profile | endpoint | count | p50 | p90 | p99 | max |
+|---|---|--:|--:|--:|--:|--:|
+| sac | getLedgers | 80 | 567.4 | 581.8 | 607.6 | 607.6 |
+| sac | getTransaction | 500 | 18.1 | 19.2 | 25.4 | 28.9 |
+| sac | getEvents | 500 | 7.8 | 8.0 | 12.0 | 12.6 |
+| token | getLedgers | 82 | 550.8 | 557.7 | 570.6 | 570.6 |
+| token | getTransaction | 500 | 18.2 | 19.5 | 24.8 | 26.8 |
+| token | getEvents | 500 | 7.5 | 7.9 | 10.0 | 13.6 |
+| soroswap | getLedgers | 127 | 355.8 | 363.8 | 370.6 | 375.3 |
+| soroswap | getTransaction | 500 | 11.6 | 12.5 | 17.6 | 19.8 |
+| soroswap | getEvents | 500 | 4.4 | 5.5 | 8.0 | 8.6 |
+
+## Query latency — COLD tier (sac; ms)
+
+Served from frozen cold artifacts. Only sac had a servable daemon catalog on the
+box (token/soroswap have cold artifacts but bench-ingest discarded their catalogs).
+
+| endpoint | tier | count | p50 | p90 | p99 | max |
+|---|---|--:|--:|--:|--:|--:|
+| getLedgers | hot | 80 | 567.4 | 581.8 | 607.6 | 607.6 |
+| getLedgers | **cold** | 71 | 641.3 | 664.4 | 685.4 | 685.4 |
+| getTransaction | hot | 500 | 18.1 | 19.2 | 25.4 | 28.9 |
+| getTransaction | **cold** | 500 | 17.7 | 30.0 | 38.7 | 45.7 |
+| getEvents | hot | 500 | 7.8 | 8.0 | 12.0 | 12.6 |
+| getEvents | **cold** | 500 | 6.2 | 8.4 | 9.5 | 12.7 |
+
+**Cold serves ≈ as fast as hot.** getEvents cold is even slightly faster at p50;
+getTransaction has a heavier cold tail (cold txhash MPHF lookup + reading the large
+ledger from the cold pack). (Cold reads here are page-cache-warm.)
+
+## Direct in-process read (no serve path)
+
+Isolates the storage read from base64/JSON/HTTP. `store.Get` is the RocksDB point
+read (compressed value); `GetLedgerRaw` adds the zstd decode.
+
+| profile | `store.Get` (compressed) | hot `GetLedgerRaw` (Get + decode) | cold `GetLedgerRaw` (pack + decode) |
+|---|--:|--:|--:|
+| sac | 0.63 ms | 8.2 ms | 7.9 ms |
+| token | 0.62 ms | 7.4 ms | 7.3 ms |
+| soroswap | 0.16 ms | 4.6 ms | 3.7 ms |
+
+## End-to-end (synthesized: ingest + query, same percentile)
+
+| profile | endpoint | e2e p50 | e2e p99 |
+|---|---|--:|--:|
+| sac | getLedgers | ~696.7 ms | ~752.9 ms |
+| sac | getTransaction | ~147.4 ms | ~170.7 ms |
+| sac | getEvents | ~137.1 ms | ~157.3 ms |
+| token | getLedgers | ~680.7 ms | ~715.3 ms |
+| token | getTransaction | ~148.1 ms | ~169.5 ms |
+| token | getEvents | ~137.4 ms | ~154.7 ms |
+| soroswap | getLedgers | ~432.5 ms | ~456.0 ms |
+| soroswap | getTransaction | ~88.3 ms | ~103.0 ms |
+| soroswap | getEvents | ~81.1 ms | ~93.4 ms |
+
+(Summing per-stage percentiles is a conservative upper bound; commit→queryable is
+treated as negligible — the design's visibility window is ~1–2 ms.)
+
+## Key findings
+
+1. **Ingest dominates the targeted endpoints.** getTransaction/getEvents add only
+   ~4–18 ms on top of the ~77–130 ms ingest leg.
+2. **getLedgers is the outlier — and it's payload-bound, not read-bound.** A direct
+   hot read (incl. zstd decode) is ~8 ms, but getLedgers over HTTP is ~567 ms:
+   **~1.4 % is the read, ~98.6 % is base64 + JSON + HTTP shipping the 10–17 MB
+   ledger.** Decompression (~6–8 ms) is cheap; the size of what's shipped is the cost.
+   `limit=1` vs `limit=5` scales ~5× linearly, confirming size-bound.
+3. **Cold ≈ hot.** For this POC the cold tier serves at essentially hot-tier latency
+   across all three endpoints (getTransaction has a somewhat heavier cold tail).
+4. **Reference — toy baseline** (1-tx/1-event synthetic ledger): full src→query
+   ~4.5 ms, ingest ~3.0 ms, visible ~1.5 ms. ~40× lighter than real steady-state
+   ingest — do not read it as a production number.
+
+### Where to spend on getLedgers (size-bound, not read-bound)
+
+1. Cap the default/max page size (`[serve].default_ledgers_limit` / `max_ledgers_limit`).
+2. Transport compression (gzip/zstd `Content-Encoding`) — base64'd XDR is highly compressible.
+3. Stream the base64 encoder instead of materializing the full string per ledger.
+4. Lighter projection (header-only / opt-out of full meta) — the only way to avoid shipping the blob.
+5. ~~Storage-read tuning~~ — the read is ~1 %; not worth it.
+
+## Caveats
+
+- Percentiles are nearest-rank. `getLedgers` p99 is over the budget-capped sample
+  count (71–127), less robust than the 500-rep getTransaction/getEvents p99s.
+- Cold reads are OS-page-cache-warm (pack touched during harvest); an uncached
+  first-touch adds disk latency.
+- The per-ledger ingest→query *visibility* (commit→query) span is not reported for
+  the real profiles: under heavy ingestion the single sequential poller can't stay
+  at the commit frontier, so that span measures poller lag, not true visibility.
+  `ingest` (in-process timestamps) and the query-latency pass are the reliable metrics.

--- a/tools/bench-suite/results/fullhistory-latency-2026-07-16/README.md
+++ b/tools/bench-suite/results/fullhistory-latency-2026-07-16/README.md
@@ -13,7 +13,16 @@ profile ledgers — both the **hot** serving tier (RocksDB) and the **cold** tie
   200-ledger warmup skip (the chunk head is contract-deploy warmup, far lighter
   than steady state). Query pass: 500 reps/endpoint, `getLedgers` at `limit=1`,
   per-endpoint 45 s wall budget.
-- Raw data: [`latency.csv`](./latency.csv). Report: [`report.html`](./report.html).
+- Raw data: [`latency.csv`](./latency.csv) and [`termsweep.csv`](./termsweep.csv).
+  Report: [`report.html`](./report.html).
+- **Two runs, same day/box/method.** Run 1 is the original upload. Run 2 (a few
+  hours later, after a methodology review of the harnesses) adds: (a) cold-tier
+  coverage for **token/soroswap** (their catalogs were frozen via
+  `TestServeProfileForBench`; freeze wall-clock: token 6m19s, soroswap 4m15s,
+  sac 11m10s in run 1), (b) the **getEvents OR-union index-term sweep**
+  (1/4/8/15 terms, hot & cold), and (c) a **reproduction check** of run 1's hot
+  and sac-cold rows. Run-1 numbers are preserved below unchanged; run-2 tables
+  are marked as such.
 
 ## Ledger characteristics (steady-state, per ledger)
 
@@ -50,10 +59,11 @@ These synthetic ledgers are large — thousands of tx + Soroban meta each.
 | soroswap | getTransaction | 500 | 11.6 | 12.5 | 17.6 | 19.8 |
 | soroswap | getEvents | 500 | 4.4 | 5.5 | 8.0 | 8.6 |
 
-## Query latency — COLD tier (sac; ms)
+## Query latency — COLD tier (run 1: sac only; ms)
 
-Served from frozen cold artifacts. Only sac had a servable daemon catalog on the
-box (token/soroswap have cold artifacts but bench-ingest discarded their catalogs).
+Served from frozen cold artifacts. At run-1 time only sac had a servable daemon
+catalog on the box (token/soroswap had cold artifacts but bench-ingest discarded
+their catalogs — run 2 below fixed that by re-freezing them).
 
 | endpoint | tier | count | p50 | p90 | p99 | max |
 |---|---|--:|--:|--:|--:|--:|
@@ -64,9 +74,83 @@ box (token/soroswap have cold artifacts but bench-ingest discarded their catalog
 | getEvents | hot | 500 | 7.8 | 8.0 | 12.0 | 12.6 |
 | getEvents | **cold** | 500 | 6.2 | 8.4 | 9.5 | 12.7 |
 
-**Cold serves ≈ as fast as hot.** getEvents cold is even slightly faster at p50;
-getTransaction has a heavier cold tail (cold txhash MPHF lookup + reading the large
-ledger from the cold pack). (Cold reads here are page-cache-warm.)
+**Cold serves ≈ as fast as hot** for these endpoints. getEvents cold is even
+slightly faster at p50; getTransaction has a heavier cold tail (cold txhash MPHF
+lookup + reading the large ledger from the cold pack). (Cold reads here are
+page-cache-warm.) **Scope note (run 2):** this "cold ≈ hot" holds for
+getLedgers/getTransaction generally and for getEvents whose filters match
+*densely* (sac/token). getEvents with *selective* filters on a contract-diverse
+profile diverges — see the term sweep below.
+
+## Query latency — COLD tier, all profiles (run 2; ms)
+
+Same window/method as run 1, after freezing token/soroswap catalogs. sac rows
+re-measure run 1 (reproduction).
+
+| profile | endpoint | count | p50 | p90 | p99 | max |
+|---|---|--:|--:|--:|--:|--:|
+| sac | getLedgers | 73 | 617.2 | 653.1 | 671.0 | 671.0 |
+| sac | getTransaction | 500 | 18.3 | 31.7 | 40.3 | 43.3 |
+| sac | getEvents | 500 | 8.8 | 10.5 | 14.4 | 14.9 |
+| token | getLedgers | 74 | 604.9 | 638.9 | 664.0 | 664.0 |
+| token | getTransaction | 500 | 16.0 | 25.4 | 34.0 | 41.5 |
+| token | getEvents | 500 | 3.4 | 4.2 | 4.9 | 5.4 |
+| soroswap | getLedgers | 109 | 415.4 | 433.9 | 449.5 | 451.6 |
+| soroswap | getTransaction | 500 | 11.7 | 18.9 | 25.4 | 26.5 |
+| soroswap | getEvents | 500 | 18.9 | 22.8 | 24.8 | 27.3 |
+
+Cross-checked black-box with fhbench against the whole frozen chunk
+(mid-chunk-sampled tx hashes, concurrency 1, 30 s): getTransaction cold p50
+sac 17.5 / token 16.3 / soroswap 10.8 ms; getLedgers(limit=1) cold p50
+sac 624.8 / token 595.2 / soroswap 390.6 ms — all within ~5 % of the harness
+rows above. The soroswap cold getEvents row (18.9 vs 4.7 ms hot) is the
+selective-filter effect: its harvested contract is one of many, so matches are
+sparse and the scan hits the POC's underfill re-query loop (next section).
+
+## getEvents OR-union index-term sweep (run 2; p50/p90/p99 ms)
+
+A *term* is one indexed constraint — a distinct contract ID, or a distinct topic
+value at a position (0–2) — exactly the eventstore index's term model. Each row
+OR-unions N real harvested terms (homogeneous filters, ≤5 per filter) over the
+20-ledger steady-state window (500 reps, limit 10). `chunk` rows are fhbench
+runs with random starts over the whole 10 000-ledger frozen chunk (30 s each).
+Full data: [`termsweep.csv`](./termsweep.csv).
+
+| profile | tier·scope | t=1 | t=4 | t=8 | t=15 |
+|---|---|--:|--:|--:|--:|
+| sac | hot·window | 8.4 / 9.7 / 11.4 | 8.4 / 9.0 / 10.8 | 8.5 / 9.1 / 11.1 | 6.8 / 7.8 / 11.4 |
+| sac | cold·window | 8.4 / 10.4 / 13.4 | 8.6 / 10.7 / 12.8 | 6.6 / 9.2 / 11.9 | 8.7 / 10.5 / 14.1 |
+| sac | cold·chunk | 8.0 / 12.2 / 14.0 | 8.4 / 12.4 / 15.3 | 8.5 / 12.6 / 14.7 | 8.4 / 12.8 / 15.5 |
+| token | hot·window | 7.6 / 7.9 / 11.9 | 6.2 / 7.7 / 8.6 | 7.5 / 7.8 / 10.2 | 7.7 / 7.9 / 12.4 |
+| token | cold·window | 3.4 / 4.2 / 4.9 | 5.1 / 6.1 / 7.1 | 8.1 / 13.2 / 15.4 | 16.9 / 19.6 / 22.0 |
+| token | cold·chunk | 4.4 / 5.9 / 7.2 | 6.7 / 8.1 / 9.5 | 8.9 / 11.6 / 13.4 | 16.5 / 18.9 / 21.8 |
+| soroswap | hot·window | 4.2 / 4.7 / 5.9 | 4.3 / 6.3 / 7.8 | 6.1 / 6.8 / 7.7 | 6.1 / 6.7 / 7.3 |
+| soroswap | cold·window | 9.5 / 12.8 / 16.4 | 52.7 / 60.0 / 67.0 | 98.5 / 115.7 / 129.6 | 137.2 / 150.2 / 158.3 |
+| soroswap | cold·chunk | 12.4 / 15.6 / 18.3 | 47.1 / 55.4 / 61.6 | 101.2 / 114.5 / 128.2 | 181.2 / 205.4 / 220.3 |
+
+What the sweep shows:
+
+1. **Hot is flat everywhere** (~4–9 ms for 1→15 terms, all profiles): term count
+   costs almost nothing on the hot tier at this window size.
+2. **Cold is flat when terms match densely.** sac's vocabulary is one match-all
+   contract + topics of ubiquitous transfer events, so every union fills the
+   10-event page from the first candidate ledger: ~8 ms regardless of N, window
+   or whole chunk.
+3. **Cold scales with term count when terms are selective.** token: 3.4→16.9 ms
+   (window) and 4.4→16.5 ms (chunk) across 1→15 terms — ≈1 ms/term. soroswap
+   (many contracts, diverse topics — the most selective vocabulary): 9.5→137 ms
+   (window) and 12.4→181 ms (chunk), ≈12 ms/term.
+4. **Why cold diverges from hot:** hot and cold share the same bitmap-driven
+   `eventstore.Query`; the cold reader, however, is opened *per request* (POC —
+   no LRU) and sparse matches trigger the POC's underfill loop in
+   `events_handler.scanChunk`, which re-queries the chunk from scratch with a
+   doubling cap until the page fills or the window is provably exhausted. Dense
+   matches (sac, or few terms on token) never enter the loop; selective unions
+   re-query repeatedly. Both are known POC costs with named productionization
+   paths (LRU'd cold readers; a streaming pager that advances a pinned event-ID
+   cursor instead of re-querying).
+5. Window and chunk sweeps agree closely everywhere, so the curve is a property
+   of term selectivity + the underfill loop, not of scan-span length.
 
 ## Direct in-process read (no serve path)
 
@@ -105,9 +189,16 @@ treated as negligible — the design's visibility window is ~1–2 ms.)
    **~1.4 % is the read, ~98.6 % is base64 + JSON + HTTP shipping the 10–17 MB
    ledger.** Decompression (~6–8 ms) is cheap; the size of what's shipped is the cost.
    `limit=1` vs `limit=5` scales ~5× linearly, confirming size-bound.
-3. **Cold ≈ hot.** For this POC the cold tier serves at essentially hot-tier latency
-   across all three endpoints (getTransaction has a somewhat heavier cold tail).
-4. **Reference — toy baseline** (1-tx/1-event synthetic ledger): full src→query
+3. **Cold ≈ hot — for getLedgers, getTransaction, and dense-match getEvents.**
+   The cold tier serves those at essentially hot-tier latency (getTransaction has
+   a somewhat heavier cold tail). Run 2 confirms this on all three profiles.
+4. **The exception (run 2): selective multi-term getEvents on cold.** OR-unions
+   of genuinely selective terms scale with term count on the cold tier (token
+   ≈1 ms/term; soroswap ≈12 ms/term, 15 terms ≈ 137–181 ms) while hot stays flat
+   (~4–9 ms). Cause: per-request cold-reader open + the POC underfill re-query
+   loop (see the term-sweep section). Known POC costs; productionization paths
+   are an LRU for cold readers and a streaming pager.
+5. **Reference — toy baseline** (1-tx/1-event synthetic ledger): full src→query
    ~4.5 ms, ingest ~3.0 ms, visible ~1.5 ms. ~40× lighter than real steady-state
    ingest — do not read it as a production number.
 
@@ -119,6 +210,55 @@ treated as negligible — the design's visibility window is ~1–2 ms.)
 4. Lighter projection (header-only / opt-out of full meta) — the only way to avoid shipping the blob.
 5. ~~Storage-read tuning~~ — the read is ~1 %; not worth it.
 
+## Run-2 reproduction check (run 1 vs run 2, p50 ms)
+
+Re-running the identical hot pass a few hours later (fresh daemon, fresh temp
+store) reproduces run 1 closely — the committed numbers are stable, not
+one-off artifacts:
+
+| metric | run 1 | run 2 | metric | run 1 | run 2 |
+|---|--:|--:|---|--:|--:|
+| sac ingest | 129.3 | 127.6 | sac hot getLedgers | 567.4 | 567.0 |
+| token ingest | 129.9 | 122.8 | token hot getLedgers | 550.8 | 548.7 |
+| soroswap ingest | 76.7 | 80.2 | soroswap hot getLedgers | 355.8 | 355.9 |
+| sac hot getTransaction | 18.1 | 18.5 | sac hot getEvents | 7.8 | 6.8 |
+| sac cold getLedgers | 641.3 | 617.2 | sac cold getEvents | 6.2 | 8.8 |
+
+Largest deltas ≈ ±5 % (single-digit percent run-to-run noise on a shared box);
+sac cold getEvents ±~2.5 ms is page-cache/alloc noise at single-ledger-decode
+scale.
+
+## Methodology review (run 2)
+
+The harness logic was reviewed before run 2; the e2e-harness methodology behind
+run 1's tables held up (in-process ingest timestamps, dense closed-loop query
+pass, nearest-rank percentiles, direct-read isolation, warmup skip). Fixes were
+applied to **tools/fhbench** — none of which invalidate run-1 numbers, which
+came from the e2e harness, not fhbench:
+
+- **Hot tier could bleed into the frozen chunk**: with fewer than a half-chunk
+  of hot ledgers above the last frozen chunk, fhbench's "hot" tier reached into
+  cold-served ledgers. It now clamps to the chunk containing `latest`.
+- **Off-by-one**: non-sweep getEvents used an exclusive `endLedger = tier.last`,
+  silently dropping the tier's last ledger (and producing empty-window freebies
+  when `startLedger == tier.last`).
+- **Errored requests** were included in latency percentiles; now tallied
+  separately and excluded.
+- **Head-biased sampling**: tx hashes and the event-term vocabulary were sampled
+  from the tier head — the deploy-warmup region on these profiles. Both now
+  sample from the tier midpoint. (Measured impact: head-sampled soroswap cold
+  getTransaction read 2.7 ms p50 vs the representative 10.8 ms.)
+- **Term-count cap**: >21 OR-union terms can exceed the protocol's 5-filter cap
+  for mixed contract/topic vocabularies; now rejected up front (docs previously
+  claimed 25).
+- Also documented: `TestServeProfileForBench`'s hot tier is **synthetic 1-tx
+  filler** (it exists to latch `/ready`); fhbench hot-tier rows against that
+  harness are not representative of real-profile hot serving — the e2e hot
+  harness (real ledgers live-ingested) is, and is what all hot tables here use.
+  `run-query-suite.sh` also gained `GETLEDGERS_LIMIT=1` (limit 50 × 8 workers ×
+  10–17 MB ledgers ≈ >8 GB in flight — the likely cause of the earlier
+  query-suite OOM/kill mid `getLedgers cold`).
+
 ## Caveats
 
 - Percentiles are nearest-rank. `getLedgers` p99 is over the budget-capped sample
@@ -129,3 +269,8 @@ treated as negligible — the design's visibility window is ~1–2 ms.)
   the real profiles: under heavy ingestion the single sequential poller can't stay
   at the commit frontier, so that span measures poller lag, not true visibility.
   `ingest` (in-process timestamps) and the query-latency pass are the reliable metrics.
+- All query passes are sequential closed-loop (concurrency 1): these are
+  unloaded-latency floors, not latency under concurrent load.
+- The term-sweep curve depends on the harvested vocabulary's selectivity, which
+  is a property of the profile (sac: one match-all contract; soroswap: many).
+  Real-network vocabularies will sit between these extremes.

--- a/tools/bench-suite/results/fullhistory-latency-2026-07-16/latency.csv
+++ b/tools/bench-suite/results/fullhistory-latency-2026-07-16/latency.csv
@@ -31,3 +31,23 @@ soroswap,cold,read_getledgerraw,-,3.685,,,,,decoded ~10.0MB
 toy,hot,visibility_full,-,4.500,,4.744,,10,source->query
 toy,hot,visibility_ingest,-,3.035,,,,10,source->commit
 toy,hot,visibility_visible,-,1.500,,1.775,,10,commit->query
+# ===================== run 2 (2026-07-16, later the same day) =====================
+# Same box/method/window, sweep-extended harness. token/soroswap catalogs were
+# frozen via TestServeProfileForBench (freeze wall: token 6m19s, soroswap 4m15s,
+# sac run-1 11m10s), unblocking their cold tiers. sac rows re-measure run 1 as a
+# reproduction check. Term-sweep data: see termsweep.csv.
+sac,hot,query,getLedgers,566.999,577.826,593.944,593.944,80,run2 repro of run1
+sac,hot,query,getTransaction,18.490,19.188,26.846,30.103,500,run2 repro of run1
+sac,hot,query,getEvents,6.802,8.152,12.198,13.692,500,run2 repro of run1
+sac,-,ingest,-,127.563,140.723,175.259,175.259,20,run2 repro of run1
+token,-,ingest,-,122.765,128.778,132.615,132.615,20,run2 repro of run1
+soroswap,-,ingest,-,80.211,84.254,87.290,87.290,20,run2 repro of run1
+sac,cold,query,getLedgers,617.248,653.133,671.021,671.021,73,run2 repro of run1
+sac,cold,query,getTransaction,18.322,31.725,40.315,43.309,500,run2 repro of run1
+sac,cold,query,getEvents,8.788,10.541,14.392,14.942,500,run2 repro of run1
+token,cold,query,getLedgers,604.933,638.877,663.991,663.991,74,run2; new cold catalog
+token,cold,query,getTransaction,15.997,25.438,33.990,41.462,500,run2; new cold catalog
+token,cold,query,getEvents,3.386,4.166,4.880,5.378,500,run2; new cold catalog
+soroswap,cold,query,getLedgers,415.400,433.864,449.496,451.625,109,run2; new cold catalog
+soroswap,cold,query,getTransaction,11.686,18.918,25.383,26.529,500,run2; new cold catalog
+soroswap,cold,query,getEvents,18.921,22.768,24.798,27.314,500,run2; contract term is 1-of-many -> sparse matches (see README)

--- a/tools/bench-suite/results/fullhistory-latency-2026-07-16/latency.csv
+++ b/tools/bench-suite/results/fullhistory-latency-2026-07-16/latency.csv
@@ -1,0 +1,33 @@
+profile,tier,metric,endpoint,p50_ms,p90_ms,p99_ms,max_ms,count,notes
+# ingest = source->durable-commit, one sample per steady-state ledger (window 10202..10221, warmup 200)
+sac,-,ingest,-,129.289,138.865,145.293,145.293,20,src->commit per ledger
+token,-,ingest,-,129.904,133.558,144.723,144.723,20,src->commit per ledger
+soroswap,-,ingest,-,76.728,82.561,85.430,85.430,20,src->commit per ledger
+# query latency, HOT tier (served from hot RocksDB); getLedgers limit=1
+sac,hot,query,getLedgers,567.426,581.782,607.643,607.643,80,budget-capped 45s
+sac,hot,query,getTransaction,18.118,19.205,25.398,28.901,500,
+sac,hot,query,getEvents,7.795,8.036,12.026,12.562,500,
+token,hot,query,getLedgers,550.752,557.650,570.621,570.621,82,budget-capped 45s
+token,hot,query,getTransaction,18.201,19.522,24.752,26.844,500,
+token,hot,query,getEvents,7.508,7.852,10.030,13.635,500,
+soroswap,hot,query,getLedgers,355.831,363.789,370.555,375.347,127,budget-capped 45s
+soroswap,hot,query,getTransaction,11.557,12.514,17.620,19.756,500,
+soroswap,hot,query,getEvents,4.442,5.486,7.976,8.585,500,
+# query latency, COLD tier (served from frozen cold artifacts); getLedgers limit=1
+sac,cold,query,getLedgers,641.281,664.384,685.442,685.442,71,budget-capped 45s
+sac,cold,query,getTransaction,17.652,29.972,38.739,45.733,500,
+sac,cold,query,getEvents,6.211,8.416,9.487,12.687,500,
+# direct in-process read (no serve path): store.Get = RocksDB point read (compressed); GetLedgerRaw = Get + zstd decode
+sac,hot,read_store_get,-,0.634,,,,,ns/op 634056; compressed ~2.1MB
+sac,hot,read_getledgerraw,-,8.248,,,,,Get+zstd decode; decoded ~17.3MB
+sac,cold,read_getledgerraw,-,7.883,,,,,pack index+seek+decode; decoded ~17.3MB
+token,hot,read_store_get,-,0.618,,,,,compressed ~1.7MB
+token,hot,read_getledgerraw,-,7.449,,,,,decoded ~16.5MB
+token,cold,read_getledgerraw,-,7.272,,,,,decoded ~16.5MB
+soroswap,hot,read_store_get,-,0.159,,,,,compressed ~0.5MB
+soroswap,hot,read_getledgerraw,-,4.648,,,,,decoded ~10.0MB
+soroswap,cold,read_getledgerraw,-,3.685,,,,,decoded ~10.0MB
+# toy baseline (1 tx / 1 event synthetic ledger), for reference
+toy,hot,visibility_full,-,4.500,,4.744,,10,source->query
+toy,hot,visibility_ingest,-,3.035,,,,10,source->commit
+toy,hot,visibility_visible,-,1.500,,1.775,,10,commit->query

--- a/tools/bench-suite/results/fullhistory-latency-2026-07-16/report.html
+++ b/tools/bench-suite/results/fullhistory-latency-2026-07-16/report.html
@@ -1,0 +1,301 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Full-history latency — sac / token / soroswap — 2026-07-16</title>
+<style>
+  :root {
+    color-scheme: light;
+    --page: #f9f9f7; --surface: #fcfcfb;
+    --ink: #0b0b0b; --ink-2: #52514e; --muted: #898781;
+    --grid: #e1e0d9; --baseline: #c3c2b7; --border: rgba(11,11,11,0.10);
+    --hot: #eb6834; --cold: #2a78d6; --good: #006300;
+    --fill-rest: #c3c2b7;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:where(:not([data-theme="light"])) {
+      color-scheme: dark;
+      --page: #0d0d0d; --surface: #1a1a19;
+      --ink: #ffffff; --ink-2: #c3c2b7; --muted: #898781;
+      --grid: #2c2c2a; --baseline: #383835; --border: rgba(255,255,255,0.10);
+      --hot: #d95926; --cold: #3987e5; --good: #0ca30c;
+      --fill-rest: #383835;
+    }
+  }
+  :root[data-theme="dark"] {
+    color-scheme: dark;
+    --page: #0d0d0d; --surface: #1a1a19;
+    --ink: #ffffff; --ink-2: #c3c2b7; --muted: #898781;
+    --grid: #2c2c2a; --baseline: #383835; --border: rgba(255,255,255,0.10);
+    --hot: #d95926; --cold: #3987e5; --good: #0ca30c;
+    --fill-rest: #383835;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--page); color: var(--ink);
+    font: 15px/1.55 system-ui, -apple-system, "Segoe UI", sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 960px; margin: 0 auto; padding: 40px 24px 80px; }
+  header h1 { font-size: 26px; line-height: 1.2; margin: 0 0 6px; letter-spacing: -0.01em; }
+  header p.sub { color: var(--ink-2); margin: 0 0 18px; max-width: 68ch; }
+  .chips { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 8px; }
+  .chip {
+    font-size: 12.5px; color: var(--ink-2); background: var(--surface);
+    border: 1px solid var(--border); border-radius: 999px; padding: 3px 11px;
+  }
+  .toggle {
+    float: right; font: inherit; font-size: 13px; cursor: pointer;
+    color: var(--ink-2); background: var(--surface); border: 1px solid var(--border);
+    border-radius: 8px; padding: 5px 10px;
+  }
+  h2 { font-size: 18px; margin: 40px 0 4px; letter-spacing: -0.01em; }
+  h2 .n { color: var(--muted); font-weight: 600; margin-right: 8px; }
+  .lede { color: var(--ink-2); margin: 0 0 16px; max-width: 72ch; }
+  section { border-top: 1px solid var(--grid); padding-top: 8px; }
+
+  /* KPI tiles */
+  .kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px,1fr)); gap: 12px; margin: 22px 0 8px; }
+  .kpi { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 14px 16px; }
+  .kpi .v { font-size: 27px; line-height: 1.1; letter-spacing: -0.02em; }
+  .kpi .u { font-size: 15px; color: var(--ink-2); }
+  .kpi .l { font-size: 12.5px; color: var(--ink-2); margin-top: 4px; }
+
+  /* findings */
+  ul.find { margin: 8px 0 0; padding: 0; list-style: none; }
+  ul.find li { position: relative; padding: 8px 0 8px 26px; border-bottom: 1px solid var(--grid); }
+  ul.find li:last-child { border-bottom: 0; }
+  ul.find li::before {
+    content: ""; position: absolute; left: 4px; top: 15px; width: 8px; height: 8px;
+    border-radius: 2px; background: var(--cold);
+  }
+  ul.find li.hot::before { background: var(--hot); }
+  ul.find b { font-weight: 650; }
+
+  /* tables */
+  .scroll { overflow-x: auto; margin: 6px 0 4px; }
+  table { border-collapse: collapse; width: 100%; font-size: 14px; }
+  caption { text-align: left; color: var(--muted); font-size: 12.5px; padding: 6px 0; }
+  th, td { padding: 7px 12px; text-align: right; white-space: nowrap; }
+  th:first-child, td:first-child { text-align: left; }
+  thead th { color: var(--ink-2); font-weight: 600; border-bottom: 1px solid var(--baseline); }
+  tbody td { border-bottom: 1px solid var(--grid); font-variant-numeric: tabular-nums; }
+  tbody tr:hover td { background: color-mix(in srgb, var(--cold) 7%, transparent); }
+  .grp td { border-top: 2px solid var(--grid); }
+  .num { font-variant-numeric: tabular-nums; }
+  .dim { color: var(--muted); }
+  .tag { display: inline-block; font-size: 11px; font-weight: 650; padding: 1px 7px; border-radius: 6px; }
+  .tag.hot { color: #fff; background: var(--hot); }
+  .tag.cold { color: #fff; background: var(--cold); }
+
+  /* anatomy proportion bar */
+  .anat { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 16px; margin: 8px 0; }
+  .anat .bar { display: flex; height: 34px; border-radius: 7px; overflow: hidden; border: 1px solid var(--border); }
+  .anat .seg { display: flex; align-items: center; padding: 0 10px; font-size: 12.5px; font-weight: 600; color: #fff; white-space: nowrap; }
+  .anat .read { background: var(--cold); }
+  .anat .rest { background: var(--fill-rest); color: var(--ink); }
+  .anat .legend { display: flex; gap: 18px; margin-top: 10px; font-size: 12.5px; color: var(--ink-2); flex-wrap: wrap; }
+  .anat .legend .sw { display: inline-block; width: 10px; height: 10px; border-radius: 3px; margin-right: 6px; vertical-align: -1px; }
+
+  /* hot vs cold mini bars */
+  .hc { display: grid; gap: 14px; margin: 10px 0; }
+  .hc .row { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 12px 14px; }
+  .hc .name { font-weight: 650; margin-bottom: 8px; }
+  .hc .track { display: grid; grid-template-columns: 52px 1fr 92px; align-items: center; gap: 10px; margin: 4px 0; }
+  .hc .track .k { font-size: 12px; color: var(--ink-2); }
+  .hc .track .barwrap { background: color-mix(in srgb, var(--baseline) 40%, transparent); border-radius: 5px; height: 14px; }
+  .hc .track .fill { height: 14px; border-radius: 5px; }
+  .hc .track .fill.hot { background: var(--hot); }
+  .hc .track .fill.cold { background: var(--cold); }
+  .hc .track .val { text-align: right; font-variant-numeric: tabular-nums; font-size: 13px; }
+
+  .callout { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--cold); border-radius: 8px; padding: 12px 16px; margin: 12px 0; color: var(--ink-2); }
+  .callout b { color: var(--ink); }
+  footer { margin-top: 48px; padding-top: 14px; border-top: 1px solid var(--grid); color: var(--muted); font-size: 12.5px; }
+  code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12.5px; background: color-mix(in srgb, var(--baseline) 22%, transparent); padding: 1px 5px; border-radius: 5px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <button class="toggle" id="themeToggle" type="button">◐ theme</button>
+  <header>
+    <h1>Full-history ingest &amp; query latency</h1>
+    <p class="sub">Latency of the <code>full-history</code> daemon on the synthetic apply-load
+      profiles (<b>sac</b>, <b>token</b>, <b>soroswap</b>), measured on <b>real</b> profile
+      ledgers across both serving tiers — <span class="tag hot">hot</span> (RocksDB) and
+      <span class="tag cold">cold</span> (frozen pack + MPHF/bitmap index artifacts).</p>
+    <div class="chips">
+      <span class="chip">AWS c6id.8xlarge · 32 vCPU · 64 GiB · local NVMe</span>
+      <span class="chip">branch poc/fullhistory-query</span>
+      <span class="chip">2026-07-16</span>
+      <span class="chip">window: 20 steady-state ledgers (warmup 200)</span>
+      <span class="chip">500 reps/endpoint · getLedgers limit=1</span>
+    </div>
+  </header>
+
+  <div class="kpis">
+    <div class="kpi"><div class="v">10–17<span class="u"> MB</span></div><div class="l">decompressed ledger size (steady state)</div></div>
+    <div class="kpi"><div class="v">77–130<span class="u"> ms</span></div><div class="l">ingest p50 (source → commit)</div></div>
+    <div class="kpi"><div class="v">4–8<span class="u"> ms</span></div><div class="l">getEvents / getTransaction p50 (hot)</div></div>
+    <div class="kpi"><div class="v">356–567<span class="u"> ms</span></div><div class="l">getLedgers p50 — payload-bound</div></div>
+  </div>
+
+  <section>
+    <h2>Key findings</h2>
+    <ul class="find">
+      <li>Ingest <b>dominates the targeted endpoints</b> — getTransaction/getEvents add only ~4–18 ms on top of the ~77–130 ms ingest leg.</li>
+      <li class="hot"><b>getLedgers is the outlier, and it is payload-bound, not read-bound.</b> A direct hot read (incl. zstd decode) is ~8 ms, but getLedgers over HTTP is ~567 ms: <b>~1.4 % is the read, ~98.6 % is base64 + JSON + HTTP shipping the 10–17 MB ledger.</b></li>
+      <li><b>Cold serves ≈ as fast as hot</b> across all three endpoints (getTransaction has a somewhat heavier cold tail). This is the property the full-history design targets.</li>
+      <li class="hot">Decompression is cheap (~6–8 ms); <b>the size of what's shipped is the cost.</b> <code>limit=1</code>→<code>limit=5</code> scales ~5× linearly, confirming size-bound.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2><span class="n">1</span>Ledger characteristics</h2>
+    <p class="lede">These synthetic ledgers are large — thousands of tx + Soroban meta each. This size drives the getLedgers cost.</p>
+    <div class="scroll"><table>
+      <thead><tr><th>profile</th><th>decompressed LCM</th><th>on-disk (zstd)</th><th>compression</th></tr></thead>
+      <tbody>
+        <tr><td>sac</td><td>~17.3 MB</td><td>~2.1 MB</td><td>~8.2×</td></tr>
+        <tr><td>token</td><td>~16.5 MB</td><td>~1.7 MB</td><td>~9.5×</td></tr>
+        <tr><td>soroswap</td><td>~10.0 MB</td><td>~0.5 MB</td><td>~19×</td></tr>
+      </tbody>
+    </table></div>
+  </section>
+
+  <section>
+    <h2><span class="n">2</span>Ingest → query (source → durable commit)</h2>
+    <p class="lede">One sample per steady-state ledger, in-process timestamps.</p>
+    <div class="scroll"><table>
+      <thead><tr><th>profile</th><th>p50</th><th>p90</th><th>p99</th></tr></thead>
+      <tbody>
+        <tr><td>sac</td><td>129.3 ms</td><td>138.9 ms</td><td>145.3 ms</td></tr>
+        <tr><td>token</td><td>129.9 ms</td><td>133.6 ms</td><td>144.7 ms</td></tr>
+        <tr><td>soroswap</td><td>76.7 ms</td><td>82.6 ms</td><td>85.4 ms</td></tr>
+      </tbody>
+    </table></div>
+  </section>
+
+  <section>
+    <h2><span class="n">3</span>Query latency — <span class="tag hot">hot</span> tier</h2>
+    <p class="lede">Served from hot RocksDB. 0 errors throughout. getLedgers <code>limit=1</code> is budget-capped (count = reps within the 45 s budget); its p99 is over fewer samples.</p>
+    <div class="scroll"><table>
+      <thead><tr><th>profile</th><th>endpoint</th><th>count</th><th>p50</th><th>p90</th><th>p99</th><th>max</th></tr></thead>
+      <tbody>
+        <tr class="grp"><td>sac</td><td>getLedgers</td><td class="dim">80</td><td>567.4</td><td>581.8</td><td>607.6</td><td>607.6</td></tr>
+        <tr><td></td><td>getTransaction</td><td class="dim">500</td><td>18.1</td><td>19.2</td><td>25.4</td><td>28.9</td></tr>
+        <tr><td></td><td>getEvents</td><td class="dim">500</td><td>7.8</td><td>8.0</td><td>12.0</td><td>12.6</td></tr>
+        <tr class="grp"><td>token</td><td>getLedgers</td><td class="dim">82</td><td>550.8</td><td>557.7</td><td>570.6</td><td>570.6</td></tr>
+        <tr><td></td><td>getTransaction</td><td class="dim">500</td><td>18.2</td><td>19.5</td><td>24.8</td><td>26.8</td></tr>
+        <tr><td></td><td>getEvents</td><td class="dim">500</td><td>7.5</td><td>7.9</td><td>10.0</td><td>13.6</td></tr>
+        <tr class="grp"><td>soroswap</td><td>getLedgers</td><td class="dim">127</td><td>355.8</td><td>363.8</td><td>370.6</td><td>375.3</td></tr>
+        <tr><td></td><td>getTransaction</td><td class="dim">500</td><td>11.6</td><td>12.5</td><td>17.6</td><td>19.8</td></tr>
+        <tr><td></td><td>getEvents</td><td class="dim">500</td><td>4.4</td><td>5.5</td><td>8.0</td><td>8.6</td></tr>
+      </tbody>
+      <caption>All values in milliseconds.</caption>
+    </table></div>
+  </section>
+
+  <section>
+    <h2><span class="n">4</span>Where the getLedgers time goes</h2>
+    <p class="lede">sac, per ledger. The read (RocksDB Get + zstd decode of a ~17 MB blob) is a sliver; base64 + JSON + HTTP transport of the decompressed payload is nearly all of it.</p>
+    <div class="anat">
+      <div class="bar">
+        <div class="seg read" style="width:1.4%" title="read (Get + zstd decode) ≈ 8 ms"></div>
+        <div class="seg rest" style="width:98.6%">base64 + JSON + HTTP transport &nbsp;≈&nbsp; 559 ms &nbsp;(98.6%)</div>
+      </div>
+      <div class="legend">
+        <span><span class="sw" style="background:var(--cold)"></span>storage read (Get + zstd decode) ≈ 8 ms (1.4%)</span>
+        <span><span class="sw" style="background:var(--fill-rest)"></span>serialize + ship the ~17 MB payload ≈ 559 ms (98.6%)</span>
+      </div>
+    </div>
+    <div class="callout"><b>Implication:</b> optimize the payload, not the read — cap page size, compress transport, stream the base64 encoder, or ship a lighter projection. Storage-read tuning can win at most ~1 %.</div>
+  </section>
+
+  <section>
+    <h2><span class="n">5</span><span class="tag hot">hot</span> vs <span class="tag cold">cold</span> — sac</h2>
+    <p class="lede">Same query pass served from frozen cold artifacts. Bars are normalized per endpoint (each endpoint's own scale). Cold serves ≈ as fast as hot; getTransaction has a heavier cold tail.</p>
+    <div class="hc">
+      <div class="row">
+        <div class="name">getLedgers <span class="dim num">— p50</span></div>
+        <div class="track"><span class="k">hot</span><div class="barwrap"><div class="fill hot" style="width:88.5%"></div></div><span class="val">567.4 ms</span></div>
+        <div class="track"><span class="k">cold</span><div class="barwrap"><div class="fill cold" style="width:100%"></div></div><span class="val">641.3 ms</span></div>
+      </div>
+      <div class="row">
+        <div class="name">getTransaction <span class="dim num">— p50 / p99</span></div>
+        <div class="track"><span class="k">hot</span><div class="barwrap"><div class="fill hot" style="width:46.8%"></div></div><span class="val">18.1 / 25.4 ms</span></div>
+        <div class="track"><span class="k">cold</span><div class="barwrap"><div class="fill cold" style="width:45.6%"></div></div><span class="val">17.7 / 38.7 ms</span></div>
+      </div>
+      <div class="row">
+        <div class="name">getEvents <span class="dim num">— p50</span></div>
+        <div class="track"><span class="k">hot</span><div class="barwrap"><div class="fill hot" style="width:100%"></div></div><span class="val">7.8 ms</span></div>
+        <div class="track"><span class="k">cold</span><div class="barwrap"><div class="fill cold" style="width:79.6%"></div></div><span class="val">6.2 ms</span></div>
+      </div>
+    </div>
+    <p class="lede dim">Cold reads here are OS-page-cache-warm. Only sac had a servable daemon catalog on the box; token/soroswap cold serving needs a catalog rebuilt over their existing cold artifacts.</p>
+  </section>
+
+  <section>
+    <h2><span class="n">6</span>Direct in-process read (no serve path)</h2>
+    <p class="lede"><code>store.Get</code> = RocksDB point read (compressed value); <code>GetLedgerRaw</code> adds the zstd decode. Cold ≈ hot; both decode-bound.</p>
+    <div class="scroll"><table>
+      <thead><tr><th>profile</th><th>store.Get (compressed)</th><th>hot GetLedgerRaw</th><th>cold GetLedgerRaw</th></tr></thead>
+      <tbody>
+        <tr><td>sac</td><td>0.63 ms</td><td>8.2 ms</td><td>7.9 ms</td></tr>
+        <tr><td>token</td><td>0.62 ms</td><td>7.4 ms</td><td>7.3 ms</td></tr>
+        <tr><td>soroswap</td><td>0.16 ms</td><td>4.6 ms</td><td>3.7 ms</td></tr>
+      </tbody>
+    </table></div>
+  </section>
+
+  <section>
+    <h2><span class="n">7</span>End-to-end (synthesized: ingest + query)</h2>
+    <p class="lede">e2e = ingest + hot query at the same percentile. Summing per-stage percentiles is a conservative upper bound; commit→queryable (~1–2 ms) is treated as negligible.</p>
+    <div class="scroll"><table>
+      <thead><tr><th>profile</th><th>endpoint</th><th>e2e p50</th><th>e2e p99</th></tr></thead>
+      <tbody>
+        <tr class="grp"><td>sac</td><td>getLedgers</td><td>~696.7 ms</td><td>~752.9 ms</td></tr>
+        <tr><td></td><td>getTransaction</td><td>~147.4 ms</td><td>~170.7 ms</td></tr>
+        <tr><td></td><td>getEvents</td><td>~137.1 ms</td><td>~157.3 ms</td></tr>
+        <tr class="grp"><td>token</td><td>getLedgers</td><td>~680.7 ms</td><td>~715.3 ms</td></tr>
+        <tr><td></td><td>getTransaction</td><td>~148.1 ms</td><td>~169.5 ms</td></tr>
+        <tr><td></td><td>getEvents</td><td>~137.4 ms</td><td>~154.7 ms</td></tr>
+        <tr class="grp"><td>soroswap</td><td>getLedgers</td><td>~432.5 ms</td><td>~456.0 ms</td></tr>
+        <tr><td></td><td>getTransaction</td><td>~88.3 ms</td><td>~103.0 ms</td></tr>
+        <tr><td></td><td>getEvents</td><td>~81.1 ms</td><td>~93.4 ms</td></tr>
+      </tbody>
+    </table></div>
+  </section>
+
+  <section>
+    <h2><span class="n">8</span>Method &amp; caveats</h2>
+    <p class="lede">Harness: <code>TestServeE2E_ProfileLatency</code> (hot) and <code>TestServeE2E_ColdQueryLatency</code> (cold);
+      direct read via <code>BenchmarkHotGetLedgerRaw</code>. Real ledgers fed through the live hot path
+      (no freeze); cold served from pre-frozen artifacts. Percentiles are nearest-rank.</p>
+    <ul class="find">
+      <li>The chunk head is contract-deploy warmup, ~40× lighter than steady state; measurements skip 200 warmup ledgers and measure ledgers 10202–10221.</li>
+      <li>getLedgers p99 is over the budget-capped sample count (71–127), less robust than the 500-rep getTransaction/getEvents p99s.</li>
+      <li>Reference toy baseline (1-tx/1-event ledger): full ~4.5 ms, ingest ~3.0 ms, visible ~1.5 ms — ~40× lighter than real ingest; not a production number.</li>
+      <li>Per-ledger commit→query <em>visibility</em> is not reported for real profiles: under heavy ingestion the sequential poller lags the commit frontier, so that span measures poller lag, not visibility. <code>ingest</code> and the query-latency pass are the reliable metrics.</li>
+    </ul>
+  </section>
+
+  <footer>
+    Data: <code>latency.csv</code> · full notes: <code>README.md</code> · driver: <code>tools/bench-suite/run-e2e-latency-suite.sh</code>
+  </footer>
+</div>
+<script>
+  (function () {
+    var btn = document.getElementById('themeToggle');
+    btn.addEventListener('click', function () {
+      var root = document.documentElement;
+      var cur = root.getAttribute('data-theme');
+      var dark = cur ? cur === 'dark'
+        : window.matchMedia('(prefers-color-scheme: dark)').matches;
+      root.setAttribute('data-theme', dark ? 'light' : 'dark');
+    });
+  })();
+</script>
+</body>
+</html>

--- a/tools/bench-suite/results/fullhistory-latency-2026-07-16/report.html
+++ b/tools/bench-suite/results/fullhistory-latency-2026-07-16/report.html
@@ -131,6 +131,7 @@
       <span class="chip">2026-07-16</span>
       <span class="chip">window: 20 steady-state ledgers (warmup 200)</span>
       <span class="chip">500 reps/endpoint · getLedgers limit=1</span>
+      <span class="chip">run 2: cold on all profiles · getEvents term sweep 1/4/8/15</span>
     </div>
   </header>
 
@@ -146,7 +147,8 @@
     <ul class="find">
       <li>Ingest <b>dominates the targeted endpoints</b> — getTransaction/getEvents add only ~4–18 ms on top of the ~77–130 ms ingest leg.</li>
       <li class="hot"><b>getLedgers is the outlier, and it is payload-bound, not read-bound.</b> A direct hot read (incl. zstd decode) is ~8 ms, but getLedgers over HTTP is ~567 ms: <b>~1.4 % is the read, ~98.6 % is base64 + JSON + HTTP shipping the 10–17 MB ledger.</b></li>
-      <li><b>Cold serves ≈ as fast as hot</b> across all three endpoints (getTransaction has a somewhat heavier cold tail). This is the property the full-history design targets.</li>
+      <li><b>Cold serves ≈ as fast as hot</b> for getLedgers, getTransaction, and dense-match getEvents (getTransaction has a somewhat heavier cold tail) — confirmed on all three profiles in run 2. This is the property the full-history design targets.</li>
+      <li class="hot"><b>The exception (run 2): selective multi-term getEvents on cold.</b> OR-unions of genuinely selective terms scale with term count on cold (token ≈1 ms/term; soroswap ≈12 ms/term — 15 terms ≈ 137–181 ms) while hot stays flat (~4–9 ms). Cause: per-request cold-reader open + the POC underfill re-query loop (§6).</li>
       <li class="hot">Decompression is cheap (~6–8 ms); <b>the size of what's shipped is the cost.</b> <code>limit=1</code>→<code>limit=5</code> scales ~5× linearly, confirming size-bound.</li>
     </ul>
   </section>
@@ -233,11 +235,49 @@
         <div class="track"><span class="k">cold</span><div class="barwrap"><div class="fill cold" style="width:79.6%"></div></div><span class="val">6.2 ms</span></div>
       </div>
     </div>
-    <p class="lede dim">Cold reads here are OS-page-cache-warm. Only sac had a servable daemon catalog on the box; token/soroswap cold serving needs a catalog rebuilt over their existing cold artifacts.</p>
+    <p class="lede dim">Cold reads here are OS-page-cache-warm. At run-1 time only sac had a servable daemon catalog; run 2 froze token/soroswap catalogs (6m19s / 4m15s wall) and completed the matrix below.</p>
+    <h2 style="border:0; margin-top:28px"><span class="n">5b</span>Cold tier, all profiles <span class="dim" style="font-size:13px">(run 2)</span></h2>
+    <p class="lede">Same window and method; sac re-measured as a reproduction check (largest run-1↔run-2 deltas ≈ ±5 %). Black-box fhbench cross-checks over the whole frozen chunk agree within ~5 %.</p>
+    <div class="scroll"><table>
+      <thead><tr><th>profile</th><th>endpoint</th><th>count</th><th>p50</th><th>p90</th><th>p99</th><th>max</th></tr></thead>
+      <tbody>
+        <tr class="grp"><td>sac</td><td>getLedgers</td><td class="dim">73</td><td>617.2</td><td>653.1</td><td>671.0</td><td>671.0</td></tr>
+        <tr><td></td><td>getTransaction</td><td class="dim">500</td><td>18.3</td><td>31.7</td><td>40.3</td><td>43.3</td></tr>
+        <tr><td></td><td>getEvents</td><td class="dim">500</td><td>8.8</td><td>10.5</td><td>14.4</td><td>14.9</td></tr>
+        <tr class="grp"><td>token</td><td>getLedgers</td><td class="dim">74</td><td>604.9</td><td>638.9</td><td>664.0</td><td>664.0</td></tr>
+        <tr><td></td><td>getTransaction</td><td class="dim">500</td><td>16.0</td><td>25.4</td><td>34.0</td><td>41.5</td></tr>
+        <tr><td></td><td>getEvents</td><td class="dim">500</td><td>3.4</td><td>4.2</td><td>4.9</td><td>5.4</td></tr>
+        <tr class="grp"><td>soroswap</td><td>getLedgers</td><td class="dim">109</td><td>415.4</td><td>433.9</td><td>449.5</td><td>451.6</td></tr>
+        <tr><td></td><td>getTransaction</td><td class="dim">500</td><td>11.7</td><td>18.9</td><td>25.4</td><td>26.5</td></tr>
+        <tr><td></td><td>getEvents</td><td class="dim">500</td><td>18.9</td><td>22.8</td><td>24.8</td><td>27.3</td></tr>
+      </tbody>
+      <caption>All values in milliseconds. soroswap getEvents cold (18.9 vs 4.7 hot) is the selective-filter effect — see §6.</caption>
+    </table></div>
   </section>
 
   <section>
-    <h2><span class="n">6</span>Direct in-process read (no serve path)</h2>
+    <h2><span class="n">6</span>getEvents index-term sweep <span class="dim" style="font-size:13px">(run 2)</span></h2>
+    <p class="lede">Each cell OR-unions N real harvested index terms (a term = a distinct contract ID or a distinct topic value at a position). <b>window</b> = the 20-ledger steady-state window, 500 reps; <b>chunk</b> = random starts over the whole 10 000-ledger frozen chunk (fhbench, 30 s). Cells are p50 / p99 ms.</p>
+    <div class="scroll"><table>
+      <thead><tr><th>profile</th><th>tier · scope</th><th>t=1</th><th>t=4</th><th>t=8</th><th>t=15</th></tr></thead>
+      <tbody>
+        <tr class="grp"><td>sac</td><td><span class="tag hot">hot</span> window</td><td>8.4 / 11.4</td><td>8.4 / 10.8</td><td>8.5 / 11.1</td><td>6.8 / 11.4</td></tr>
+        <tr><td></td><td><span class="tag cold">cold</span> window</td><td>8.4 / 13.4</td><td>8.6 / 12.8</td><td>6.6 / 11.9</td><td>8.7 / 14.1</td></tr>
+        <tr><td></td><td><span class="tag cold">cold</span> chunk</td><td>8.0 / 14.0</td><td>8.4 / 15.3</td><td>8.5 / 14.7</td><td>8.4 / 15.5</td></tr>
+        <tr class="grp"><td>token</td><td><span class="tag hot">hot</span> window</td><td>7.6 / 11.9</td><td>6.2 / 8.6</td><td>7.5 / 10.2</td><td>7.7 / 12.4</td></tr>
+        <tr><td></td><td><span class="tag cold">cold</span> window</td><td>3.4 / 4.9</td><td>5.1 / 7.1</td><td>8.1 / 15.4</td><td>16.9 / 22.0</td></tr>
+        <tr><td></td><td><span class="tag cold">cold</span> chunk</td><td>4.4 / 7.2</td><td>6.7 / 9.5</td><td>8.9 / 13.4</td><td>16.5 / 21.8</td></tr>
+        <tr class="grp"><td>soroswap</td><td><span class="tag hot">hot</span> window</td><td>4.2 / 5.9</td><td>4.3 / 7.8</td><td>6.1 / 7.7</td><td>6.1 / 7.3</td></tr>
+        <tr><td></td><td><span class="tag cold">cold</span> window</td><td>9.5 / 16.4</td><td>52.7 / 67.0</td><td>98.5 / 129.6</td><td>137.2 / 158.3</td></tr>
+        <tr><td></td><td><span class="tag cold">cold</span> chunk</td><td>12.4 / 18.3</td><td>47.1 / 61.6</td><td>101.2 / 128.2</td><td>181.2 / 220.3</td></tr>
+      </tbody>
+      <caption>p50 / p99 ms · limit 10 · full data in termsweep.csv.</caption>
+    </table></div>
+    <div class="callout"><b>Reading the curve:</b> hot is flat everywhere; cold is flat when terms match densely (sac) and scales with term count when terms are selective (token ≈1 ms/term, soroswap ≈12 ms/term). Hot and cold share the same bitmap-driven <code>eventstore.Query</code> — the divergence is the per-request cold-reader open (POC: no LRU) plus the underfill loop in <code>scanChunk</code>, which re-queries the chunk with a doubling cap when sparse matches leave the page short. Productionization paths: LRU'd cold readers; a streaming pager that advances a pinned event-ID cursor. Window ≈ chunk everywhere, so the curve tracks term selectivity, not scan-span length.</div>
+  </section>
+
+  <section>
+    <h2><span class="n">7</span>Direct in-process read (no serve path)</h2>
     <p class="lede"><code>store.Get</code> = RocksDB point read (compressed value); <code>GetLedgerRaw</code> adds the zstd decode. Cold ≈ hot; both decode-bound.</p>
     <div class="scroll"><table>
       <thead><tr><th>profile</th><th>store.Get (compressed)</th><th>hot GetLedgerRaw</th><th>cold GetLedgerRaw</th></tr></thead>
@@ -250,7 +290,7 @@
   </section>
 
   <section>
-    <h2><span class="n">7</span>End-to-end (synthesized: ingest + query)</h2>
+    <h2><span class="n">8</span>End-to-end (synthesized: ingest + query)</h2>
     <p class="lede">e2e = ingest + hot query at the same percentile. Summing per-stage percentiles is a conservative upper bound; commit→queryable (~1–2 ms) is treated as negligible.</p>
     <div class="scroll"><table>
       <thead><tr><th>profile</th><th>endpoint</th><th>e2e p50</th><th>e2e p99</th></tr></thead>
@@ -269,20 +309,23 @@
   </section>
 
   <section>
-    <h2><span class="n">8</span>Method &amp; caveats</h2>
+    <h2><span class="n">9</span>Method &amp; caveats</h2>
     <p class="lede">Harness: <code>TestServeE2E_ProfileLatency</code> (hot) and <code>TestServeE2E_ColdQueryLatency</code> (cold);
-      direct read via <code>BenchmarkHotGetLedgerRaw</code>. Real ledgers fed through the live hot path
-      (no freeze); cold served from pre-frozen artifacts. Percentiles are nearest-rank.</p>
+      direct read via <code>BenchmarkHotGetLedgerRaw</code>; black-box cross-checks and the chunk-scope sweep via <code>tools/fhbench</code>.
+      Real ledgers fed through the live hot path (no freeze); cold served from pre-frozen artifacts. Percentiles are nearest-rank.</p>
     <ul class="find">
-      <li>The chunk head is contract-deploy warmup, ~40× lighter than steady state; measurements skip 200 warmup ledgers and measure ledgers 10202–10221.</li>
+      <li>The chunk head is contract-deploy warmup, ~40× lighter than steady state; measurements skip 200 warmup ledgers and measure ledgers 10202–10221. Run 2 also moved fhbench's tx-hash/term sampling from the tier head to the tier midpoint for the same reason (head-sampled soroswap cold getTransaction read 2.7 ms vs the representative 10.8 ms).</li>
       <li>getLedgers p99 is over the budget-capped sample count (71–127), less robust than the 500-rep getTransaction/getEvents p99s.</li>
+      <li>All query passes are sequential closed-loop — unloaded-latency floors, not latency under concurrent load.</li>
+      <li><b>Run-2 reproduction:</b> re-running run 1's hot pass reproduced it within ±5 % (e.g. soroswap getLedgers 355.8 → 355.9 ms; sac getLedgers 567.4 → 567.0 ms). A methodology review fixed several fhbench issues (hot-tier clamp to the live chunk, endLedger off-by-one, error-latency exclusion, mid-tier sampling, term-count cap) — none affect run-1 tables, which came from the e2e harness.</li>
+      <li>The term-sweep curve depends on the harvested vocabulary's selectivity — a property of the profile (sac: one match-all contract; soroswap: many contracts). Real-network vocabularies sit between the extremes.</li>
       <li>Reference toy baseline (1-tx/1-event ledger): full ~4.5 ms, ingest ~3.0 ms, visible ~1.5 ms — ~40× lighter than real ingest; not a production number.</li>
       <li>Per-ledger commit→query <em>visibility</em> is not reported for real profiles: under heavy ingestion the sequential poller lags the commit frontier, so that span measures poller lag, not visibility. <code>ingest</code> and the query-latency pass are the reliable metrics.</li>
     </ul>
   </section>
 
   <footer>
-    Data: <code>latency.csv</code> · full notes: <code>README.md</code> · driver: <code>tools/bench-suite/run-e2e-latency-suite.sh</code>
+    Data: <code>latency.csv</code> · <code>termsweep.csv</code> · full notes: <code>README.md</code> · driver: <code>tools/bench-suite/run-e2e-latency-suite.sh</code>
   </footer>
 </div>
 <script>

--- a/tools/bench-suite/results/fullhistory-latency-2026-07-16/run2-logs/cold-sac.txt
+++ b/tools/bench-suite/results/fullhistory-latency-2026-07-16/run2-logs/cold-sac.txt
@@ -1,0 +1,13 @@
+=== RUN   TestServeE2E_ColdQueryLatency
+    serve_e2e_cold_latency_test.go:128: COLD query-latency on "sac" chunk 1, window [10202,10221]: 500 reps/endpoint (200 tx hashes, contract="CCMPGRP4VKR5CJR77YQHDWB3KIKYYRHZSVWGC5F2JRIME2UNM4JLI64D")
+    serve_e2e_cold_latency_test.go:130:   endpoint         count    p50          p90          p99          max          errors
+    serve_e2e_cold_latency_test.go:164:   getLedgers       73       617.248ms    653.133ms    671.021ms    671.021ms    0  (budget-capped at 45s)
+    serve_e2e_cold_latency_test.go:164:   getTransaction   500      18.322ms     31.725ms     40.315ms     43.309ms     0
+    serve_e2e_cold_latency_test.go:164:   getEvents        500      8.788ms      10.541ms     14.392ms     14.942ms     0
+    serve_e2e_cold_latency_test.go:212: getEvents term sweep over [10202,10221]: 402 terms harvested (limit 10/page):
+    serve_e2e_cold_latency_test.go:164:   getEvents[t=1]   500      8.44ms       10.361ms     13.402ms     14.282ms     0
+    serve_e2e_cold_latency_test.go:164:   getEvents[t=4]   500      8.629ms      10.675ms     12.816ms     15.383ms     0
+    serve_e2e_cold_latency_test.go:164:   getEvents[t=8]   500      6.623ms      9.232ms      11.923ms     13.312ms     0
+    serve_e2e_cold_latency_test.go:164:   getEvents[t=15]  500      8.666ms      10.466ms     14.113ms     15.358ms     0
+--- PASS: TestServeE2E_ColdQueryLatency (77.97s)
+PASS

--- a/tools/bench-suite/results/fullhistory-latency-2026-07-16/run2-logs/cold-soroswap.txt
+++ b/tools/bench-suite/results/fullhistory-latency-2026-07-16/run2-logs/cold-soroswap.txt
@@ -1,0 +1,13 @@
+=== RUN   TestServeE2E_ColdQueryLatency
+    serve_e2e_cold_latency_test.go:128: COLD query-latency on "soroswap" chunk 1, window [10202,10221]: 500 reps/endpoint (200 tx hashes, contract="CAWUNDBJDSUIPM5A3XAPFDHMMWI6EE5V6NBOEV6BFQTY3JD55P4S75AC")
+    serve_e2e_cold_latency_test.go:130:   endpoint         count    p50          p90          p99          max          errors
+    serve_e2e_cold_latency_test.go:164:   getLedgers       109      415.4ms      433.864ms    449.496ms    451.625ms    0  (budget-capped at 45s)
+    serve_e2e_cold_latency_test.go:164:   getTransaction   500      11.686ms     18.918ms     25.383ms     26.529ms     0
+    serve_e2e_cold_latency_test.go:164:   getEvents        500      18.921ms     22.768ms     24.798ms     27.314ms     0
+    serve_e2e_cold_latency_test.go:212: getEvents term sweep over [10202,10221]: 91 terms harvested (limit 10/page):
+    serve_e2e_cold_latency_test.go:164:   getEvents[t=1]   500      9.497ms      12.772ms     16.439ms     17.918ms     0
+    serve_e2e_cold_latency_test.go:164:   getEvents[t=4]   500      52.697ms     60.01ms      67.019ms     73.349ms     0
+    serve_e2e_cold_latency_test.go:164:   getEvents[t=8]   453      98.49ms      115.712ms    129.649ms    137.659ms    0  (budget-capped at 45s)
+    serve_e2e_cold_latency_test.go:164:   getEvents[t=15]  332      137.214ms    150.247ms    158.341ms    171.999ms    0  (budget-capped at 45s)
+--- PASS: TestServeE2E_ColdQueryLatency (183.36s)
+PASS

--- a/tools/bench-suite/results/fullhistory-latency-2026-07-16/run2-logs/cold-token.txt
+++ b/tools/bench-suite/results/fullhistory-latency-2026-07-16/run2-logs/cold-token.txt
@@ -1,0 +1,13 @@
+=== RUN   TestServeE2E_ColdQueryLatency
+    serve_e2e_cold_latency_test.go:128: COLD query-latency on "token" chunk 1, window [10202,10221]: 500 reps/endpoint (200 tx hashes, contract="CA5EIFMV7WOGRAAZS4PG66LTAWHGNKJRD63MRJLZJPFPOWOIRKBGF63C")
+    serve_e2e_cold_latency_test.go:130:   endpoint         count    p50          p90          p99          max          errors
+    serve_e2e_cold_latency_test.go:164:   getLedgers       74       604.933ms    638.877ms    663.991ms    663.991ms    0  (budget-capped at 45s)
+    serve_e2e_cold_latency_test.go:164:   getTransaction   500      15.997ms     25.438ms     33.99ms      41.462ms     0
+    serve_e2e_cold_latency_test.go:164:   getEvents        500      3.386ms      4.166ms      4.88ms       5.378ms      0
+    serve_e2e_cold_latency_test.go:212: getEvents term sweep over [10202,10221]: 402 terms harvested (limit 10/page):
+    serve_e2e_cold_latency_test.go:164:   getEvents[t=1]   500      3.449ms      4.239ms      4.85ms       5.29ms       0
+    serve_e2e_cold_latency_test.go:164:   getEvents[t=4]   500      5.123ms      6.143ms      7.076ms      9.435ms      0
+    serve_e2e_cold_latency_test.go:164:   getEvents[t=8]   500      8.149ms      13.171ms     15.393ms     18.359ms     0
+    serve_e2e_cold_latency_test.go:164:   getEvents[t=15]  500      16.933ms     19.646ms     22.035ms     23.051ms     0
+--- PASS: TestServeE2E_ColdQueryLatency (73.90s)
+PASS

--- a/tools/bench-suite/results/fullhistory-latency-2026-07-16/run2-logs/fhbench-cold-gettx2-sac.txt
+++ b/tools/bench-suite/results/fullhistory-latency-2026-07-16/run2-logs/fhbench-cold-gettx2-sac.txt
@@ -1,0 +1,5 @@
+### sac COLD getTransaction (mid-tier hash sample, concurrency 1)
+
+endpoint         tier   terms    count        RPS       p50       p90       p99       max   errors
+--------------------------------------------------------------------------------------------------
+getTransaction   cold       -     1565       52.2  17.468ms  27.335ms  36.755ms  47.844ms        0

--- a/tools/bench-suite/results/fullhistory-latency-2026-07-16/run2-logs/fhbench-cold-gettx2-soroswap.txt
+++ b/tools/bench-suite/results/fullhistory-latency-2026-07-16/run2-logs/fhbench-cold-gettx2-soroswap.txt
@@ -1,0 +1,5 @@
+### soroswap COLD getTransaction (mid-tier hash sample, concurrency 1)
+
+endpoint         tier   terms    count        RPS       p50       p90       p99       max   errors
+--------------------------------------------------------------------------------------------------
+getTransaction   cold       -     2497       83.2  10.828ms  18.009ms  25.495ms  28.548ms        0

--- a/tools/bench-suite/results/fullhistory-latency-2026-07-16/run2-logs/fhbench-cold-gettx2-token.txt
+++ b/tools/bench-suite/results/fullhistory-latency-2026-07-16/run2-logs/fhbench-cold-gettx2-token.txt
@@ -1,0 +1,5 @@
+### token COLD getTransaction (mid-tier hash sample, concurrency 1)
+
+endpoint         tier   terms    count        RPS       p50       p90       p99       max   errors
+--------------------------------------------------------------------------------------------------
+getTransaction   cold       -     1704       56.8  16.297ms   24.41ms   35.27ms  40.784ms        0

--- a/tools/bench-suite/results/fullhistory-latency-2026-07-16/run2-logs/fhbench-cold-sac.txt
+++ b/tools/bench-suite/results/fullhistory-latency-2026-07-16/run2-logs/fhbench-cold-sac.txt
@@ -1,0 +1,20 @@
+### sac COLD getEvents term sweep (full frozen chunk, limit 10, concurrency 1)
+
+endpoint         tier   terms    count        RPS       p50       p90       p99       max   errors
+--------------------------------------------------------------------------------------------------
+getEvents        cold       1     3422      114.1   8.028ms  12.151ms  14.004ms   16.85ms        0
+getEvents        cold       4     3343      111.4   8.444ms  12.423ms  15.301ms  17.493ms        0
+getEvents        cold       8     3409      113.6    8.48ms  12.555ms   14.67ms  18.926ms        0
+getEvents        cold      15     3302      110.1    8.36ms  12.791ms  15.519ms  18.322ms        0
+
+### sac COLD getTransaction (concurrency 1)
+
+endpoint         tier   terms    count        RPS       p50       p90       p99       max   errors
+--------------------------------------------------------------------------------------------------
+getTransaction   cold       -     2121       70.7  15.338ms  22.776ms  35.249ms  43.757ms        0
+
+### sac COLD getLedgers (limit 1, concurrency 1)
+
+endpoint         tier   terms    count        RPS       p50       p90       p99       max   errors
+--------------------------------------------------------------------------------------------------
+getLedgers       cold       -       47        1.6 624.845ms 665.083ms 680.266ms 680.266ms        0

--- a/tools/bench-suite/results/fullhistory-latency-2026-07-16/run2-logs/fhbench-cold-soroswap.txt
+++ b/tools/bench-suite/results/fullhistory-latency-2026-07-16/run2-logs/fhbench-cold-soroswap.txt
@@ -1,0 +1,20 @@
+### soroswap COLD getEvents term sweep (full frozen chunk, limit 10, concurrency 1)
+
+endpoint         tier   terms    count        RPS       p50       p90       p99       max   errors
+--------------------------------------------------------------------------------------------------
+getEvents        cold       1     2399       80.0  12.433ms  15.647ms  18.268ms  23.399ms        0
+getEvents        cold       4      623       20.8  47.076ms  55.431ms  61.596ms  66.871ms        0
+getEvents        cold       8      295        9.8 101.203ms 114.535ms 128.231ms 129.401ms        0
+getEvents        cold      15      166        5.5 181.201ms  205.37ms 220.335ms 236.675ms        0
+
+### soroswap COLD getTransaction (concurrency 1)
+
+endpoint         tier   terms    count        RPS       p50       p90       p99       max   errors
+--------------------------------------------------------------------------------------------------
+getTransaction   cold       -     9721      324.0   2.687ms   4.843ms   6.513ms   9.193ms        0
+
+### soroswap COLD getLedgers (limit 1, concurrency 1)
+
+endpoint         tier   terms    count        RPS       p50       p90       p99       max   errors
+--------------------------------------------------------------------------------------------------
+getLedgers       cold       -       78        2.6 390.585ms 416.619ms  462.88ms  462.88ms        0

--- a/tools/bench-suite/results/fullhistory-latency-2026-07-16/run2-logs/fhbench-cold-token.txt
+++ b/tools/bench-suite/results/fullhistory-latency-2026-07-16/run2-logs/fhbench-cold-token.txt
@@ -1,0 +1,20 @@
+### token COLD getEvents term sweep (full frozen chunk, limit 10, concurrency 1)
+
+endpoint         tier   terms    count        RPS       p50       p90       p99       max   errors
+--------------------------------------------------------------------------------------------------
+getEvents        cold       1     6613      220.4   4.446ms   5.906ms   7.174ms  17.772ms        0
+getEvents        cold       4     4489      149.6   6.722ms   8.128ms   9.481ms  15.836ms        0
+getEvents        cold       8     3270      109.0   8.901ms   11.58ms   13.35ms  21.878ms        0
+getEvents        cold      15     1818       60.6  16.467ms  18.922ms   21.78ms  25.015ms        0
+
+### token COLD getTransaction (concurrency 1)
+
+endpoint         tier   terms    count        RPS       p50       p90       p99       max   errors
+--------------------------------------------------------------------------------------------------
+getTransaction   cold       -     1692       56.4   16.62ms   27.14ms   37.47ms  41.236ms        0
+
+### token COLD getLedgers (limit 1, concurrency 1)
+
+endpoint         tier   terms    count        RPS       p50       p90       p99       max   errors
+--------------------------------------------------------------------------------------------------
+getLedgers       cold       -       51        1.7 595.192ms 622.129ms 641.239ms 641.239ms        0

--- a/tools/bench-suite/results/fullhistory-latency-2026-07-16/run2-logs/hot-sac.txt
+++ b/tools/bench-suite/results/fullhistory-latency-2026-07-16/run2-logs/hot-sac.txt
@@ -1,0 +1,19 @@
+=== RUN   TestServeE2E_ProfileLatency
+    serve_e2e_profile_latency_test.go:593: ingest→query visibility on real "sac" ledgers [10202..10221], warmup=200 (20 samples, one per ledger):
+    serve_e2e_profile_latency_test.go:595:   span       p50            p90            p99            max
+    serve_e2e_profile_latency_test.go:596:   (NOTE: p90/p99 over 20 one-per-ledger samples collapse toward max; see the query-latency pass below for a dense p99)
+    serve_e2e_profile_latency_test.go:586:   full       p50=1m22.746662s p90=1m26.242083s p99=1m27.105077s max=1m27.105077s
+    serve_e2e_profile_latency_test.go:586:   ingest     p50=127.563ms  p90=140.723ms  p99=175.259ms  max=175.259ms
+    serve_e2e_profile_latency_test.go:586:   visible    p50=1m22.619099s p90=1m26.115167s p99=1m26.964353s max=1m26.964353s
+    serve_e2e_profile_latency_test.go:605: query-latency pass: 500 reps/endpoint over [10202,10221] (200 tx hashes, contract="CCMPGRP4VKR5CJR77YQHDWB3KIKYYRHZSVWGC5F2JRIME2UNM4JLI64D"):
+    serve_e2e_profile_latency_test.go:607:   endpoint         count    p50          p90          p99          max          errors
+    serve_e2e_profile_latency_test.go:647:   getLedgers       80       566.999ms    577.826ms    593.944ms    593.944ms    0  (budget-capped at 45s)
+    serve_e2e_profile_latency_test.go:647:   getTransaction   500      18.49ms      19.188ms     26.846ms     30.103ms     0
+    serve_e2e_profile_latency_test.go:647:   getEvents        500      6.802ms      8.152ms      12.198ms     13.692ms     0
+    serve_e2e_profile_latency_test.go:697: getEvents term sweep over [10202,10221]: 402 terms harvested (limit 10/page):
+    serve_e2e_profile_latency_test.go:647:   getEvents[t=1]   500      8.435ms      9.678ms      11.417ms     27.601ms     0
+    serve_e2e_profile_latency_test.go:647:   getEvents[t=4]   500      8.387ms      9.009ms      10.751ms     12.932ms     0
+    serve_e2e_profile_latency_test.go:647:   getEvents[t=8]   500      8.522ms      9.112ms      11.133ms     12.248ms     0
+    serve_e2e_profile_latency_test.go:647:   getEvents[t=15]  500      6.773ms      7.841ms      11.383ms     14.988ms     0
+--- PASS: TestServeE2E_ProfileLatency (193.27s)
+PASS

--- a/tools/bench-suite/results/fullhistory-latency-2026-07-16/run2-logs/hot-soroswap.txt
+++ b/tools/bench-suite/results/fullhistory-latency-2026-07-16/run2-logs/hot-soroswap.txt
@@ -1,0 +1,19 @@
+=== RUN   TestServeE2E_ProfileLatency
+    serve_e2e_profile_latency_test.go:593: ingest→query visibility on real "soroswap" ledgers [10202..10221], warmup=200 (20 samples, one per ledger):
+    serve_e2e_profile_latency_test.go:595:   span       p50            p90            p99            max
+    serve_e2e_profile_latency_test.go:596:   (NOTE: p90/p99 over 20 one-per-ledger samples collapse toward max; see the query-latency pass below for a dense p99)
+    serve_e2e_profile_latency_test.go:586:   full       p50=41.343576s p90=43.48722s  p99=44.050247s max=44.050247s
+    serve_e2e_profile_latency_test.go:586:   ingest     p50=80.211ms   p90=84.254ms   p99=87.29ms    max=87.29ms
+    serve_e2e_profile_latency_test.go:586:   visible    p50=41.268695s p90=43.407009s p99=43.972513s max=43.972513s
+    serve_e2e_profile_latency_test.go:605: query-latency pass: 500 reps/endpoint over [10202,10221] (200 tx hashes, contract="CAWUNDBJDSUIPM5A3XAPFDHMMWI6EE5V6NBOEV6BFQTY3JD55P4S75AC"):
+    serve_e2e_profile_latency_test.go:607:   endpoint         count    p50          p90          p99          max          errors
+    serve_e2e_profile_latency_test.go:647:   getLedgers       126      355.867ms    368.602ms    387.096ms    391.362ms    0  (budget-capped at 45s)
+    serve_e2e_profile_latency_test.go:647:   getTransaction   500      11.049ms     12.065ms     13.415ms     14.126ms     0
+    serve_e2e_profile_latency_test.go:647:   getEvents        500      4.747ms      5.084ms      6.419ms      7.331ms      0
+    serve_e2e_profile_latency_test.go:697: getEvents term sweep over [10202,10221]: 91 terms harvested (limit 10/page):
+    serve_e2e_profile_latency_test.go:647:   getEvents[t=1]   500      4.16ms       4.724ms      5.917ms      7.013ms      0
+    serve_e2e_profile_latency_test.go:647:   getEvents[t=4]   500      4.337ms      6.273ms      7.773ms      8.677ms      0
+    serve_e2e_profile_latency_test.go:647:   getEvents[t=8]   500      6.133ms      6.819ms      7.731ms      8.663ms      0
+    serve_e2e_profile_latency_test.go:647:   getEvents[t=15]  500      6.124ms      6.746ms      7.345ms      7.666ms      0
+--- PASS: TestServeE2E_ProfileLatency (123.85s)
+PASS

--- a/tools/bench-suite/results/fullhistory-latency-2026-07-16/run2-logs/hot-token.txt
+++ b/tools/bench-suite/results/fullhistory-latency-2026-07-16/run2-logs/hot-token.txt
@@ -1,0 +1,19 @@
+=== RUN   TestServeE2E_ProfileLatency
+    serve_e2e_profile_latency_test.go:593: ingest→query visibility on real "token" ledgers [10202..10221], warmup=200 (20 samples, one per ledger):
+    serve_e2e_profile_latency_test.go:595:   span       p50            p90            p99            max
+    serve_e2e_profile_latency_test.go:596:   (NOTE: p90/p99 over 20 one-per-ledger samples collapse toward max; see the query-latency pass below for a dense p99)
+    serve_e2e_profile_latency_test.go:586:   full       p50=1m19.367581s p90=1m22.665839s p99=1m23.510799s max=1m23.510799s
+    serve_e2e_profile_latency_test.go:586:   ingest     p50=122.765ms  p90=128.778ms  p99=132.615ms  max=132.615ms
+    serve_e2e_profile_latency_test.go:586:   visible    p50=1m19.246581s p90=1m22.539908s p99=1m23.409197s max=1m23.409197s
+    serve_e2e_profile_latency_test.go:605: query-latency pass: 500 reps/endpoint over [10202,10221] (200 tx hashes, contract="CA5EIFMV7WOGRAAZS4PG66LTAWHGNKJRD63MRJLZJPFPOWOIRKBGF63C"):
+    serve_e2e_profile_latency_test.go:607:   endpoint         count    p50          p90          p99          max          errors
+    serve_e2e_profile_latency_test.go:647:   getLedgers       83       548.691ms    557.727ms    563.645ms    563.645ms    0  (budget-capped at 45s)
+    serve_e2e_profile_latency_test.go:647:   getTransaction   500      18.185ms     19.135ms     25.126ms     27.636ms     0
+    serve_e2e_profile_latency_test.go:647:   getEvents        500      7.614ms      7.843ms      11.265ms     12.059ms     0
+    serve_e2e_profile_latency_test.go:697: getEvents term sweep over [10202,10221]: 402 terms harvested (limit 10/page):
+    serve_e2e_profile_latency_test.go:647:   getEvents[t=1]   500      7.624ms      7.94ms       11.878ms     12.15ms      0
+    serve_e2e_profile_latency_test.go:647:   getEvents[t=4]   500      6.205ms      7.682ms      8.55ms       11.796ms     0
+    serve_e2e_profile_latency_test.go:647:   getEvents[t=8]   500      7.532ms      7.763ms      10.195ms     12.163ms     0
+    serve_e2e_profile_latency_test.go:647:   getEvents[t=15]  500      7.66ms       7.877ms      12.412ms     12.813ms     0
+--- PASS: TestServeE2E_ProfileLatency (183.94s)
+PASS

--- a/tools/bench-suite/results/fullhistory-latency-2026-07-16/termsweep.csv
+++ b/tools/bench-suite/results/fullhistory-latency-2026-07-16/termsweep.csv
@@ -1,0 +1,44 @@
+profile,tier,scope,terms,p50_ms,p90_ms,p99_ms,max_ms,count,notes
+# getEvents OR-union index-term sweep (run 2, 2026-07-16). A term = one indexed
+# constraint (distinct contract ID, or distinct topic value at position 0..2),
+# harvested from real events and OR-united into homogeneous filters, limit 10.
+# scope=window20: fixed span = the 20-ledger steady-state window [10202..10221],
+#   sequential closed loop, 500 reps (45 s budget), via the e2e harness sweeps.
+# scope=chunk: random start over the whole frozen chunk [10002..20001], endLedger
+#   = chunk end, fhbench --concurrency 1 --duration 30s (count = reps completed).
+sac,hot,window20,1,8.435,9.678,11.417,27.601,500,
+sac,hot,window20,4,8.387,9.009,10.751,12.932,500,
+sac,hot,window20,8,8.522,9.112,11.133,12.248,500,
+sac,hot,window20,15,6.773,7.841,11.383,14.988,500,
+token,hot,window20,1,7.624,7.940,11.878,12.150,500,
+token,hot,window20,4,6.205,7.682,8.550,11.796,500,
+token,hot,window20,8,7.532,7.763,10.195,12.163,500,
+token,hot,window20,15,7.660,7.877,12.412,12.813,500,
+soroswap,hot,window20,1,4.160,4.724,5.917,7.013,500,
+soroswap,hot,window20,4,4.337,6.273,7.773,8.677,500,
+soroswap,hot,window20,8,6.133,6.819,7.731,8.663,500,
+soroswap,hot,window20,15,6.124,6.746,7.345,7.666,500,
+sac,cold,window20,1,8.440,10.361,13.402,14.282,500,
+sac,cold,window20,4,8.629,10.675,12.816,15.383,500,
+sac,cold,window20,8,6.623,9.232,11.923,13.312,500,
+sac,cold,window20,15,8.666,10.466,14.113,15.358,500,
+token,cold,window20,1,3.449,4.239,4.850,5.290,500,
+token,cold,window20,4,5.123,6.143,7.076,9.435,500,
+token,cold,window20,8,8.149,13.171,15.393,18.359,500,
+token,cold,window20,15,16.933,19.646,22.035,23.051,500,
+soroswap,cold,window20,1,9.497,12.772,16.439,17.918,500,
+soroswap,cold,window20,4,52.697,60.010,67.019,73.349,500,
+soroswap,cold,window20,8,98.490,115.712,129.649,137.659,453,budget-capped 45s
+soroswap,cold,window20,15,137.214,150.247,158.341,171.999,332,budget-capped 45s
+sac,cold,chunk,1,8.028,12.151,14.004,16.850,3422,
+sac,cold,chunk,4,8.444,12.423,15.301,17.493,3343,
+sac,cold,chunk,8,8.480,12.555,14.670,18.926,3409,
+sac,cold,chunk,15,8.360,12.791,15.519,18.322,3302,
+token,cold,chunk,1,4.446,5.906,7.174,17.772,6613,
+token,cold,chunk,4,6.722,8.128,9.481,15.836,4489,
+token,cold,chunk,8,8.901,11.580,13.350,21.878,3270,
+token,cold,chunk,15,16.467,18.922,21.780,25.015,1818,
+soroswap,cold,chunk,1,12.433,15.647,18.268,23.399,2399,
+soroswap,cold,chunk,4,47.076,55.431,61.596,66.871,623,
+soroswap,cold,chunk,8,101.203,114.535,128.231,129.401,295,
+soroswap,cold,chunk,15,181.201,205.370,220.335,236.675,166,

--- a/tools/bench-suite/results/fullhistory-query-latency-combined-2026-07-16.html
+++ b/tools/bench-suite/results/fullhistory-query-latency-combined-2026-07-16.html
@@ -1,0 +1,513 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Stellar RPC v2 — Query Latency Report (2026-07-16)</title>
+<style>
+:root {
+  --page: #f6f7f9;
+  --surface: #fcfdfe;
+  --ink: #101720;
+  --ink-2: #4a5460;
+  --muted: #828b98;
+  --grid: #e4e8ed;
+  --baseline: #c5ccd4;
+  --border: rgba(16, 23, 32, 0.10);
+  --accent: #2a78d6;
+  --s1: #2a78d6;  /* blue   — cold tier / extract / ingest_total */
+  --s2: #1baf7a;  /* aqua   */
+  --s3: #eda100;  /* yellow */
+  --s5: #4a3aa7;  /* violet — apply */
+  --s6: #e34948;  /* red    — commit/fsync, MPHF finalize */
+  --hot: #eb6834; /* orange — hot tier / block-interval reference */
+  --deemph: #aeb6c0;
+  --good: #0ca30c;
+  --good-text: #006300;
+  --warn: #b95f04;
+  --tip-bg: #101720;
+  --tip-ink: #f3f6f9;
+  --tip-ink2: #b9c2cc;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --page: #0b0e12; --surface: #14181e; --ink: #f3f6f9; --ink-2: #b9c2cc;
+    --muted: #8a93a0; --grid: #242b34; --baseline: #39424d;
+    --border: rgba(255,255,255,0.10); --accent: #3987e5;
+    --s1: #3987e5; --s2: #199e70; --s3: #c98500; --s5: #9085e9; --s6: #e66767;
+    --hot: #d95926; --deemph: #4a545f; --good: #0ca30c; --good-text: #0ca30c;
+    --warn: #e08a2e;
+    --tip-bg: #f3f6f9; --tip-ink: #101720; --tip-ink2: #4a5460;
+  }
+}
+:root[data-theme="light"] {
+  --page: #f6f7f9; --surface: #fcfdfe; --ink: #101720; --ink-2: #4a5460;
+  --muted: #828b98; --grid: #e4e8ed; --baseline: #c5ccd4;
+  --border: rgba(16,23,32,0.10); --accent: #2a78d6;
+  --s1: #2a78d6; --s2: #1baf7a; --s3: #eda100; --s5: #4a3aa7; --s6: #e34948;
+  --hot: #eb6834; --deemph: #aeb6c0; --good: #0ca30c; --good-text: #006300;
+  --warn: #b95f04;
+  --tip-bg: #101720; --tip-ink: #f3f6f9; --tip-ink2: #b9c2cc;
+}
+:root[data-theme="dark"] {
+  --page: #0b0e12; --surface: #14181e; --ink: #f3f6f9; --ink-2: #b9c2cc;
+  --muted: #8a93a0; --grid: #242b34; --baseline: #39424d;
+  --border: rgba(255,255,255,0.10); --accent: #3987e5;
+  --s1: #3987e5; --s2: #199e70; --s3: #c98500; --s5: #9085e9; --s6: #e66767;
+  --hot: #d95926; --deemph: #4a545f; --good: #0ca30c; --good-text: #0ca30c;
+  --warn: #e08a2e;
+  --tip-bg: #f3f6f9; --tip-ink: #101720; --tip-ink2: #4a5460;
+}
+
+* { box-sizing: border-box; }
+html { background: var(--page); }
+body {
+  margin: 0; background: var(--page); color: var(--ink);
+  font: 15px/1.6 -apple-system, "Segoe UI", system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  border-top: 4px solid var(--accent);
+}
+.mono { font-family: ui-monospace, "SF Mono", "Cascadia Code", Menlo, Consolas, monospace; }
+.wrap { max-width: 940px; margin: 0 auto; padding: 0 24px 80px; }
+
+.masthead { padding: 40px 0 0; }
+.mast-eyebrow {
+  display: flex; justify-content: space-between; align-items: baseline; gap: 16px;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 11.5px; letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--ink-2); border-bottom: 1px solid var(--baseline); padding-bottom: 10px;
+}
+h1 {
+  font-size: clamp(28px, 4.6vw, 40px); line-height: 1.12; font-weight: 750;
+  letter-spacing: -0.015em; text-wrap: balance; margin: 26px 0 10px; max-width: 21em;
+}
+.mast-sub { color: var(--ink-2); font-size: 16.5px; max-width: 44em; margin: 0 0 28px; text-wrap: balance; }
+.meta-grid {
+  display: grid; grid-template-columns: 1fr;
+  border: 1px solid var(--border); border-radius: 10px; overflow: hidden; background: var(--surface);
+}
+.meta-cell { padding: 12px 16px 11px; border-top: 1px solid var(--border); }
+.meta-grid .meta-cell:first-child { border-top: none; }
+@media (min-width: 760px) {
+  .meta-grid { grid-template-columns: repeat(3, 1fr); }
+  .meta-grid .meta-cell:nth-child(-n+3) { border-top: none; }
+  .meta-cell:not(:nth-child(3n+1)) { border-left: 1px solid var(--border); }
+}
+.meta-k {
+  font-family: ui-monospace, Menlo, Consolas, monospace;
+  font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--muted); margin-bottom: 3px;
+}
+.meta-v { font-size: 13.5px; color: var(--ink); font-family: ui-monospace, Menlo, Consolas, monospace; overflow-wrap: anywhere; }
+.meta-v a { color: var(--accent); text-decoration: none; border-bottom: 1px solid transparent; }
+.meta-v a:hover { border-bottom-color: var(--accent); }
+
+section { margin-top: 64px; }
+.sec-head { display: flex; align-items: baseline; gap: 14px; border-bottom: 1px solid var(--baseline); padding-bottom: 8px; margin-bottom: 8px; }
+.sec-num { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 13px; color: var(--accent); letter-spacing: 0.08em; }
+h2 { font-size: 23px; font-weight: 700; letter-spacing: -0.01em; margin: 0; text-wrap: balance; }
+.sec-intro { color: var(--ink-2); max-width: 46em; }
+p { max-width: 46em; }
+p strong { font-weight: 650; color: var(--ink); }
+code { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 0.9em; background: color-mix(in srgb, var(--ink) 6%, transparent); padding: 1px 5px; border-radius: 4px; }
+
+.banner {
+  display: flex; align-items: center; gap: 22px; flex-wrap: wrap;
+  background: var(--surface); border: 1px solid var(--border);
+  border-left: 4px solid var(--good);
+  border-radius: 10px; padding: 20px 24px; margin: 24px 0 18px;
+}
+.banner-figure { font-size: 52px; font-weight: 750; letter-spacing: -0.02em; line-height: 1; }
+.banner-figure .of { color: var(--muted); font-weight: 500; }
+.banner-copy { flex: 1 1 320px; min-width: 260px; }
+.banner-copy .lead { font-weight: 650; }
+.banner-copy p { margin: 2px 0 0; color: var(--ink-2); font-size: 13.5px; line-height: 1.5; }
+.chip {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 11px; letter-spacing: 0.08em;
+  color: var(--good-text); border: 1px solid color-mix(in srgb, var(--good) 45%, transparent);
+  background: color-mix(in srgb, var(--good) 9%, transparent);
+  border-radius: 999px; padding: 2px 9px; vertical-align: 2px;
+}
+.chip.warn {
+  color: var(--warn); border-color: color-mix(in srgb, var(--warn) 45%, transparent);
+  background: color-mix(in srgb, var(--warn) 9%, transparent);
+}
+.tiles { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 12px; margin-top: 14px; }
+.tile { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 16px 18px 14px; }
+.tile-label { font-size: 12.5px; color: var(--ink-2); line-height: 1.45; }
+.tile-value { font-size: 30px; font-weight: 700; letter-spacing: -0.01em; line-height: 1.15; margin-bottom: 4px; }
+.tile-value small { font-size: 16px; font-weight: 600; color: var(--ink-2); }
+
+figure.fig { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; margin: 22px 0; padding: 18px 20px 12px; }
+.fig-head { display: flex; justify-content: space-between; gap: 16px; align-items: baseline; flex-wrap: wrap; margin-bottom: 4px; }
+.fig-title { font-weight: 650; font-size: 15px; }
+.fig-no {
+  font-family: ui-monospace, Menlo, Consolas, monospace;
+  font-size: 10.5px; letter-spacing: 0.12em; color: var(--muted); text-transform: uppercase;
+  display: block; margin-bottom: 2px;
+}
+.legend { display: flex; gap: 14px; flex-wrap: wrap; align-items: center; font-size: 12px; color: var(--ink-2); }
+.lg-item { display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; }
+.lg-sw { width: 11px; height: 11px; border-radius: 3px; flex: none; }
+.lg-ln { width: 16px; height: 2px; border-radius: 1px; flex: none; }
+.fig-body { min-height: 40px; }
+.fig-body svg { display: block; width: 100%; height: auto; }
+figcaption { color: var(--muted); font-size: 12.5px; line-height: 1.5; margin: 8px 0 6px; max-width: 60em; }
+
+.ax { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 11px; fill: var(--muted); font-variant-numeric: tabular-nums; }
+.rowlab { font-size: 12.5px; fill: var(--ink); font-weight: 550; }
+.rowsub { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 10.5px; fill: var(--muted); }
+.vallab { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 11px; fill: var(--ink-2); font-variant-numeric: tabular-nums; }
+.gridline { stroke: var(--grid); stroke-width: 1; }
+.baseline-l { stroke: var(--baseline); stroke-width: 1; }
+.paneltitle { font-size: 12.5px; fill: var(--ink); font-weight: 620; }
+.refline { stroke: var(--hot); stroke-width: 1.5; stroke-dasharray: 4 4; }
+.reflab { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 10.5px; fill: var(--hot); letter-spacing: 0.04em; }
+
+.hit { cursor: default; }
+.hit:hover { filter: brightness(1.08); }
+.hit:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+@media (prefers-reduced-motion: no-preference) { .hit { transition: filter 120ms ease; } }
+
+.tip {
+  position: fixed; z-index: 50; pointer-events: none; opacity: 0;
+  background: var(--tip-bg); color: var(--tip-ink);
+  border-radius: 8px; padding: 9px 12px; font-size: 12.5px; line-height: 1.5;
+  max-width: 300px; box-shadow: 0 4px 18px rgba(0,0,0,0.25);
+}
+.tip-title { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--tip-ink2); margin-bottom: 4px; }
+.tip-row { display: flex; align-items: baseline; gap: 7px; white-space: nowrap; }
+.tip-key { width: 12px; height: 3px; border-radius: 1.5px; flex: none; align-self: center; }
+.tip-val { font-weight: 650; font-variant-numeric: tabular-nums; }
+.tip-lab { color: var(--tip-ink2); }
+
+details.tv { border-top: 1px solid var(--grid); margin-top: 4px; }
+details.tv summary {
+  cursor: pointer; list-style: none; padding: 8px 0 6px;
+  font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 11px; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--muted);
+}
+details.tv summary::before { content: "▸ "; }
+details.tv[open] summary::before { content: "▾ "; }
+details.tv summary:hover { color: var(--accent); }
+.tv-scroll { overflow-x: auto; padding-bottom: 8px; }
+table.data { border-collapse: collapse; font-size: 12.5px; min-width: 480px; }
+table.data th {
+  text-align: right; font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 10.5px;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted);
+  font-weight: 500; padding: 4px 12px 6px 0; border-bottom: 1px solid var(--baseline);
+}
+table.data th:first-child, table.data td:first-child { text-align: left; padding-left: 0; }
+table.data td {
+  text-align: right; padding: 5px 12px 5px 0; border-bottom: 1px solid var(--grid);
+  font-family: ui-monospace, Menlo, Consolas, monospace; font-variant-numeric: tabular-nums; color: var(--ink-2);
+}
+table.data td:first-child { color: var(--ink); font-family: -apple-system, "Segoe UI", system-ui, sans-serif; }
+
+.target-table-wrap { overflow-x: auto; margin-top: 18px; }
+table.target { border-collapse: collapse; width: 100%; min-width: 600px; background: var(--surface); border: 1px solid var(--border); border-radius: 10px; overflow: hidden; }
+table.target th, table.target td { padding: 10px 14px; border-bottom: 1px solid var(--grid); text-align: right; }
+table.target th { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); font-weight: 500; }
+table.target td { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 13px; font-variant-numeric: tabular-nums; color: var(--ink); }
+table.target th:first-child, table.target td:first-child { text-align: left; }
+table.target td:first-child { font-family: -apple-system, "Segoe UI", system-ui, sans-serif; font-size: 13.5px; }
+.cell-ok { color: var(--good-text); font-size: 10px; letter-spacing: 0.06em; margin-left: 6px; }
+.cell-warn { color: var(--warn); font-size: 10px; letter-spacing: 0.06em; margin-left: 6px; }
+
+.method dl { max-width: 52em; }
+.method dt { font-weight: 650; margin-top: 16px; }
+.method dd { margin: 4px 0 0; color: var(--ink-2); }
+pre.metadata {
+  background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
+  padding: 16px 18px; overflow-x: auto; font-family: ui-monospace, Menlo, Consolas, monospace;
+  font-size: 12px; line-height: 1.6; color: var(--ink-2); margin-top: 14px;
+}
+.footer {
+  margin-top: 72px; padding-top: 16px; border-top: 1px solid var(--baseline);
+  color: var(--muted); font-size: 12.5px; line-height: 1.6;
+}
+.note-callout {
+  border: 1px solid var(--border); border-left: 3px solid var(--hot);
+  background: var(--surface); border-radius: 8px; padding: 12px 16px; margin: 16px 0;
+  font-size: 13.5px; color: var(--ink-2); max-width: 52em;
+}
+.note-callout strong { color: var(--ink); }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="masthead">
+  <div class="mast-eyebrow">
+    <span>Stellar RPC v2 · Full-History Storage Engine</span>
+    <span>Query Latency Report · 2026-07-16</span>
+  </div>
+  <h1>Query latency — synthetic profiles (hot + cold) and live-pubnet hot tip</h1>
+  <p class="mast-sub">Query-serving latency of the <code>full-history</code> daemon over JSON-RPC, combining two
+  regimes: <strong>(A)</strong> three synthetic apply-load profiles — sac / token / soroswap — on both the hot
+  RocksDB tier and the frozen cold tier, and <strong>(B)</strong> live pubnet tip queries on the hot tier with a
+  concurrency sweep. The two ran on different hardware — compare shapes and ratios, not raw ms across parts.</p>
+  <div class="meta-grid">
+    <div class="meta-cell"><div class="meta-k">Part A — machine</div><div class="meta-v">AWS c6id.8xlarge · Xeon Platinum 8375C · 32 vCPU · 64 GiB · local NVMe</div></div>
+    <div class="meta-cell"><div class="meta-k">Part B — machine</div><div class="meta-v">16 vCPU · 58 GB · Debian 13 · data dir on tmpfs · loopback (~0 RTT)</div></div>
+    <div class="meta-cell"><div class="meta-k">Build</div><div class="meta-v">poc/fullhistory-query</div></div>
+    <div class="meta-cell"><div class="meta-k">Part A — method</div><div class="meta-v">real profile ledgers; window 20 steady-state ledgers (10202–10221); 500 reps/endpoint; getLedgers limit=1, 45 s budget; sequential (c=1)</div></div>
+    <div class="meta-cell"><div class="meta-k">Part B — method</div><div class="meta-v">live pubnet, tip ≈ 63,499,700; stellar-core 27.1.0 (proto 27); hey 0.1.5; retention 2 chunks</div></div>
+    <div class="meta-cell"><div class="meta-k">Source</div><div class="meta-v">stellar-rpc <span class="mono">tools/bench-suite/results/</span> · 0 errors throughout</div></div>
+  </div>
+</header>
+
+<section id="glance">
+  <div class="sec-head"><span class="sec-num">01</span><h2>At a glance</h2></div>
+  <div class="banner">
+    <div class="banner-copy">
+      <div class="lead">getTransaction / getEvents stay cheap; <code>getLedgers</code> is payload-bound, not read-bound. <span class="chip">✓ COLD ≈ HOT</span> <span class="chip warn">SELECTIVE getEvents TAIL</span></div>
+      <p>On the light endpoints, query adds only ~4–18 ms on top of ingest. A direct hot read of a 17 MB ledger
+      (incl. zstd decode) is ~8 ms, yet serving it over HTTP is ~567 ms — <strong>~98.6 % is base64 + JSON + HTTP</strong>
+      shipping the blob, ~1.4 % is the storage read. Cold serves ≈ as fast as hot, with one exception: selective
+      multi-term getEvents on cold scales with term count while hot stays flat.</p>
+    </div>
+  </div>
+  <div class="tiles">
+    <div class="tile"><div class="tile-value">~35 <small>ms</small></div><div class="tile-label">Live-pubnet <code>getLedgers</code> (limit 1) end-to-end p50 on a ~1.7 MB ledger; ~4.6 ms of that is the server handler.</div></div>
+    <div class="tile"><div class="tile-value">~567 <small>ms</small></div><div class="tile-label">Synthetic sac <code>getLedgers</code> hot p50 on a ~17 MB ledger — ~1.4 % read, ~98.6 % transfer.</div></div>
+    <div class="tile"><div class="tile-value">1.7–2.9 <small>ms</small></div><div class="tile-label">Live-pubnet <code>getEvents</code> / <code>getTransaction</code> p50 at the tip — the light endpoints are near-instant.</div></div>
+    <div class="tile"><div class="tile-value">≈12 <small>ms / term</small></div><div class="tile-label">soroswap selective <code>getEvents</code> on cold: latency scales with OR-union term count (hot stays flat). POC cold-reader open + underfill loop.</div></div>
+  </div>
+</section>
+
+<section id="synthetic-hot">
+  <div class="sec-head"><span class="sec-num">02</span><h2>Part A — synthetic profiles, hot tier</h2></div>
+  <p class="sec-intro">Real sac / token / soroswap apply-load ledgers replayed through the daemon and served from
+  the hot RocksDB tier. These ledgers are large — thousands of tx + Soroban meta each.</p>
+
+  <div class="target-table-wrap"><table class="target">
+    <thead><tr><th>profile</th><th>decompressed LCM</th><th>on-disk (zstd)</th><th>compression</th></tr></thead>
+    <tbody>
+      <tr><td>sac</td><td>~17.3 MB</td><td>~2.1 MB</td><td>8.2×</td></tr>
+      <tr><td>token</td><td>~16.5 MB</td><td>~1.7 MB</td><td>9.5×</td></tr>
+      <tr><td>soroswap</td><td>~10.0 MB</td><td>~0.5 MB</td><td>19×</td></tr>
+    </tbody>
+  </table></div>
+
+  <p style="margin-top:22px"><strong>Ingest → durable commit, per ledger</strong> (source → commit, ms):</p>
+  <div class="target-table-wrap"><table class="target">
+    <thead><tr><th>profile</th><th>p50</th><th>p90</th><th>p99</th></tr></thead>
+    <tbody>
+      <tr><td>sac</td><td>129.3</td><td>138.9</td><td>145.3</td></tr>
+      <tr><td>token</td><td>129.9</td><td>133.6</td><td>144.7</td></tr>
+      <tr><td>soroswap</td><td>76.7</td><td>82.6</td><td>85.4</td></tr>
+    </tbody>
+  </table></div>
+
+  <p style="margin-top:22px"><strong>Query latency — hot tier</strong> (ms). getLedgers at limit=1 (budget-capped
+  <code>count</code>); getTransaction / getEvents 500 reps:</p>
+  <div class="target-table-wrap"><table class="target">
+    <thead><tr><th>profile</th><th>endpoint</th><th>count</th><th>p50</th><th>p90</th><th>p99</th><th>max</th></tr></thead>
+    <tbody>
+      <tr><td>sac</td><td>getLedgers</td><td>80</td><td>567.4</td><td>581.8</td><td>607.6</td><td>607.6</td></tr>
+      <tr><td>sac</td><td>getTransaction</td><td>500</td><td>18.1</td><td>19.2</td><td>25.4</td><td>28.9</td></tr>
+      <tr><td>sac</td><td>getEvents</td><td>500</td><td>7.8</td><td>8.0</td><td>12.0</td><td>12.6</td></tr>
+      <tr><td>token</td><td>getLedgers</td><td>82</td><td>550.8</td><td>557.7</td><td>570.6</td><td>570.6</td></tr>
+      <tr><td>token</td><td>getTransaction</td><td>500</td><td>18.2</td><td>19.5</td><td>24.8</td><td>26.8</td></tr>
+      <tr><td>token</td><td>getEvents</td><td>500</td><td>7.5</td><td>7.9</td><td>10.0</td><td>13.6</td></tr>
+      <tr><td>soroswap</td><td>getLedgers</td><td>127</td><td>355.8</td><td>363.8</td><td>370.6</td><td>375.3</td></tr>
+      <tr><td>soroswap</td><td>getTransaction</td><td>500</td><td>11.6</td><td>12.5</td><td>17.6</td><td>19.8</td></tr>
+      <tr><td>soroswap</td><td>getEvents</td><td>500</td><td>4.4</td><td>5.5</td><td>8.0</td><td>8.6</td></tr>
+    </tbody>
+  </table></div>
+</section>
+
+<section id="synthetic-cold">
+  <div class="sec-head"><span class="sec-num">03</span><h2>Part A — synthetic profiles, cold tier</h2></div>
+  <p class="sec-intro">Served from frozen cold artifacts (<code>.pack</code> + MPHF/bitmap index), page-cache-warm.
+  Run 2 froze all three profiles' catalogs and re-measured sac as a reproduction check.</p>
+
+  <div class="target-table-wrap"><table class="target">
+    <thead><tr><th>profile</th><th>endpoint</th><th>count</th><th>p50</th><th>p90</th><th>p99</th><th>max</th></tr></thead>
+    <tbody>
+      <tr><td>sac</td><td>getLedgers</td><td>73</td><td>617.2</td><td>653.1</td><td>671.0</td><td>671.0</td></tr>
+      <tr><td>sac</td><td>getTransaction</td><td>500</td><td>18.3</td><td>31.7</td><td>40.3</td><td>43.3</td></tr>
+      <tr><td>sac</td><td>getEvents</td><td>500</td><td>8.8</td><td>10.5</td><td>14.4</td><td>14.9</td></tr>
+      <tr><td>token</td><td>getLedgers</td><td>74</td><td>604.9</td><td>638.9</td><td>664.0</td><td>664.0</td></tr>
+      <tr><td>token</td><td>getTransaction</td><td>500</td><td>16.0</td><td>25.4</td><td>34.0</td><td>41.5</td></tr>
+      <tr><td>token</td><td>getEvents</td><td>500</td><td>3.4</td><td>4.2</td><td>4.9</td><td>5.4</td></tr>
+      <tr><td>soroswap</td><td>getLedgers</td><td>109</td><td>415.4</td><td>433.9</td><td>449.5</td><td>451.6</td></tr>
+      <tr><td>soroswap</td><td>getTransaction</td><td>500</td><td>11.7</td><td>18.9</td><td>25.4</td><td>26.5</td></tr>
+      <tr><td>soroswap</td><td>getEvents</td><td>500</td><td>18.9</td><td>22.8</td><td>24.8</td><td>27.3</td></tr>
+    </tbody>
+  </table></div>
+
+  <div class="note-callout"><strong>Cold ≈ hot — for getLedgers, getTransaction, and dense-match getEvents.</strong>
+  getEvents cold is even slightly faster at p50 on dense-match profiles; getTransaction has a heavier cold tail
+  (cold txhash MPHF lookup + reading the large ledger from the pack). The exception is selective multi-term
+  getEvents on cold — see the term sweep below.</div>
+
+  <p style="margin-top:22px"><strong>getEvents OR-union index-term sweep</strong> (p50 / p90 / p99 ms). A
+  <em>term</em> = one indexed constraint (a contract ID, or a topic value at a position); each row OR-unions N real
+  harvested terms, 500 reps, limit 10:</p>
+  <div class="target-table-wrap"><table class="target">
+    <thead><tr><th>profile</th><th>tier·scope</th><th>t=1</th><th>t=4</th><th>t=8</th><th>t=15</th></tr></thead>
+    <tbody>
+      <tr><td>sac</td><td>hot·window</td><td>8.4 / 9.7 / 11.4</td><td>8.4 / 9.0 / 10.8</td><td>8.5 / 9.1 / 11.1</td><td>6.8 / 7.8 / 11.4</td></tr>
+      <tr><td>sac</td><td>cold·window</td><td>8.4 / 10.4 / 13.4</td><td>8.6 / 10.7 / 12.8</td><td>6.6 / 9.2 / 11.9</td><td>8.7 / 10.5 / 14.1</td></tr>
+      <tr><td>token</td><td>hot·window</td><td>7.6 / 7.9 / 11.9</td><td>6.2 / 7.7 / 8.6</td><td>7.5 / 7.8 / 10.2</td><td>7.7 / 7.9 / 12.4</td></tr>
+      <tr><td>token</td><td>cold·window</td><td>3.4 / 4.2 / 4.9</td><td>5.1 / 6.1 / 7.1</td><td>8.1 / 13.2 / 15.4</td><td>16.9 / 19.6 / 22.0</td></tr>
+      <tr><td>soroswap</td><td>hot·window</td><td>4.2 / 4.7 / 5.9</td><td>4.3 / 6.3 / 7.8</td><td>6.1 / 6.8 / 7.7</td><td>6.1 / 6.7 / 7.3</td></tr>
+      <tr><td>soroswap</td><td>cold·window</td><td>9.5 / 12.8 / 16.4</td><td>52.7 / 60.0 / 67.0</td><td>98.5 / 115.7 / 129.6</td><td>137.2 / 150.2 / 158.3</td></tr>
+    </tbody>
+  </table></div>
+  <p style="font-size:13.5px; color:var(--ink-2)">Hot is flat everywhere (~4–9 ms, 1→15 terms). Cold is flat when
+  terms match densely (sac). Cold scales with term count when terms are selective: token ≈1 ms/term; soroswap
+  (most selective vocabulary) ≈12 ms/term → 15 terms ≈ 137 ms. Cause: the cold reader is opened per request (POC,
+  no LRU) and sparse matches trigger the POC underfill re-query loop in <code>events_handler.scanChunk</code>.
+  Productionization paths: an LRU for cold readers and a streaming pager.</p>
+
+  <p style="margin-top:22px"><strong>Direct in-process read</strong>, no serve path (ms). <code>store.Get</code> =
+  RocksDB point read (compressed); <code>GetLedgerRaw</code> adds the zstd decode:</p>
+  <div class="target-table-wrap"><table class="target">
+    <thead><tr><th>profile</th><th>store.Get (compressed)</th><th>hot GetLedgerRaw</th><th>cold GetLedgerRaw</th></tr></thead>
+    <tbody>
+      <tr><td>sac</td><td>0.63</td><td>8.2</td><td>7.9</td></tr>
+      <tr><td>token</td><td>0.62</td><td>7.4</td><td>7.3</td></tr>
+      <tr><td>soroswap</td><td>0.16</td><td>4.6</td><td>3.7</td></tr>
+    </tbody>
+  </table></div>
+</section>
+
+<section id="livepubnet">
+  <div class="sec-head"><span class="sec-num">04</span><h2>Part B — live pubnet, hot-DB tip querying</h2></div>
+  <p class="sec-intro">Local daemon ingesting live pubnet and serving over JSON-RPC on loopback. Data dir on
+  tmpfs (best-case storage latency). All HTTP 200, zero errors.</p>
+
+  <p><strong>Single-request latency</strong> (warm, sequential, n=40; end-to-end <code>curl</code>
+  <code>time_total</code>, ms):</p>
+  <div class="target-table-wrap"><table class="target">
+    <thead><tr><th>method</th><th>resp size</th><th>min</th><th>p50</th><th>p90</th><th>p99</th><th>max</th><th>mean</th></tr></thead>
+    <tbody>
+      <tr><td>getLedgers (limit 1)</td><td>1.7 MB</td><td>33.0</td><td>35.0</td><td>38.1</td><td>38.9</td><td>39.1</td><td>35.4</td></tr>
+      <tr><td>getTransactions (limit 5)</td><td>17.5 KB</td><td>7.9</td><td>8.5</td><td>9.8</td><td>16.5</td><td>16.7</td><td>9.2</td></tr>
+      <tr><td>getTransaction (by hash)</td><td>2.9 KB</td><td>2.4</td><td>2.5</td><td>4.0</td><td>4.1</td><td>10.4</td><td>2.9</td></tr>
+      <tr><td>getEvents (limit 10)</td><td>4.9 KB</td><td>1.7</td><td>1.7</td><td>1.8</td><td>2.2</td><td>4.2</td><td>1.8</td></tr>
+    </tbody>
+  </table></div>
+  <div class="note-callout">Server-side handler latency (from <code>/metrics</code>, excludes network/transfer):
+  getEvents avg 1.68 ms · getTransaction 2.89 ms · getLedgers 4.61 ms · getTransactions 10.51 ms.
+  <strong>getLedgers end-to-end (35 ms) is dominated by shipping the ~1.7 MB LedgerCloseMeta, not the ~4.6 ms
+  handler.</strong></div>
+
+  <p style="margin-top:22px"><strong>Concurrency sweep</strong> (<code>hey</code>, loopback, keep-alive; latencies ms):</p>
+  <div class="tiles" style="grid-template-columns:repeat(auto-fit,minmax(300px,1fr))">
+    <div>
+      <div class="fig-no" style="margin-bottom:6px">getTransaction · ~2.9 KB</div>
+      <div class="target-table-wrap"><table class="target" style="min-width:0">
+        <thead><tr><th>conc</th><th>req/s</th><th>p50</th><th>p90</th><th>p99</th><th>max</th></tr></thead>
+        <tbody>
+          <tr><td>1</td><td>323</td><td>2.5</td><td>4.7</td><td>9.3</td><td>11</td></tr>
+          <tr><td>8</td><td>1,324</td><td>4.2</td><td>11.3</td><td>16.6</td><td>19</td></tr>
+          <tr><td>16</td><td>1,637</td><td>8.1</td><td>17.5</td><td>22.8</td><td>33</td></tr>
+          <tr><td>32</td><td>1,650</td><td>19.1</td><td>29.4</td><td>37.9</td><td>51</td></tr>
+          <tr><td>64</td><td>1,700</td><td>36.5</td><td>51.2</td><td>64.5</td><td>101</td></tr>
+        </tbody>
+      </table></div>
+    </div>
+    <div>
+      <div class="fig-no" style="margin-bottom:6px">getEvents (limit 10) · ~4.9 KB</div>
+      <div class="target-table-wrap"><table class="target" style="min-width:0">
+        <thead><tr><th>conc</th><th>req/s</th><th>p50</th><th>p90</th><th>p99</th><th>max</th></tr></thead>
+        <tbody>
+          <tr><td>1</td><td>460</td><td>1.9</td><td>2.5</td><td>7.1</td><td>14</td></tr>
+          <tr><td>8</td><td>1,905</td><td>2.9</td><td>8.3</td><td>13.7</td><td>16</td></tr>
+          <tr><td>16</td><td>2,207</td><td>5.3</td><td>13.4</td><td>19.9</td><td>24</td></tr>
+          <tr><td>32</td><td>2,213</td><td>13.4</td><td>22.9</td><td>29.8</td><td>38</td></tr>
+          <tr><td>64</td><td>2,256</td><td>27.5</td><td>38.6</td><td>55.8</td><td>74</td></tr>
+        </tbody>
+      </table></div>
+    </div>
+    <div>
+      <div class="fig-no" style="margin-bottom:6px">getTransactions (limit 5) · ~29 KB</div>
+      <div class="target-table-wrap"><table class="target" style="min-width:0">
+        <thead><tr><th>conc</th><th>req/s</th><th>p50</th><th>p90</th><th>p99</th><th>max</th></tr></thead>
+        <tbody>
+          <tr><td>1</td><td>121</td><td>7.4</td><td>11.9</td><td>16.4</td><td>20</td></tr>
+          <tr><td>8</td><td>519</td><td>15.4</td><td>21.3</td><td>25.9</td><td>34</td></tr>
+          <tr><td>16</td><td>532</td><td>28.3</td><td>42.3</td><td>55.8</td><td>75</td></tr>
+          <tr><td>32</td><td>538</td><td>57.2</td><td>81.3</td><td>98.3</td><td>134</td></tr>
+        </tbody>
+      </table></div>
+    </div>
+    <div>
+      <div class="fig-no" style="margin-bottom:6px">getLedgers (limit 1) · ~1.3 MB — heavy payload</div>
+      <div class="target-table-wrap"><table class="target" style="min-width:0">
+        <thead><tr><th>conc</th><th>req/s</th><th>p50</th><th>p90</th><th>p99</th><th>max</th></tr></thead>
+        <tbody>
+          <tr><td>1</td><td>36</td><td>27.0</td><td>30.4</td><td>35.4</td><td>44</td></tr>
+          <tr><td>4</td><td>83</td><td>47.5</td><td>58.3</td><td>68.0</td><td>72</td></tr>
+          <tr><td>8</td><td>80</td><td>95.6</td><td>118.7</td><td>158.5</td><td>165</td></tr>
+          <tr><td>16</td><td>80</td><td>193.8</td><td>244.0</td><td>311.4</td><td>372</td></tr>
+        </tbody>
+      </table></div>
+    </div>
+  </div>
+  <p style="font-size:13.5px; color:var(--ink-2)">Throughput ceilings (16-core box): getEvents ~2,250 req/s ·
+  getTransaction ~1,700 · getTransactions ~535 · getLedgers ~80 req/s. Saturates at concurrency ≈ 8–16, then
+  degrades linearly with concurrency (textbook worker-pool queueing) — no errors, no cliff.</p>
+</section>
+
+<section id="analysis">
+  <div class="sec-head"><span class="sec-num">05</span><h2>Combined analysis</h2></div>
+
+  <div class="note-callout"><strong>getLedgers is payload-bound everywhere.</strong> Live pubnet (~1.7 MB LCM) →
+  ~35 ms end-to-end; synthetic (~17 MB LCM) → ~567 ms. ~10× payload ⇒ ~15× latency while the storage read stays
+  ~5–8 ms. The direct-read numbers confirm it: ~1.4 % read, ~98.6 % base64 + JSON + HTTP.</div>
+
+  <div class="note-callout"><strong>Light endpoints stay cheap even on heavy ledgers.</strong> getTransaction /
+  getEvents: ~1.8–2.9 ms on the pubnet tip → ~8–18 ms on 17 MB synthetic ledgers. They scale with the target
+  ledger's size but never approach getLedgers' cost.</div>
+
+  <div class="note-callout"><strong>Cold ≈ hot — with one exception.</strong> The cold tier serves getLedgers,
+  getTransaction, and dense-match getEvents at essentially hot-tier latency. The exception is selective multi-term
+  getEvents on cold, which scales with term count (token ≈1 ms/term; soroswap ≈12 ms/term → 15 terms ≈ 137 ms)
+  while hot stays flat — the POC's per-request cold-reader open + underfill re-query loop (fixable with an LRU +
+  streaming pager).</div>
+
+  <div class="note-callout"><strong>Ingest gates freshness.</strong> 77–130 ms src→commit on synthetic profiles
+  dwarfs the ~2–18 ms query legs, so how fast a brand-new ledger becomes queryable is ingest-bound for everything
+  except getLedgers.</div>
+
+  <h3 style="margin-top:28px">Where to spend on getLedgers (size-bound, not read-bound)</h3>
+  <ol style="max-width:52em; color:var(--ink-2); line-height:1.7">
+    <li>Cap default/max page size (<code>[serve].default_ledgers_limit</code> / <code>max_ledgers_limit</code>).</li>
+    <li>Transport compression (gzip/zstd <code>Content-Encoding</code>) — base64'd XDR is highly compressible.</li>
+    <li>Stream the base64 encoder instead of materializing the full string per ledger.</li>
+    <li>Lighter projection (header-only / opt-out of full meta).</li>
+    <li><s>Storage-read tuning</s> — the read is ~1 %; not worth it.</li>
+  </ol>
+</section>
+
+<section id="caveats" class="method">
+  <div class="sec-head"><span class="sec-num">06</span><h2>Caveats</h2></div>
+  <dl>
+    <dt>Different hardware between parts</dt>
+    <dd>Part A ran on a 32 vCPU c6id.8xlarge / NVMe; Part B on a 16 vCPU Debian box / tmpfs. Compare shapes and ratios, not raw ms across parts.</dd>
+    <dt>Percentiles</dt>
+    <dd>Nearest-rank. Synthetic getLedgers p99 is over a budget-capped sample (71–127), less robust than the 500-rep getTransaction/getEvents p99s.</dd>
+    <dt>Cold reads are cache-warm</dt>
+    <dd>Synthetic cold reads are OS-page-cache-warm; an uncached first-touch adds disk latency.</dd>
+    <dt>Live-pubnet client contention</dt>
+    <dd>Client + server shared 16 cores (client stole CPU) and loopback RTT ≈ 0 — add real network latency to every p50 and expect higher ceilings on a dedicated client.</dd>
+    <dt>Concurrency</dt>
+    <dd>All Part A query passes are sequential (concurrency 1): unloaded-latency floors, not latency under concurrent load. Part B sweeps concurrency 1–64.</dd>
+  </dl>
+</section>
+
+<div class="footer">
+  Full-history query POC · branch <span class="mono">poc/fullhistory-query</span>. Synthetic profiles measured on
+  AWS c6id.8xlarge; live pubnet on a 16 vCPU Debian box. Source data and prose:
+  <span class="mono">stellar-rpc/tools/bench-suite/results/</span>. No value was invented, interpolated, or smoothed.
+</div>
+
+</div>
+</body>
+</html>

--- a/tools/bench-suite/results/fullhistory-query-latency-combined-2026-07-16.html
+++ b/tools/bench-suite/results/fullhistory-query-latency-combined-2026-07-16.html
@@ -236,6 +236,18 @@ pre.metadata {
 </style>
 </head>
 <body>
+<style>
+  /* comparison-table extras (scoped, self-contained) */
+  table.cmp th.grp { text-align: center; border-bottom: 1px solid var(--baseline); }
+  table.cmp th.g2, table.cmp td.g2 { border-left: 1px solid var(--baseline); }
+  table.cmp td.hi { color: var(--warn); font-weight: 650; }
+  table.cmp td.lo { color: var(--good-text); }
+  .defs dt { font-weight: 650; margin-top: 14px; color: var(--ink); }
+  .defs dt code { font-weight: 650; }
+  .defs dd { margin: 3px 0 0; color: var(--ink-2); }
+  .tbl-note { font-size: 12.5px; color: var(--muted); margin: 8px 0 26px; max-width: 60em; }
+  .tbl-cap { font-weight: 650; margin: 26px 0 8px; }
+</style>
 <div class="wrap">
 
 <header class="masthead">
@@ -243,7 +255,7 @@ pre.metadata {
     <span>Stellar RPC v2 · Full-History Storage Engine</span>
     <span>Query Latency Report · 2026-07-16</span>
   </div>
-  <h1>Query latency — synthetic profiles (hot + cold) and live-pubnet hot tip</h1>
+  <h1>Query latency — synthetic profiles (hot vs cold) and live-pubnet hot tip</h1>
   <p class="mast-sub">Query-serving latency of the <code>full-history</code> daemon over JSON-RPC, combining two
   regimes: <strong>(A)</strong> three synthetic apply-load profiles — sac / token / soroswap — on both the hot
   RocksDB tier and the frozen cold tier, and <strong>(B)</strong> live pubnet tip queries on the hot tier with a
@@ -277,13 +289,50 @@ pre.metadata {
   </div>
 </section>
 
-<section id="synthetic-hot">
-  <div class="sec-head"><span class="sec-num">02</span><h2>Part A — synthetic profiles, hot tier</h2></div>
-  <p class="sec-intro">Real sac / token / soroswap apply-load ledgers replayed through the daemon and served from
-  the hot RocksDB tier. These ledgers are large — thousands of tx + Soroban meta each.</p>
+<section id="defs" class="method">
+  <div class="sec-head"><span class="sec-num">02</span><h2>How to read this report</h2></div>
+  <p class="sec-intro">Every latency below is milliseconds (ms), lower is better, measured end-to-end over JSON-RPC
+  unless a row says otherwise. Definitions of every term and column header:</p>
+  <dl class="defs">
+    <dt>Hot tier vs cold tier</dt>
+    <dd><strong>hot</strong> = the daemon's live RocksDB store, holding recent ledgers in the "hot" DB.
+    <strong>cold</strong> = frozen, immutable chunk artifacts for older history — a zstd <code>.pack</code> file
+    plus MPHF + roaring-bitmap index files. A query hits one tier depending on how old the target ledger is.</dd>
+    <dt><code>p50</code> / <code>p90</code> / <code>p99</code> / <code>max</code></dt>
+    <dd>Latency percentiles (nearest-rank) over the request sample. <strong>p50</strong> = median (half the
+    requests were faster); <strong>p90</strong> / <strong>p99</strong> = the slowest 10 % / 1 % boundary;
+    <strong>max</strong> = the single slowest request. p50 tells you the typical case, p99 the tail.</dd>
+    <dt><code>count</code> / reps</dt>
+    <dd>Number of requests in the sample. Light endpoints use 500 reps; <code>getLedgers</code> is capped by a
+    45-second wall budget (so its count is however many requests fit — 71–127), which makes its p99 less robust.</dd>
+    <dt>Endpoints</dt>
+    <dd><code>getLedgers</code> = fetch whole ledger(s) including the full <code>LedgerCloseMeta</code> blob
+    (large — 10–17 MB each here, measured at <code>limit=1</code>). <code>getTransaction</code> = one transaction
+    by hash. <code>getTransactions</code> = a page of transactions. <code>getEvents</code> = a filtered contract-event
+    query.</dd>
+    <dt>Ingest (source → durable commit)</dt>
+    <dd>Time from the daemon receiving a ledger to it being durably committed (one fsync). This is the "how fresh"
+    leg — separate from query latency, which reads already-committed data.</dd>
+    <dt><code>conc</code> / <code>req/s</code> (Part B)</dt>
+    <dd><strong>conc</strong> = number of concurrent in-flight requests the load generator keeps open.
+    <strong>req/s</strong> = completed requests per second (throughput) at that concurrency.</dd>
+    <dt>term / OR-union (getEvents sweep)</dt>
+    <dd>A <strong>term</strong> is one indexed constraint — a distinct contract ID, or a distinct topic value at a
+    position. A query <strong>OR-unions</strong> N terms (matches any of them). <strong>window</strong> = the query
+    spans the 20-ledger steady-state window; <strong>chunk</strong> = random starts over the whole 10,000-ledger
+    frozen chunk.</dd>
+  </dl>
+</section>
 
+<section id="synthetic">
+  <div class="sec-head"><span class="sec-num">03</span><h2>Part A — synthetic profiles: hot vs cold</h2></div>
+  <p class="sec-intro">Real sac / token / soroswap apply-load ledgers replayed through the daemon and served from
+  each tier. These ledgers are large — thousands of tx + Soroban meta each. Query passes are sequential
+  (one request at a time).</p>
+
+  <div class="tbl-cap">Ledger size per profile</div>
   <div class="target-table-wrap"><table class="target">
-    <thead><tr><th>profile</th><th>decompressed LCM</th><th>on-disk (zstd)</th><th>compression</th></tr></thead>
+    <thead><tr><th>profile</th><th>decompressed LCM (in-memory)</th><th>on-disk (zstd)</th><th>compression ratio</th></tr></thead>
     <tbody>
       <tr><td>sac</td><td>~17.3 MB</td><td>~2.1 MB</td><td>8.2×</td></tr>
       <tr><td>token</td><td>~16.5 MB</td><td>~1.7 MB</td><td>9.5×</td></tr>
@@ -291,9 +340,9 @@ pre.metadata {
     </tbody>
   </table></div>
 
-  <p style="margin-top:22px"><strong>Ingest → durable commit, per ledger</strong> (source → commit, ms):</p>
+  <div class="tbl-cap">Ingest → durable commit, per ledger (source → committed; not a query)</div>
   <div class="target-table-wrap"><table class="target">
-    <thead><tr><th>profile</th><th>p50</th><th>p90</th><th>p99</th></tr></thead>
+    <thead><tr><th>profile</th><th>p50 (median)</th><th>p90</th><th>p99</th></tr></thead>
     <tbody>
       <tr><td>sac</td><td>129.3</td><td>138.9</td><td>145.3</td></tr>
       <tr><td>token</td><td>129.9</td><td>133.6</td><td>144.7</td></tr>
@@ -301,90 +350,117 @@ pre.metadata {
     </tbody>
   </table></div>
 
-  <p style="margin-top:22px"><strong>Query latency — hot tier</strong> (ms). getLedgers at limit=1 (budget-capped
-  <code>count</code>); getTransaction / getEvents 500 reps:</p>
-  <div class="target-table-wrap"><table class="target">
-    <thead><tr><th>profile</th><th>endpoint</th><th>count</th><th>p50</th><th>p90</th><th>p99</th><th>max</th></tr></thead>
+  <div class="tbl-cap">Query latency — hot vs cold, side by side (ms)</div>
+  <div class="target-table-wrap"><table class="target cmp">
+    <thead>
+      <tr>
+        <th rowspan="2">profile</th>
+        <th rowspan="2">endpoint</th>
+        <th class="grp" colspan="2">p50 — typical (ms)</th>
+        <th class="grp g2" colspan="2">p99 — tail (ms)</th>
+      </tr>
+      <tr>
+        <th>hot</th><th>cold</th><th class="g2">hot</th><th>cold</th>
+      </tr>
+    </thead>
     <tbody>
-      <tr><td>sac</td><td>getLedgers</td><td>80</td><td>567.4</td><td>581.8</td><td>607.6</td><td>607.6</td></tr>
-      <tr><td>sac</td><td>getTransaction</td><td>500</td><td>18.1</td><td>19.2</td><td>25.4</td><td>28.9</td></tr>
-      <tr><td>sac</td><td>getEvents</td><td>500</td><td>7.8</td><td>8.0</td><td>12.0</td><td>12.6</td></tr>
-      <tr><td>token</td><td>getLedgers</td><td>82</td><td>550.8</td><td>557.7</td><td>570.6</td><td>570.6</td></tr>
-      <tr><td>token</td><td>getTransaction</td><td>500</td><td>18.2</td><td>19.5</td><td>24.8</td><td>26.8</td></tr>
-      <tr><td>token</td><td>getEvents</td><td>500</td><td>7.5</td><td>7.9</td><td>10.0</td><td>13.6</td></tr>
-      <tr><td>soroswap</td><td>getLedgers</td><td>127</td><td>355.8</td><td>363.8</td><td>370.6</td><td>375.3</td></tr>
-      <tr><td>soroswap</td><td>getTransaction</td><td>500</td><td>11.6</td><td>12.5</td><td>17.6</td><td>19.8</td></tr>
-      <tr><td>soroswap</td><td>getEvents</td><td>500</td><td>4.4</td><td>5.5</td><td>8.0</td><td>8.6</td></tr>
+      <tr><td>sac</td><td>getLedgers</td><td>567.4</td><td>617.2</td><td class="g2">607.6</td><td>671.0</td></tr>
+      <tr><td>sac</td><td>getTransaction</td><td>18.1</td><td>18.3</td><td class="g2">25.4</td><td class="hi">40.3</td></tr>
+      <tr><td>sac</td><td>getEvents</td><td>7.8</td><td>8.8</td><td class="g2">12.0</td><td>14.4</td></tr>
+      <tr><td>token</td><td>getLedgers</td><td>550.8</td><td>604.9</td><td class="g2">570.6</td><td>664.0</td></tr>
+      <tr><td>token</td><td>getTransaction</td><td>18.2</td><td class="lo">16.0</td><td class="g2">24.8</td><td class="hi">34.0</td></tr>
+      <tr><td>token</td><td>getEvents</td><td>7.5</td><td class="lo">3.4</td><td class="g2">10.0</td><td class="lo">4.9</td></tr>
+      <tr><td>soroswap</td><td>getLedgers</td><td>355.8</td><td>415.4</td><td class="g2">370.6</td><td>449.5</td></tr>
+      <tr><td>soroswap</td><td>getTransaction</td><td>11.6</td><td>11.7</td><td class="g2">17.6</td><td class="hi">25.4</td></tr>
+      <tr><td>soroswap</td><td>getEvents</td><td>4.4</td><td class="hi">18.9</td><td class="g2">8.0</td><td class="hi">24.8</td></tr>
     </tbody>
   </table></div>
-</section>
+  <p class="tbl-note"><strong>hot</strong> = live RocksDB tier, <strong>cold</strong> = frozen chunk artifacts.
+  Lower is better. <span style="color:var(--warn); font-weight:650">Orange</span> = cold notably slower than hot;
+  <span style="color:var(--good-text)">green</span> = cold faster than hot. Hot figures are the run-1 pass;
+  cold are the run-2 all-profile pass (hot reproduced within ~5 % run-to-run). <strong>Takeaway: cold tracks hot
+  closely everywhere except soroswap getEvents</strong> (selective filters — see the term sweep below), and cold
+  getTransaction carries a heavier p99 tail (cold txhash MPHF lookup).</p>
 
-<section id="synthetic-cold">
-  <div class="sec-head"><span class="sec-num">03</span><h2>Part A — synthetic profiles, cold tier</h2></div>
-  <p class="sec-intro">Served from frozen cold artifacts (<code>.pack</code> + MPHF/bitmap index), page-cache-warm.
-  Run 2 froze all three profiles' catalogs and re-measured sac as a reproduction check.</p>
-
-  <div class="target-table-wrap"><table class="target">
-    <thead><tr><th>profile</th><th>endpoint</th><th>count</th><th>p50</th><th>p90</th><th>p99</th><th>max</th></tr></thead>
-    <tbody>
-      <tr><td>sac</td><td>getLedgers</td><td>73</td><td>617.2</td><td>653.1</td><td>671.0</td><td>671.0</td></tr>
-      <tr><td>sac</td><td>getTransaction</td><td>500</td><td>18.3</td><td>31.7</td><td>40.3</td><td>43.3</td></tr>
-      <tr><td>sac</td><td>getEvents</td><td>500</td><td>8.8</td><td>10.5</td><td>14.4</td><td>14.9</td></tr>
-      <tr><td>token</td><td>getLedgers</td><td>74</td><td>604.9</td><td>638.9</td><td>664.0</td><td>664.0</td></tr>
-      <tr><td>token</td><td>getTransaction</td><td>500</td><td>16.0</td><td>25.4</td><td>34.0</td><td>41.5</td></tr>
-      <tr><td>token</td><td>getEvents</td><td>500</td><td>3.4</td><td>4.2</td><td>4.9</td><td>5.4</td></tr>
-      <tr><td>soroswap</td><td>getLedgers</td><td>109</td><td>415.4</td><td>433.9</td><td>449.5</td><td>451.6</td></tr>
-      <tr><td>soroswap</td><td>getTransaction</td><td>500</td><td>11.7</td><td>18.9</td><td>25.4</td><td>26.5</td></tr>
-      <tr><td>soroswap</td><td>getEvents</td><td>500</td><td>18.9</td><td>22.8</td><td>24.8</td><td>27.3</td></tr>
-    </tbody>
-  </table></div>
+  <details class="tv"><summary>Full percentiles — hot and cold (p50 / p90 / p99 / max, with sample count)</summary>
+  <div class="tv-scroll" style="padding-top:12px">
+    <div class="tbl-cap" style="margin-top:8px">Hot tier</div>
+    <table class="data" style="width:100%">
+      <thead><tr><th>profile</th><th>endpoint</th><th>count</th><th>p50</th><th>p90</th><th>p99</th><th>max</th></tr></thead>
+      <tbody>
+        <tr><td>sac</td><td>getLedgers</td><td>80</td><td>567.4</td><td>581.8</td><td>607.6</td><td>607.6</td></tr>
+        <tr><td>sac</td><td>getTransaction</td><td>500</td><td>18.1</td><td>19.2</td><td>25.4</td><td>28.9</td></tr>
+        <tr><td>sac</td><td>getEvents</td><td>500</td><td>7.8</td><td>8.0</td><td>12.0</td><td>12.6</td></tr>
+        <tr><td>token</td><td>getLedgers</td><td>82</td><td>550.8</td><td>557.7</td><td>570.6</td><td>570.6</td></tr>
+        <tr><td>token</td><td>getTransaction</td><td>500</td><td>18.2</td><td>19.5</td><td>24.8</td><td>26.8</td></tr>
+        <tr><td>token</td><td>getEvents</td><td>500</td><td>7.5</td><td>7.9</td><td>10.0</td><td>13.6</td></tr>
+        <tr><td>soroswap</td><td>getLedgers</td><td>127</td><td>355.8</td><td>363.8</td><td>370.6</td><td>375.3</td></tr>
+        <tr><td>soroswap</td><td>getTransaction</td><td>500</td><td>11.6</td><td>12.5</td><td>17.6</td><td>19.8</td></tr>
+        <tr><td>soroswap</td><td>getEvents</td><td>500</td><td>4.4</td><td>5.5</td><td>8.0</td><td>8.6</td></tr>
+      </tbody>
+    </table>
+    <div class="tbl-cap">Cold tier (run 2, all profiles)</div>
+    <table class="data" style="width:100%">
+      <thead><tr><th>profile</th><th>endpoint</th><th>count</th><th>p50</th><th>p90</th><th>p99</th><th>max</th></tr></thead>
+      <tbody>
+        <tr><td>sac</td><td>getLedgers</td><td>73</td><td>617.2</td><td>653.1</td><td>671.0</td><td>671.0</td></tr>
+        <tr><td>sac</td><td>getTransaction</td><td>500</td><td>18.3</td><td>31.7</td><td>40.3</td><td>43.3</td></tr>
+        <tr><td>sac</td><td>getEvents</td><td>500</td><td>8.8</td><td>10.5</td><td>14.4</td><td>14.9</td></tr>
+        <tr><td>token</td><td>getLedgers</td><td>74</td><td>604.9</td><td>638.9</td><td>664.0</td><td>664.0</td></tr>
+        <tr><td>token</td><td>getTransaction</td><td>500</td><td>16.0</td><td>25.4</td><td>34.0</td><td>41.5</td></tr>
+        <tr><td>token</td><td>getEvents</td><td>500</td><td>3.4</td><td>4.2</td><td>4.9</td><td>5.4</td></tr>
+        <tr><td>soroswap</td><td>getLedgers</td><td>109</td><td>415.4</td><td>433.9</td><td>449.5</td><td>451.6</td></tr>
+        <tr><td>soroswap</td><td>getTransaction</td><td>500</td><td>11.7</td><td>18.9</td><td>25.4</td><td>26.5</td></tr>
+        <tr><td>soroswap</td><td>getEvents</td><td>500</td><td>18.9</td><td>22.8</td><td>24.8</td><td>27.3</td></tr>
+      </tbody>
+    </table>
+  </div>
+  </details>
 
   <div class="note-callout"><strong>Cold ≈ hot — for getLedgers, getTransaction, and dense-match getEvents.</strong>
-  getEvents cold is even slightly faster at p50 on dense-match profiles; getTransaction has a heavier cold tail
-  (cold txhash MPHF lookup + reading the large ledger from the pack). The exception is selective multi-term
-  getEvents on cold — see the term sweep below.</div>
+  getEvents cold is even faster than hot on dense-match profiles (token). getTransaction has a heavier cold p99
+  tail (cold txhash MPHF lookup + reading the large ledger from the pack). The one real divergence is selective
+  multi-term getEvents on cold — quantified next.</div>
 
-  <p style="margin-top:22px"><strong>getEvents OR-union index-term sweep</strong> (p50 / p90 / p99 ms). A
-  <em>term</em> = one indexed constraint (a contract ID, or a topic value at a position); each row OR-unions N real
-  harvested terms, 500 reps, limit 10:</p>
+  <div class="tbl-cap">getEvents OR-union index-term sweep — how latency grows with the number of terms</div>
   <div class="target-table-wrap"><table class="target">
-    <thead><tr><th>profile</th><th>tier·scope</th><th>t=1</th><th>t=4</th><th>t=8</th><th>t=15</th></tr></thead>
+    <thead><tr><th>profile</th><th>tier · scope</th><th>1 term</th><th>4 terms</th><th>8 terms</th><th>15 terms</th></tr></thead>
     <tbody>
-      <tr><td>sac</td><td>hot·window</td><td>8.4 / 9.7 / 11.4</td><td>8.4 / 9.0 / 10.8</td><td>8.5 / 9.1 / 11.1</td><td>6.8 / 7.8 / 11.4</td></tr>
-      <tr><td>sac</td><td>cold·window</td><td>8.4 / 10.4 / 13.4</td><td>8.6 / 10.7 / 12.8</td><td>6.6 / 9.2 / 11.9</td><td>8.7 / 10.5 / 14.1</td></tr>
-      <tr><td>token</td><td>hot·window</td><td>7.6 / 7.9 / 11.9</td><td>6.2 / 7.7 / 8.6</td><td>7.5 / 7.8 / 10.2</td><td>7.7 / 7.9 / 12.4</td></tr>
-      <tr><td>token</td><td>cold·window</td><td>3.4 / 4.2 / 4.9</td><td>5.1 / 6.1 / 7.1</td><td>8.1 / 13.2 / 15.4</td><td>16.9 / 19.6 / 22.0</td></tr>
-      <tr><td>soroswap</td><td>hot·window</td><td>4.2 / 4.7 / 5.9</td><td>4.3 / 6.3 / 7.8</td><td>6.1 / 6.8 / 7.7</td><td>6.1 / 6.7 / 7.3</td></tr>
-      <tr><td>soroswap</td><td>cold·window</td><td>9.5 / 12.8 / 16.4</td><td>52.7 / 60.0 / 67.0</td><td>98.5 / 115.7 / 129.6</td><td>137.2 / 150.2 / 158.3</td></tr>
+      <tr><td>sac</td><td>hot · window</td><td>8.4 / 9.7 / 11.4</td><td>8.4 / 9.0 / 10.8</td><td>8.5 / 9.1 / 11.1</td><td>6.8 / 7.8 / 11.4</td></tr>
+      <tr><td>sac</td><td>cold · window</td><td>8.4 / 10.4 / 13.4</td><td>8.6 / 10.7 / 12.8</td><td>6.6 / 9.2 / 11.9</td><td>8.7 / 10.5 / 14.1</td></tr>
+      <tr><td>token</td><td>hot · window</td><td>7.6 / 7.9 / 11.9</td><td>6.2 / 7.7 / 8.6</td><td>7.5 / 7.8 / 10.2</td><td>7.7 / 7.9 / 12.4</td></tr>
+      <tr><td>token</td><td>cold · window</td><td>3.4 / 4.2 / 4.9</td><td>5.1 / 6.1 / 7.1</td><td>8.1 / 13.2 / 15.4</td><td class="hi">16.9 / 19.6 / 22.0</td></tr>
+      <tr><td>soroswap</td><td>hot · window</td><td>4.2 / 4.7 / 5.9</td><td>4.3 / 6.3 / 7.8</td><td>6.1 / 6.8 / 7.7</td><td>6.1 / 6.7 / 7.3</td></tr>
+      <tr><td>soroswap</td><td>cold · window</td><td>9.5 / 12.8 / 16.4</td><td>52.7 / 60.0 / 67.0</td><td>98.5 / 115.7 / 129.6</td><td class="hi">137.2 / 150.2 / 158.3</td></tr>
     </tbody>
   </table></div>
-  <p style="font-size:13.5px; color:var(--ink-2)">Hot is flat everywhere (~4–9 ms, 1→15 terms). Cold is flat when
-  terms match densely (sac). Cold scales with term count when terms are selective: token ≈1 ms/term; soroswap
-  (most selective vocabulary) ≈12 ms/term → 15 terms ≈ 137 ms. Cause: the cold reader is opened per request (POC,
-  no LRU) and sparse matches trigger the POC underfill re-query loop in <code>events_handler.scanChunk</code>.
-  Productionization paths: an LRU for cold readers and a streaming pager.</p>
+  <p class="tbl-note">Each cell is <strong>p50 / p90 / p99</strong> in ms (500 reps, limit 10). Hot is flat
+  everywhere (~4–9 ms for 1→15 terms). Cold is flat when terms match densely (sac). Cold scales with term count
+  when terms are selective: token ≈1 ms/term; soroswap (most selective vocabulary) ≈12 ms/term → 15 terms ≈ 137 ms.
+  Cause: the cold reader is opened per request (POC, no LRU) and sparse matches trigger the POC underfill re-query
+  loop in <code>events_handler.scanChunk</code>. Productionization: an LRU for cold readers and a streaming pager.</p>
 
-  <p style="margin-top:22px"><strong>Direct in-process read</strong>, no serve path (ms). <code>store.Get</code> =
-  RocksDB point read (compressed); <code>GetLedgerRaw</code> adds the zstd decode:</p>
+  <div class="tbl-cap">Direct in-process read — no serve path (isolates the storage read from HTTP; ms)</div>
   <div class="target-table-wrap"><table class="target">
-    <thead><tr><th>profile</th><th>store.Get (compressed)</th><th>hot GetLedgerRaw</th><th>cold GetLedgerRaw</th></tr></thead>
+    <thead><tr><th>profile</th><th>store.Get (RocksDB point read, compressed)</th><th>hot GetLedgerRaw (+ zstd decode)</th><th>cold GetLedgerRaw (pack + decode)</th></tr></thead>
     <tbody>
       <tr><td>sac</td><td>0.63</td><td>8.2</td><td>7.9</td></tr>
       <tr><td>token</td><td>0.62</td><td>7.4</td><td>7.3</td></tr>
       <tr><td>soroswap</td><td>0.16</td><td>4.6</td><td>3.7</td></tr>
     </tbody>
   </table></div>
+  <p class="tbl-note">The read itself is single-digit ms — proof that <code>getLedgers</code>' ~350–670 ms serve
+  time is transfer/serialization, not storage.</p>
 </section>
 
 <section id="livepubnet">
   <div class="sec-head"><span class="sec-num">04</span><h2>Part B — live pubnet, hot-DB tip querying</h2></div>
   <p class="sec-intro">Local daemon ingesting live pubnet and serving over JSON-RPC on loopback. Data dir on
-  tmpfs (best-case storage latency). All HTTP 200, zero errors.</p>
+  tmpfs (best-case storage latency). All HTTP 200, zero errors. Different machine from Part A.</p>
 
-  <p><strong>Single-request latency</strong> (warm, sequential, n=40; end-to-end <code>curl</code>
-  <code>time_total</code>, ms):</p>
+  <div class="tbl-cap">Single-request latency — warm, sequential, n=40 (end-to-end curl time_total, ms)</div>
   <div class="target-table-wrap"><table class="target">
-    <thead><tr><th>method</th><th>resp size</th><th>min</th><th>p50</th><th>p90</th><th>p99</th><th>max</th><th>mean</th></tr></thead>
+    <thead><tr><th>method</th><th>resp size</th><th>min</th><th>p50 (median)</th><th>p90</th><th>p99</th><th>max</th><th>mean</th></tr></thead>
     <tbody>
       <tr><td>getLedgers (limit 1)</td><td>1.7 MB</td><td>33.0</td><td>35.0</td><td>38.1</td><td>38.9</td><td>39.1</td><td>35.4</td></tr>
       <tr><td>getTransactions (limit 5)</td><td>17.5 KB</td><td>7.9</td><td>8.5</td><td>9.8</td><td>16.5</td><td>16.7</td><td>9.2</td></tr>
@@ -397,7 +473,8 @@ pre.metadata {
   <strong>getLedgers end-to-end (35 ms) is dominated by shipping the ~1.7 MB LedgerCloseMeta, not the ~4.6 ms
   handler.</strong></div>
 
-  <p style="margin-top:22px"><strong>Concurrency sweep</strong> (<code>hey</code>, loopback, keep-alive; latencies ms):</p>
+  <div class="tbl-cap">Concurrency sweep — throughput and latency as concurrent load rises (hey, loopback, keep-alive)</div>
+  <p class="tbl-note" style="margin-top:0"><strong>conc</strong> = concurrent in-flight requests · <strong>req/s</strong> = completed requests per second · p50 / p90 / p99 / max in ms.</p>
   <div class="tiles" style="grid-template-columns:repeat(auto-fit,minmax(300px,1fr))">
     <div>
       <div class="fig-no" style="margin-bottom:6px">getTransaction · ~2.9 KB</div>
@@ -450,9 +527,9 @@ pre.metadata {
       </table></div>
     </div>
   </div>
-  <p style="font-size:13.5px; color:var(--ink-2)">Throughput ceilings (16-core box): getEvents ~2,250 req/s ·
-  getTransaction ~1,700 · getTransactions ~535 · getLedgers ~80 req/s. Saturates at concurrency ≈ 8–16, then
-  degrades linearly with concurrency (textbook worker-pool queueing) — no errors, no cliff.</p>
+  <p class="tbl-note">Throughput ceilings (16-core box): getEvents ~2,250 req/s · getTransaction ~1,700 ·
+  getTransactions ~535 · getLedgers ~80 req/s. Saturates at concurrency ≈ 8–16, then latency grows linearly with
+  concurrency (textbook worker-pool queueing) — no errors, no cliff.</p>
 </section>
 
 <section id="analysis">

--- a/tools/bench-suite/results/fullhistory-query-latency-combined-2026-07-16.html
+++ b/tools/bench-suite/results/fullhistory-query-latency-combined-2026-07-16.html
@@ -451,6 +451,26 @@ pre.metadata {
   </table></div>
   <p class="tbl-note">The read itself is single-digit ms — proof that <code>getLedgers</code>' ~350–670 ms serve
   time is transfer/serialization, not storage.</p>
+
+  <div class="tbl-cap">End-to-end — brand-new ledger, ingest → queryable (synthesized: ingest + hot query, ms)</div>
+  <div class="target-table-wrap"><table class="target">
+    <thead><tr><th>profile</th><th>endpoint</th><th>e2e p50</th><th>e2e p99</th></tr></thead>
+    <tbody>
+      <tr><td>sac</td><td>getLedgers</td><td>~696.7</td><td>~752.9</td></tr>
+      <tr><td>sac</td><td>getTransaction</td><td>~147.4</td><td>~170.7</td></tr>
+      <tr><td>sac</td><td>getEvents</td><td>~137.1</td><td>~157.3</td></tr>
+      <tr><td>token</td><td>getLedgers</td><td>~680.7</td><td>~715.3</td></tr>
+      <tr><td>token</td><td>getTransaction</td><td>~148.1</td><td>~169.5</td></tr>
+      <tr><td>token</td><td>getEvents</td><td>~137.4</td><td>~154.7</td></tr>
+      <tr><td>soroswap</td><td>getLedgers</td><td>~432.5</td><td>~456.0</td></tr>
+      <tr><td>soroswap</td><td>getTransaction</td><td>~88.3</td><td>~103.0</td></tr>
+      <tr><td>soroswap</td><td>getEvents</td><td>~81.1</td><td>~93.4</td></tr>
+    </tbody>
+  </table></div>
+  <p class="tbl-note">The full path for a just-closed ledger: <strong>e2e = ingest (source → commit) + hot query</strong>,
+  summed at the same percentile. Summing per-stage percentiles is a conservative upper bound; commit → queryable is
+  treated as negligible (the design's visibility window is ~1–2 ms). Ingest (~77–130 ms) dominates the light
+  endpoints; for getLedgers the query transfer still dominates.</p>
 </section>
 
 <section id="livepubnet">

--- a/tools/bench-suite/results/fullhistory-query-latency-combined-2026-07-16.md
+++ b/tools/bench-suite/results/fullhistory-query-latency-combined-2026-07-16.md
@@ -1,0 +1,251 @@
+# Full-history query POC — combined latency results (2026-07-16)
+
+Two complementary measurement regimes for the full-history query POC, merged:
+
+| Source branch | Regime | Tiers | Ledgers |
+|---|---|---|---|
+| `poc/fullhistory-query` | **Synthetic apply-load profiles** (sac / token / soroswap) | hot + cold | large: 10–17 MB decompressed LCM, thousands of tx + Soroban meta |
+| `poc/fullhistory-query-localrun` | **Live pubnet, hot-DB tip querying** | hot only | real pubnet tip, ~1.3–1.7 MB LCM |
+
+- Synthetic source: [`fullhistory-latency-2026-07-16/README.md`](./fullhistory-latency-2026-07-16/README.md) · [`latency.csv`](./fullhistory-latency-2026-07-16/latency.csv)
+- Live-pubnet source: [`local-run/BENCHMARKS.md`](../../../cmd/stellar-rpc/internal/fullhistory/local-run/BENCHMARKS.md)
+
+The two were run on **different hardware** — see per-section environment rows. Compare
+*shapes and ratios* across them, not raw absolute numbers.
+
+---
+
+# Part A — Synthetic ledger profiles (hot + cold tier)
+
+Branch `poc/fullhistory-query`. Real profile ledgers replayed through the daemon.
+
+**Environment:** AWS `c6id.8xlarge` — Intel Xeon Platinum 8375C, 32 vCPU, 64 GiB, local NVMe.
+Harness: `TestServeE2E_ProfileLatency` (hot) / `TestServeE2E_ColdQueryLatency` (cold) /
+`BenchmarkHotGetLedgerRaw` (direct read). Window: 20 steady-state ledgers (10202–10221)
+after a 200-ledger warmup skip. Query pass: 500 reps/endpoint, `getLedgers` at `limit=1`,
+45 s per-endpoint wall budget. 0 errors throughout.
+
+## A.0 Ledger characteristics (steady-state, per ledger)
+
+| profile | decompressed LCM | on-disk (zstd) | compression |
+|---|--:|--:|--:|
+| sac | ~17.3 MB | ~2.1 MB | ~8.2× |
+| token | ~16.5 MB | ~1.7 MB | ~9.5× |
+| soroswap | ~10.0 MB | ~0.5 MB | ~19× |
+
+## A.1 Ingest → durable commit, per ledger (ms)
+
+| profile | p50 | p90 | p99 |
+|---|--:|--:|--:|
+| sac | 129.3 | 138.9 | 145.3 |
+| token | 129.9 | 133.6 | 144.7 |
+| soroswap | 76.7 | 82.6 | 85.4 |
+
+## A.2 Query latency — HOT tier (ms)
+
+`getLedgers` at `limit=1` (budget-capped `count`); getTransaction/getEvents 500 reps.
+
+| profile | endpoint | count | p50 | p90 | p99 | max |
+|---|---|--:|--:|--:|--:|--:|
+| sac | getLedgers | 80 | 567.4 | 581.8 | 607.6 | 607.6 |
+| sac | getTransaction | 500 | 18.1 | 19.2 | 25.4 | 28.9 |
+| sac | getEvents | 500 | 7.8 | 8.0 | 12.0 | 12.6 |
+| token | getLedgers | 82 | 550.8 | 557.7 | 570.6 | 570.6 |
+| token | getTransaction | 500 | 18.2 | 19.5 | 24.8 | 26.8 |
+| token | getEvents | 500 | 7.5 | 7.9 | 10.0 | 13.6 |
+| soroswap | getLedgers | 127 | 355.8 | 363.8 | 370.6 | 375.3 |
+| soroswap | getTransaction | 500 | 11.6 | 12.5 | 17.6 | 19.8 |
+| soroswap | getEvents | 500 | 4.4 | 5.5 | 8.0 | 8.6 |
+
+## A.3 Query latency — COLD tier (ms)
+
+Served from frozen cold artifacts (page-cache-warm). Run 1 covered sac only; run 2
+(same day/box/method, after a methodology review) added token/soroswap by re-freezing
+their catalogs and re-measured sac as a reproduction check.
+
+**Run 1 — sac, hot vs cold:**
+
+| endpoint | tier | count | p50 | p90 | p99 | max |
+|---|---|--:|--:|--:|--:|--:|
+| getLedgers | hot | 80 | 567.4 | 581.8 | 607.6 | 607.6 |
+| getLedgers | **cold** | 71 | 641.3 | 664.4 | 685.4 | 685.4 |
+| getTransaction | hot | 500 | 18.1 | 19.2 | 25.4 | 28.9 |
+| getTransaction | **cold** | 500 | 17.7 | 30.0 | 38.7 | 45.7 |
+| getEvents | hot | 500 | 7.8 | 8.0 | 12.0 | 12.6 |
+| getEvents | **cold** | 500 | 6.2 | 8.4 | 9.5 | 12.7 |
+
+**Run 2 — cold tier, all profiles:**
+
+| profile | endpoint | count | p50 | p90 | p99 | max |
+|---|---|--:|--:|--:|--:|--:|
+| sac | getLedgers | 73 | 617.2 | 653.1 | 671.0 | 671.0 |
+| sac | getTransaction | 500 | 18.3 | 31.7 | 40.3 | 43.3 |
+| sac | getEvents | 500 | 8.8 | 10.5 | 14.4 | 14.9 |
+| token | getLedgers | 74 | 604.9 | 638.9 | 664.0 | 664.0 |
+| token | getTransaction | 500 | 16.0 | 25.4 | 34.0 | 41.5 |
+| token | getEvents | 500 | 3.4 | 4.2 | 4.9 | 5.4 |
+| soroswap | getLedgers | 109 | 415.4 | 433.9 | 449.5 | 451.6 |
+| soroswap | getTransaction | 500 | 11.7 | 18.9 | 25.4 | 26.5 |
+| soroswap | getEvents | 500 | 18.9 | 22.8 | 24.8 | 27.3 |
+
+**Cold ≈ hot — for getLedgers, getTransaction, and dense-match getEvents.** getEvents
+cold is even slightly faster at p50 on dense-match profiles; getTransaction has a
+heavier cold tail (cold txhash MPHF lookup + reading the large ledger from the pack).
+The exception is **selective multi-term getEvents on cold** — see A.3b.
+
+## A.3b getEvents OR-union index-term sweep (run 2; p50/p90/p99 ms)
+
+A *term* = one indexed constraint (a contract ID, or a topic value at a position).
+Each row OR-unions N real harvested terms, 500 reps, limit 10.
+
+| profile | tier·scope | t=1 | t=4 | t=8 | t=15 |
+|---|---|--:|--:|--:|--:|
+| sac | hot·window | 8.4 / 9.7 / 11.4 | 8.4 / 9.0 / 10.8 | 8.5 / 9.1 / 11.1 | 6.8 / 7.8 / 11.4 |
+| sac | cold·window | 8.4 / 10.4 / 13.4 | 8.6 / 10.7 / 12.8 | 6.6 / 9.2 / 11.9 | 8.7 / 10.5 / 14.1 |
+| token | hot·window | 7.6 / 7.9 / 11.9 | 6.2 / 7.7 / 8.6 | 7.5 / 7.8 / 10.2 | 7.7 / 7.9 / 12.4 |
+| token | cold·window | 3.4 / 4.2 / 4.9 | 5.1 / 6.1 / 7.1 | 8.1 / 13.2 / 15.4 | 16.9 / 19.6 / 22.0 |
+| soroswap | hot·window | 4.2 / 4.7 / 5.9 | 4.3 / 6.3 / 7.8 | 6.1 / 6.8 / 7.7 | 6.1 / 6.7 / 7.3 |
+| soroswap | cold·window | 9.5 / 12.8 / 16.4 | 52.7 / 60.0 / 67.0 | 98.5 / 115.7 / 129.6 | 137.2 / 150.2 / 158.3 |
+
+- **Hot is flat everywhere** (~4–9 ms, 1→15 terms) — term count is nearly free on hot.
+- **Cold is flat when terms match densely** (sac: one match-all contract → ~8 ms for any N).
+- **Cold scales with term count when terms are selective:** token ≈1 ms/term; soroswap
+  (most selective vocabulary) ≈12 ms/term → 15 terms ≈ 137 ms.
+- **Cause:** the cold reader is opened *per request* (POC, no LRU) and sparse matches
+  trigger the POC underfill re-query loop in `events_handler.scanChunk`. Known POC costs;
+  productionization paths are an LRU for cold readers and a streaming pager.
+
+## A.4 Direct in-process read (no serve path; ms)
+
+`store.Get` = RocksDB point read (compressed value); `GetLedgerRaw` adds the zstd decode.
+
+| profile | `store.Get` (compressed) | hot `GetLedgerRaw` | cold `GetLedgerRaw` |
+|---|--:|--:|--:|
+| sac | 0.63 | 8.2 | 7.9 |
+| token | 0.62 | 7.4 | 7.3 |
+| soroswap | 0.16 | 4.6 | 3.7 |
+
+---
+
+# Part B — Live pubnet, hot-DB tip querying
+
+Branch `poc/fullhistory-query-localrun`. Local `stellar-rpc full-history` daemon
+ingesting live **pubnet** and serving over JSON-RPC on `localhost:8000`.
+
+**Environment:** 16 vCPU, 58 GB RAM, Debian 13; stellar-core 27.1.0 (protocol 27);
+data dir on **tmpfs** (RAM-backed); loopback (~0 RTT); load tool `hey` 0.1.5.
+Retention 2 chunks (20,000 ledgers), `earliest_ledger = "now"`. Tip ≈ 63,499,700;
+queries 500–1000 ledgers behind tip. All HTTP 200, zero errors.
+
+> tmpfs data dir ⇒ best-case storage latency; a disk/network-volume deployment
+> would be slower on cold reads.
+
+## B.1 Single-request latency (warm, sequential, n=40; ms)
+
+End-to-end `curl` `time_total` over loopback:
+
+| method | resp size | min | p50 | p90 | p99 | max | mean |
+|---|--:|--:|--:|--:|--:|--:|--:|
+| `getLedgers` (limit 1) | 1.7 MB | 33.0 | 35.0 | 38.1 | 38.9 | 39.1 | 35.4 |
+| `getTransactions` (limit 5) | 17.5 KB | 7.9 | 8.5 | 9.8 | 16.5 | 16.7 | 9.2 |
+| `getTransaction` (by hash) | 2.9 KB | 2.4 | 2.5 | 4.0 | 4.1 | 10.4 | 2.9 |
+| `getEvents` (limit 10) | 4.9 KB | 1.7 | 1.7 | 1.8 | 2.2 | 4.2 | 1.8 |
+
+Server-side handler latency (from `/metrics`, excludes network/transfer):
+
+| method | avg | p95 ≤ | p99 ≤ |
+|---|--:|--:|--:|
+| `getEvents` | 1.68 | 5 | 5 |
+| `getTransaction` | 2.89 | 5 | 10 |
+| `getLedgers` | 4.61 | 10 | 25 |
+| `getTransactions` | 10.51 | 25 | 25 |
+
+`getLedgers` end-to-end (35 ms) is dominated by shipping the ~1.7 MB `LedgerCloseMeta`,
+not by the ~4.6 ms server handler.
+
+## B.2 Concurrency sweep (`hey`, loopback, keep-alive)
+
+### getTransaction (~2.9 KB)
+| conc | req/s | p50 | p90 | p99 | max |
+|--:|--:|--:|--:|--:|--:|
+| 1 | 323 | 2.5 | 4.7 | 9.3 | 11 |
+| 8 | 1,324 | 4.2 | 11.3 | 16.6 | 19 |
+| 16 | 1,637 | 8.1 | 17.5 | 22.8 | 33 |
+| 32 | 1,650 | 19.1 | 29.4 | 37.9 | 51 |
+| 64 | 1,700 | 36.5 | 51.2 | 64.5 | 101 |
+
+### getEvents (limit 10, ~4.9 KB)
+| conc | req/s | p50 | p90 | p99 | max |
+|--:|--:|--:|--:|--:|--:|
+| 1 | 460 | 1.9 | 2.5 | 7.1 | 14 |
+| 8 | 1,905 | 2.9 | 8.3 | 13.7 | 16 |
+| 16 | 2,207 | 5.3 | 13.4 | 19.9 | 24 |
+| 32 | 2,213 | 13.4 | 22.9 | 29.8 | 38 |
+| 64 | 2,256 | 27.5 | 38.6 | 55.8 | 74 |
+
+### getTransactions (limit 5, ~29 KB)
+| conc | req/s | p50 | p90 | p99 | max |
+|--:|--:|--:|--:|--:|--:|
+| 1 | 121 | 7.4 | 11.9 | 16.4 | 20 |
+| 8 | 519 | 15.4 | 21.3 | 25.9 | 34 |
+| 16 | 532 | 28.3 | 42.3 | 55.8 | 75 |
+| 32 | 538 | 57.2 | 81.3 | 98.3 | 134 |
+
+### getLedgers (limit 1, ~1.3 MB) — heavy payload
+| conc | req/s | p50 | p90 | p99 | max |
+|--:|--:|--:|--:|--:|--:|
+| 1 | 36 | 27.0 | 30.4 | 35.4 | 44 |
+| 4 | 83 | 47.5 | 58.3 | 68.0 | 72 |
+| 8 | 80 | 95.6 | 118.7 | 158.5 | 165 |
+| 16 | 80 | 193.8 | 244.0 | 311.4 | 372 |
+
+Throughput ceilings (16-core box): getEvents ~2,250 req/s · getTransaction ~1,700 ·
+getTransactions ~535 · getLedgers ~80 req/s. Saturates at concurrency ≈ 8–16, then
+degrades gracefully (linear latency growth, textbook worker-pool queueing, no cliff).
+
+---
+
+# Combined analysis
+
+The two regimes agree on the mechanism and bracket the range:
+
+1. **`getLedgers` is payload-bound everywhere.** Live pubnet (~1.7 MB LCM) → ~35 ms
+   end-to-end; synthetic (~17 MB LCM) → ~567 ms. ~10× payload ⇒ ~15× latency, while
+   the storage read stays ~5–8 ms in both. Confirmed independently by the synthetic
+   direct-read numbers (§A.4: 8 ms read vs 567 ms served = ~1.4 % read, ~98.6 % base64 +
+   JSON + HTTP). The read path is *not* the cost; the size of the shipped blob is.
+
+2. **The light endpoints stay cheap even on heavy ledgers.** getTransaction/getEvents:
+   ~1.8–2.9 ms on pubnet tip (§B.1) → ~8–18 ms on 17 MB synthetic ledgers (§A.2). They
+   scale with the target ledger's size but never approach getLedgers' cost.
+
+3. **Cold ≈ hot — with one exception** (§A.3, §A.3b): the frozen `.pack` + MPHF/bitmap
+   cold tier serves getLedgers, getTransaction, and dense-match getEvents at essentially
+   hot-tier latency (cold getTransaction has a heavier tail from the txhash MPHF lookup).
+   The exception is **selective multi-term getEvents on cold**, which scales with term
+   count (token ≈1 ms/term; soroswap ≈12 ms/term → 15 terms ≈ 137 ms) while hot stays
+   flat — caused by the POC's per-request cold-reader open + underfill re-query loop
+   (fixable with an LRU + streaming pager). Cold reads here were page-cache-warm.
+
+4. **Ingest dominates freshly-committed ledgers** (§A.1): 77–130 ms src→commit on
+   synthetic profiles, vs the ~2–18 ms query legs — so end-to-end "how fast is a brand
+   new ledger queryable" is gated by ingest, not query, for everything except getLedgers.
+
+## Where to spend on getLedgers (size-bound, not read-bound)
+
+1. Cap default/max page size (`[serve].default_ledgers_limit` / `max_ledgers_limit`).
+2. Transport compression (gzip/zstd `Content-Encoding`) — base64'd XDR is highly compressible.
+3. Stream the base64 encoder instead of materializing the full string per ledger.
+4. Lighter projection (header-only / opt-out of full meta).
+5. ~~Storage-read tuning~~ — the read is ~1 %; not worth it.
+
+## Caveats (both regimes)
+
+- **Different hardware** (32 vCPU c6id vs 16 vCPU Debian) and different data-dir media
+  (NVMe vs tmpfs) — do not compare absolute ms across Part A and Part B, only shapes/ratios.
+- Percentiles are nearest-rank. Synthetic `getLedgers` p99 is over a budget-capped sample
+  (71–127), less robust than the 500-rep getTransaction/getEvents p99s.
+- Live-pubnet numbers: client + server shared 16 cores (client stole CPU) and loopback
+  RTT ≈ 0 — add real network latency to every p50 and expect higher ceilings on a
+  dedicated client.
+- Synthetic cold reads are OS-page-cache-warm; an uncached first-touch adds disk latency.

--- a/tools/bench-suite/run-e2e-latency-suite.sh
+++ b/tools/bench-suite/run-e2e-latency-suite.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# run-e2e-latency-suite.sh — ingest→query LATENCY across synthetic profiles on
+# REAL ledgers, via the TestServeE2E_ProfileLatency gate in the fullhistory
+# package (prebuilt into fullhistory.test).
+#
+# For each profile it live-ingests a small window of the profile's real frozen
+# ledgers through the daemon's hot path (no cold freeze — cheap, seconds not
+# minutes), measures per-ledger ingest→query visibility, then runs a dense
+# closed-loop query pass for a real p99 per endpoint. This is the fast,
+# realistic-workload counterpart to the toy TestServeE2E_IngestToQueryLatency.
+#
+# IMPORTANT — warmup: the head of a profile chunk is warmup (contract deploys /
+# account setup) and far lighter than steady state. Set WARMUP to skip past it
+# so the measured window reflects representative load. Ingesting WARMUP+WINDOW
+# heavy ledgers is the cost here (tens of ms each), so keep WARMUP modest.
+#
+# Env knobs: OUT, WINDOW(=20), WARMUP(=200), REPS(=500), FIRST_CHUNK(=1),
+# PASSPHRASE, TESTBIN, LEDGERS_ROOTS (space-separated "name:ledgers-root" pairs;
+# a ledgers-root is the dir whose <bucket>/<chunk>.pack tree holds the profile's
+# ledgers — either a packs-root/<profile> or a served data dir's .../ledgers).
+set -euo pipefail
+
+WORK=/mnt/nvme/ledgers/fhbench-work
+TESTBIN="${TESTBIN:-$WORK/bin/fullhistory.test}"
+OUT="${OUT:-$WORK/results/e2e-latency-$(date +%F)}"
+WINDOW="${WINDOW:-20}"
+WARMUP="${WARMUP:-200}"
+REPS="${REPS:-500}"
+FIRST_CHUNK="${FIRST_CHUNK:-1}"
+PASSPHRASE="${PASSPHRASE:-Public Global Stellar Network ; September 2015}"
+
+export LD_LIBRARY_PATH="/home/simon/.zstd/lib:/home/simon/.rocksdb/lib:${LD_LIBRARY_PATH:-}"
+
+# "name:ledgers-root" per profile. Default points at the apply-load pack trees;
+# override LEDGERS_ROOTS to run against a different packs-root/<profile> tree.
+# A ledgers-root is the dir whose <bucket>/<chunk>.pack tree holds the profile's
+# ledgers (e.g. an apply-load out/<profile>/cold/ledgers, or a served data dir's
+# .../ledgers). Only WARMUP+WINDOW ledgers are read, so a partial pack suffices.
+APPLY_LOAD="${APPLY_LOAD:-/mnt/nvme/ledgers/apply-load-20k/out}"
+DEFAULT_ROOTS="sac:$APPLY_LOAD/sac/cold/ledgers token:$APPLY_LOAD/token/cold/ledgers soroswap:$APPLY_LOAD/soroswap/cold/ledgers"
+read -r -a ROOTS <<<"${LEDGERS_ROOTS:-$DEFAULT_ROOTS}"
+
+mkdir -p "$OUT"
+echo "e2e latency suite -> $OUT (window=$WINDOW warmup=$WARMUP reps=$REPS)"
+
+for entry in "${ROOTS[@]}"; do
+	IFS=: read -r name root <<<"$entry"
+	if [ ! -f "$root/00000/$(printf '%08d' "$FIRST_CHUNK").pack" ]; then
+		echo "SKIP $name: no chunk $FIRST_CHUNK pack under $root" >&2
+		continue
+	fi
+	echo "=== $name: ingest→query latency (window $WINDOW, warmup $WARMUP) ==="
+	FHBENCH_PROFILE_LEDGERS="$root" \
+	FHBENCH_PROFILE_NAME="$name" \
+	FHBENCH_FIRST_CHUNK="$FIRST_CHUNK" \
+	FHBENCH_WINDOW_LEDGERS="$WINDOW" \
+	FHBENCH_WARMUP_LEDGERS="$WARMUP" \
+	FHBENCH_QUERY_REPS="$REPS" \
+	FHBENCH_PASSPHRASE="$PASSPHRASE" \
+		"$TESTBIN" -test.run '^TestServeE2E_ProfileLatency$' -test.v -test.timeout 0 \
+		>"$OUT/$name.txt" 2>&1 || echo "  $name FAILED (see $OUT/$name.txt)"
+	# Pull just the report lines into a combined summary.
+	grep -E "visibility|span|full |ingest |visible |query-latency|endpoint|getLedgers|getTransaction|getEvents" \
+		"$OUT/$name.txt" | grep -v "level=" >>"$OUT/summary.txt" || true
+	echo >>"$OUT/summary.txt"
+done
+
+echo
+echo "Done. Per-profile logs + summary.txt under: $OUT"

--- a/tools/bench-suite/run-e2e-latency-suite.sh
+++ b/tools/bench-suite/run-e2e-latency-suite.sh
@@ -16,6 +16,7 @@
 # heavy ledgers is the cost here (tens of ms each), so keep WARMUP modest.
 #
 # Env knobs: OUT, WINDOW(=20), WARMUP(=200), REPS(=500), FIRST_CHUNK(=1),
+# EVENT_TERMS(=1,4,8,15; "none" disables the getEvents OR-union term sweep),
 # PASSPHRASE, TESTBIN, LEDGERS_ROOTS (space-separated "name:ledgers-root" pairs;
 # a ledgers-root is the dir whose <bucket>/<chunk>.pack tree holds the profile's
 # ledgers — either a packs-root/<profile> or a served data dir's .../ledgers).
@@ -28,6 +29,7 @@ WINDOW="${WINDOW:-20}"
 WARMUP="${WARMUP:-200}"
 REPS="${REPS:-500}"
 FIRST_CHUNK="${FIRST_CHUNK:-1}"
+EVENT_TERMS="${EVENT_TERMS:-1,4,8,15}"
 PASSPHRASE="${PASSPHRASE:-Public Global Stellar Network ; September 2015}"
 
 export LD_LIBRARY_PATH="/home/simon/.zstd/lib:/home/simon/.rocksdb/lib:${LD_LIBRARY_PATH:-}"
@@ -57,6 +59,7 @@ for entry in "${ROOTS[@]}"; do
 	FHBENCH_WINDOW_LEDGERS="$WINDOW" \
 	FHBENCH_WARMUP_LEDGERS="$WARMUP" \
 	FHBENCH_QUERY_REPS="$REPS" \
+	FHBENCH_EVENT_TERMS="$EVENT_TERMS" \
 	FHBENCH_PASSPHRASE="$PASSPHRASE" \
 		"$TESTBIN" -test.run '^TestServeE2E_ProfileLatency$' -test.v -test.timeout 0 \
 		>"$OUT/$name.txt" 2>&1 || echo "  $name FAILED (see $OUT/$name.txt)"

--- a/tools/bench-suite/run-ingest-suite.sh
+++ b/tools/bench-suite/run-ingest-suite.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# run-ingest-suite.sh — run the full-history INGESTION benchmark across synthetic
+# apply-load profiles (sac/token/soroswap), laying the CSVs out exactly as the
+# stellar-rpc-benchmarks converter (convert.py, KIND=synthetic) expects:
+#
+#   <OUT>/synth-cold-<profile>-run<N>/  driver.csv ledgers.csv txhash.csv events.csv
+#   <OUT>/synth-hot-<profile>-run<N>/   driver.csv hot.csv
+#   <OUT>/machine-metadata.txt
+#
+# This is stage 2 of the pipeline (see README.md). Stage 1 (generating the pack
+# trees per profile) is external; stage 3 (convert + publish) runs in the
+# stellar-rpc-benchmarks repo.
+#
+# Prereqs:
+#   - a built stellar-rpc binary   (STELLAR_RPC, default: `stellar-rpc` on PATH)
+#   - one synthetic ledger pack tree per profile, {bucket:05d}/{chunk:08d}.pack
+#
+# Configure the profiles below (name:pack-dir:start-chunk), then:
+#   PACKS_ROOT=/data/packs INSTANCE_TYPE=m6id.2xlarge ./run-ingest-suite.sh
+#
+# Env knobs: OUT, REPS(=5), WORKERS(=4), NUM_CHUNKS(=1), NUM_LEDGERS(=0=whole
+# chunk; set e.g. 500 for a cheap smoke run), SCRATCH, STELLAR_RPC, PACKS_ROOT,
+# INSTANCE_TYPE, and <PROFILE>_CHUNK per profile.
+#
+# NOTE on runtime: a full hot run ingests a whole 10k-ledger chunk with one
+# synced WriteBatch per ledger — tens of minutes per run. 5 reps × 3 profiles ×
+# (cold + hot) is a multi-hour campaign; that is why it runs on a devbox. Use
+# NUM_LEDGERS for a quick shape check first.
+set -euo pipefail
+
+STELLAR_RPC="${STELLAR_RPC:-stellar-rpc}"
+OUT="${OUT:-./results-in/synthetic-$(date +%F)}"
+REPS="${REPS:-5}"
+WORKERS="${WORKERS:-4}"
+NUM_CHUNKS="${NUM_CHUNKS:-1}"
+NUM_LEDGERS="${NUM_LEDGERS:-0}" # 0 = whole range (hot); >0 caps the run for a smoke test
+SCRATCH="${SCRATCH:-$(mktemp -d)}"
+PACKS_ROOT="${PACKS_ROOT:-/data/packs}"
+
+# Profiles: "name:pack-dir:start-chunk". Point each pack-dir at that profile's
+# {bucket:05d}/{chunk:08d}.pack tree and set the chunk id it holds.
+PROFILES=(
+	"sac:${PACKS_ROOT}/sac:${SAC_CHUNK:-0}"
+	"token:${PACKS_ROOT}/token:${TOKEN_CHUNK:-0}"
+	"soroswap:${PACKS_ROOT}/soroswap:${SOROSWAP_CHUNK:-0}"
+)
+
+mkdir -p "$OUT"
+
+# machine-metadata.txt: convert.py globs *machine-metadata*.txt, keeps the whole
+# file as machine.raw, and best-effort parses instance-type, lscpu, and a
+# "repo: <sha> (branch)" line for build provenance.
+{
+	date -u
+	echo "instance-type: ${INSTANCE_TYPE:-unknown}"
+	uname -a
+	lscpu 2>/dev/null || sysctl -n machdep.cpu.brand_string 2>/dev/null || true
+	echo "repo: $(git rev-parse HEAD) ($(git rev-parse --abbrev-ref HEAD))"
+} >"$OUT/machine-metadata.txt"
+
+for entry in "${PROFILES[@]}"; do
+	IFS=: read -r name packdir chunk <<<"$entry"
+	if [ ! -d "$packdir" ]; then
+		echo "ERROR: pack dir for profile '$name' not found: $packdir" >&2
+		exit 1
+	fi
+	for r in $(seq 1 "$REPS"); do
+		echo ">>> $name  cold  run $r"
+		"$STELLAR_RPC" bench-ingest cold \
+			--source=pack --pack-dir="$packdir" \
+			--start-chunk="$chunk" --num-chunks="$NUM_CHUNKS" --workers="$WORKERS" \
+			--cold-out-dir="$SCRATCH/cold-$name-$r" \
+			--out="$OUT/synth-cold-$name-run$r"
+		rm -rf "$SCRATCH/cold-$name-$r"
+
+		echo ">>> $name  hot   run $r"
+		"$STELLAR_RPC" bench-ingest hot \
+			--source=pack --pack-dir="$packdir" \
+			--start-chunk="$chunk" --num-ledgers="$NUM_LEDGERS" \
+			--hot-dir="$SCRATCH/hot-$name-$r" \
+			--out="$OUT/synth-hot-$name-run$r"
+		rm -rf "$SCRATCH/hot-$name-$r"
+	done
+done
+
+cat <<EOF
+
+Done. Results laid out in: $OUT
+Next (stage 3, in the stellar-rpc-benchmarks repo):
+
+  make convert RESULTS=$OUT RUN_ID=synthetic-$(date +%F) \\
+    RUN_NAME="Synthetic apply-load — sac/token/soroswap" \\
+    KIND=synthetic RUN_DATE=$(date +%F) \\
+    FACTS=converter/facts/<your-sidecar>.json
+  make serve   # view at http://localhost:8000
+EOF

--- a/tools/bench-suite/run-query-suite.sh
+++ b/tools/bench-suite/run-query-suite.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# run-query-suite.sh — full-history QUERY benchmark across synthetic profiles.
+#
+# For each profile it boots the serve-harness (the TestServeProfileForBench gate in
+# the fullhistory package, prebuilt into fullhistory.test) which backfills the
+# profile's ledger packs into a fresh servable data dir (cold tier) plus a
+# synthetic hot tier, binds a [serve] port, and holds. Then it points fhbench at
+# that server for every (endpoint, tier) and captures the latency tables + a
+# /metrics snapshot.
+#
+# Runs ONE profile at a time (each cold freeze peaks ~20-30 GB) — do NOT overlap
+# with the ingest campaign. See tools/fhbench/README.md for fhbench itself.
+#
+# Env knobs: OUT, PORT(=8100), DURATION(=45s), HOT_LEDGERS(=5200), CONCURRENCY(=8),
+# PASSPHRASE(=Public Global Stellar Network ; September 2015), READY_TIMEOUT(=1800),
+# TESTBIN, FHBENCH, PACKS_ROOT.
+set -euo pipefail
+
+WORK=/mnt/nvme/ledgers/fhbench-work
+TESTBIN="${TESTBIN:-$WORK/bin/fullhistory.test}"
+FHBENCH="${FHBENCH:-$WORK/bin/fhbench}"
+PACKS_ROOT="${PACKS_ROOT:-$WORK/packs-root}"
+OUT="${OUT:-$WORK/results/query-$(date +%F)}"
+PORT="${PORT:-8100}"
+DURATION="${DURATION:-45s}"
+HOT_LEDGERS="${HOT_LEDGERS:-5200}"
+CONCURRENCY="${CONCURRENCY:-8}"
+EVENT_TERMS="${EVENT_TERMS:-1,4,8,15}"
+PASSPHRASE="${PASSPHRASE:-Public Global Stellar Network ; September 2015}"
+READY_TIMEOUT="${READY_TIMEOUT:-3600}"
+
+export LD_LIBRARY_PATH="/home/simon/.zstd/lib:/home/simon/.rocksdb/lib:${LD_LIBRARY_PATH:-}"
+
+# profile:last-chunk (packs live under $PACKS_ROOT/<profile>, chunk ids start at 1)
+PROFILES=(
+	"sac:1"
+	"token:1"
+	"soroswap:2"
+)
+ENDPOINTS=(getLedgers getTransactions getTransaction getEvents)
+
+mkdir -p "$OUT"
+echo "query suite -> $OUT (port $PORT, duration $DURATION, hot_ledgers $HOT_LEDGERS)"
+
+for entry in "${PROFILES[@]}"; do
+	IFS=: read -r name lastchunk <<<"$entry"
+	packs="$PACKS_ROOT/$name"
+	datadir="$WORK/serve-data/$name"
+	pdir="$OUT/$name"
+	mkdir -p "$pdir"
+	rm -rf "$datadir"
+	mkdir -p "$datadir"
+
+	echo "=== $name: booting serve-harness (cold chunks 1..$lastchunk) ==="
+	FHBENCH_PROFILE_LEDGERS="$packs" \
+	FHBENCH_DATA_DIR="$datadir" \
+	FHBENCH_SERVE_ADDR="127.0.0.1:$PORT" \
+	FHBENCH_FIRST_CHUNK=1 \
+	FHBENCH_LAST_CHUNK="$lastchunk" \
+	FHBENCH_HOT_LEDGERS="$HOT_LEDGERS" \
+	FHBENCH_HOLD_SEC=3600 \
+	FHBENCH_PASSPHRASE="$PASSPHRASE" \
+		"$TESTBIN" -test.run '^TestServeProfileForBench$' -test.v -test.timeout 0 \
+		>"$pdir/harness.log" 2>&1 &
+	harness_pid=$!
+
+	# Wait for READY (cold freeze can take many minutes).
+	base="http://127.0.0.1:$PORT"
+	ready=0
+	for _ in $(seq 1 "$READY_TIMEOUT"); do
+		if ! kill -0 "$harness_pid" 2>/dev/null; then
+			echo "ERROR: harness for $name exited before READY; see $pdir/harness.log" >&2
+			tail -20 "$pdir/harness.log" >&2 || true
+			break
+		fi
+		if curl -sf "$base/ready" >/dev/null 2>&1; then ready=1; break; fi
+		sleep 1
+	done
+	if [ "$ready" -ne 1 ]; then
+		echo "ERROR: $name never became ready" >&2
+		kill "$harness_pid" 2>/dev/null || true
+		wait "$harness_pid" 2>/dev/null || true
+		continue
+	fi
+	echo "    $name READY; running fhbench"
+
+	# Served-range snapshot + a pre-run metrics scrape.
+	curl -s "$base/metrics" >"$pdir/metrics-before.txt" 2>/dev/null || true
+
+	# fhbench per endpoint, both tiers; aggregate tables into one file.
+	report="$pdir/fhbench.txt"
+	: >"$report"
+	for ep in "${ENDPOINTS[@]}"; do
+		echo "### $name $ep (both tiers)" >>"$report"
+		"$FHBENCH" --url "$base" --endpoint "$ep" --tier both \
+			--concurrency "$CONCURRENCY" --duration "$DURATION" --limit 50 \
+			>>"$report" 2>>"$pdir/fhbench.err" || echo "fhbench $ep failed (see fhbench.err)" >>"$report"
+		echo >>"$report"
+	done
+
+	# getEvents index-term sweep: the SELECTIVE path (term-count -> latency curve),
+	# vs the unselective type-filter worst case measured in the loop above.
+	echo "### $name getEvents index-term sweep (--event-terms $EVENT_TERMS, both tiers)" >>"$report"
+	"$FHBENCH" --url "$base" --endpoint getEvents --tier both \
+		--concurrency "$CONCURRENCY" --duration "$DURATION" --limit 50 \
+		--event-terms "$EVENT_TERMS" \
+		>>"$report" 2>>"$pdir/fhbench.err" || echo "fhbench term-sweep failed (see fhbench.err)" >>"$report"
+	echo >>"$report"
+
+	curl -s "$base/metrics" >"$pdir/metrics-after.txt" 2>/dev/null || true
+
+	echo "    $name done; stopping harness"
+	kill "$harness_pid" 2>/dev/null || true
+	wait "$harness_pid" 2>/dev/null || true
+	rm -rf "$datadir"
+	sleep 3 # let the port free
+done
+
+echo
+echo "Query suite complete. Per-profile fhbench tables + metrics under: $OUT"

--- a/tools/bench-suite/run-query-suite.sh
+++ b/tools/bench-suite/run-query-suite.sh
@@ -12,8 +12,19 @@
 # Runs ONE profile at a time (each cold freeze peaks ~20-30 GB) — do NOT overlap
 # with the ingest campaign. See tools/fhbench/README.md for fhbench itself.
 #
+# CAVEATS:
+#   - The harness's HOT tier is SYNTHETIC 1-tx/1-event filler ledgers (it exists
+#     to latch /ready and give the hot tier something to serve) — hot-tier rows
+#     here are NOT representative of real-profile hot serving. Use
+#     run-e2e-latency-suite.sh (real ledgers live-ingested hot) for that.
+#   - getLedgers returns WHOLE ledgers; on these profiles one decoded ledger is
+#     10-17 MB, so limit 50 × 8 workers ≈ >8 GB of in-flight responses — an OOM
+#     risk on a shared box. GETLEDGERS_LIMIT (default 1) caps that endpoint
+#     separately; raise it deliberately.
+#
 # Env knobs: OUT, PORT(=8100), DURATION(=45s), HOT_LEDGERS(=5200), CONCURRENCY(=8),
-# PASSPHRASE(=Public Global Stellar Network ; September 2015), READY_TIMEOUT(=1800),
+# GETLEDGERS_LIMIT(=1), EVENT_TERMS(=1,4,8,15),
+# PASSPHRASE(=Public Global Stellar Network ; September 2015), READY_TIMEOUT(=3600),
 # TESTBIN, FHBENCH, PACKS_ROOT.
 set -euo pipefail
 
@@ -26,6 +37,7 @@ PORT="${PORT:-8100}"
 DURATION="${DURATION:-45s}"
 HOT_LEDGERS="${HOT_LEDGERS:-5200}"
 CONCURRENCY="${CONCURRENCY:-8}"
+GETLEDGERS_LIMIT="${GETLEDGERS_LIMIT:-1}"
 EVENT_TERMS="${EVENT_TERMS:-1,4,8,15}"
 PASSPHRASE="${PASSPHRASE:-Public Global Stellar Network ; September 2015}"
 READY_TIMEOUT="${READY_TIMEOUT:-3600}"
@@ -89,12 +101,15 @@ for entry in "${PROFILES[@]}"; do
 	curl -s "$base/metrics" >"$pdir/metrics-before.txt" 2>/dev/null || true
 
 	# fhbench per endpoint, both tiers; aggregate tables into one file.
+	# getLedgers uses its own (small) limit — whole 10-17 MB ledgers per item.
 	report="$pdir/fhbench.txt"
 	: >"$report"
 	for ep in "${ENDPOINTS[@]}"; do
-		echo "### $name $ep (both tiers)" >>"$report"
+		limit=50
+		[ "$ep" = getLedgers ] && limit="$GETLEDGERS_LIMIT"
+		echo "### $name $ep (both tiers, limit $limit)" >>"$report"
 		"$FHBENCH" --url "$base" --endpoint "$ep" --tier both \
-			--concurrency "$CONCURRENCY" --duration "$DURATION" --limit 50 \
+			--concurrency "$CONCURRENCY" --duration "$DURATION" --limit "$limit" \
 			>>"$report" 2>>"$pdir/fhbench.err" || echo "fhbench $ep failed (see fhbench.err)" >>"$report"
 		echo >>"$report"
 	done

--- a/tools/fhbench/README.md
+++ b/tools/fhbench/README.md
@@ -1,0 +1,180 @@
+# fhbench — full-history query benchmark harness
+
+`fhbench` is a small, dependency-free load generator and latency reporter for the
+full-history query POC's JSON-RPC read server. It is a **black-box** benchmark:
+it speaks only the public HTTP JSON-RPC API (`getLedgers`, `getTransactions`,
+`getTransaction`, `getEvents`) plus scrapes `/metrics`, and imports nothing from
+the daemon (just `net/http` + `encoding/json`).
+
+The point of the harness is to compare the **hot** serving path (recently
+ingested ledgers still in RocksDB, plus the live chunk) against the **cold**
+serving path (an old sealed chunk served from cold artifacts), so latency can be
+attributed to each tier.
+
+## 1. Run the daemon with a `[serve]` endpoint
+
+The read server is off by default. Enable it by giving `[serve].endpoint` a
+`host:port` in the full-history daemon's TOML config:
+
+```toml
+[service]
+default_data_dir = "/var/lib/fullhistory"
+
+[retention]
+earliest_ledger = "genesis"   # or a chunk-aligned ledger; "now" for tip-only
+# retention_chunks = 0        # 0 = full history
+
+[ingestion]
+captive_core_config = "/etc/stellar/captive-core.cfg"
+history_archive_urls = ["https://history.stellar.org/prd/core-live/core_live_001"]
+
+[serve]
+endpoint = "127.0.0.1:8000"   # "" (or omitted) disables serving
+# Per-endpoint limits default to the v1 RPC caps; override only if needed:
+# max_ledgers_limit = 200
+# default_ledgers_limit = 50
+# max_transactions_limit = 200
+# default_transactions_limit = 50
+# max_events_limit = 10000
+# default_events_limit = 100
+```
+
+Start the daemon:
+
+```sh
+stellar-rpc full-history --config /etc/stellar/fullhistory.toml
+```
+
+The server then exposes, on `[serve].endpoint`:
+
+| Path       | What |
+| ---------- | --- |
+| `/`        | JSON-RPC 2.0 over HTTP POST (the four query methods) |
+| `/metrics` | Prometheus text exposition |
+| `/health`  | 200 when the daemon is up |
+| `/ready`   | 200 once ingestion has committed a ledger, else 503 |
+
+Let the daemon ingest (and, for a meaningful cold tier, freeze at least one full
+chunk) before benchmarking. Poll `/ready` until it returns 200.
+
+## 2. Build and run fhbench
+
+```sh
+go build -o /tmp/fhbench ./tools/fhbench
+# or run directly:
+go run ./tools/fhbench --url http://127.0.0.1:8000 --endpoint all --tier both \
+    --concurrency 8 --duration 60s --limit 50
+```
+
+### Flags
+
+| Flag            | Default                  | Meaning |
+| --------------- | ------------------------ | --- |
+| `--url`         | `http://127.0.0.1:8000`  | Base URL of the JSON-RPC server |
+| `--endpoint`    | `all`                    | `getLedgers` \| `getTransactions` \| `getTransaction` \| `getEvents` \| `all` |
+| `--tier`        | `both`                   | `hot` \| `cold` \| `both` |
+| `--concurrency` | `8`                      | Closed-loop workers per (endpoint, tier) |
+| `--duration`    | `60s`                    | Load duration per (endpoint, tier) |
+| `--limit`       | `50`                     | Page limit for range/events requests |
+| `--chunk-size`  | `10000`                  | Ledgers per chunk — must match the daemon's geometry (see below) |
+| `--sample-size` | `100`                    | Target tx-hash samples per tier for `getTransaction` |
+
+### How it works
+
+1. **Discovery.** fhbench sends one `getLedgers` probe to learn the served range.
+   Because v1 `getLedgers` validates that `startLedger` is inside the served
+   range *before* returning that range, there is no zero-knowledge "successful"
+   probe — so the probe deliberately uses `startLedger=1` (always below the
+   genesis-clamped floor of 2) and reads `oldest`/`latest` out of the resulting
+   out-of-range error message. If a server does answer, it takes the range from
+   the successful response instead.
+2. **Tiering.**
+   - **hot** = the last `chunk-size/2` ledgers before `latest`.
+   - **cold** = the oldest full chunk at or after `oldest` — chunk *k* covers
+     `[k*chunk-size+2 .. (k+1)*chunk-size+1]` (genesis-anchored, `FirstLedgerSeq=2`).
+3. **Sampling.** For `getTransaction`, fhbench pages `getTransactions` within each
+   tier to collect real tx hashes *before* timing starts.
+4. **Load.** N workers per (endpoint, tier) issue randomized requests in a closed
+   loop (random start ledger for range endpoints, random sampled hash for
+   `getTransaction`, rotating event filters incl. no-filter) for `--duration`,
+   recording each request's wall time and status.
+
+`--chunk-size` is **not** derived from the server (fhbench is black-box). The
+daemon's `geometry`/`chunk.LedgersPerChunk` is `10000`; override the flag only if
+the daemon is built with a different value. It shapes only the tier partition, not
+correctness.
+
+### Sample report
+
+```
+endpoint         tier     count        RPS       p50       p90       p99       max   errors
+--------------------------------------------------------------------------------------------
+getLedgers       hot       48213    803.5     8.9ms    14.2ms    31.7ms    88.1ms        0
+getLedgers       cold       9127    152.1    48.6ms    71.3ms   130.4ms   402.9ms        0
+getTransaction   hot       61044   1017.4     6.1ms     9.8ms    22.5ms    61.0ms        0
+getTransaction   cold      12880    214.7    34.2ms    58.9ms   119.6ms   350.2ms        0
+...
+```
+
+Quantiles use the **nearest-rank** method (`rank = ceil(q*N)`, value at that
+1-based rank) over the sorted per-tier latency slice — no dependencies.
+
+## 3. Prometheus queries
+
+Point Prometheus (or `curl http://127.0.0.1:8000/metrics`) at the server while a
+run is in progress. All metric names below are verified against the daemon's
+`observability.go` and the serve server.
+
+### Ingestion progress (namespace `soroban_rpc`, subsystem `fullhistory_streaming`)
+
+```promql
+# Ledgers committed per second (ingestion throughput).
+rate(soroban_rpc_fullhistory_streaming_last_committed_ledger[1m])
+
+# Absolute progress and retention floor (the two ends of the served window).
+soroban_rpc_fullhistory_streaming_last_committed_ledger
+soroban_rpc_fullhistory_streaming_retention_floor_ledger
+
+# Hot-chunk count on disk, chunk-boundary handoffs, and swept/discarded artifacts.
+soroban_rpc_fullhistory_streaming_live_hot_chunks
+rate(soroban_rpc_fullhistory_streaming_chunk_boundaries_total[5m])
+rate(soroban_rpc_fullhistory_streaming_discarded_hot_chunks_total[5m])
+rate(soroban_rpc_fullhistory_streaming_pruned_artifacts_total[5m])
+
+# Per-phase wall-clock (label `phase` = backfill_pass|freeze|rebuild|discard|prune).
+histogram_quantile(0.99,
+  sum by (le, phase) (rate(soroban_rpc_fullhistory_streaming_phase_duration_seconds_bucket[5m])))
+```
+
+### Per-endpoint query latency (`fullhistory_rpc_request_duration_seconds`, labels `endpoint`, `status`)
+
+This histogram (buckets spanning 100µs–10s) is the server-side counterpart to
+fhbench's client-side numbers.
+
+```promql
+# p50 / p90 / p99 latency per endpoint.
+histogram_quantile(0.50,
+  sum by (le, endpoint) (rate(fullhistory_rpc_request_duration_seconds_bucket[1m])))
+histogram_quantile(0.90,
+  sum by (le, endpoint) (rate(fullhistory_rpc_request_duration_seconds_bucket[1m])))
+histogram_quantile(0.99,
+  sum by (le, endpoint) (rate(fullhistory_rpc_request_duration_seconds_bucket[1m])))
+
+# Request rate and error rate per endpoint.
+sum by (endpoint) (rate(fullhistory_rpc_request_duration_seconds_count[1m]))
+sum by (endpoint) (rate(fullhistory_rpc_request_duration_seconds_count{status="error"}[1m]))
+```
+
+The `endpoint` label is the JSON-RPC method name (`getLedgers`,
+`getTransactions`, `getTransaction`, `getEvents`); `status` is `ok` or `error`.
+The server does not label by tier, so use fhbench's `--tier hot` / `--tier cold`
+runs (or watch the retention floor vs. the range you query) to separate the two
+serving paths.
+
+## Known POC performance note
+
+`getEvents` with filters that are **type-selective but index-unselective** (e.g.
+a bare `type=contract` filter with no contract-ID or topic narrowing) re-decodes
+the whole scan window on every page/re-query. This is a deliberate POC latency
+cliff — expect `getEvents` cold-tier latency to dominate the report when running
+with type-only filters. Narrow with contract IDs/topics to avoid it.

--- a/tools/fhbench/README.md
+++ b/tools/fhbench/README.md
@@ -102,9 +102,12 @@ go run ./tools/fhbench --endpoint getEvents --tier both --event-terms 1,4,8,15
 
 Terms pack into homogeneous filters (contract-only and topic-only, ≤5 each) so
 they are OR'd, never AND'd, staying within the protocol's 5-filter / 5-per-filter
-caps (so up to ~25 terms are expressible; the sweep is meant for ≤15). Topic terms
-are built as `["*"×pos, value, "**"]` — position-anchored but length-flexible, so
-they match their source events.
+caps. Any contract/topic mix of up to 21 terms fits the cap; counts above 21 are
+rejected at flag parse (the sweep is meant for ≤15). The vocabulary is harvested
+from the tier **midpoint** (a chunk head is often deploy/setup noise), and a run's
+`terms` column reports the count actually OR'd (clamped to the harvested vocab).
+Topic terms are built as `["*"×pos, value, "**"]` — position-anchored but
+length-flexible, so they match their source events.
 
 ### How it works
 
@@ -117,7 +120,10 @@ they match their source events.
    `oldest`/`latest` out of the resulting out-of-range error message — or from
    the successful response if the server happens to answer.
 2. **Tiering.**
-   - **hot** = the last `chunk-size/2` ledgers before `latest`.
+   - **hot** = the last `chunk-size/2` ledgers before `latest`, clamped to the
+     chunk containing `latest` (complete chunks below it may already be frozen
+     cold — the clamp keeps the hot label pure at the cost of a shorter span
+     right after a chunk boundary).
    - **cold** = the oldest full chunk at or after `oldest` — chunk *k* covers
      `[k*chunk-size+2 .. (k+1)*chunk-size+1]` (genesis-anchored, `FirstLedgerSeq=2`).
 3. **Sampling.** For `getTransaction`, fhbench pages `getTransactions` within each

--- a/tools/fhbench/README.md
+++ b/tools/fhbench/README.md
@@ -81,13 +81,14 @@ go run ./tools/fhbench --url http://127.0.0.1:8000 --endpoint all --tier both \
 
 ### How it works
 
-1. **Discovery.** fhbench sends one `getLedgers` probe to learn the served range.
-   Because v1 `getLedgers` validates that `startLedger` is inside the served
-   range *before* returning that range, there is no zero-knowledge "successful"
-   probe — so the probe deliberately uses `startLedger=1` (always below the
-   genesis-clamped floor of 2) and reads `oldest`/`latest` out of the resulting
-   out-of-range error message. If a server does answer, it takes the range from
-   the successful response instead.
+1. **Discovery.** fhbench probes `getTransaction` with a dummy all-zeros hash:
+   the handler populates the structured `oldestLedger`/`latestLedger` response
+   fields *before* returning the `NOT_FOUND` status, so a single 200 response
+   carries the served range with no string parsing. If that probe fails (e.g. a
+   server without `getTransaction`), it falls back to a `getLedgers` probe with
+   `startLedger=1` (always below the genesis-clamped floor of 2) and reads
+   `oldest`/`latest` out of the resulting out-of-range error message — or from
+   the successful response if the server happens to answer.
 2. **Tiering.**
    - **hot** = the last `chunk-size/2` ledgers before `latest`.
    - **cold** = the oldest full chunk at or after `oldest` — chunk *k* covers

--- a/tools/fhbench/README.md
+++ b/tools/fhbench/README.md
@@ -78,6 +78,33 @@ go run ./tools/fhbench --url http://127.0.0.1:8000 --endpoint all --tier both \
 | `--limit`       | `50`                     | Page limit for range/events requests |
 | `--chunk-size`  | `10000`                  | Ledgers per chunk — must match the daemon's geometry (see below) |
 | `--sample-size` | `100`                    | Target tx-hash samples per tier for `getTransaction` |
+| `--event-terms` | (none)                   | getEvents OR-union term sweep: comma-separated distinct-term counts, e.g. `1,4,8,15` |
+| `--event-vocab` | `500`                    | Events sampled per tier to harvest the term vocabulary for `--event-terms` |
+
+### getEvents index-term sweep (`--event-terms`)
+
+By default the getEvents load rotates no-filter / `type=contract` / `type=system`
+— all **index-unselective** (the type constraint isn't indexed), so every request
+scans the whole window and filters in Go. That measures the worst case, not the
+path the index accelerates.
+
+`--event-terms` measures the selective path as a function of **index-term count**.
+A *term* is one indexed constraint: a distinct contract ID, or a distinct topic
+value at a distinct position (0–2) — exactly the eventstore index's term model.
+Before timing, fhbench harvests a real vocabulary of both kinds from unfiltered
+getEvents over each tier, then for each requested count *N* it builds a getEvents
+request whose filters **OR-union** *N* real terms and runs a full load. The report
+adds a `terms` column so you get a term-count → latency curve:
+
+```sh
+go run ./tools/fhbench --endpoint getEvents --tier both --event-terms 1,4,8,15
+```
+
+Terms pack into homogeneous filters (contract-only and topic-only, ≤5 each) so
+they are OR'd, never AND'd, staying within the protocol's 5-filter / 5-per-filter
+caps (so up to ~25 terms are expressible; the sweep is meant for ≤15). Topic terms
+are built as `["*"×pos, value, "**"]` — position-anchored but length-flexible, so
+they match their source events.
 
 ### How it works
 

--- a/tools/fhbench/main.go
+++ b/tools/fhbench/main.go
@@ -1,0 +1,573 @@
+// Command fhbench is a dependency-free load generator + latency reporter for the
+// full-history query POC's JSON-RPC read server. It speaks only the public HTTP
+// JSON-RPC API (getLedgers/getTransactions/getTransaction/getEvents), so it is a
+// black-box benchmark: no imports from the daemon, just net/http + encoding/json.
+//
+// Two phases:
+//
+//   - Discovery learns the served ledger range, partitions it into a "hot" tier
+//     (recently ingested, likely still in RocksDB) and a "cold" tier (an old
+//     sealed chunk served from cold artifacts), and samples transaction hashes
+//     per tier for the by-hash endpoint. All of this happens before timing.
+//   - Load runs N closed-loop workers per (endpoint, tier) for a fixed duration,
+//     recording each request's wall time and status, then prints a plain-text
+//     table of count / RPS / p50 / p90 / p99 / max / errors.
+//
+// Pair the printed client-side latencies with the server's Prometheus metrics
+// (see README.md) to attribute latency to hot vs cold serving paths.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"net/http"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+)
+
+func main() {
+	var (
+		url         = flag.String("url", "http://127.0.0.1:8000", "base URL of the full-history JSON-RPC server")
+		endpoint    = flag.String("endpoint", "all", "getLedgers|getTransaction|getTransactions|getEvents|all")
+		tierFlag    = flag.String("tier", "both", "hot|cold|both")
+		concurrency = flag.Int("concurrency", 8, "number of closed-loop worker goroutines per (endpoint,tier)")
+		duration    = flag.Duration("duration", 60*time.Second, "load duration per (endpoint,tier)")
+		limit       = flag.Int("limit", 50, "page limit for getLedgers/getTransactions/getEvents requests")
+		// chunkSize is NOT derived from the server (fhbench is black-box); the
+		// daemon's geometry.chunk.LedgersPerChunk is 10_000. Override if the
+		// daemon is built with a different chunk size. It only shapes the tier
+		// partition (hot half-chunk, cold oldest full chunk), not correctness.
+		chunkSize  = flag.Uint("chunk-size", 10_000, "ledgers per chunk (matches the daemon's geometry)")
+		sampleSize = flag.Int("sample-size", 100, "target transaction-hash samples per tier for getTransaction")
+	)
+	flag.Parse()
+
+	if err := run(context.Background(), runConfig{
+		url:         *url,
+		endpoint:    *endpoint,
+		tier:        *tierFlag,
+		concurrency: *concurrency,
+		duration:    *duration,
+		limit:       *limit,
+		chunkSize:   uint32(*chunkSize),
+		sampleSize:  *sampleSize,
+	}); err != nil {
+		fmt.Fprintln(os.Stderr, "fhbench:", err)
+		os.Exit(1)
+	}
+}
+
+type runConfig struct {
+	url         string
+	endpoint    string
+	tier        string
+	concurrency int
+	duration    time.Duration
+	limit       int
+	chunkSize   uint32
+	sampleSize  int
+}
+
+// endpoints resolves the --endpoint selector to the concrete method list.
+func (c runConfig) endpoints() ([]string, error) {
+	all := []string{"getLedgers", "getTransactions", "getTransaction", "getEvents"}
+	if c.endpoint == "all" {
+		return all, nil
+	}
+	for _, e := range all {
+		if e == c.endpoint {
+			return []string{e}, nil
+		}
+	}
+	return nil, fmt.Errorf("unknown --endpoint %q (want one of getLedgers|getTransactions|getTransaction|getEvents|all)", c.endpoint)
+}
+
+func run(ctx context.Context, cfg runConfig) error {
+	if cfg.concurrency < 1 {
+		return errors.New("--concurrency must be >= 1")
+	}
+	eps, err := cfg.endpoints()
+	if err != nil {
+		return err
+	}
+	c := newRPCClient(cfg.url)
+
+	fmt.Fprintf(os.Stderr, "discovering ledger range at %s ...\n", cfg.url)
+	window, err := discover(ctx, c)
+	if err != nil {
+		return fmt.Errorf("discovery: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "served range: [%d, %d] (%d ledgers)\n", window.oldest, window.latest, window.latest-window.oldest+1)
+
+	tiers := computeTiers(window, cfg.chunkSize, cfg.tier)
+	if len(tiers) == 0 {
+		return fmt.Errorf("no tiers for --tier %q", cfg.tier)
+	}
+
+	// Sample tx hashes per tier up front (only needed if getTransaction runs).
+	needHashes := false
+	for _, e := range eps {
+		if e == "getTransaction" {
+			needHashes = true
+		}
+	}
+	hashes := map[string][]string{}
+	if needHashes {
+		for _, tr := range tiers {
+			hs, err := sampleTxHashes(ctx, c, tr, cfg.sampleSize)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "warning: sampling %s tier hashes: %v\n", tr.name, err)
+			}
+			fmt.Fprintf(os.Stderr, "sampled %d tx hashes in %s tier [%d,%d]\n", len(hs), tr.name, tr.first, tr.last)
+			hashes[tr.name] = hs
+		}
+	}
+
+	var results []result
+	for _, e := range eps {
+		for _, tr := range tiers {
+			fmt.Fprintf(os.Stderr, "running %s / %s tier for %s (%d workers) ...\n", e, tr.name, cfg.duration, cfg.concurrency)
+			res := runLoad(ctx, c, e, tr, hashes[tr.name], cfg.concurrency, cfg.duration, cfg.limit, cfg.chunkSize)
+			results = append(results, res)
+		}
+	}
+
+	fmt.Print(formatReport(results))
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// JSON-RPC client
+// ---------------------------------------------------------------------------
+
+type rpcClient struct {
+	url    string
+	http   *http.Client
+	nextID int64
+	mu     sync.Mutex
+}
+
+func newRPCClient(url string) *rpcClient {
+	return &rpcClient{
+		url:  url,
+		http: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// rpcError is a JSON-RPC 2.0 error object. It doubles as a Go error so callers
+// can distinguish protocol errors (e.g. out-of-range) from transport failures.
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func (e *rpcError) Error() string { return fmt.Sprintf("rpc error %d: %s", e.Code, e.Message) }
+
+func (c *rpcClient) id() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.nextID++
+	return c.nextID
+}
+
+// call issues one JSON-RPC request. A JSON-RPC error is returned as *rpcError;
+// transport/decode failures are returned as plain errors. On success, result is
+// unmarshalled into out (may be nil to ignore the body).
+func (c *rpcClient) call(ctx context.Context, method string, params any, out any) error {
+	reqBody, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      c.id(),
+		"method":  method,
+		"params":  params,
+	})
+	if err != nil {
+		return err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url, bytes.NewReader(reqBody))
+	if err != nil {
+		return err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(httpReq)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	var envelope struct {
+		Result json.RawMessage `json:"result"`
+		Error  *rpcError       `json:"error"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return fmt.Errorf("decode response (http %d): %w", resp.StatusCode, err)
+	}
+	if envelope.Error != nil {
+		return envelope.Error
+	}
+	if out != nil && len(envelope.Result) > 0 {
+		if err := json.Unmarshal(envelope.Result, out); err != nil {
+			return fmt.Errorf("decode result: %w", err)
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Discovery
+// ---------------------------------------------------------------------------
+
+type ledgerWindow struct {
+	oldest, latest uint32
+}
+
+// getLedgersResponse mirrors the fields fhbench reads (subset of the wire type).
+type getLedgersResponse struct {
+	Ledgers      []ledgerInfo `json:"ledgers"`
+	LatestLedger uint32       `json:"latestLedger"`
+	OldestLedger uint32       `json:"oldestLedger"`
+	Cursor       string       `json:"cursor"`
+}
+
+type ledgerInfo struct {
+	Sequence uint32 `json:"sequence"`
+}
+
+// rangeErrRe extracts the served range from v1's out-of-range error string:
+// "start ledger (N) must be between the oldest ledger: X and the latest ledger: Y ...".
+var rangeErrRe = regexp.MustCompile(`oldest ledger: (\d+) and the latest ledger: (\d+)`)
+
+// discover learns the served ledger range. Because v1 getLedgers validates that
+// startLedger is inside the served range BEFORE returning the range, there is no
+// zero-knowledge "successful" probe: we send startLedger=1 (always below the
+// genesis-clamped floor of 2) and read the range from the error message. If a
+// server does answer (e.g. oldest happens to be <=1), we take the range from the
+// successful response instead.
+func discover(ctx context.Context, c *rpcClient) (ledgerWindow, error) {
+	var resp getLedgersResponse
+	err := c.call(ctx, "getLedgers", map[string]any{
+		"startLedger": 1,
+		"pagination":  map[string]any{"limit": 1},
+	}, &resp)
+	if err == nil && resp.LatestLedger != 0 {
+		return ledgerWindow{oldest: resp.OldestLedger, latest: resp.LatestLedger}, nil
+	}
+
+	var rerr *rpcError
+	if errors.As(err, &rerr) {
+		if m := rangeErrRe.FindStringSubmatch(rerr.Message); m != nil {
+			oldest, _ := strconv.ParseUint(m[1], 10, 32)
+			latest, _ := strconv.ParseUint(m[2], 10, 32)
+			if latest > 0 {
+				return ledgerWindow{oldest: uint32(oldest), latest: uint32(latest)}, nil
+			}
+		}
+		return ledgerWindow{}, fmt.Errorf("could not parse range from server error: %s", rerr.Message)
+	}
+	if err != nil {
+		return ledgerWindow{}, err
+	}
+	return ledgerWindow{}, errors.New("server returned an empty ledger range")
+}
+
+// ---------------------------------------------------------------------------
+// Tiers
+// ---------------------------------------------------------------------------
+
+type tier struct {
+	name        string
+	first, last uint32 // inclusive ledger bounds sampled/queried within this tier
+}
+
+// computeTiers partitions the served window into hot and/or cold tiers.
+//   - hot  = the last chunkSize/2 ledgers before latest (recently ingested; the
+//     RocksDB hot path plus the live chunk).
+//   - cold = the oldest full chunk at or after oldest (a sealed chunk served from
+//     cold artifacts). A chunk is [k*chunkSize+2 .. (k+1)*chunkSize+1], matching
+//     the daemon's genesis-anchored geometry (FirstLedgerSeq=2).
+func computeTiers(w ledgerWindow, chunkSize uint32, which string) []tier {
+	var out []tier
+	if which == "hot" || which == "both" {
+		half := chunkSize / 2
+		first := w.latest
+		if w.latest > half {
+			first = w.latest - half + 1
+		}
+		if first < w.oldest {
+			first = w.oldest
+		}
+		out = append(out, tier{name: "hot", first: first, last: w.latest})
+	}
+	if which == "cold" || which == "both" {
+		// Index of the first chunk whose full span is at/after oldest.
+		// chunk k covers ledgers [k*chunkSize+2, (k+1)*chunkSize+1].
+		var k uint32
+		if w.oldest >= 2 {
+			k = (w.oldest - 2) / chunkSize
+		}
+		first := k*chunkSize + 2
+		last := (k+1)*chunkSize + 1
+		if first < w.oldest {
+			first = w.oldest
+		}
+		if last > w.latest {
+			last = w.latest
+		}
+		out = append(out, tier{name: "cold", first: first, last: last})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Transaction-hash sampling
+// ---------------------------------------------------------------------------
+
+type getTransactionsResponse struct {
+	Transactions []struct {
+		TxHash string `json:"txHash"`
+		Ledger uint32 `json:"ledger"`
+	} `json:"transactions"`
+	Cursor string `json:"cursor"`
+}
+
+// sampleTxHashes pages getTransactions from the tier's first ledger, collecting
+// up to want distinct tx hashes that fall within the tier bounds. It stops at
+// want, on an empty/absent cursor, or after a page returns no transactions.
+func sampleTxHashes(ctx context.Context, c *rpcClient, t tier, want int) ([]string, error) {
+	var (
+		hashes []string
+		seen   = map[string]bool{}
+		cursor string
+	)
+	for len(hashes) < want {
+		params := map[string]any{"pagination": map[string]any{"limit": 200}}
+		if cursor == "" {
+			params["startLedger"] = t.first
+		} else {
+			params["pagination"] = map[string]any{"limit": 200, "cursor": cursor}
+		}
+		var resp getTransactionsResponse
+		if err := c.call(ctx, "getTransactions", params, &resp); err != nil {
+			return hashes, err
+		}
+		if len(resp.Transactions) == 0 {
+			break
+		}
+		for _, tx := range resp.Transactions {
+			if tx.Ledger > t.last {
+				return hashes, nil // walked past the tier
+			}
+			if tx.TxHash != "" && !seen[tx.TxHash] {
+				seen[tx.TxHash] = true
+				hashes = append(hashes, tx.TxHash)
+				if len(hashes) >= want {
+					return hashes, nil
+				}
+			}
+		}
+		if resp.Cursor == "" || resp.Cursor == cursor {
+			break
+		}
+		cursor = resp.Cursor
+	}
+	return hashes, nil
+}
+
+// ---------------------------------------------------------------------------
+// Load phase
+// ---------------------------------------------------------------------------
+
+type result struct {
+	endpoint  string
+	tier      string
+	durations []time.Duration
+	errors    int
+	wall      time.Duration
+}
+
+func (r result) rps() float64 {
+	if r.wall <= 0 {
+		return 0
+	}
+	return float64(len(r.durations)) / r.wall.Seconds()
+}
+
+// runLoad drives `concurrency` closed-loop workers against one (endpoint, tier)
+// for `dur`, recording each request's wall time and error status.
+func runLoad(ctx context.Context, c *rpcClient, endpoint string, t tier, hashes []string,
+	concurrency int, dur time.Duration, limit int, chunkSize uint32,
+) result {
+	ctx, cancel := context.WithTimeout(ctx, dur)
+	defer cancel()
+
+	type sample struct {
+		d   time.Duration
+		err bool
+	}
+	samples := make([][]sample, concurrency)
+
+	var wg sync.WaitGroup
+	start := time.Now()
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			rng := rand.New(rand.NewSource(time.Now().UnixNano() + int64(worker)))
+			var local []sample
+			iter := 0
+			for ctx.Err() == nil {
+				params := buildRequest(endpoint, t, hashes, limit, rng, iter)
+				iter++
+				if params == nil {
+					// No request buildable (e.g. getTransaction with no samples).
+					return
+				}
+				t0 := time.Now()
+				err := c.call(ctx, endpoint, params, nil)
+				elapsed := time.Since(t0)
+				if ctx.Err() != nil && err != nil {
+					// Deadline hit mid-request; do not count the truncated request.
+					break
+				}
+				local = append(local, sample{d: elapsed, err: err != nil})
+			}
+			samples[worker] = local
+		}(i)
+	}
+	wg.Wait()
+	wall := time.Since(start)
+
+	res := result{endpoint: endpoint, tier: t.name, wall: wall}
+	for _, ls := range samples {
+		for _, s := range ls {
+			res.durations = append(res.durations, s.d)
+			if s.err {
+				res.errors++
+			}
+		}
+	}
+	return res
+}
+
+// buildRequest returns the JSON-RPC params for one randomized request within the
+// tier, or nil when no request can be built (getTransaction with no samples).
+func buildRequest(endpoint string, t tier, hashes []string, limit int, rng *rand.Rand, iter int) any {
+	span := t.last - t.first + 1
+	randStart := func() uint32 {
+		if span <= 1 {
+			return t.first
+		}
+		return t.first + uint32(rng.Int63n(int64(span)))
+	}
+	switch endpoint {
+	case "getLedgers", "getTransactions":
+		return map[string]any{
+			"startLedger": randStart(),
+			"pagination":  map[string]any{"limit": limit},
+		}
+	case "getTransaction":
+		if len(hashes) == 0 {
+			return nil
+		}
+		return map[string]any{"hash": hashes[rng.Intn(len(hashes))]}
+	case "getEvents":
+		startLedger := randStart()
+		endLedger := t.last
+		params := map[string]any{
+			"startLedger": startLedger,
+			"endLedger":   endLedger,
+			"pagination":  map[string]any{"limit": limit},
+			"filters":     []any{},
+		}
+		// Rotate through no-filter, contract-type, and system-type filters.
+		switch iter % 3 {
+		case 1:
+			params["filters"] = []any{map[string]any{"type": "contract"}}
+		case 2:
+			params["filters"] = []any{map[string]any{"type": "system"}}
+		}
+		return params
+	default:
+		return nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Quantiles + report
+// ---------------------------------------------------------------------------
+
+// quantile returns the q-th (0..1) quantile of an ascending-sorted slice using
+// the nearest-rank method: rank = ceil(q*N), value at that 1-based rank. No deps.
+func quantile(sorted []time.Duration, q float64) time.Duration {
+	n := len(sorted)
+	if n == 0 {
+		return 0
+	}
+	if q <= 0 {
+		return sorted[0]
+	}
+	if q >= 1 {
+		return sorted[n-1]
+	}
+	rank := int(math.Ceil(q * float64(n)))
+	idx := rank - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= n {
+		idx = n - 1
+	}
+	return sorted[idx]
+}
+
+// formatReport renders the per-(endpoint,tier) latency table as plain text.
+func formatReport(results []result) string {
+	var b bytes.Buffer
+	header := fmt.Sprintf("%-16s %-5s %8s %10s %9s %9s %9s %9s %8s\n",
+		"endpoint", "tier", "count", "RPS", "p50", "p90", "p99", "max", "errors")
+	b.WriteString("\n")
+	b.WriteString(header)
+	b.WriteString(fmt.Sprintf("%s\n", dashes(len(header)-1)))
+
+	for _, r := range results {
+		sorted := append([]time.Duration(nil), r.durations...)
+		sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+		b.WriteString(fmt.Sprintf(
+			"%-16s %-5s %8d %10.1f %9s %9s %9s %9s %8d\n",
+			r.endpoint, r.tier, len(r.durations), r.rps(),
+			fmtDur(quantile(sorted, 0.50)),
+			fmtDur(quantile(sorted, 0.90)),
+			fmtDur(quantile(sorted, 0.99)),
+			fmtDur(quantile(sorted, 1.0)),
+			r.errors,
+		))
+	}
+	return b.String()
+}
+
+func dashes(n int) string {
+	return string(bytes.Repeat([]byte("-"), n))
+}
+
+// fmtDur renders a duration compactly with millisecond precision.
+func fmtDur(d time.Duration) string {
+	if d == 0 {
+		return "-"
+	}
+	return d.Round(time.Microsecond).String()
+}

--- a/tools/fhbench/main.go
+++ b/tools/fhbench/main.go
@@ -340,7 +340,10 @@ func computeTiers(w ledgerWindow, chunkSize uint32, which string) []tier {
 	var out []tier
 	if which == "hot" || which == "both" {
 		half := chunkSize / 2
-		first := w.latest
+		// Default to the whole window; take the last half-chunk only when the
+		// window is longer than that (else a sub-half-chunk window — e.g. a young
+		// or single-hot-chunk daemon — would collapse the hot tier to [latest,latest]).
+		first := w.oldest
 		if w.latest > half {
 			first = w.latest - half + 1
 		}

--- a/tools/fhbench/main.go
+++ b/tools/fhbench/main.go
@@ -32,6 +32,7 @@ import (
 	"regexp"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -50,8 +51,19 @@ func main() {
 		// partition (hot half-chunk, cold oldest full chunk), not correctness.
 		chunkSize  = flag.Uint("chunk-size", 10_000, "ledgers per chunk (matches the daemon's geometry)")
 		sampleSize = flag.Int("sample-size", 100, "target transaction-hash samples per tier for getTransaction")
+		eventTerms = flag.String("event-terms", "",
+			"getEvents OR-union term sweep: comma-separated distinct-term counts (e.g. 1,4,8,15). "+
+				"Each run OR's that many real harvested contract-ID/topic terms. Empty = type-filter rotation.")
+		eventVocab = flag.Int("event-vocab", 500,
+			"events sampled per tier to harvest the contract-ID/topic term vocabulary for --event-terms")
 	)
 	flag.Parse()
+
+	terms, err := parseTermCounts(*eventTerms)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "fhbench:", err)
+		os.Exit(1)
+	}
 
 	if err := run(context.Background(), runConfig{
 		url:         *url,
@@ -62,6 +74,8 @@ func main() {
 		limit:       *limit,
 		chunkSize:   uint32(*chunkSize), //nolint:gosec // --chunk-size flag; never within range of a uint32 overflow
 		sampleSize:  *sampleSize,
+		eventTerms:  terms,
+		eventVocab:  *eventVocab,
 	}); err != nil {
 		fmt.Fprintln(os.Stderr, "fhbench:", err)
 		os.Exit(1)
@@ -77,6 +91,24 @@ type runConfig struct {
 	limit       int
 	chunkSize   uint32
 	sampleSize  int
+	eventTerms  []int // getEvents OR-union term-count sweep (nil = type-filter rotation)
+	eventVocab  int
+}
+
+// parseTermCounts parses the --event-terms comma list into positive term counts.
+func parseTermCounts(s string) ([]int, error) {
+	if strings.TrimSpace(s) == "" {
+		return nil, nil
+	}
+	var out []int
+	for _, part := range strings.Split(s, ",") {
+		n, err := strconv.Atoi(strings.TrimSpace(part))
+		if err != nil || n < 1 {
+			return nil, fmt.Errorf("invalid --event-terms value %q (want positive integers)", part)
+		}
+		out = append(out, n)
+	}
+	return out, nil
 }
 
 // endpoints resolves the --endpoint selector to the concrete method list.
@@ -138,12 +170,35 @@ func run(ctx context.Context, cfg runConfig) error {
 		}
 	}
 
+	// Harvest the getEvents term vocabulary per tier (only for a --event-terms sweep).
+	vocab := map[string][]term{}
+	if len(cfg.eventTerms) > 0 && slices.Contains(eps, "getEvents") {
+		for _, tr := range tiers {
+			vs, err := harvestEventVocab(ctx, c, tr, cfg.eventVocab)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "warning: harvesting %s tier event vocab: %v\n", tr.name, err)
+			}
+			fmt.Fprintf(os.Stderr, "harvested %d event terms in %s tier [%d,%d]\n", len(vs), tr.name, tr.first, tr.last)
+			vocab[tr.name] = vs
+		}
+	}
+
 	var results []result
 	for _, e := range eps {
 		for _, tr := range tiers {
+			// getEvents with a term sweep runs once per requested term count.
+			if e == "getEvents" && len(cfg.eventTerms) > 0 {
+				for _, n := range cfg.eventTerms {
+					fmt.Fprintf(os.Stderr, "running getEvents[terms=%d] / %s tier for %s (%d workers) ...\n",
+						n, tr.name, cfg.duration, cfg.concurrency)
+					results = append(results,
+						runLoad(ctx, c, e, tr, nil, vocab[tr.name], n, cfg.concurrency, cfg.duration, cfg.limit))
+				}
+				continue
+			}
 			fmt.Fprintf(os.Stderr, "running %s / %s tier for %s (%d workers) ...\n", e, tr.name, cfg.duration, cfg.concurrency)
-			res := runLoad(ctx, c, e, tr, hashes[tr.name], cfg.concurrency, cfg.duration, cfg.limit)
-			results = append(results, res)
+			results = append(results,
+				runLoad(ctx, c, e, tr, hashes[tr.name], nil, 0, cfg.concurrency, cfg.duration, cfg.limit))
 		}
 	}
 
@@ -428,12 +483,153 @@ func sampleTxHashes(ctx context.Context, c *rpcClient, t tier, want int) ([]stri
 }
 
 // ---------------------------------------------------------------------------
+// getEvents term vocabulary + OR-union filter construction
+// ---------------------------------------------------------------------------
+
+// term is one indexed getEvents constraint harvested from real data: a contract
+// ID, or an exact topic value at a position. Each maps to exactly one eventstore
+// index term (contract-id term, or (position, value) topic term).
+type term struct {
+	contractID string // set iff a contract term (strkey)
+	topicPos   int    // topic position (topic terms only)
+	topicVal   string // base64 ScVal (topic terms only)
+}
+
+func (t term) isContract() bool { return t.contractID != "" }
+
+// maxIndexedTopicPos is the highest topic position harvested as a term. Positions
+// 0..2 leave room for a trailing "**" (zero-or-more) segment inside the 4-position
+// index, so the built filter stays length-flexible and matches its source events;
+// position 3 has no room for "**" and is skipped.
+const maxIndexedTopicPos = 2
+
+// eventInfoLite is the subset of a getEvents EventInfo fhbench reads to harvest terms.
+type eventInfoLite struct {
+	ContractID string   `json:"contractId"`
+	Topic      []string `json:"topic"` // base64 ScVals, one per position
+}
+
+type getEventsResponse struct {
+	Events []eventInfoLite `json:"events"`
+	Cursor string          `json:"cursor"`
+}
+
+// harvestEventVocab pages unfiltered getEvents over the tier and collects up to
+// `want` DISTINCT terms — contract IDs and (position,value) topic terms —
+// interleaved so a small term count still mixes both kinds.
+func harvestEventVocab(ctx context.Context, c *rpcClient, t tier, want int) ([]term, error) {
+	var (
+		contracts, topics []term
+		seenC             = map[string]bool{}
+		seenT             = map[string]bool{}
+		cursor            string
+	)
+	for len(contracts)+len(topics) < want {
+		params := map[string]any{"pagination": map[string]any{"limit": 200}}
+		if cursor == "" {
+			params["startLedger"] = t.first
+			params["endLedger"] = t.last + 1 // endLedger is exclusive; +1 includes t.last
+		} else {
+			params["pagination"] = map[string]any{"limit": 200, "cursor": cursor}
+		}
+		var resp getEventsResponse
+		if err := c.call(ctx, "getEvents", params, &resp); err != nil {
+			return interleaveTerms(contracts, topics), err
+		}
+		if len(resp.Events) == 0 {
+			break
+		}
+		for _, ev := range resp.Events {
+			if ev.ContractID != "" && !seenC[ev.ContractID] {
+				seenC[ev.ContractID] = true
+				contracts = append(contracts, term{contractID: ev.ContractID})
+			}
+			for pos, val := range ev.Topic {
+				if pos > maxIndexedTopicPos {
+					break
+				}
+				if val == "" {
+					continue
+				}
+				key := strconv.Itoa(pos) + ":" + val
+				if !seenT[key] {
+					seenT[key] = true
+					topics = append(topics, term{topicPos: pos, topicVal: val})
+				}
+			}
+		}
+		if resp.Cursor == "" || resp.Cursor == cursor {
+			break
+		}
+		cursor = resp.Cursor
+	}
+	return interleaveTerms(contracts, topics), nil
+}
+
+// interleaveTerms zips the two pools so any prefix of length N mixes contract and
+// topic terms rather than being all-contract then all-topic.
+func interleaveTerms(contracts, topics []term) []term {
+	out := make([]term, 0, len(contracts)+len(topics))
+	for i := 0; i < len(contracts) || i < len(topics); i++ {
+		if i < len(contracts) {
+			out = append(out, contracts[i])
+		}
+		if i < len(topics) {
+			out = append(out, topics[i])
+		}
+	}
+	return out
+}
+
+// buildEventTermsFilters builds an OR-union getEvents `filters` value from the
+// first n harvested terms. Terms pack into HOMOGENEOUS filters — contract-only
+// and topic-only — so distinct terms are OR'd, never AND'd (a filter mixing a
+// contract ID with a topic would AND them). Contract IDs pack <=5 per filter and
+// topic clauses <=5 per filter, so total filters stay within the protocol's
+// 5-filter cap for n up to 25.
+func buildEventTermsFilters(vocab []term, n int) []any {
+	n = min(n, len(vocab))
+	var (
+		contractIDs  []string
+		topicClauses []any
+	)
+	for _, t := range vocab[:n] {
+		if t.isContract() {
+			contractIDs = append(contractIDs, t.contractID)
+		} else {
+			topicClauses = append(topicClauses, topicSegments(t.topicPos, t.topicVal))
+		}
+	}
+	var filters []any
+	for i := 0; i < len(contractIDs); i += 5 {
+		filters = append(filters, map[string]any{"contractIds": contractIDs[i:min(i+5, len(contractIDs))]})
+	}
+	for i := 0; i < len(topicClauses); i += 5 {
+		filters = append(filters, map[string]any{"topics": topicClauses[i:min(i+5, len(topicClauses))]})
+	}
+	return filters
+}
+
+// topicSegments builds one topic filter constraining position pos to val: earlier
+// positions wildcarded with "*", val at pos, and a trailing "**" (zero-or-more) so
+// it terms the index at exactly (pos, val) yet stays length-flexible and matches
+// events with additional topics.
+func topicSegments(pos int, val string) []any {
+	segs := make([]any, 0, pos+2)
+	for range pos {
+		segs = append(segs, "*")
+	}
+	return append(segs, val, "**")
+}
+
+// ---------------------------------------------------------------------------
 // Load phase
 // ---------------------------------------------------------------------------
 
 type result struct {
 	endpoint  string
 	tier      string
+	terms     int // getEvents OR-union term count (0 = not a term-sweep row)
 	durations []time.Duration
 	errors    int
 	wall      time.Duration
@@ -449,7 +645,7 @@ func (r result) rps() float64 {
 // runLoad drives `concurrency` closed-loop workers against one (endpoint, tier)
 // for `dur`, recording each request's wall time and error status.
 func runLoad(ctx context.Context, c *rpcClient, endpoint string, t tier, hashes []string,
-	concurrency int, dur time.Duration, limit int,
+	vocab []term, eventTerms int, concurrency int, dur time.Duration, limit int,
 ) result {
 	ctx, cancel := context.WithTimeout(ctx, dur)
 	defer cancel()
@@ -471,7 +667,7 @@ func runLoad(ctx context.Context, c *rpcClient, endpoint string, t tier, hashes 
 			var local []sample
 			iter := 0
 			for ctx.Err() == nil {
-				params := buildRequest(endpoint, t, hashes, limit, rng, iter)
+				params := buildRequest(endpoint, t, hashes, vocab, eventTerms, limit, rng, iter)
 				iter++
 				if params == nil {
 					// No request buildable (e.g. getTransaction with no samples).
@@ -492,7 +688,7 @@ func runLoad(ctx context.Context, c *rpcClient, endpoint string, t tier, hashes 
 	wg.Wait()
 	wall := time.Since(start)
 
-	res := result{endpoint: endpoint, tier: t.name, wall: wall}
+	res := result{endpoint: endpoint, tier: t.name, terms: eventTerms, wall: wall}
 	for _, ls := range samples {
 		for _, s := range ls {
 			res.durations = append(res.durations, s.d)
@@ -506,7 +702,9 @@ func runLoad(ctx context.Context, c *rpcClient, endpoint string, t tier, hashes 
 
 // buildRequest returns the JSON-RPC params for one randomized request within the
 // tier, or nil when no request can be built (getTransaction with no samples).
-func buildRequest(endpoint string, t tier, hashes []string, limit int, rng *rand.Rand, iter int) any {
+func buildRequest(
+	endpoint string, t tier, hashes []string, vocab []term, eventTerms, limit int, rng *rand.Rand, iter int,
+) any {
 	span := t.last - t.first + 1
 	randStart := func() uint32 {
 		if span <= 1 {
@@ -528,10 +726,19 @@ func buildRequest(endpoint string, t tier, hashes []string, limit int, rng *rand
 		return map[string]any{"hash": hashes[rng.Intn(len(hashes))]}
 	case "getEvents":
 		startLedger := randStart()
-		endLedger := t.last
+		// Term-sweep mode: OR-union eventTerms real harvested contract/topic terms
+		// over the whole tier (endLedger is exclusive, so +1 includes t.last).
+		if eventTerms > 0 {
+			return map[string]any{
+				"startLedger": startLedger,
+				"endLedger":   t.last + 1,
+				"pagination":  map[string]any{"limit": limit},
+				"filters":     buildEventTermsFilters(vocab, eventTerms),
+			}
+		}
 		params := map[string]any{
 			"startLedger": startLedger,
-			"endLedger":   endLedger,
+			"endLedger":   t.last,
 			"pagination":  map[string]any{"limit": limit},
 			"filters":     []any{},
 		}
@@ -576,8 +783,8 @@ func quantile(sorted []time.Duration, q float64) time.Duration {
 // formatReport renders the per-(endpoint,tier) latency table as plain text.
 func formatReport(results []result) string {
 	var b bytes.Buffer
-	header := fmt.Sprintf("%-16s %-5s %8s %10s %9s %9s %9s %9s %8s\n",
-		"endpoint", "tier", "count", "RPS", "p50", "p90", "p99", "max", "errors")
+	header := fmt.Sprintf("%-16s %-5s %6s %8s %10s %9s %9s %9s %9s %8s\n",
+		"endpoint", "tier", "terms", "count", "RPS", "p50", "p90", "p99", "max", "errors")
 	b.WriteString("\n")
 	b.WriteString(header)
 	b.WriteString(dashes(len(header)-1) + "\n")
@@ -585,10 +792,14 @@ func formatReport(results []result) string {
 	for _, r := range results {
 		sorted := append([]time.Duration(nil), r.durations...)
 		slices.Sort(sorted)
+		termsStr := "-"
+		if r.terms > 0 {
+			termsStr = strconv.Itoa(r.terms)
+		}
 		fmt.Fprintf(
 			&b,
-			"%-16s %-5s %8d %10.1f %9s %9s %9s %9s %8d\n",
-			r.endpoint, r.tier, len(r.durations), r.rps(),
+			"%-16s %-5s %6s %8d %10.1f %9s %9s %9s %9s %8d\n",
+			r.endpoint, r.tier, termsStr, len(r.durations), r.rps(),
 			fmtDur(quantile(sorted, 0.50)),
 			fmtDur(quantile(sorted, 0.90)),
 			fmtDur(quantile(sorted, 0.99)),

--- a/tools/fhbench/main.go
+++ b/tools/fhbench/main.go
@@ -252,13 +252,45 @@ type ledgerInfo struct {
 // "start ledger (N) must be between the oldest ledger: X and the latest ledger: Y ...".
 var rangeErrRe = regexp.MustCompile(`oldest ledger: (\d+) and the latest ledger: (\d+)`)
 
-// discover learns the served ledger range. Because v1 getLedgers validates that
-// startLedger is inside the served range BEFORE returning the range, there is no
-// zero-knowledge "successful" probe: we send startLedger=1 (always below the
-// genesis-clamped floor of 2) and read the range from the error message. If a
-// server does answer (e.g. oldest happens to be <=1), we take the range from the
-// successful response instead.
+// discover learns the served ledger range.
+//
+// Primary probe: getTransaction with a dummy all-zeros hash. Its handler fills
+// the structured oldestLedger/latestLedger response fields BEFORE returning the
+// NOT_FOUND status, so one 200 response carries the range with no string
+// parsing (methods/get_transaction.go).
+//
+// Fallback (covers servers without getTransaction): a getLedgers probe. Because
+// v1 getLedgers validates that startLedger is inside the served range BEFORE
+// returning the range, there is no zero-knowledge "successful" probe: we send
+// startLedger=1 (always below the genesis-clamped floor of 2) and read the
+// range from the out-of-range error message. If a server does answer (e.g.
+// oldest happens to be <=1), we take the range from the successful response.
 func discover(ctx context.Context, c *rpcClient) (ledgerWindow, error) {
+	if w, err := discoverViaGetTransaction(ctx, c); err == nil {
+		return w, nil
+	}
+	return discoverViaGetLedgers(ctx, c)
+}
+
+// discoverViaGetTransaction is the structured primary probe (see discover).
+func discoverViaGetTransaction(ctx context.Context, c *rpcClient) (ledgerWindow, error) {
+	var resp struct {
+		Status       string `json:"status"`
+		OldestLedger uint32 `json:"oldestLedger"`
+		LatestLedger uint32 `json:"latestLedger"`
+	}
+	dummyHash := "0000000000000000000000000000000000000000000000000000000000000000"
+	if err := c.call(ctx, "getTransaction", map[string]any{"hash": dummyHash}, &resp); err != nil {
+		return ledgerWindow{}, err
+	}
+	if resp.LatestLedger == 0 {
+		return ledgerWindow{}, errors.New("getTransaction probe returned an empty ledger range")
+	}
+	return ledgerWindow{oldest: resp.OldestLedger, latest: resp.LatestLedger}, nil
+}
+
+// discoverViaGetLedgers is the error-parsing fallback probe (see discover).
+func discoverViaGetLedgers(ctx context.Context, c *rpcClient) (ledgerWindow, error) {
 	var resp getLedgersResponse
 	err := c.call(ctx, "getLedgers", map[string]any{
 		"startLedger": 1,

--- a/tools/fhbench/main.go
+++ b/tools/fhbench/main.go
@@ -30,7 +30,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
-	"sort"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -60,7 +60,7 @@ func main() {
 		concurrency: *concurrency,
 		duration:    *duration,
 		limit:       *limit,
-		chunkSize:   uint32(*chunkSize),
+		chunkSize:   uint32(*chunkSize), //nolint:gosec // --chunk-size flag; never within range of a uint32 overflow
 		sampleSize:  *sampleSize,
 	}); err != nil {
 		fmt.Fprintln(os.Stderr, "fhbench:", err)
@@ -90,7 +90,10 @@ func (c runConfig) endpoints() ([]string, error) {
 			return []string{e}, nil
 		}
 	}
-	return nil, fmt.Errorf("unknown --endpoint %q (want one of getLedgers|getTransactions|getTransaction|getEvents|all)", c.endpoint)
+	return nil, fmt.Errorf(
+		"unknown --endpoint %q (want one of getLedgers|getTransactions|getTransaction|getEvents|all)",
+		c.endpoint,
+	)
 }
 
 func run(ctx context.Context, cfg runConfig) error {
@@ -108,7 +111,8 @@ func run(ctx context.Context, cfg runConfig) error {
 	if err != nil {
 		return fmt.Errorf("discovery: %w", err)
 	}
-	fmt.Fprintf(os.Stderr, "served range: [%d, %d] (%d ledgers)\n", window.oldest, window.latest, window.latest-window.oldest+1)
+	fmt.Fprintf(os.Stderr, "served range: [%d, %d] (%d ledgers)\n",
+		window.oldest, window.latest, window.latest-window.oldest+1)
 
 	tiers := computeTiers(window, cfg.chunkSize, cfg.tier)
 	if len(tiers) == 0 {
@@ -138,12 +142,12 @@ func run(ctx context.Context, cfg runConfig) error {
 	for _, e := range eps {
 		for _, tr := range tiers {
 			fmt.Fprintf(os.Stderr, "running %s / %s tier for %s (%d workers) ...\n", e, tr.name, cfg.duration, cfg.concurrency)
-			res := runLoad(ctx, c, e, tr, hashes[tr.name], cfg.concurrency, cfg.duration, cfg.limit, cfg.chunkSize)
+			res := runLoad(ctx, c, e, tr, hashes[tr.name], cfg.concurrency, cfg.duration, cfg.limit)
 			results = append(results, res)
 		}
 	}
 
-	fmt.Print(formatReport(results))
+	fmt.Fprint(os.Stdout, formatReport(results))
 	return nil
 }
 
@@ -442,7 +446,7 @@ func (r result) rps() float64 {
 // runLoad drives `concurrency` closed-loop workers against one (endpoint, tier)
 // for `dur`, recording each request's wall time and error status.
 func runLoad(ctx context.Context, c *rpcClient, endpoint string, t tier, hashes []string,
-	concurrency int, dur time.Duration, limit int, chunkSize uint32,
+	concurrency int, dur time.Duration, limit int,
 ) result {
 	ctx, cancel := context.WithTimeout(ctx, dur)
 	defer cancel()
@@ -455,10 +459,11 @@ func runLoad(ctx context.Context, c *rpcClient, endpoint string, t tier, hashes 
 
 	var wg sync.WaitGroup
 	start := time.Now()
-	for i := 0; i < concurrency; i++ {
+	for i := range concurrency {
 		wg.Add(1)
 		go func(worker int) {
 			defer wg.Done()
+			//nolint:gosec // load-generator sampling; a weak PRNG is intentional (no security use)
 			rng := rand.New(rand.NewSource(time.Now().UnixNano() + int64(worker)))
 			var local []sample
 			iter := 0
@@ -504,6 +509,7 @@ func buildRequest(endpoint string, t tier, hashes []string, limit int, rng *rand
 		if span <= 1 {
 			return t.first
 		}
+		//nolint:gosec // rng.Int63n(span) < span <= uint32 max, so the conversion cannot overflow
 		return t.first + uint32(rng.Int63n(int64(span)))
 	}
 	switch endpoint {
@@ -557,10 +563,7 @@ func quantile(sorted []time.Duration, q float64) time.Duration {
 		return sorted[n-1]
 	}
 	rank := int(math.Ceil(q * float64(n)))
-	idx := rank - 1
-	if idx < 0 {
-		idx = 0
-	}
+	idx := max(rank-1, 0)
 	if idx >= n {
 		idx = n - 1
 	}
@@ -574,12 +577,13 @@ func formatReport(results []result) string {
 		"endpoint", "tier", "count", "RPS", "p50", "p90", "p99", "max", "errors")
 	b.WriteString("\n")
 	b.WriteString(header)
-	b.WriteString(fmt.Sprintf("%s\n", dashes(len(header)-1)))
+	b.WriteString(dashes(len(header)-1) + "\n")
 
 	for _, r := range results {
 		sorted := append([]time.Duration(nil), r.durations...)
-		sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
-		b.WriteString(fmt.Sprintf(
+		slices.Sort(sorted)
+		fmt.Fprintf(
+			&b,
 			"%-16s %-5s %8d %10.1f %9s %9s %9s %9s %8d\n",
 			r.endpoint, r.tier, len(r.durations), r.rps(),
 			fmtDur(quantile(sorted, 0.50)),
@@ -587,7 +591,7 @@ func formatReport(results []result) string {
 			fmtDur(quantile(sorted, 0.99)),
 			fmtDur(quantile(sorted, 1.0)),
 			r.errors,
-		))
+		)
 	}
 	return b.String()
 }

--- a/tools/fhbench/main.go
+++ b/tools/fhbench/main.go
@@ -95,6 +95,13 @@ type runConfig struct {
 	eventVocab  int
 }
 
+// maxSweepTerms is the largest --event-terms count guaranteed expressible: any
+// contract/topic split of n<=21 packs into <=5 homogeneous filters (ceil(c/5)+
+// ceil(t/5) <= 5), the protocol's per-request cap. From 22 up, a near-even split
+// (e.g. 11+11 -> 3+3 filters) exceeds the cap, so those are rejected up front
+// rather than failing per-request against the server.
+const maxSweepTerms = 21
+
 // parseTermCounts parses the --event-terms comma list into positive term counts.
 func parseTermCounts(s string) ([]int, error) {
 	if strings.TrimSpace(s) == "" {
@@ -105,6 +112,11 @@ func parseTermCounts(s string) ([]int, error) {
 		n, err := strconv.Atoi(strings.TrimSpace(part))
 		if err != nil || n < 1 {
 			return nil, fmt.Errorf("invalid --event-terms value %q (want positive integers)", part)
+		}
+		if n > maxSweepTerms {
+			return nil, fmt.Errorf(
+				"--event-terms value %d exceeds %d (a mixed contract/topic split past that "+
+					"can overflow the protocol's 5-filter cap)", n, maxSweepTerms)
 		}
 		out = append(out, n)
 	}
@@ -186,13 +198,25 @@ func run(ctx context.Context, cfg runConfig) error {
 	var results []result
 	for _, e := range eps {
 		for _, tr := range tiers {
-			// getEvents with a term sweep runs once per requested term count.
+			// getEvents with a term sweep runs once per requested term count. The
+			// count is clamped to the harvested vocabulary up front so the reported
+			// `terms` column is the number of terms actually OR'd, never an
+			// aspirational one the vocab could not honor.
 			if e == "getEvents" && len(cfg.eventTerms) > 0 {
 				for _, n := range cfg.eventTerms {
+					eff := min(n, len(vocab[tr.name]))
+					if eff == 0 {
+						fmt.Fprintf(os.Stderr, "skipping getEvents[terms=%d] / %s tier: empty term vocabulary\n", n, tr.name)
+						continue
+					}
+					if eff < n {
+						fmt.Fprintf(os.Stderr, "warning: %s tier vocab has only %d terms; running terms=%d instead of %d\n",
+							tr.name, eff, eff, n)
+					}
 					fmt.Fprintf(os.Stderr, "running getEvents[terms=%d] / %s tier for %s (%d workers) ...\n",
-						n, tr.name, cfg.duration, cfg.concurrency)
+						eff, tr.name, cfg.duration, cfg.concurrency)
 					results = append(results,
-						runLoad(ctx, c, e, tr, nil, vocab[tr.name], n, cfg.concurrency, cfg.duration, cfg.limit))
+						runLoad(ctx, c, e, tr, nil, vocab[tr.name], eff, cfg.concurrency, cfg.duration, cfg.limit))
 				}
 				continue
 			}
@@ -387,7 +411,11 @@ type tier struct {
 
 // computeTiers partitions the served window into hot and/or cold tiers.
 //   - hot  = the last chunkSize/2 ledgers before latest (recently ingested; the
-//     RocksDB hot path plus the live chunk).
+//     RocksDB hot path), clamped to the chunk CONTAINING latest: the daemon
+//     freezes complete chunks to cold, so ledgers below the live chunk's first
+//     ledger may already be cold-served — letting the hot tier span them would
+//     silently mix cold reads into the "hot" rows. The clamp trades a shorter
+//     hot span right after a chunk boundary for a pure-hot label.
 //   - cold = the oldest full chunk at or after oldest (a sealed chunk served from
 //     cold artifacts). A chunk is [k*chunkSize+2 .. (k+1)*chunkSize+1], matching
 //     the daemon's genesis-anchored geometry (FirstLedgerSeq=2).
@@ -401,6 +429,13 @@ func computeTiers(w ledgerWindow, chunkSize uint32, which string) []tier {
 		first := w.oldest
 		if w.latest > half {
 			first = w.latest - half + 1
+		}
+		// Clamp to the live chunk (the chunk containing latest) — everything below
+		// its first ledger is a complete chunk the daemon may have frozen cold.
+		if w.latest >= 2 {
+			if liveFirst := (w.latest-2)/chunkSize*chunkSize + 2; first < liveFirst {
+				first = liveFirst
+			}
 		}
 		if first < w.oldest {
 			first = w.oldest
@@ -439,9 +474,11 @@ type getTransactionsResponse struct {
 	Cursor string `json:"cursor"`
 }
 
-// sampleTxHashes pages getTransactions from the tier's first ledger, collecting
-// up to want distinct tx hashes that fall within the tier bounds. It stops at
-// want, on an empty/absent cursor, or after a page returns no transactions.
+// sampleTxHashes pages getTransactions from the tier MIDPOINT (the head of a
+// chunk is often deploy/setup warmup with far lighter ledgers than steady state,
+// so head-sampled hashes understate the by-hash read cost), collecting up to
+// want distinct tx hashes that fall within the tier bounds. It stops at want,
+// on an empty/absent cursor, or after a page returns no transactions.
 func sampleTxHashes(ctx context.Context, c *rpcClient, t tier, want int) ([]string, error) {
 	var (
 		hashes []string
@@ -451,7 +488,7 @@ func sampleTxHashes(ctx context.Context, c *rpcClient, t tier, want int) ([]stri
 	for len(hashes) < want {
 		params := map[string]any{"pagination": map[string]any{"limit": 200}}
 		if cursor == "" {
-			params["startLedger"] = t.first
+			params["startLedger"] = t.first + (t.last-t.first)/2
 		} else {
 			params["pagination"] = map[string]any{"limit": 200, "cursor": cursor}
 		}
@@ -516,7 +553,10 @@ type getEventsResponse struct {
 
 // harvestEventVocab pages unfiltered getEvents over the tier and collects up to
 // `want` DISTINCT terms — contract IDs and (position,value) topic terms —
-// interleaved so a small term count still mixes both kinds.
+// interleaved so a small term count still mixes both kinds. Harvesting starts at
+// the tier MIDPOINT, not its head: a chunk's head is often unrepresentative
+// (contract deploys / account setup on the synthetic profiles), and sweep
+// queries land anywhere in the tier, so terms should come from steady state.
 func harvestEventVocab(ctx context.Context, c *rpcClient, t tier, want int) ([]term, error) {
 	var (
 		contracts, topics []term
@@ -527,7 +567,7 @@ func harvestEventVocab(ctx context.Context, c *rpcClient, t tier, want int) ([]t
 	for len(contracts)+len(topics) < want {
 		params := map[string]any{"pagination": map[string]any{"limit": 200}}
 		if cursor == "" {
-			params["startLedger"] = t.first
+			params["startLedger"] = t.first + (t.last-t.first)/2
 			params["endLedger"] = t.last + 1 // endLedger is exclusive; +1 includes t.last
 		} else {
 			params["pagination"] = map[string]any{"limit": 200, "cursor": cursor}
@@ -585,8 +625,8 @@ func interleaveTerms(contracts, topics []term) []term {
 // first n harvested terms. Terms pack into HOMOGENEOUS filters — contract-only
 // and topic-only — so distinct terms are OR'd, never AND'd (a filter mixing a
 // contract ID with a topic would AND them). Contract IDs pack <=5 per filter and
-// topic clauses <=5 per filter, so total filters stay within the protocol's
-// 5-filter cap for n up to 25.
+// topic clauses <=5 per filter; any contract/topic split of n <= maxSweepTerms
+// (21) stays within the protocol's 5-filter cap (parseTermCounts rejects more).
 func buildEventTermsFilters(vocab []term, n int) []any {
 	n = min(n, len(vocab))
 	var (
@@ -680,6 +720,10 @@ func runLoad(ctx context.Context, c *rpcClient, endpoint string, t tier, hashes 
 					// Deadline hit mid-request; do not count the truncated request.
 					break
 				}
+				// Errored requests are tallied but excluded from the latency
+				// distribution — an error return (validation, out-of-range, 5xx)
+				// is not a served request, and its (often fast-fail) latency
+				// would skew the percentiles the table reports.
 				local = append(local, sample{d: elapsed, err: err != nil})
 			}
 			samples[worker] = local
@@ -691,10 +735,11 @@ func runLoad(ctx context.Context, c *rpcClient, endpoint string, t tier, hashes 
 	res := result{endpoint: endpoint, tier: t.name, terms: eventTerms, wall: wall}
 	for _, ls := range samples {
 		for _, s := range ls {
-			res.durations = append(res.durations, s.d)
 			if s.err {
 				res.errors++
+				continue
 			}
+			res.durations = append(res.durations, s.d)
 		}
 	}
 	return res
@@ -738,7 +783,7 @@ func buildRequest(
 		}
 		params := map[string]any{
 			"startLedger": startLedger,
-			"endLedger":   t.last,
+			"endLedger":   t.last + 1, // exclusive; +1 includes t.last, matching the sweep mode
 			"pagination":  map[string]any{"limit": limit},
 			"filters":     []any{},
 		}

--- a/tools/fhbench/main_test.go
+++ b/tools/fhbench/main_test.go
@@ -60,9 +60,11 @@ func TestComputeTiers(t *testing.T) {
 	if !ok {
 		t.Fatalf("no hot tier")
 	}
-	// hot = last chunkSize/2 ledgers before latest -> [45000-5000+1, 45000]
-	if hot.first != 40_001 || hot.last != 45_000 {
-		t.Errorf("hot tier = [%d,%d], want [40001,45000]", hot.first, hot.last)
+	// hot = last chunkSize/2 ledgers before latest, clamped to the live chunk
+	// (chunk 4 = [40002,50001]) so it cannot bleed into possibly-frozen chunks:
+	// [45000-5000+1, 45000] -> clamp 40001 up to 40002.
+	if hot.first != 40_002 || hot.last != 45_000 {
+		t.Errorf("hot tier = [%d,%d], want [40002,45000]", hot.first, hot.last)
 	}
 
 	cold, ok := byName["cold"]
@@ -83,6 +85,30 @@ func TestComputeTiers(t *testing.T) {
 	small := computeTiers(ledgerWindow{oldest: 2, latest: 4_000}, chunkSize, "hot")
 	if len(small) != 1 || small[0].first != 2 || small[0].last != 4_000 {
 		t.Errorf("small-window hot tier = %+v, want [2,4000]", small)
+	}
+
+	// Fewer than half-chunk hot ledgers above the last frozen chunk (e.g. a
+	// serve-harness daemon: cold chunk [10002,20001], hot commits to 23933): the
+	// hot tier must clamp to the live chunk [20002,...], NOT reach back into the
+	// frozen chunk (latest-4999 = 18934 would mislabel 1068 cold ledgers as hot).
+	clamped := computeTiers(ledgerWindow{oldest: 10_002, latest: 23_933}, chunkSize, "hot")
+	if len(clamped) != 1 || clamped[0].first != 20_002 || clamped[0].last != 23_933 {
+		t.Errorf("post-freeze hot tier = %+v, want [20002,23933]", clamped)
+	}
+}
+
+func TestParseTermCounts(t *testing.T) {
+	got, err := parseTermCounts(" 1, 4,8,15 ")
+	if err != nil || !reflect.DeepEqual(got, []int{1, 4, 8, 15}) {
+		t.Errorf("parseTermCounts = %v, %v", got, err)
+	}
+	if _, err := parseTermCounts(""); err != nil {
+		t.Errorf("empty list must be nil, nil: %v", err)
+	}
+	for _, bad := range []string{"0", "-3", "x", "1,,2", "22", "25"} {
+		if _, err := parseTermCounts(bad); err == nil {
+			t.Errorf("parseTermCounts(%q) must fail (zero/negative/garbage/over-cap)", bad)
+		}
 	}
 }
 
@@ -337,5 +363,26 @@ func TestRunLoadSmoke(t *testing.T) {
 	}
 	if res.errors != 0 {
 		t.Errorf("runLoad recorded %d errors against a healthy stub", res.errors)
+	}
+}
+
+// TestRunLoadExcludesErrorLatencies pins that errored requests are tallied in
+// `errors` but kept OUT of the latency distribution (fast-fail errors would
+// otherwise drag the percentiles down).
+func TestRunLoadExcludesErrorLatencies(t *testing.T) {
+	srv := rpcStub(t, map[string]func(json.RawMessage) (any, *rpcError){
+		//nolint:unparam // uniform rpcStub handler signature
+		"getLedgers": func(json.RawMessage) (any, *rpcError) {
+			return nil, &rpcError{Code: -32600, Message: "boom"}
+		},
+	})
+
+	tr := tier{name: "hot", first: 50, last: 100}
+	res := runLoad(context.Background(), newRPCClient(srv.URL), "getLedgers", tr, nil, nil, 0, 1, 100*time.Millisecond, 10)
+	if res.errors == 0 {
+		t.Fatalf("all-error stub recorded no errors")
+	}
+	if len(res.durations) != 0 {
+		t.Errorf("errored requests leaked %d samples into the latency distribution", len(res.durations))
 	}
 }

--- a/tools/fhbench/main_test.go
+++ b/tools/fhbench/main_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -81,6 +83,67 @@ func TestComputeTiers(t *testing.T) {
 	small := computeTiers(ledgerWindow{oldest: 2, latest: 4_000}, chunkSize, "hot")
 	if len(small) != 1 || small[0].first != 2 || small[0].last != 4_000 {
 		t.Errorf("small-window hot tier = %+v, want [2,4000]", small)
+	}
+}
+
+func TestBuildEventTermsFilters(t *testing.T) {
+	// 6 contract + 6 topic terms, interleaved (any prefix mixes both kinds).
+	var contracts, topics []term
+	for i := 0; i < 6; i++ {
+		contracts = append(contracts, term{contractID: fmt.Sprintf("C%d", i)})
+		topics = append(topics, term{topicPos: i % 3, topicVal: fmt.Sprintf("T%d", i)})
+	}
+	vocab := interleaveTerms(contracts, topics) // 12 terms, alternating C,T,C,T...
+
+	// One term → exactly one filter.
+	if got := buildEventTermsFilters(vocab, 1); len(got) != 1 {
+		t.Fatalf("n=1: got %d filters, want 1", len(got))
+	}
+
+	// All 12 terms: <=5 filters, every filter HOMOGENEOUS (OR, never AND), each
+	// group <=5, and all terms accounted for.
+	filters := buildEventTermsFilters(vocab, 12)
+	if len(filters) > 5 {
+		t.Fatalf("got %d filters, exceeds protocol max 5", len(filters))
+	}
+	nContract, nTopic := 0, 0
+	for _, raw := range filters {
+		m := raw.(map[string]any)
+		_, hasC := m["contractIds"]
+		_, hasT := m["topics"]
+		if hasC && hasT {
+			t.Errorf("filter mixes contractIds and topics — that ANDs them, breaking OR-union")
+		}
+		if hasC {
+			ids := m["contractIds"].([]string)
+			if len(ids) > 5 {
+				t.Errorf("contractIds group of %d exceeds 5", len(ids))
+			}
+			nContract += len(ids)
+		}
+		if hasT {
+			clauses := m["topics"].([]any)
+			if len(clauses) > 5 {
+				t.Errorf("topics group of %d exceeds 5", len(clauses))
+			}
+			nTopic += len(clauses)
+		}
+	}
+	if nContract != 6 || nTopic != 6 {
+		t.Errorf("term accounting: %d contract + %d topic, want 6 + 6", nContract, nTopic)
+	}
+
+	// topicSegments: pos i wildcards positions 0..i-1, exact val at i, trailing "**".
+	if got := topicSegments(2, "V"); !reflect.DeepEqual(got, []any{"*", "*", "V", "**"}) {
+		t.Errorf("topicSegments(2,V) = %v", got)
+	}
+	if got := topicSegments(0, "V"); !reflect.DeepEqual(got, []any{"V", "**"}) {
+		t.Errorf("topicSegments(0,V) = %v", got)
+	}
+
+	// n over the vocabulary size clamps instead of panicking.
+	if got := buildEventTermsFilters(vocab, 1000); len(got) == 0 {
+		t.Errorf("n>len(vocab) should still build filters from the whole vocab")
 	}
 }
 
@@ -268,7 +331,7 @@ func TestRunLoadSmoke(t *testing.T) {
 	})
 
 	tr := tier{name: "hot", first: 50, last: 100}
-	res := runLoad(context.Background(), newRPCClient(srv.URL), "getLedgers", tr, nil, 2, 150*time.Millisecond, 10)
+	res := runLoad(context.Background(), newRPCClient(srv.URL), "getLedgers", tr, nil, nil, 0, 2, 150*time.Millisecond, 10)
 	if len(res.durations) == 0 {
 		t.Fatalf("runLoad recorded no samples")
 	}

--- a/tools/fhbench/main_test.go
+++ b/tools/fhbench/main_test.go
@@ -114,6 +114,7 @@ func rpcStub(t *testing.T, handlers map[string]func(params json.RawMessage) (any
 // oldestLedger/latestLedger fields carry the served range.
 func TestDiscoverPrimaryGetTransaction(t *testing.T) {
 	srv := rpcStub(t, map[string]func(json.RawMessage) (any, *rpcError){
+		//nolint:unparam // uniform rpcStub handler signature; not every stub exercises every result
 		"getTransaction": func(params json.RawMessage) (any, *rpcError) {
 			var req struct {
 				Hash string `json:"hash"`
@@ -142,9 +143,11 @@ func TestDiscoverPrimaryGetTransaction(t *testing.T) {
 // unavailable: parse the served range out of getLedgers' out-of-range error.
 func TestDiscoverFallbackFromError(t *testing.T) {
 	srv := rpcStub(t, map[string]func(json.RawMessage) (any, *rpcError){
+		//nolint:unparam // uniform rpcStub handler signature; not every stub exercises every result
 		"getTransaction": func(json.RawMessage) (any, *rpcError) {
 			return nil, &rpcError{Code: -32601, Message: "method not found"}
 		},
+		//nolint:unparam // uniform rpcStub handler signature; not every stub exercises every result
 		"getLedgers": func(json.RawMessage) (any, *rpcError) {
 			return nil, &rpcError{Code: -32600, Message: "start ledger (1) must be between the oldest " +
 				"ledger: 40001 and the latest ledger: 98765 for this rpc instance"}
@@ -164,9 +167,11 @@ func TestDiscoverFallbackFromError(t *testing.T) {
 // server whose range includes the startLedger=1 probe).
 func TestDiscoverFallbackFromSuccess(t *testing.T) {
 	srv := rpcStub(t, map[string]func(json.RawMessage) (any, *rpcError){
+		//nolint:unparam // uniform rpcStub handler signature; not every stub exercises every result
 		"getTransaction": func(json.RawMessage) (any, *rpcError) {
 			return nil, &rpcError{Code: -32601, Message: "method not found"}
 		},
+		//nolint:unparam // uniform rpcStub handler signature; not every stub exercises every result
 		"getLedgers": func(json.RawMessage) (any, *rpcError) {
 			return map[string]any{
 				"ledgers":      []any{},
@@ -189,6 +194,7 @@ func TestSampleTxHashes(t *testing.T) {
 	// Two pages of two txs each, then an empty page.
 	page := 0
 	srv := rpcStub(t, map[string]func(json.RawMessage) (any, *rpcError){
+		//nolint:unparam // uniform rpcStub handler signature; not every stub exercises every result
 		"getTransactions": func(json.RawMessage) (any, *rpcError) {
 			page++
 			switch page {
@@ -248,13 +254,14 @@ func TestFormatReport(t *testing.T) {
 
 func TestRunLoadSmoke(t *testing.T) {
 	srv := rpcStub(t, map[string]func(json.RawMessage) (any, *rpcError){
+		//nolint:unparam // uniform rpcStub handler signature; not every stub exercises every result
 		"getLedgers": func(json.RawMessage) (any, *rpcError) {
 			return map[string]any{"ledgers": []any{}, "oldestLedger": 2, "latestLedger": 100}, nil
 		},
 	})
 
 	tr := tier{name: "hot", first: 50, last: 100}
-	res := runLoad(context.Background(), newRPCClient(srv.URL), "getLedgers", tr, nil, 2, 150*time.Millisecond, 10, 10_000)
+	res := runLoad(context.Background(), newRPCClient(srv.URL), "getLedgers", tr, nil, 2, 150*time.Millisecond, 10)
 	if len(res.durations) == 0 {
 		t.Fatalf("runLoad recorded no samples")
 	}

--- a/tools/fhbench/main_test.go
+++ b/tools/fhbench/main_test.go
@@ -109,8 +109,42 @@ func rpcStub(t *testing.T, handlers map[string]func(params json.RawMessage) (any
 	return srv
 }
 
-func TestDiscoverFromError(t *testing.T) {
+// TestDiscoverPrimaryGetTransaction covers the primary probe: getTransaction
+// with a dummy all-zeros hash returns a structured NOT_FOUND response whose
+// oldestLedger/latestLedger fields carry the served range.
+func TestDiscoverPrimaryGetTransaction(t *testing.T) {
 	srv := rpcStub(t, map[string]func(json.RawMessage) (any, *rpcError){
+		"getTransaction": func(params json.RawMessage) (any, *rpcError) {
+			var req struct {
+				Hash string `json:"hash"`
+			}
+			if err := json.Unmarshal(params, &req); err != nil || len(req.Hash) != 64 {
+				t.Errorf("probe hash = %q, want 64 hex chars", req.Hash)
+			}
+			return map[string]any{
+				"status":       "NOT_FOUND",
+				"oldestLedger": 40_001,
+				"latestLedger": 98_765,
+			}, nil
+		},
+	})
+
+	w, err := discover(context.Background(), newRPCClient(srv.URL))
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if w.oldest != 40_001 || w.latest != 98_765 {
+		t.Errorf("discover = [%d,%d], want [40001,98765]", w.oldest, w.latest)
+	}
+}
+
+// TestDiscoverFallbackFromError covers the fallback when getTransaction is
+// unavailable: parse the served range out of getLedgers' out-of-range error.
+func TestDiscoverFallbackFromError(t *testing.T) {
+	srv := rpcStub(t, map[string]func(json.RawMessage) (any, *rpcError){
+		"getTransaction": func(json.RawMessage) (any, *rpcError) {
+			return nil, &rpcError{Code: -32601, Message: "method not found"}
+		},
 		"getLedgers": func(json.RawMessage) (any, *rpcError) {
 			return nil, &rpcError{Code: -32600, Message: "start ledger (1) must be between the oldest " +
 				"ledger: 40001 and the latest ledger: 98765 for this rpc instance"}
@@ -126,8 +160,13 @@ func TestDiscoverFromError(t *testing.T) {
 	}
 }
 
-func TestDiscoverFromSuccess(t *testing.T) {
+// TestDiscoverFallbackFromSuccess covers the fallback's success branch (a
+// server whose range includes the startLedger=1 probe).
+func TestDiscoverFallbackFromSuccess(t *testing.T) {
 	srv := rpcStub(t, map[string]func(json.RawMessage) (any, *rpcError){
+		"getTransaction": func(json.RawMessage) (any, *rpcError) {
+			return nil, &rpcError{Code: -32601, Message: "method not found"}
+		},
 		"getLedgers": func(json.RawMessage) (any, *rpcError) {
 			return map[string]any{
 				"ledgers":      []any{},

--- a/tools/fhbench/main_test.go
+++ b/tools/fhbench/main_test.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ms is a small helper to write latency literals in milliseconds.
+func ms(n int) time.Duration { return time.Duration(n) * time.Millisecond }
+
+func TestQuantileKnownSet(t *testing.T) {
+	// Sorted 1ms..100ms. Nearest-rank: rank = ceil(q*N), value at that 1-based rank.
+	sorted := make([]time.Duration, 0, 100)
+	for i := 1; i <= 100; i++ {
+		sorted = append(sorted, ms(i))
+	}
+
+	cases := []struct {
+		q    float64
+		want time.Duration
+	}{
+		{0.50, ms(50)},
+		{0.90, ms(90)},
+		{0.99, ms(99)},
+		{1.00, ms(100)}, // max
+		{0.0, ms(1)},
+	}
+	for _, c := range cases {
+		if got := quantile(sorted, c.q); got != c.want {
+			t.Errorf("quantile(q=%.2f) = %v, want %v", c.q, got, c.want)
+		}
+	}
+
+	if got := quantile(nil, 0.5); got != 0 {
+		t.Errorf("quantile(nil) = %v, want 0", got)
+	}
+	if got := quantile([]time.Duration{ms(7)}, 0.9); got != ms(7) {
+		t.Errorf("quantile(single) = %v, want 7ms", got)
+	}
+}
+
+func TestComputeTiers(t *testing.T) {
+	w := ledgerWindow{oldest: 2, latest: 45_000}
+	const chunkSize = 10_000
+
+	tiers := computeTiers(w, chunkSize, "both")
+	byName := map[string]tier{}
+	for _, tr := range tiers {
+		byName[tr.name] = tr
+	}
+
+	hot, ok := byName["hot"]
+	if !ok {
+		t.Fatalf("no hot tier")
+	}
+	// hot = last chunkSize/2 ledgers before latest -> [45000-5000+1, 45000]
+	if hot.first != 40_001 || hot.last != 45_000 {
+		t.Errorf("hot tier = [%d,%d], want [40001,45000]", hot.first, hot.last)
+	}
+
+	cold, ok := byName["cold"]
+	if !ok {
+		t.Fatalf("no cold tier")
+	}
+	// cold = oldest full chunk >= oldest. oldest=2 -> first full chunk covers [2,10001].
+	if cold.first != 2 || cold.last != 10_001 {
+		t.Errorf("cold tier = [%d,%d], want [2,10001]", cold.first, cold.last)
+	}
+
+	if got := computeTiers(w, chunkSize, "hot"); len(got) != 1 || got[0].name != "hot" {
+		t.Errorf("computeTiers hot-only = %+v", got)
+	}
+}
+
+// rpcStub builds an httptest server that dispatches on JSON-RPC method.
+func rpcStub(t *testing.T, handlers map[string]func(params json.RawMessage) (any, *rpcError)) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+			ID     int             `json:"id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("stub decode: %v", err)
+			return
+		}
+		h, ok := handlers[req.Method]
+		if !ok {
+			t.Errorf("stub: unexpected method %q", req.Method)
+			return
+		}
+		result, rerr := h(req.Params)
+		resp := map[string]any{"jsonrpc": "2.0", "id": req.ID}
+		if rerr != nil {
+			resp["error"] = map[string]any{"code": rerr.Code, "message": rerr.Message}
+		} else {
+			resp["result"] = result
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestDiscoverFromError(t *testing.T) {
+	srv := rpcStub(t, map[string]func(json.RawMessage) (any, *rpcError){
+		"getLedgers": func(json.RawMessage) (any, *rpcError) {
+			return nil, &rpcError{Code: -32600, Message: "start ledger (1) must be between the oldest " +
+				"ledger: 40001 and the latest ledger: 98765 for this rpc instance"}
+		},
+	})
+
+	w, err := discover(context.Background(), newRPCClient(srv.URL))
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if w.oldest != 40_001 || w.latest != 98_765 {
+		t.Errorf("discover = [%d,%d], want [40001,98765]", w.oldest, w.latest)
+	}
+}
+
+func TestDiscoverFromSuccess(t *testing.T) {
+	srv := rpcStub(t, map[string]func(json.RawMessage) (any, *rpcError){
+		"getLedgers": func(json.RawMessage) (any, *rpcError) {
+			return map[string]any{
+				"ledgers":      []any{},
+				"oldestLedger": 2,
+				"latestLedger": 12_345,
+			}, nil
+		},
+	})
+
+	w, err := discover(context.Background(), newRPCClient(srv.URL))
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if w.oldest != 2 || w.latest != 12_345 {
+		t.Errorf("discover = [%d,%d], want [2,12345]", w.oldest, w.latest)
+	}
+}
+
+func TestSampleTxHashes(t *testing.T) {
+	// Two pages of two txs each, then an empty page.
+	page := 0
+	srv := rpcStub(t, map[string]func(json.RawMessage) (any, *rpcError){
+		"getTransactions": func(json.RawMessage) (any, *rpcError) {
+			page++
+			switch page {
+			case 1:
+				return map[string]any{
+					"transactions": []any{
+						map[string]any{"txHash": "aaaa", "ledger": 100},
+						map[string]any{"txHash": "bbbb", "ledger": 100},
+					},
+					"cursor": "1",
+				}, nil
+			case 2:
+				return map[string]any{
+					"transactions": []any{
+						map[string]any{"txHash": "cccc", "ledger": 101},
+					},
+					"cursor": "2",
+				}, nil
+			default:
+				return map[string]any{"transactions": []any{}, "cursor": ""}, nil
+			}
+		},
+	})
+
+	got, err := sampleTxHashes(context.Background(), newRPCClient(srv.URL), tier{name: "cold", first: 100, last: 200}, 3)
+	if err != nil {
+		t.Fatalf("sampleTxHashes: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("sampled %d hashes, want 3: %v", len(got), got)
+	}
+	want := map[string]bool{"aaaa": true, "bbbb": true, "cccc": true}
+	for _, h := range got {
+		if !want[h] {
+			t.Errorf("unexpected hash %q", h)
+		}
+	}
+}
+
+func TestFormatReport(t *testing.T) {
+	results := []result{
+		{
+			endpoint:  "getLedgers",
+			tier:      "hot",
+			durations: []time.Duration{ms(1), ms(2), ms(3), ms(4)},
+			errors:    1,
+			wall:      2 * time.Second,
+		},
+	}
+	out := formatReport(results)
+	for _, want := range []string{"getLedgers", "hot", "p50", "p90", "p99", "RPS", "errors"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunLoadSmoke(t *testing.T) {
+	srv := rpcStub(t, map[string]func(json.RawMessage) (any, *rpcError){
+		"getLedgers": func(json.RawMessage) (any, *rpcError) {
+			return map[string]any{"ledgers": []any{}, "oldestLedger": 2, "latestLedger": 100}, nil
+		},
+	})
+
+	tr := tier{name: "hot", first: 50, last: 100}
+	res := runLoad(context.Background(), newRPCClient(srv.URL), "getLedgers", tr, nil, 2, 150*time.Millisecond, 10, 10_000)
+	if len(res.durations) == 0 {
+		t.Fatalf("runLoad recorded no samples")
+	}
+	if res.errors != 0 {
+		t.Errorf("runLoad recorded %d errors against a healthy stub", res.errors)
+	}
+}

--- a/tools/fhbench/main_test.go
+++ b/tools/fhbench/main_test.go
@@ -75,6 +75,13 @@ func TestComputeTiers(t *testing.T) {
 	if got := computeTiers(w, chunkSize, "hot"); len(got) != 1 || got[0].name != "hot" {
 		t.Errorf("computeTiers hot-only = %+v", got)
 	}
+
+	// Sub-half-chunk window (young / single-hot-chunk daemon): the hot tier must
+	// span the whole window, not collapse to [latest,latest].
+	small := computeTiers(ledgerWindow{oldest: 2, latest: 4_000}, chunkSize, "hot")
+	if len(small) != 1 || small[0].first != 2 || small[0].last != 4_000 {
+		t.Errorf("small-window hot tier = %+v, want [2,4000]", small)
+	}
 }
 
 // rpcStub builds an httptest server that dispatches on JSON-RPC method.


### PR DESCRIPTION
## Full-history query POC — combined latency results

Adds a single combined results file merging the two query-POC measurement regimes:

- **Part A — synthetic ledger profiles** (sac / token / soroswap), hot + cold tiers, run 1 + run 2 (cold-tier-all-profiles + getEvents term-selectivity sweep). From this branch's `tools/bench-suite/results/fullhistory-latency-2026-07-16/`.
- **Part B — live pubnet hot-DB tip querying** (single-request + concurrency sweep), from `poc/fullhistory-query-localrun`'s `local-run/BENCHMARKS.md`.
- **Combined analysis** — the cross-read only visible side by side: `getLedgers` is payload-bound in both regimes (~1.7 MB → 35 ms live vs ~17 MB → 567 ms synthetic; read stays ~5–8 ms), light endpoints stay cheap, cold ≈ hot except selective multi-term getEvents on cold, ingest gates freshness.

New file: `tools/bench-suite/results/fullhistory-query-latency-combined-2026-07-16.md`.

> Base is `main`, so this diff carries the entire `poc/fullhistory-query` POC branch (~69 commits), not just the results file. Draft — for review of the combined results, not for merge to `main` as-is.

### Notes
- The two regimes ran on **different hardware** (32-vCPU c6id/NVMe vs 16-vCPU Debian/tmpfs) — the file flags this; compare shapes/ratios, not raw ms across parts.
