### PR TITLE
Add a [service] serving config section and derived CLI override flags to v2 (#882)

### DIFF
--- a/cmd/stellar-rpc/internal/rpcv2/backfill/backend.go
+++ b/cmd/stellar-rpc/internal/rpcv2/backfill/backend.go
@@ -33,27 +33,20 @@ type Backend interface {
 	Tip(ctx context.Context) (uint32, error)
 }
 
-// Default buffered-storage tuning, applied when a NewBSBBackend caller leaves a
-// field zero. The SDK's BufferedStorageBackend rejects BufferSize == 0 (and
-// requires NumWorkers <= BufferSize), so zero values must be filled before
-// streaming.
+// Default buffered-storage tuning. Exported because the config package fills
+// them into an unset [backfill.bsb] section and the bench command uses them as
+// its flag defaults — the values are defined once, here.
 //
-// These are the BACKFILL-workload values the rpc-hack bulk-ingest benchmarking
-// converged on, not the daemon's serving-path defaults: the pubnet lake stores one
-// ledger per object, so download throughput is request-latency-bound and scales
-// with workers, and a deep prefetch buffer keeps the download overlapped with
-// ingest.
-//
-// The retry defaults are deliberately non-zero: a multi-day full-history backfill
-// will hit transient object-store errors with certainty, and with RetryLimit 0 a
-// single one fails the whole chunk. Disabling retries entirely is therefore not
-// expressible through the zero value — pass an explicit RetryLimit for a different
-// policy.
+// The buffer and worker defaults are deliberately modest, sized for a daemon
+// that shares its host with serving. The rpc-hack bulk-ingest benchmarking
+// converged on much larger values (buffer 5000, 50 workers) for dedicated
+// backfill runs — raise [backfill.bsb] in the config when download throughput
+// matters more than memory and connection footprint.
 const (
-	defaultBSBBufferSize = 5000
-	defaultBSBNumWorkers = 50
-	defaultBSBRetryLimit = 3
-	defaultBSBRetryWait  = 5 * time.Second
+	DefaultBSBBufferSize = 100
+	DefaultBSBNumWorkers = 10
+	DefaultBSBMaxRetries = 3
+	DefaultBSBRetryWait  = 5 * time.Second
 )
 
 // bsbSource is the Backend over an SDK datastore (the pubnet lake): a
@@ -71,31 +64,27 @@ var _ Backend = (*bsbSource)(nil)
 // NewBSBBackend returns a Backend over the SDK datastore described by cfg. The
 // ledger stream owns its own per-iteration datastore lifecycle (the SDK closes it
 // when iteration ends); the separate, long-lived ds is used only for the frontier
-// Tip and is owned and Closed by the caller (the daemon). Zero bsb fields fall back
-// to the benchmarked backfill defaults.
+// Tip and is owned and Closed by the caller (the daemon).
+//
+// A zero BufferSize or NumWorkers falls back to the defaults above (the SDK
+// backend rejects BufferSize == 0). The retry fields are used VERBATIM —
+// RetryLimit 0 really means no retries — so a caller wanting the default retry
+// policy must pass DefaultBSBMaxRetries / DefaultBSBRetryWait explicitly. The
+// daemon's config layer does exactly that for an unset [backfill.bsb], which is
+// what makes an operator's explicit max_retries = 0 honorable at all.
 func NewBSBBackend(
 	ds datastore.DataStore,
 	cfg datastore.DataStoreConfig,
 	bsb ledgerbackend.BufferedStorageBackendConfig,
 ) Backend {
-	// Fill zero values: the SDK backend rejects BufferSize == 0 and requires
-	// NumWorkers <= BufferSize, so a zero-value config would fail before reading
-	// any ledger, and a zero retry policy would fail whole chunks on the first
-	// transient error.
 	if bsb.BufferSize == 0 {
-		bsb.BufferSize = defaultBSBBufferSize
+		bsb.BufferSize = DefaultBSBBufferSize
 	}
 	if bsb.NumWorkers == 0 {
-		bsb.NumWorkers = defaultBSBNumWorkers
+		bsb.NumWorkers = DefaultBSBNumWorkers
 	}
 	if bsb.NumWorkers > bsb.BufferSize {
 		bsb.NumWorkers = bsb.BufferSize
-	}
-	if bsb.RetryLimit == 0 {
-		bsb.RetryLimit = defaultBSBRetryLimit
-	}
-	if bsb.RetryWait == 0 {
-		bsb.RetryWait = defaultBSBRetryWait
 	}
 	return &bsbSource{
 		LedgerStream: ledgerbackend.NewBufferedStorageStream(bsb, cfg, nil),
@@ -108,6 +97,12 @@ func NewBSBBackend(
 // at shutdown. The datastore type (GCS/S3/Filesystem/...) is whatever dsCfg.Type names —
 // any SDK datastore works. The batch schema is read from the lake manifest by the
 // stream, so dsCfg need not set Schema.
+//
+// When dsCfg.NetworkPassphrase is non-empty, the lake's manifest is verified
+// against it (and the rest of dsCfg) HERE, eagerly. The stream re-runs the same
+// check on every open anyway; failing now turns a wrong-network lake into one
+// clear startup error instead of a retried chunk-task crash loop. A lake with
+// no manifest at all passes — the SDK skips the comparison for it.
 func NewBSBBackendFromConfig(
 	ctx context.Context,
 	dsCfg datastore.DataStoreConfig,
@@ -116,6 +111,12 @@ func NewBSBBackendFromConfig(
 	ds, err := datastore.NewDataStore(ctx, dsCfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("open datastore (type %q): %w", dsCfg.Type, err)
+	}
+	if dsCfg.NetworkPassphrase != "" {
+		if _, err := datastore.LoadSchema(ctx, ds, dsCfg); err != nil {
+			_ = ds.Close()
+			return nil, nil, fmt.Errorf("verify datastore manifest (type %q): %w", dsCfg.Type, err)
+		}
 	}
 	return NewBSBBackend(ds, dsCfg, bsb), func() { _ = ds.Close() }, nil
 }

--- a/cmd/stellar-rpc/internal/rpcv2/backfill/backend.go
+++ b/cmd/stellar-rpc/internal/rpcv2/backfill/backend.go
@@ -69,9 +69,8 @@ var _ Backend = (*bsbSource)(nil)
 // A zero BufferSize or NumWorkers falls back to the defaults above (the SDK
 // backend rejects BufferSize == 0). The retry fields are used VERBATIM —
 // RetryLimit 0 really means no retries — so a caller wanting the default retry
-// policy must pass DefaultBSBMaxRetries / DefaultBSBRetryWait explicitly. The
-// daemon's config layer does exactly that for an unset [backfill.bsb], which is
-// what makes an operator's explicit max_retries = 0 honorable at all.
+// policy must pass DefaultBSBMaxRetries / DefaultBSBRetryWait explicitly, as
+// the daemon's config layer does for an unset [backfill.bsb].
 func NewBSBBackend(
 	ds datastore.DataStore,
 	cfg datastore.DataStoreConfig,
@@ -99,10 +98,11 @@ func NewBSBBackend(
 // stream, so dsCfg need not set Schema.
 //
 // When dsCfg.NetworkPassphrase is non-empty, the lake's manifest is verified
-// against it (and the rest of dsCfg) HERE, eagerly. The stream re-runs the same
-// check on every open anyway; failing now turns a wrong-network lake into one
-// clear startup error instead of a retried chunk-task crash loop. A lake with
-// no manifest at all passes — the SDK skips the comparison for it.
+// against dsCfg eagerly, here: the stream re-runs the same check on every open
+// anyway, and failing now turns a wrong-network lake into one clear startup
+// error instead of a retried chunk-task crash loop. A lake with no manifest
+// skips the comparison — provided dsCfg carries the schema (LoadSchema needs
+// one of the two).
 func NewBSBBackendFromConfig(
 	ctx context.Context,
 	dsCfg datastore.DataStoreConfig,

--- a/cmd/stellar-rpc/internal/rpcv2/backfill/backend.go
+++ b/cmd/stellar-rpc/internal/rpcv2/backfill/backend.go
@@ -37,14 +37,17 @@ type Backend interface {
 // them into an unset [backfill.bsb] section and the bench command uses them as
 // its flag defaults — the values are defined once, here.
 //
-// The buffer and worker defaults are deliberately modest, sized for a daemon
-// that shares its host with serving. The rpc-hack bulk-ingest benchmarking
-// converged on much larger values (buffer 5000, 50 workers) for dedicated
-// backfill runs — raise [backfill.bsb] in the config when download throughput
-// matters more than memory and connection footprint.
+// The buffer and worker values are the BACKFILL-workload numbers the rpc-hack
+// bulk-ingest benchmarking converged on: the pubnet lake stores one ledger per
+// object, so download throughput is request-latency-bound and scales with
+// workers, and a deep prefetch buffer keeps the download overlapped with
+// ingest. They apply PER BSB INSTANCE — each backfill chunk task opens its own
+// stream — so aggregate connections and prefetch RAM scale with
+// [backfill].workers. TODO: revisit once the #800 ingestion experiments sweep
+// buffer depth and worker count for real.
 const (
-	DefaultBSBBufferSize = 100
-	DefaultBSBNumWorkers = 10
+	DefaultBSBBufferSize = 5000
+	DefaultBSBNumWorkers = 50
 	DefaultBSBMaxRetries = 3
 	DefaultBSBRetryWait  = 5 * time.Second
 )

--- a/cmd/stellar-rpc/internal/rpcv2/backfill/backend_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/backfill/backend_test.go
@@ -1,0 +1,109 @@
+package backfill
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
+	"github.com/stellar/go-stellar-sdk/support/datastore"
+)
+
+const (
+	testnetPassphrase = "Test SDF Network ; September 2015"
+	pubnetPassphrase  = "Public Global Stellar Network ; September 2015"
+)
+
+// filesystemLake creates a local lake directory whose manifest (.config.json)
+// names the given network passphrase, and returns a datastore config pointing
+// at it. An empty passphrase writes no manifest (a manifest-less lake).
+func filesystemLake(t *testing.T, manifestPassphrase string) datastore.DataStoreConfig {
+	t.Helper()
+	dir := t.TempDir()
+	if manifestPassphrase != "" {
+		manifest := fmt.Sprintf(
+			`{"networkPassphrase":%q,"version":"1.0","ledgersPerBatch":1,"batchesPerPartition":64000}`,
+			manifestPassphrase)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, ".config.json"), []byte(manifest), 0o644))
+	}
+	return datastore.DataStoreConfig{
+		Type:   "Filesystem",
+		Params: map[string]string{"destination_path": dir},
+	}
+}
+
+func TestNewBSBBackendFromConfig_RejectsWrongNetworkLake(t *testing.T) {
+	dsCfg := filesystemLake(t, testnetPassphrase)
+	dsCfg.NetworkPassphrase = pubnetPassphrase
+
+	_, _, err := NewBSBBackendFromConfig(context.Background(), dsCfg,
+		ledgerbackend.BufferedStorageBackendConfig{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "verify datastore manifest")
+	assert.Contains(t, err.Error(), "networkPassphrase")
+}
+
+func TestNewBSBBackendFromConfig_AcceptsMatchingNetworkLake(t *testing.T) {
+	dsCfg := filesystemLake(t, pubnetPassphrase)
+	dsCfg.NetworkPassphrase = pubnetPassphrase
+
+	backend, release, err := NewBSBBackendFromConfig(context.Background(), dsCfg,
+		ledgerbackend.BufferedStorageBackendConfig{})
+	require.NoError(t, err)
+	require.NotNil(t, backend)
+	release()
+}
+
+func TestNewBSBBackendFromConfig_EmptyPassphraseSkipsManifestCheck(t *testing.T) {
+	// Injected test cores carry no passphrase; the check must not fire even
+	// against a lake whose manifest names some network.
+	dsCfg := filesystemLake(t, testnetPassphrase)
+
+	backend, release, err := NewBSBBackendFromConfig(context.Background(), dsCfg,
+		ledgerbackend.BufferedStorageBackendConfig{})
+	require.NoError(t, err)
+	require.NotNil(t, backend)
+	release()
+}
+
+func TestNewBSBBackendFromConfig_RejectsManifestWithoutPassphrase(t *testing.T) {
+	// A manifest that exists but names no network fails the check (fail fast:
+	// empty vs configured non-empty is a mismatch, not a skip).
+	dsCfg := filesystemLake(t, "")
+	manifest := `{"networkPassphrase":"","version":"1.0","ledgersPerBatch":1,"batchesPerPartition":64000}`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dsCfg.Params["destination_path"], ".config.json"), []byte(manifest), 0o644))
+	dsCfg.NetworkPassphrase = pubnetPassphrase
+
+	_, _, err := NewBSBBackendFromConfig(context.Background(), dsCfg,
+		ledgerbackend.BufferedStorageBackendConfig{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "networkPassphrase")
+}
+
+func TestNewBSBBackendFromConfig_ManifestlessLakeNeedsSchema(t *testing.T) {
+	dsCfg := filesystemLake(t, "")
+	dsCfg.NetworkPassphrase = pubnetPassphrase
+
+	t.Run("schema in config: check skipped, lake accepted", func(t *testing.T) {
+		cfg := dsCfg
+		cfg.Schema = datastore.DataStoreSchema{LedgersPerFile: 1, FilesPerPartition: 64000}
+		backend, release, err := NewBSBBackendFromConfig(context.Background(), cfg,
+			ledgerbackend.BufferedStorageBackendConfig{})
+		require.NoError(t, err)
+		require.NotNil(t, backend)
+		release()
+	})
+
+	t.Run("no schema anywhere: rejected", func(t *testing.T) {
+		_, _, err := NewBSBBackendFromConfig(context.Background(), dsCfg,
+			ledgerbackend.BufferedStorageBackendConfig{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "manifest")
+	})
+}

--- a/cmd/stellar-rpc/internal/rpcv2/bench/command.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/command.go
@@ -11,6 +11,7 @@ import (
 
 	supportlog "github.com/stellar/go-stellar-sdk/support/log"
 
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/backfill"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
 )
 
@@ -51,8 +52,10 @@ func (f *sourceFlags) bind(cmd *cobra.Command) {
 		"BSB prefetch buffer depth PER worker (0 = backfill default)")
 	fs.Uint32Var(&f.bsbNumWorkers, "bsb-num-workers", 0,
 		"BSB download workers PER worker (0 = backfill default)")
-	fs.Uint32Var(&f.retryLimit, "retry-limit", 0, "BSB retry attempts on transient failure (0 = backfill default)")
-	fs.DurationVar(&f.retryWait, "retry-wait", 0, "BSB delay between retries (0 = backfill default)")
+	fs.Uint32Var(&f.retryLimit, "retry-limit", backfill.DefaultBSBMaxRetries,
+		"BSB retry attempts per object download (0 = no retries)")
+	fs.DurationVar(&f.retryWait, "retry-wait", backfill.DefaultBSBRetryWait,
+		"BSB delay between per-object retries")
 	fs.StringVar(&f.datastoreType, "datastore-type", "GCS",
 		"BSB datastore type: GCS | S3 | Filesystem (used iff --source=bsb)")
 	fs.StringVar(&f.region, "region", "", "bucket region for --datastore-type=S3, e.g. us-east-2")

--- a/cmd/stellar-rpc/internal/rpcv2/bench/sources.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/sources.go
@@ -45,21 +45,20 @@ type sourceConfig struct {
 
 	// BufferSize is the BSB prefetch buffer depth PER WORKER: total prefetch
 	// multiplies by the cold driver's Workers. Zero falls back to the backfill
-	// package's benchmarked default.
+	// package's default.
 	BufferSize uint32
 
 	// NumWorkers is the BSB download concurrency PER WORKER: total downloads
 	// in flight multiply by the cold driver's Workers. Zero falls back to the
-	// backfill package's benchmarked default.
+	// backfill package's default.
 	NumWorkers uint32
 
-	// RetryLimit caps BSB download retries on transient datastore errors.
-	// Zero falls back to the backfill package's default — retries cannot be
-	// disabled.
+	// RetryLimit caps BSB download retries on transient datastore errors,
+	// used verbatim: zero means no retries (the flag defaults to the backfill
+	// package's default, not zero).
 	RetryLimit uint32
 
-	// RetryWait is the pause between BSB download retries. Zero falls back to
-	// the backfill package's default.
+	// RetryWait is the pause between BSB download retries, used verbatim.
 	RetryWait time.Duration
 
 	// DatastoreType selects the SDK datastore backing the BSB source:
@@ -98,7 +97,7 @@ func (c sourceConfig) validate() error {
 //   - pack: a packBackend over the frozen ledgers tree under PackDir. Local and
 //     fully repeatable.
 //   - bsb: the production BSB source (backfill.NewBSBBackendFromConfig) over a
-//     GCS, S3, or Filesystem datastore, with its benchmarked default tuning.
+//     GCS, S3, or Filesystem datastore.
 //     Each RawLedgers call owns an independent datastore + prefetch lifecycle,
 //     so concurrent workers do not contend on shared cursor state.
 func openSource(ctx context.Context, cfg sourceConfig) (backfill.Backend, func(), error) {

--- a/cmd/stellar-rpc/internal/rpcv2/config/config.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/config.go
@@ -43,9 +43,10 @@ type Config struct {
 }
 
 // ServiceConfig is [service] — the JSON-RPC read-serving policy (issue #882).
-// Everything here is dormant until the read server exists, except
-// [service.fee_stats], which live ingestion consumes (issue #881). The whole
-// section is optional: absent keys get v1's defaults in WithDefaults.
+// Everything here is dormant today: the read server arrives with #772, and
+// #881 wires [service.fee_stats] into live ingestion — until then the values
+// are only parsed, defaulted, and validated. The whole section is optional:
+// absent keys get v1's defaults in WithDefaults.
 //
 // Key naming rule: camelCase table keys ONLY where the key is a wire identifier
 // (the [service.methods.<methodName>] tables, named after the JSON-RPC method);
@@ -72,9 +73,10 @@ type ServiceConfig struct {
 }
 
 // FeeStatsConfig is [service.fee_stats] — the sizes, in ledgers, of the two
-// in-memory fee windows live ingestion feeds (issue #881). They live here and
-// NOT in the getFeeStats method table because they size ingestion-time memory,
-// not request handling. Both must be positive and are capped at
+// in-memory fee windows behind getFeeStats. Live ingestion will feed them when
+// #881 lands; nothing consumes them yet. They live here and NOT in the
+// getFeeStats method table because they size ingestion-time memory, not
+// request handling. Both must be positive and are capped at
 // limits.MaxFeeStatsRetentionWindow.
 type FeeStatsConfig struct {
 	ClassicFeeWindowLedgers          *uint32 `toml:"classic_fee_window_ledgers"`

--- a/cmd/stellar-rpc/internal/rpcv2/config/config.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/pelletier/go-toml"
 
@@ -27,6 +28,11 @@ import (
 // mismatch) on every restart; its field doc flags the set-once contract.
 // (The tx-hash index width is not configurable — it is the fixed
 // geometry.ChunksPerTxhashIndex constant.)
+//
+// Every leaf key is also settable from the command line as a flag named by its
+// dotted TOML path (--storage.default_data_dir, --service.methods.getLedgers.queue_limit);
+// see BindFlags/ApplyFlags in flags.go. Flags override the file; the file stays
+// the single source of truth and --config stays required.
 type Config struct {
 	Service   ServiceConfig   `toml:"service"`
 	Retention RetentionConfig `toml:"retention"`
@@ -36,10 +42,101 @@ type Config struct {
 	Logging   LoggingConfig   `toml:"logging"`
 }
 
-// ServiceConfig is [service].
+// ServiceConfig is [service] — the JSON-RPC read-serving policy (issue #882).
+// Everything here is dormant until the read server exists, except
+// [service.fee_stats], which live ingestion consumes (issue #881). The whole
+// section is optional: absent keys get v1's defaults in WithDefaults.
+//
+// Key naming rule: camelCase table keys ONLY where the key is a wire identifier
+// (the [service.methods.<methodName>] tables, spelled exactly as a client sends
+// the JSON-RPC method); snake_case for every other key.
 type ServiceConfig struct {
-	// Base dir for the catalog and default storage paths. Required.
-	DefaultDataDir string `toml:"default_data_dir"`
+	// Endpoint is the address the JSON-RPC server listens on. Default "localhost:8000".
+	Endpoint string `toml:"endpoint"`
+	// AdminEndpoint serves pprof/metrics over plaintext HTTP. "" (the default)
+	// disables the admin server; it should never be reachable from the internet.
+	AdminEndpoint string `toml:"admin_endpoint"`
+
+	// The three keys below are the HTTP-layer gate wrapped around the WHOLE mux,
+	// exactly as in v1 (internal/jsonrpc): they always act, on every request, in
+	// ADDITION to the per-method limits — max_concurrent_requests bounds the SUM
+	// of in-flight requests across all methods, which no per-method limit can.
+	MaxConcurrentRequests            *uint          `toml:"max_concurrent_requests"`
+	MaxRequestExecutionDuration      *time.Duration `toml:"max_request_execution_duration"`
+	RequestExecutionWarningThreshold *time.Duration `toml:"request_execution_warning_threshold"`
+
+	FeeStats FeeStatsConfig `toml:"fee_stats"`
+	Methods  MethodsConfig  `toml:"methods"`
+}
+
+// FeeStatsConfig is [service.fee_stats] — the sizes, in ledgers, of the two
+// in-memory fee windows live ingestion feeds (issue #881). They live here and
+// NOT in the getFeeStats method table because they size ingestion-time memory,
+// not request handling. Both must be positive and are capped at
+// limits.MaxFeeStatsRetentionWindow.
+type FeeStatsConfig struct {
+	ClassicFeeWindowLedgers          *uint32 `toml:"classic_fee_window_ledgers"`
+	SorobanInclusionFeeWindowLedgers *uint32 `toml:"soroban_inclusion_fee_window_ledgers"`
+}
+
+// MethodsConfig is [service.methods]: one table per served JSON-RPC method,
+// keyed by the method's wire name, plus an optional methods-wide DEFAULT tier —
+// the two bare keys below — for the two fields every method has.
+//
+// Precedence per method and field: explicit per-method value → methods-wide
+// default → compiled default (v1's values). Specificity beats source: a CLI
+// --service.methods.queue_limit=30 raises the default tier but never overrides
+// a per-method value set in the file. The cascade is resolved in WithDefaults;
+// after it, every per-method field is non-nil.
+//
+// One struct field per method — never a map — so the strict decoder rejects a
+// typo'd method table instead of silently accepting it.
+type MethodsConfig struct {
+	QueueLimit           *uint          `toml:"queue_limit"`
+	MaxExecutionDuration *time.Duration `toml:"max_execution_duration"`
+
+	GetHealth       HealthMethodConfig    `toml:"getHealth"`
+	GetNetwork      MethodConfig          `toml:"getNetwork"`
+	GetVersionInfo  MethodConfig          `toml:"getVersionInfo"`
+	GetLatestLedger MethodConfig          `toml:"getLatestLedger"`
+	GetTransaction  MethodConfig          `toml:"getTransaction"`
+	GetTransactions PaginatedMethodConfig `toml:"getTransactions"`
+	GetLedgers      PaginatedMethodConfig `toml:"getLedgers"`
+	GetEvents       PaginatedMethodConfig `toml:"getEvents"`
+	GetFeeStats     MethodConfig          `toml:"getFeeStats"`
+}
+
+// MethodConfig is one method's serving knobs: the per-method request backlog
+// cap and the per-method execution budget (v1's request-backlog-*-queue-limit /
+// max-*-execution-duration pairs).
+type MethodConfig struct {
+	QueueLimit           *uint          `toml:"queue_limit"`
+	MaxExecutionDuration *time.Duration `toml:"max_execution_duration"`
+}
+
+// PaginatedMethodConfig extends MethodConfig for the cursor-paginated methods
+// (getTransactions, getLedgers, getEvents): max_items_per_response caps the
+// client's pagination limit, default_items_per_response applies when the
+// request omits it. These two have NO methods-wide default tier — they exist
+// on only three methods, so a wide default would mostly be a trap.
+type PaginatedMethodConfig struct {
+	QueueLimit           *uint          `toml:"queue_limit"`
+	MaxExecutionDuration *time.Duration `toml:"max_execution_duration"`
+
+	MaxItemsPerResponse     *uint `toml:"max_items_per_response"`
+	DefaultItemsPerResponse *uint `toml:"default_items_per_response"`
+}
+
+// HealthMethodConfig extends MethodConfig for getHealth with the staleness
+// threshold: the last committed ledger's close time must be within
+// max_healthy_ledger_latency of now for the daemon to report healthy. It lives
+// here because the staleness judgment is the getHealth handler's check policy
+// (see rpcv2/health.go) — the daemon itself only exposes the raw signal.
+type HealthMethodConfig struct {
+	QueueLimit           *uint          `toml:"queue_limit"`
+	MaxExecutionDuration *time.Duration `toml:"max_execution_duration"`
+
+	MaxHealthyLedgerLatency *time.Duration `toml:"max_healthy_ledger_latency"`
 }
 
 // RetentionConfig is [retention] — the two inputs to the retention floor:
@@ -55,10 +152,15 @@ type RetentionConfig struct {
 	RetentionChunks *uint32 `toml:"retention_chunks"`
 }
 
-// StorageConfig is [storage] — one optional path per on-disk tree (consolidating
-// what were the separate [catalog] / [immutable_storage.*] / [streaming.hot_storage]
-// sections). An empty value defaults under [service].default_data_dir.
+// StorageConfig is [storage]: the data root plus one optional path per on-disk
+// tree (consolidating what were the separate [catalog] / [immutable_storage.*] /
+// [streaming.hot_storage] sections). An empty per-store value defaults under
+// default_data_dir.
 type StorageConfig struct {
+	// Base dir for the catalog and default storage paths. Required.
+	// (Moved here from [service] in #882 — it governs storage placement.)
+	DefaultDataDir string `toml:"default_data_dir"`
+
 	Catalog     string `toml:"catalog"`      // catalog RocksDB dir
 	Ledgers     string `toml:"ledgers"`      // immutable ledger packs root
 	Events      string `toml:"events"`       // immutable events segments root
@@ -138,36 +240,102 @@ const (
 	DefaultEarliestLedger = EarliestGenesis
 )
 
+// [service] defaults — v1's values, kept identical so the two daemons serve
+// under the same policy until an operator tunes them.
+const (
+	DefaultEndpoint = "localhost:8000"
+
+	DefaultMaxConcurrentRequests            uint          = 5000
+	DefaultMaxRequestExecutionDuration      time.Duration = 25 * time.Second
+	DefaultRequestExecutionWarningThreshold time.Duration = 5 * time.Second
+
+	// DefaultMethodQueueLimit and the three below it are the compiled
+	// per-method defaults — the last tier of the methods cascade.
+	DefaultMethodQueueLimit           uint          = 1000
+	DefaultGetFeeStatsQueueLimit      uint          = 100
+	DefaultMethodMaxExecutionDuration time.Duration = 5 * time.Second
+	// DefaultScanMethodMaxExecutionDuration is the doubled budget v1 gives
+	// getEvents and getLedgers, which scan wider ranges.
+	DefaultScanMethodMaxExecutionDuration time.Duration = 10 * time.Second
+
+	DefaultMaxHealthyLedgerLatency time.Duration = 30 * time.Second
+
+	DefaultGetEventsMaxItemsPerResponse           uint = 10000
+	DefaultGetEventsDefaultItemsPerResponse       uint = 100
+	DefaultGetTransactionsMaxItemsPerResponse     uint = 200
+	DefaultGetTransactionsDefaultItemsPerResponse uint = 50
+	DefaultGetLedgersMaxItemsPerResponse          uint = 200
+	DefaultGetLedgersDefaultItemsPerResponse      uint = 50
+
+	DefaultClassicFeeWindowLedgers          uint32 = 10
+	DefaultSorobanInclusionFeeWindowLedgers uint32 = 50
+)
+
 // LoadConfig reads and parses the TOML config at path. It applies defaults but
 // does NOT validate semantics or touch any pin — that is validateConfig's job.
 // See ParseConfig.
 func LoadConfig(path string) (Config, error) {
+	return LoadConfigWithFlags(path, nil)
+}
+
+// LoadConfigWithFlags is LoadConfig with CLI overrides: decode the file
+// (strict), overlay every flag the user actually set (nil fs = none), THEN
+// resolve defaults — so a flag participates in the methods cascade at its own
+// specificity tier before any default is filled. See flags.go for the
+// flag-name/TOML-path correspondence.
+func LoadConfigWithFlags(path string, fs FlagOverrides) (Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return Config{}, fmt.Errorf("read config %q: %w", path, err)
 	}
-	return ParseConfig(data)
+	cfg, err := DecodeConfig(data)
+	if err != nil {
+		return Config{}, err
+	}
+	if fs != nil {
+		if err := ApplyFlags(&cfg, fs); err != nil {
+			return Config{}, err
+		}
+	}
+	return cfg.WithDefaults(), nil
 }
 
 // ParseConfig parses TOML bytes into a Config with defaults applied. Split from
 // LoadConfig so tests parse in-memory documents without a temp file.
+func ParseConfig(data []byte) (Config, error) {
+	cfg, err := DecodeConfig(data)
+	if err != nil {
+		return Config{}, err
+	}
+	return cfg.WithDefaults(), nil
+}
+
+// DecodeConfig strictly decodes TOML bytes into a Config WITHOUT applying
+// defaults — the seam LoadConfigWithFlags uses to overlay CLI flags between
+// decode and defaulting.
 //
 // Decoding is STRICT (Decoder.Strict(true)): any unknown key is an error, not
 // silently ignored (go-toml v1's plain Unmarshal ignores them). A typo in the
 // immutable, pinned earliest_ledger key must fail loudly, not pin the wrong
 // value on first start; and the removed chunks_per_txhash_index key (and its
 // whole [layout] section) is rejected, not silently ignored.
-func ParseConfig(data []byte) (Config, error) {
+func DecodeConfig(data []byte) (Config, error) {
 	var cfg Config
 	if err := toml.NewDecoder(bytes.NewReader(data)).Strict(true).Decode(&cfg); err != nil {
 		return Config{}, fmt.Errorf("parse config: %w", err)
 	}
-	return cfg.WithDefaults(), nil
+	return cfg, nil
 }
 
 // WithDefaults returns a copy of cfg with every documented default filled for
 // an unset (nil pointer / empty string) field. Explicit zeros are preserved
 // (and later rejected by validateConfig where a zero is illegal).
+//
+// For the per-method serving fields it also resolves the methods cascade:
+// explicit per-method value → [service.methods] wide default → compiled
+// default. After WithDefaults every per-method field is non-nil.
+//
+//nolint:funlen // one linear fill per config field; splitting it hides fields
 func (cfg Config) WithDefaults() Config {
 	if cfg.Backfill.Workers == nil {
 		v := backfill.DefaultWorkers()
@@ -190,7 +358,96 @@ func (cfg Config) WithDefaults() Config {
 	if cfg.Logging.Format == "" {
 		cfg.Logging.Format = DefaultLogFormat
 	}
+
+	svc := &cfg.Service
+	if svc.Endpoint == "" {
+		svc.Endpoint = DefaultEndpoint
+	}
+	fillUint(&svc.MaxConcurrentRequests, DefaultMaxConcurrentRequests)
+	fillDuration(&svc.MaxRequestExecutionDuration, DefaultMaxRequestExecutionDuration)
+	fillDuration(&svc.RequestExecutionWarningThreshold, DefaultRequestExecutionWarningThreshold)
+	fillUint32(&svc.FeeStats.ClassicFeeWindowLedgers, DefaultClassicFeeWindowLedgers)
+	fillUint32(&svc.FeeStats.SorobanInclusionFeeWindowLedgers, DefaultSorobanInclusionFeeWindowLedgers)
+
+	// The methods cascade. queue/dur fill one per-method field: an explicit
+	// per-method value stays; else the [service.methods] wide default applies;
+	// else the compiled default. The wide-tier fields themselves are left as
+	// decoded — they are only ever read here.
+	m := &svc.Methods
+	queue := func(p **uint, compiled uint) {
+		if *p != nil {
+			return
+		}
+		if m.QueueLimit != nil {
+			compiled = *m.QueueLimit
+		}
+		v := compiled
+		*p = &v
+	}
+	dur := func(p **time.Duration, compiled time.Duration) {
+		if *p != nil {
+			return
+		}
+		if m.MaxExecutionDuration != nil {
+			compiled = *m.MaxExecutionDuration
+		}
+		v := compiled
+		*p = &v
+	}
+
+	queue(&m.GetHealth.QueueLimit, DefaultMethodQueueLimit)
+	dur(&m.GetHealth.MaxExecutionDuration, DefaultMethodMaxExecutionDuration)
+	fillDuration(&m.GetHealth.MaxHealthyLedgerLatency, DefaultMaxHealthyLedgerLatency)
+
+	queue(&m.GetNetwork.QueueLimit, DefaultMethodQueueLimit)
+	dur(&m.GetNetwork.MaxExecutionDuration, DefaultMethodMaxExecutionDuration)
+
+	queue(&m.GetVersionInfo.QueueLimit, DefaultMethodQueueLimit)
+	dur(&m.GetVersionInfo.MaxExecutionDuration, DefaultMethodMaxExecutionDuration)
+
+	queue(&m.GetLatestLedger.QueueLimit, DefaultMethodQueueLimit)
+	dur(&m.GetLatestLedger.MaxExecutionDuration, DefaultMethodMaxExecutionDuration)
+
+	queue(&m.GetTransaction.QueueLimit, DefaultMethodQueueLimit)
+	dur(&m.GetTransaction.MaxExecutionDuration, DefaultMethodMaxExecutionDuration)
+
+	queue(&m.GetTransactions.QueueLimit, DefaultMethodQueueLimit)
+	dur(&m.GetTransactions.MaxExecutionDuration, DefaultMethodMaxExecutionDuration)
+	fillUint(&m.GetTransactions.MaxItemsPerResponse, DefaultGetTransactionsMaxItemsPerResponse)
+	fillUint(&m.GetTransactions.DefaultItemsPerResponse, DefaultGetTransactionsDefaultItemsPerResponse)
+
+	queue(&m.GetLedgers.QueueLimit, DefaultMethodQueueLimit)
+	dur(&m.GetLedgers.MaxExecutionDuration, DefaultScanMethodMaxExecutionDuration)
+	fillUint(&m.GetLedgers.MaxItemsPerResponse, DefaultGetLedgersMaxItemsPerResponse)
+	fillUint(&m.GetLedgers.DefaultItemsPerResponse, DefaultGetLedgersDefaultItemsPerResponse)
+
+	queue(&m.GetEvents.QueueLimit, DefaultMethodQueueLimit)
+	dur(&m.GetEvents.MaxExecutionDuration, DefaultScanMethodMaxExecutionDuration)
+	fillUint(&m.GetEvents.MaxItemsPerResponse, DefaultGetEventsMaxItemsPerResponse)
+	fillUint(&m.GetEvents.DefaultItemsPerResponse, DefaultGetEventsDefaultItemsPerResponse)
+
+	queue(&m.GetFeeStats.QueueLimit, DefaultGetFeeStatsQueueLimit)
+	dur(&m.GetFeeStats.MaxExecutionDuration, DefaultMethodMaxExecutionDuration)
+
 	return cfg
+}
+
+func fillUint(p **uint, v uint) {
+	if *p == nil {
+		*p = &v
+	}
+}
+
+func fillUint32(p **uint32, v uint32) {
+	if *p == nil {
+		*p = &v
+	}
+}
+
+func fillDuration(p **time.Duration, v time.Duration) {
+	if *p == nil {
+		*p = &v
+	}
 }
 
 // Paths is the resolved set of on-disk paths the daemon uses — the single place
@@ -213,7 +470,7 @@ type Paths struct {
 // test helpers through NewLayout, so a rename to the tree can't leave the two
 // disagreeing.
 func (cfg Config) ResolvePaths() Paths {
-	dataDir := cfg.Service.DefaultDataDir
+	dataDir := cfg.Storage.DefaultDataDir
 	def := geometry.NewLayout(dataDir)
 	pick := func(override, defPath string) string {
 		if override != "" {

--- a/cmd/stellar-rpc/internal/rpcv2/config/config.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/config.go
@@ -48,8 +48,10 @@ type Config struct {
 // section is optional: absent keys get v1's defaults in WithDefaults.
 //
 // Key naming rule: camelCase table keys ONLY where the key is a wire identifier
-// (the [service.methods.<methodName>] tables, spelled exactly as a client sends
-// the JSON-RPC method); snake_case for every other key.
+// (the [service.methods.<methodName>] tables, named after the JSON-RPC method);
+// snake_case for every other key. The decoder cannot ENFORCE the casing —
+// go-toml matches keys case-insensitively, so a miscased method table is
+// accepted — the rule exists so configs read like the wire protocol.
 type ServiceConfig struct {
 	// Endpoint is the address the JSON-RPC server listens on. Default "localhost:8000".
 	Endpoint string `toml:"endpoint"`
@@ -89,8 +91,9 @@ type FeeStatsConfig struct {
 // a per-method value set in the file. The cascade is resolved in WithDefaults;
 // after it, every per-method field is non-nil.
 //
-// One struct field per method — never a map — so the strict decoder rejects a
-// typo'd method table instead of silently accepting it.
+// One struct field per method — never a map — so the strict decoder rejects an
+// unknown method table instead of silently accepting it. (go-toml matches keys
+// case-insensitively, so this catches misspellings but not wrong casing.)
 type MethodsConfig struct {
 	QueueLimit           *uint          `toml:"queue_limit"`
 	MaxExecutionDuration *time.Duration `toml:"max_execution_duration"`
@@ -170,9 +173,6 @@ type StorageConfig struct {
 }
 
 // BackfillConfig is [backfill] plus the nested [backfill.datastore] and [backfill.bsb].
-// The datastore and BSB blocks reuse the SDK config types verbatim, so any SDK
-// datastore (GCS, S3, Filesystem, ...) works as the bulk source — backfill needs only
-// correct ledger metadata, not a specific store.
 type BackfillConfig struct {
 	// Concurrent task-slot count for bulk backfill; >= 1. Default GOMAXPROCS.
 	Workers *int `toml:"workers"`
@@ -184,11 +184,92 @@ type BackfillConfig struct {
 	// DataStore is the bulk ledger source. An empty Type means no lake — backfill
 	// then replays through captive core from the history archives; otherwise any
 	// SDK datastore type is accepted.
-	DataStore datastore.DataStoreConfig `toml:"datastore"`
+	DataStore DataStoreConfig `toml:"datastore"`
 
-	// BSB tunes the buffered-storage stream over DataStore; zero fields fall back to
-	// the backfill defaults applied in backfill.NewBSBBackend.
-	BSB ledgerbackend.BufferedStorageBackendConfig `toml:"bsb"`
+	// BSB tunes the buffered-storage stream over DataStore.
+	BSB BSBConfig `toml:"bsb"`
+}
+
+// DataStoreConfig is [backfill.datastore] — the bulk ledger source. The key
+// names match the SDK's datastore.DataStoreConfig, but the struct is a mirror
+// rather than the SDK type itself: the SDK struct carries extra untagged fields
+// (NetworkPassphrase, Compression), and go-toml matches untagged exported
+// fields by name, so embedding it would silently admit those as file keys. In
+// particular the network passphrase must never come from this file — the
+// captive-core config is its single source, and the daemon copies it into the
+// SDK config at startup (see SDKConfig).
+type DataStoreConfig struct {
+	// Type is the SDK datastore type: "GCS", "S3", "Filesystem", ... Empty
+	// means no lake.
+	Type string `toml:"type"`
+	// Params are the datastore-type-specific parameters (e.g. GCS's
+	// destination_bucket_path).
+	Params map[string]string `toml:"params"`
+	// Schema describes the lake's file layout. Optional when the lake carries a
+	// manifest — the stream reads the schema from there.
+	Schema DataStoreSchemaConfig `toml:"schema"`
+}
+
+// DataStoreSchemaConfig is [backfill.datastore.schema] — how the lake's ledger
+// files are laid out. Must match how the lake was exported.
+type DataStoreSchemaConfig struct {
+	LedgersPerFile    uint32 `toml:"ledgers_per_file"`
+	FilesPerPartition uint32 `toml:"files_per_partition"`
+}
+
+// SDKConfig converts the [backfill.datastore] section into the SDK's config
+// type. networkPassphrase is the one read back from the captive-core file (empty
+// = unknown, e.g. an injected test core): when non-empty, the SDK compares it
+// against the lake's manifest and refuses a lake exported from a different
+// network.
+func (d DataStoreConfig) SDKConfig(networkPassphrase string) datastore.DataStoreConfig {
+	return datastore.DataStoreConfig{
+		Type:   d.Type,
+		Params: d.Params,
+		Schema: datastore.DataStoreSchema{
+			LedgersPerFile:    d.Schema.LedgersPerFile,
+			FilesPerPartition: d.Schema.FilesPerPartition,
+		},
+		NetworkPassphrase: networkPassphrase,
+	}
+}
+
+// BSBConfig is [backfill.bsb] — tuning for the buffered-storage stream that
+// downloads ledger objects from [backfill.datastore] during backfill. It mirrors
+// the SDK's ledgerbackend.BufferedStorageBackendConfig rather than embedding it,
+// for two reasons: the fields are pointers so an absent key is distinguishable
+// from an explicit zero (max_retries = 0 genuinely disables retries), and the
+// key is named max_retries to match [backfill].max_retries instead of the SDK's
+// retry_limit. SDKConfig converts to the SDK type at the daemon boundary.
+type BSBConfig struct {
+	// BufferSize is how many downloaded ledgers are buffered in memory, keeping
+	// the download ahead of ingest; >= 1. Default backfill.DefaultBSBBufferSize.
+	BufferSize *uint32 `toml:"buffer_size"`
+	// NumWorkers is how many object downloads run concurrently; >= 1. Default
+	// backfill.DefaultBSBNumWorkers.
+	NumWorkers *uint32 `toml:"num_workers"`
+	// MaxRetries caps how many times ONE object download (a single ledger file
+	// fetched from the datastore) is retried after a transient error, waiting
+	// RetryWait between attempts; when the budget is exhausted the whole stream
+	// fails. 0 = fail on the first error, no retries. This is a different knob
+	// from [backfill].max_retries, which re-runs a whole chunk task. Default
+	// backfill.DefaultBSBMaxRetries.
+	MaxRetries *uint32 `toml:"max_retries"`
+	// RetryWait is the pause between retries of one object download; >= 1ms
+	// (validateConfig applies the same nanosecond-typo guard as the [service]
+	// durations). Default backfill.DefaultBSBRetryWait.
+	RetryWait *time.Duration `toml:"retry_wait"`
+}
+
+// SDKConfig converts the resolved [backfill.bsb] section into the SDK's config
+// type. Call it only after WithDefaults, when every field is non-nil.
+func (b BSBConfig) SDKConfig() ledgerbackend.BufferedStorageBackendConfig {
+	return ledgerbackend.BufferedStorageBackendConfig{
+		BufferSize: *b.BufferSize,
+		NumWorkers: *b.NumWorkers,
+		RetryLimit: *b.MaxRetries,
+		RetryWait:  *b.RetryWait,
+	}
 }
 
 // IngestionConfig is [ingestion] — the live-network ingestion (captive-core)
@@ -271,18 +352,12 @@ const (
 	DefaultSorobanInclusionFeeWindowLedgers uint32 = 50
 )
 
-// LoadConfig reads and parses the TOML config at path. It applies defaults but
+// LoadConfigWithFlags reads and parses the TOML config at path, with CLI
+// overrides: decode the file (strict), overlay every flag the user actually set
+// (nil fs = none), THEN resolve defaults — so a flag participates in the
+// methods cascade at its own specificity tier before any default is filled. It
 // does NOT validate semantics or touch any pin — that is validateConfig's job.
-// See ParseConfig.
-func LoadConfig(path string) (Config, error) {
-	return LoadConfigWithFlags(path, nil)
-}
-
-// LoadConfigWithFlags is LoadConfig with CLI overrides: decode the file
-// (strict), overlay every flag the user actually set (nil fs = none), THEN
-// resolve defaults — so a flag participates in the methods cascade at its own
-// specificity tier before any default is filled. See flags.go for the
-// flag-name/TOML-path correspondence.
+// See flags.go for the flag-name/TOML-path correspondence.
 func LoadConfigWithFlags(path string, fs FlagOverrides) (Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -345,6 +420,10 @@ func (cfg Config) WithDefaults() Config {
 		v := DefaultMaxRetries
 		cfg.Backfill.MaxRetries = &v
 	}
+	fillUint32(&cfg.Backfill.BSB.BufferSize, backfill.DefaultBSBBufferSize)
+	fillUint32(&cfg.Backfill.BSB.NumWorkers, backfill.DefaultBSBNumWorkers)
+	fillUint32(&cfg.Backfill.BSB.MaxRetries, backfill.DefaultBSBMaxRetries)
+	fillDuration(&cfg.Backfill.BSB.RetryWait, backfill.DefaultBSBRetryWait)
 	if cfg.Retention.RetentionChunks == nil {
 		v := uint32(0)
 		cfg.Retention.RetentionChunks = &v

--- a/cmd/stellar-rpc/internal/rpcv2/config/config.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/config.go
@@ -343,12 +343,21 @@ const (
 
 	DefaultMaxHealthyLedgerLatency time.Duration = 30 * time.Second
 
-	DefaultGetEventsMaxItemsPerResponse           uint = 10000
+	// DefaultGetEventsMaxItemsPerResponse and the getLedgers pair below are the
+	// two deliberate breaks from v1's page sizes (TODO: revisit both under the
+	// v2 benchmarking epic):
+	//   - getEvents max is 1000, not v1's 10000 — the finalized getEvents v2
+	//     API fixes the page cap at 1,000 as a spec constant
+	//     (github.com/orgs/stellar/discussions/1872).
+	//   - getLedgers is 20/5, not v1's 200/50 — the item here is a full
+	//     LedgerCloseMeta (megabytes each on a busy pubnet ledger), so v1's
+	//     200-item page could exceed a hundred MB of XDR in one response.
+	DefaultGetEventsMaxItemsPerResponse           uint = 1000
 	DefaultGetEventsDefaultItemsPerResponse       uint = 100
 	DefaultGetTransactionsMaxItemsPerResponse     uint = 200
 	DefaultGetTransactionsDefaultItemsPerResponse uint = 50
-	DefaultGetLedgersMaxItemsPerResponse          uint = 200
-	DefaultGetLedgersDefaultItemsPerResponse      uint = 50
+	DefaultGetLedgersMaxItemsPerResponse          uint = 20
+	DefaultGetLedgersDefaultItemsPerResponse      uint = 5
 
 	DefaultClassicFeeWindowLedgers          uint32 = 10
 	DefaultSorobanInclusionFeeWindowLedgers uint32 = 50

--- a/cmd/stellar-rpc/internal/rpcv2/config/config_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/config_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/backfill"
 )
 
 // A fully-populated, documented-valid config. Every section present with
@@ -112,8 +114,8 @@ func TestParseConfig_FullDocument(t *testing.T) {
 	assert.Equal(t, 5, *cfg.Backfill.MaxRetries)
 	assert.Equal(t, "GCS", cfg.Backfill.DataStore.Type)
 	assert.Equal(t, "my-bucket/ledgers", cfg.Backfill.DataStore.Params["destination_bucket_path"])
-	assert.Equal(t, uint32(2000), cfg.Backfill.BSB.BufferSize)
-	assert.Equal(t, uint32(40), cfg.Backfill.BSB.NumWorkers)
+	assert.Equal(t, uint32(2000), *cfg.Backfill.BSB.BufferSize)
+	assert.Equal(t, uint32(40), *cfg.Backfill.BSB.NumWorkers)
 	assert.Equal(t, "/etc/captive-core.toml", cfg.Ingestion.CaptiveCoreConfig)
 	assert.Equal(t, "debug", cfg.Logging.Level)
 	assert.Equal(t, "json", cfg.Logging.Format)
@@ -131,10 +133,47 @@ func TestParseConfig_MinimalAppliesDefaults(t *testing.T) {
 	// Documented defaults filled.
 	assert.Equal(t, runtime.GOMAXPROCS(0), *cfg.Backfill.Workers)
 	assert.Equal(t, DefaultMaxRetries, *cfg.Backfill.MaxRetries)
+	assert.Equal(t, uint32(backfill.DefaultBSBBufferSize), *cfg.Backfill.BSB.BufferSize)
+	assert.Equal(t, uint32(backfill.DefaultBSBNumWorkers), *cfg.Backfill.BSB.NumWorkers)
+	assert.Equal(t, uint32(backfill.DefaultBSBMaxRetries), *cfg.Backfill.BSB.MaxRetries)
+	assert.Equal(t, backfill.DefaultBSBRetryWait, *cfg.Backfill.BSB.RetryWait)
 	assert.Equal(t, uint32(0), *cfg.Retention.RetentionChunks)
 	assert.Equal(t, DefaultEarliestLedger, cfg.Retention.EarliestLedger)
 	assert.Equal(t, DefaultLogLevel, cfg.Logging.Level)
 	assert.Equal(t, DefaultLogFormat, cfg.Logging.Format)
+}
+
+func TestDecodeConfig_RejectsPassphraseUnderDatastore(t *testing.T) {
+	_, err := DecodeConfig([]byte(`
+[backfill.datastore]
+type = "GCS"
+NetworkPassphrase = "oops"
+`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "NetworkPassphrase")
+}
+
+func TestDataStoreConfig_SDKConfigCarriesPassphrase(t *testing.T) {
+	d := DataStoreConfig{
+		Type:   "GCS",
+		Params: map[string]string{"destination_bucket_path": "b/p"},
+		Schema: DataStoreSchemaConfig{LedgersPerFile: 1, FilesPerPartition: 64000},
+	}
+	sdk := d.SDKConfig("Public Global Stellar Network ; September 2015")
+
+	assert.Equal(t, "GCS", sdk.Type)
+	assert.Equal(t, "b/p", sdk.Params["destination_bucket_path"])
+	assert.Equal(t, uint32(1), sdk.Schema.LedgersPerFile)
+	assert.Equal(t, uint32(64000), sdk.Schema.FilesPerPartition)
+	assert.Equal(t, "Public Global Stellar Network ; September 2015", sdk.NetworkPassphrase)
+}
+
+func TestParseConfig_ExplicitZeroBSBMaxRetriesSurvives(t *testing.T) {
+	cfg, err := ParseConfig([]byte(minimalValidConfig + "\n[backfill.bsb]\nmax_retries = 0\n"))
+	require.NoError(t, err)
+
+	assert.Zero(t, *cfg.Backfill.BSB.MaxRetries)
+	assert.Zero(t, cfg.Backfill.BSB.SDKConfig().RetryLimit)
 }
 
 func TestParseConfig_ServiceDefaults(t *testing.T) {

--- a/cmd/stellar-rpc/internal/rpcv2/config/config_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,13 +15,34 @@ import (
 // end.
 const fullValidConfig = `
 [service]
-default_data_dir = "/var/lib/fullhistory"
+endpoint = "0.0.0.0:9000"
+admin_endpoint = "localhost:9001"
+max_concurrent_requests = 7000
+max_request_execution_duration = "30s"
+request_execution_warning_threshold = "3s"
+
+[service.fee_stats]
+classic_fee_window_ledgers = 20
+soroban_inclusion_fee_window_ledgers = 60
+
+[service.methods]
+queue_limit = 200
+max_execution_duration = "8s"
+
+[service.methods.getLedgers]
+queue_limit = 500
+max_items_per_response = 400
+default_items_per_response = 40
+
+[service.methods.getFeeStats]
+max_execution_duration = "2s"
 
 [retention]
 earliest_ledger = "now"
 retention_chunks = 100
 
 [storage]
+default_data_dir = "/var/lib/fullhistory"
 catalog = "/mnt/catalog"
 ledgers = "/mnt/ledgers"
 events = "/mnt/events"
@@ -52,7 +74,7 @@ format = "json"
 
 // A minimal config: only the required keys, everything else defaulted.
 const minimalValidConfig = `
-[service]
+[storage]
 default_data_dir = "/data"
 
 [backfill.datastore]
@@ -69,9 +91,17 @@ func TestParseConfig_FullDocument(t *testing.T) {
 	cfg, err := ParseConfig([]byte(fullValidConfig))
 	require.NoError(t, err)
 
-	assert.Equal(t, "/var/lib/fullhistory", cfg.Service.DefaultDataDir)
+	assert.Equal(t, "0.0.0.0:9000", cfg.Service.Endpoint)
+	assert.Equal(t, "localhost:9001", cfg.Service.AdminEndpoint)
+	assert.Equal(t, uint(7000), *cfg.Service.MaxConcurrentRequests)
+	assert.Equal(t, 30*time.Second, *cfg.Service.MaxRequestExecutionDuration)
+	assert.Equal(t, 3*time.Second, *cfg.Service.RequestExecutionWarningThreshold)
+	assert.Equal(t, uint32(20), *cfg.Service.FeeStats.ClassicFeeWindowLedgers)
+	assert.Equal(t, uint32(60), *cfg.Service.FeeStats.SorobanInclusionFeeWindowLedgers)
+
 	assert.Equal(t, "now", cfg.Retention.EarliestLedger)
 	assert.Equal(t, uint32(100), *cfg.Retention.RetentionChunks)
+	assert.Equal(t, "/var/lib/fullhistory", cfg.Storage.DefaultDataDir)
 	assert.Equal(t, "/mnt/catalog", cfg.Storage.Catalog)
 	assert.Equal(t, "/mnt/ledgers", cfg.Storage.Ledgers)
 	assert.Equal(t, "/mnt/events", cfg.Storage.Events)
@@ -94,7 +124,7 @@ func TestParseConfig_MinimalAppliesDefaults(t *testing.T) {
 	require.NoError(t, err)
 
 	// Required keys preserved.
-	assert.Equal(t, "/data", cfg.Service.DefaultDataDir)
+	assert.Equal(t, "/data", cfg.Storage.DefaultDataDir)
 	assert.Equal(t, "bucket/path", cfg.Backfill.DataStore.Params["destination_bucket_path"])
 	assert.Equal(t, "/etc/cc.toml", cfg.Ingestion.CaptiveCoreConfig)
 
@@ -107,16 +137,93 @@ func TestParseConfig_MinimalAppliesDefaults(t *testing.T) {
 	assert.Equal(t, DefaultLogFormat, cfg.Logging.Format)
 }
 
+func TestParseConfig_ServiceDefaults(t *testing.T) {
+	// An entirely absent [service] section is valid and fully defaulted.
+	cfg, err := ParseConfig([]byte(minimalValidConfig))
+	require.NoError(t, err)
+
+	assert.Equal(t, DefaultEndpoint, cfg.Service.Endpoint)
+	assert.Empty(t, cfg.Service.AdminEndpoint, "admin server disabled by default")
+	assert.Equal(t, DefaultMaxConcurrentRequests, *cfg.Service.MaxConcurrentRequests)
+	assert.Equal(t, DefaultMaxRequestExecutionDuration, *cfg.Service.MaxRequestExecutionDuration)
+	assert.Equal(t, DefaultRequestExecutionWarningThreshold, *cfg.Service.RequestExecutionWarningThreshold)
+	assert.Equal(t, DefaultClassicFeeWindowLedgers, *cfg.Service.FeeStats.ClassicFeeWindowLedgers)
+	assert.Equal(t, DefaultSorobanInclusionFeeWindowLedgers, *cfg.Service.FeeStats.SorobanInclusionFeeWindowLedgers)
+
+	m := cfg.Service.Methods
+	assert.Nil(t, m.QueueLimit, "the wide-default tier stays unset")
+	assert.Nil(t, m.MaxExecutionDuration, "the wide-default tier stays unset")
+
+	assert.Equal(t, DefaultMethodQueueLimit, *m.GetHealth.QueueLimit)
+	assert.Equal(t, DefaultMethodMaxExecutionDuration, *m.GetHealth.MaxExecutionDuration)
+	assert.Equal(t, DefaultMaxHealthyLedgerLatency, *m.GetHealth.MaxHealthyLedgerLatency)
+
+	assert.Equal(t, DefaultGetFeeStatsQueueLimit, *m.GetFeeStats.QueueLimit)
+	assert.Equal(t, DefaultScanMethodMaxExecutionDuration, *m.GetLedgers.MaxExecutionDuration)
+	assert.Equal(t, DefaultScanMethodMaxExecutionDuration, *m.GetEvents.MaxExecutionDuration)
+	assert.Equal(t, DefaultMethodMaxExecutionDuration, *m.GetTransactions.MaxExecutionDuration)
+
+	assert.Equal(t, DefaultGetEventsMaxItemsPerResponse, *m.GetEvents.MaxItemsPerResponse)
+	assert.Equal(t, DefaultGetEventsDefaultItemsPerResponse, *m.GetEvents.DefaultItemsPerResponse)
+	assert.Equal(t, DefaultGetTransactionsMaxItemsPerResponse, *m.GetTransactions.MaxItemsPerResponse)
+	assert.Equal(t, DefaultGetLedgersMaxItemsPerResponse, *m.GetLedgers.MaxItemsPerResponse)
+}
+
+func TestParseConfig_MethodsCascade(t *testing.T) {
+	t.Run("wide default applies to unspecified methods, per-method value survives", func(t *testing.T) {
+		cfg, err := ParseConfig([]byte(fullValidConfig))
+		require.NoError(t, err)
+		m := cfg.Service.Methods
+
+		// getLedgers set queue_limit = 500 explicitly; the wide tier is 200.
+		assert.Equal(t, uint(500), *m.GetLedgers.QueueLimit)
+		// getFeeStats set only its duration; queue falls to the wide tier — NOT
+		// its compiled default of 100.
+		assert.Equal(t, uint(200), *m.GetFeeStats.QueueLimit)
+		assert.Equal(t, 2*time.Second, *m.GetFeeStats.MaxExecutionDuration)
+		// Untouched methods take both wide-tier values.
+		assert.Equal(t, uint(200), *m.GetHealth.QueueLimit)
+		assert.Equal(t, 8*time.Second, *m.GetHealth.MaxExecutionDuration)
+		// getLedgers' duration was not set per-method, so the wide tier wins over
+		// its compiled 10s default.
+		assert.Equal(t, 8*time.Second, *m.GetLedgers.MaxExecutionDuration)
+	})
+
+	t.Run("no wide tier: compiled per-method defaults", func(t *testing.T) {
+		cfg, err := ParseConfig([]byte(minimalValidConfig))
+		require.NoError(t, err)
+		m := cfg.Service.Methods
+
+		assert.Equal(t, DefaultMethodQueueLimit, *m.GetLedgers.QueueLimit)
+		assert.Equal(t, DefaultGetFeeStatsQueueLimit, *m.GetFeeStats.QueueLimit)
+	})
+
+	t.Run("pagination caps have no wide tier", func(t *testing.T) {
+		cfg, err := ParseConfig([]byte(fullValidConfig))
+		require.NoError(t, err)
+		m := cfg.Service.Methods
+
+		// getLedgers overrode its caps; getEvents keeps its own compiled defaults
+		// (10000/100), untouched by getLedgers' 400/40 or any wide value.
+		assert.Equal(t, uint(400), *m.GetLedgers.MaxItemsPerResponse)
+		assert.Equal(t, uint(40), *m.GetLedgers.DefaultItemsPerResponse)
+		assert.Equal(t, DefaultGetEventsMaxItemsPerResponse, *m.GetEvents.MaxItemsPerResponse)
+		assert.Equal(t, DefaultGetEventsDefaultItemsPerResponse, *m.GetEvents.DefaultItemsPerResponse)
+	})
+}
+
 func TestParseConfig_ExplicitZeroPreserved(t *testing.T) {
 	// An explicit zero must NOT be overwritten by the default — validateConfig
 	// is what rejects an illegal zero (e.g. workers = 0), so the defaulting layer
 	// must preserve it for that rejection to fire.
 	const cfgText = `
-[service]
+[storage]
 default_data_dir = "/d"
 [backfill]
 workers = 0
 max_retries = 0
+[service.methods.getLedgers]
+queue_limit = 0
 [ingestion]
 captive_core_config = "/cc"
 `
@@ -124,6 +231,7 @@ captive_core_config = "/cc"
 	require.NoError(t, err)
 	assert.Equal(t, 0, *cfg.Backfill.Workers)
 	assert.Equal(t, 0, *cfg.Backfill.MaxRetries)
+	assert.Equal(t, uint(0), *cfg.Service.Methods.GetLedgers.QueueLimit)
 }
 
 func TestParseConfig_Malformed(t *testing.T) {
@@ -146,7 +254,7 @@ func TestParseConfig_RejectsUnknownKeys(t *testing.T) {
 			// correctly it (and the [layout] section) must now be rejected.
 			name: "removed chunks_per_txhash_index key",
 			text: `
-[service]
+[storage]
 default_data_dir = "/d"
 [layout]
 chunks_per_txhash_index = 1000
@@ -157,7 +265,7 @@ captive_core_config = "/cc"
 		{
 			name: "typo'd earliest_ledger",
 			text: `
-[service]
+[storage]
 default_data_dir = "/d"
 [retention]
 earliest_ledgr = "now"
@@ -169,7 +277,7 @@ captive_core_config = "/cc"
 			name: "unknown top-level key",
 			text: `
 default_data_dirr = "/d"
-[service]
+[storage]
 default_data_dir = "/d"
 [ingestion]
 captive_core_config = "/cc"
@@ -178,7 +286,7 @@ captive_core_config = "/cc"
 		{
 			name: "unknown section",
 			text: `
-[service]
+[storage]
 default_data_dir = "/d"
 [bogus_section]
 foo = "bar"
@@ -189,11 +297,33 @@ captive_core_config = "/cc"
 		{
 			name: "unknown nested key under known section",
 			text: `
-[service]
+[storage]
 default_data_dir = "/d"
 [backfill.bsb]
 bucket_path = "b/p"
 bufer_size = 10
+[ingestion]
+captive_core_config = "/cc"
+`,
+		},
+		{
+			// default_data_dir moved to [storage] in #882 — its old home must fail
+			// loudly, not be silently accepted.
+			name: "default_data_dir under its pre-#882 [service] home",
+			text: `
+[service]
+default_data_dir = "/d"
+[ingestion]
+captive_core_config = "/cc"
+`,
+		},
+		{
+			name: "typo'd method table",
+			text: `
+[storage]
+default_data_dir = "/d"
+[service.methods.getLegders]
+queue_limit = 5
 [ingestion]
 captive_core_config = "/cc"
 `,

--- a/cmd/stellar-rpc/internal/rpcv2/config/config_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"testing"
 	"time"
@@ -141,6 +142,27 @@ func TestParseConfig_MinimalAppliesDefaults(t *testing.T) {
 	assert.Equal(t, DefaultEarliestLedger, cfg.Retention.EarliestLedger)
 	assert.Equal(t, DefaultLogLevel, cfg.Logging.Level)
 	assert.Equal(t, DefaultLogFormat, cfg.Logging.Format)
+}
+
+func TestWithDefaults_FillsEveryPointerLeaf(t *testing.T) {
+	// The two wide-tier keys are the deliberate exceptions: they stay nil when
+	// unset so WithDefaults can tell "operator set a wide default" apart from
+	// "fall through to the compiled default".
+	optional := map[string]bool{
+		"service.methods.queue_limit":            true,
+		"service.methods.max_execution_duration": true,
+	}
+
+	cfg, err := ParseConfig([]byte(minimalValidConfig))
+	require.NoError(t, err)
+
+	walkLeaves(reflect.ValueOf(&cfg).Elem(), "", func(path string, f reflect.Value) {
+		if f.Kind() != reflect.Pointer || optional[path] {
+			return
+		}
+		assert.False(t, f.IsNil(), "pointer leaf %s is nil after WithDefaults — "+
+			"a new optional field needs its fill in WithDefaults", path)
+	})
 }
 
 func TestDecodeConfig_RejectsPassphraseUnderDatastore(t *testing.T) {

--- a/cmd/stellar-rpc/internal/rpcv2/config/config_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/config_test.go
@@ -145,9 +145,8 @@ func TestParseConfig_MinimalAppliesDefaults(t *testing.T) {
 }
 
 func TestWithDefaults_FillsEveryPointerLeaf(t *testing.T) {
-	// The two wide-tier keys are the deliberate exceptions: they stay nil when
-	// unset so WithDefaults can tell "operator set a wide default" apart from
-	// "fall through to the compiled default".
+	// The wide-tier keys stay nil when unset — that's how WithDefaults tells
+	// "operator set a wide default" from "use the compiled default".
 	optional := map[string]bool{
 		"service.methods.queue_limit":            true,
 		"service.methods.max_execution_duration": true,

--- a/cmd/stellar-rpc/internal/rpcv2/config/flags.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/flags.go
@@ -1,0 +1,233 @@
+package config
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/spf13/pflag"
+)
+
+// Every TOML leaf of Config is settable from the command line as a flag named
+// by its dotted TOML path:
+//
+//	--storage.default_data_dir=/var/stellar
+//	--service.methods.getLedgers.queue_limit=500
+//	--service.methods.queue_limit=30          (the methods-wide default tier)
+//
+// The flag set is DERIVED from the Config struct by reflection over the `toml`
+// tags — there is no second declaration list that could drift out of lockstep
+// with the file schema (v1's failure mode). Adding a field to any config struct
+// automatically creates its flag; TestBindFlags_LockstepWithTOMLSchema pins the
+// correspondence.
+//
+// Precedence is implemented by ORDER, not by these functions: the daemon
+// decodes the file, then ApplyFlags overlays only the flags the user actually
+// set, then WithDefaults resolves the methods cascade and fills defaults. A
+// flag therefore beats the file at the SAME specificity tier, while a more
+// specific file value still beats a less specific flag (specificity beats
+// source).
+
+// FlagOverrides is the surface ApplyFlags needs from *pflag.FlagSet; an
+// interface so config doesn't force a pflag dependency on every caller of
+// LoadConfigWithFlags (nil = no overrides).
+type FlagOverrides interface {
+	Changed(name string) bool
+	GetString(name string) (string, error)
+	GetUint(name string) (uint, error)
+	GetUint32(name string) (uint32, error)
+	GetInt(name string) (int, error)
+	GetDuration(name string) (time.Duration, error)
+	GetStringSlice(name string) ([]string, error)
+	GetStringToString(name string) (map[string]string, error)
+}
+
+var _ FlagOverrides = (*pflag.FlagSet)(nil)
+
+// BindFlags registers one override flag per TOML leaf of Config on fs. Call it
+// once on the root command's flag set, before parsing.
+func BindFlags(fs *pflag.FlagSet) {
+	walkLeaves(reflect.ValueOf(&Config{}).Elem(), "", func(path string, f reflect.Value) {
+		usage := "overrides " + path + " from the config file"
+		switch leafKind(f.Type()) {
+		case kindString:
+			fs.String(path, "", usage)
+		case kindUint:
+			fs.Uint(path, 0, usage)
+		case kindUint32:
+			fs.Uint32(path, 0, usage)
+		case kindInt:
+			fs.Int(path, 0, usage)
+		case kindDuration:
+			fs.Duration(path, 0, usage)
+		case kindStringSlice:
+			fs.StringSlice(path, nil, usage)
+		case kindStringMap:
+			fs.StringToString(path, nil, usage)
+		case kindUnsupported:
+			// unreachable: walkLeaves panics on an unsupported leaf before visiting
+		}
+	})
+}
+
+// ApplyFlags writes every flag the user actually set (fs.Changed) into cfg,
+// allocating pointer fields as needed. Run it AFTER DecodeConfig and BEFORE
+// WithDefaults so the overlay participates in defaulting at its own tier.
+func ApplyFlags(cfg *Config, fs FlagOverrides) error {
+	var firstErr error
+	walkLeaves(reflect.ValueOf(cfg).Elem(), "", func(path string, f reflect.Value) {
+		if firstErr != nil || !fs.Changed(path) {
+			return
+		}
+		if err := setLeaf(f, path, fs); err != nil {
+			firstErr = err
+		}
+	})
+	return firstErr
+}
+
+//nolint:cyclop // one case per supported leaf type; splitting hides the correspondence
+func setLeaf(f reflect.Value, path string, fs FlagOverrides) error {
+	fail := func(err error) error { return fmt.Errorf("apply flag --%s: %w", path, err) }
+	switch leafKind(f.Type()) {
+	case kindString:
+		v, err := fs.GetString(path)
+		if err != nil {
+			return fail(err)
+		}
+		setPossiblyPointer(f, reflect.ValueOf(v))
+	case kindUint:
+		v, err := fs.GetUint(path)
+		if err != nil {
+			return fail(err)
+		}
+		setPossiblyPointer(f, reflect.ValueOf(v))
+	case kindUint32:
+		v, err := fs.GetUint32(path)
+		if err != nil {
+			return fail(err)
+		}
+		setPossiblyPointer(f, reflect.ValueOf(v))
+	case kindInt:
+		v, err := fs.GetInt(path)
+		if err != nil {
+			return fail(err)
+		}
+		setPossiblyPointer(f, reflect.ValueOf(v))
+	case kindDuration:
+		v, err := fs.GetDuration(path)
+		if err != nil {
+			return fail(err)
+		}
+		setPossiblyPointer(f, reflect.ValueOf(v))
+	case kindStringSlice:
+		v, err := fs.GetStringSlice(path)
+		if err != nil {
+			return fail(err)
+		}
+		setPossiblyPointer(f, reflect.ValueOf(v))
+	case kindStringMap:
+		v, err := fs.GetStringToString(path)
+		if err != nil {
+			return fail(err)
+		}
+		setPossiblyPointer(f, reflect.ValueOf(v))
+	case kindUnsupported:
+		// unreachable: walkLeaves panics on an unsupported leaf before visiting
+	}
+	return nil
+}
+
+// setPossiblyPointer assigns v to f, allocating first when f is a pointer field
+// (the pointer-typed optionals: a set flag means "explicitly set", so it always
+// lands as a non-nil pointer).
+func setPossiblyPointer(f, v reflect.Value) {
+	if f.Kind() == reflect.Pointer {
+		p := reflect.New(f.Type().Elem())
+		p.Elem().Set(v.Convert(f.Type().Elem()))
+		f.Set(p)
+		return
+	}
+	f.Set(v.Convert(f.Type()))
+}
+
+type kind int
+
+const (
+	kindUnsupported kind = iota
+	kindString
+	kindUint
+	kindUint32
+	kindInt
+	kindDuration
+	kindStringSlice
+	kindStringMap
+)
+
+func durationType() reflect.Type { return reflect.TypeFor[time.Duration]() }
+
+// leafKind classifies a (possibly pointer-typed) leaf field. time.Duration must
+// be checked by TYPE before any Kind switch — its Kind is int64.
+//
+//nolint:exhaustive // every unlisted reflect.Kind falls through to unsupported
+func leafKind(t reflect.Type) kind {
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t == durationType() {
+		return kindDuration
+	}
+	switch t.Kind() {
+	case reflect.String:
+		return kindString
+	case reflect.Uint:
+		return kindUint
+	case reflect.Uint32:
+		return kindUint32
+	case reflect.Int:
+		return kindInt
+	case reflect.Slice:
+		if t.Elem().Kind() == reflect.String {
+			return kindStringSlice
+		}
+	case reflect.Map:
+		if t.Key().Kind() == reflect.String && t.Elem().Kind() == reflect.String {
+			return kindStringMap
+		}
+	}
+	return kindUnsupported
+}
+
+// walkLeaves visits every flag-eligible leaf of a config struct value, calling
+// visit with the leaf's dotted TOML path and its field Value. Rules:
+//
+//   - only fields with a non-empty, non-"-" `toml` tag participate (untagged
+//     SDK fields like DataStoreConfig.NetworkPassphrase are not part of the
+//     file schema, so they get no flag either);
+//   - a tagged struct field recurses with its tag as a path segment;
+//   - a tagged leaf of an unsupported type PANICS at BindFlags time — adding a
+//     config field of a new type must extend leafKind, not silently lose its flag.
+func walkLeaves(v reflect.Value, prefix string, visit func(path string, f reflect.Value)) {
+	t := v.Type()
+	for i := range t.NumField() {
+		field := t.Field(i)
+		tag := field.Tag.Get("toml")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		path := tag
+		if prefix != "" {
+			path = prefix + "." + tag
+		}
+		f := v.Field(i)
+		ft := field.Type
+		if ft.Kind() == reflect.Struct && ft != durationType() {
+			walkLeaves(f, path, visit)
+			continue
+		}
+		if leafKind(ft) == kindUnsupported {
+			panic(fmt.Sprintf("config flags: field %s (%s) has no flag mapping; extend leafKind", path, ft))
+		}
+		visit(path, f)
+	}
+}

--- a/cmd/stellar-rpc/internal/rpcv2/config/flags.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/flags.go
@@ -201,9 +201,12 @@ func leafKind(t reflect.Type) kind {
 // walkLeaves visits every flag-eligible leaf of a config struct value, calling
 // visit with the leaf's dotted TOML path and its field Value. Rules:
 //
-//   - only fields with a non-empty, non-"-" `toml` tag participate (untagged
-//     SDK fields like DataStoreConfig.NetworkPassphrase are not part of the
-//     file schema, so they get no flag either);
+//   - only fields with a non-empty, non-"-" `toml` tag participate. Config
+//     deliberately contains no SDK struct types — it mirrors them (BSBConfig,
+//     DataStoreConfig) — because go-toml matches UNTAGGED exported fields by
+//     name, so an embedded SDK struct would silently admit its untagged fields
+//     (e.g. NetworkPassphrase) as file keys, breaking both the strictness
+//     guarantee and the flag/TOML lockstep;
 //   - a tagged struct field recurses with its tag as a path segment;
 //   - a tagged leaf of an unsupported type PANICS at BindFlags time — adding a
 //     config field of a new type must extend leafKind, not silently lose its flag.

--- a/cmd/stellar-rpc/internal/rpcv2/config/flags.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/flags.go
@@ -201,12 +201,14 @@ func leafKind(t reflect.Type) kind {
 // walkLeaves visits every flag-eligible leaf of a config struct value, calling
 // visit with the leaf's dotted TOML path and its field Value. Rules:
 //
-//   - only fields with a non-empty, non-"-" `toml` tag participate. Config
-//     deliberately contains no SDK struct types — it mirrors them (BSBConfig,
-//     DataStoreConfig) — because go-toml matches UNTAGGED exported fields by
-//     name, so an embedded SDK struct would silently admit its untagged fields
-//     (e.g. NetworkPassphrase) as file keys, breaking both the strictness
-//     guarantee and the flag/TOML lockstep;
+//   - every exported field must carry a `toml` tag ("-" to opt out); an
+//     untagged exported field PANICS at BindFlags time. go-toml matches
+//     untagged exported fields by NAME, so a forgotten tag would silently
+//     become a settable file key with no flag — the one way the file schema
+//     and the flag set could drift apart. (Config deliberately contains no
+//     SDK struct types for the same reason — it mirrors them as BSBConfig and
+//     DataStoreConfig, whose untagged SDK fields like NetworkPassphrase must
+//     not be file keys.)
 //   - a tagged struct field recurses with its tag as a path segment;
 //   - a tagged leaf of an unsupported type PANICS at BindFlags time — adding a
 //     config field of a new type must extend leafKind, not silently lose its flag.
@@ -214,8 +216,16 @@ func walkLeaves(v reflect.Value, prefix string, visit func(path string, f reflec
 	t := v.Type()
 	for i := range t.NumField() {
 		field := t.Field(i)
+		if !field.IsExported() {
+			continue
+		}
 		tag := field.Tag.Get("toml")
-		if tag == "" || tag == "-" {
+		if tag == "" {
+			panic(fmt.Sprintf("config flags: exported field %s.%s has no toml tag — go-toml would "+
+				"still accept it as a file key (matched by field name) but it would get no flag; "+
+				"tag it, or mark it `toml:\"-\"` to exclude it from the file schema", t.Name(), field.Name))
+		}
+		if tag == "-" {
 			continue
 		}
 		path := tag

--- a/cmd/stellar-rpc/internal/rpcv2/config/flags.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/flags.go
@@ -42,8 +42,6 @@ type FlagOverrides interface {
 	GetStringToString(name string) (map[string]string, error)
 }
 
-var _ FlagOverrides = (*pflag.FlagSet)(nil)
-
 // BindFlags registers one override flag per TOML leaf of Config on fs. Call it
 // once on the root command's flag set, before parsing.
 func BindFlags(fs *pflag.FlagSet) {
@@ -134,11 +132,9 @@ func setLeaf(f reflect.Value, path string, fs FlagOverrides) error {
 		if err != nil {
 			return fail(err)
 		}
-		// Merge per key instead of replacing the file's map: a map flag names
-		// individual entries (--backfill.datastore.params=region=x), and
-		// clobbering the sibling entries the file set is never what the
-		// operator meant. Like every other flag, a map flag can set values but
-		// never remove them.
+		// Merge per key, don't replace the map: a map flag names individual
+		// entries, and clobbering the file's sibling entries is never what the
+		// operator meant.
 		if f.IsNil() {
 			f.Set(reflect.MakeMap(f.Type()))
 		}
@@ -218,10 +214,8 @@ func leafKind(t reflect.Type) kind {
 //     untagged exported field PANICS at BindFlags time. go-toml matches
 //     untagged exported fields by NAME, so a forgotten tag would silently
 //     become a settable file key with no flag — the one way the file schema
-//     and the flag set could drift apart. (Config deliberately contains no
-//     SDK struct types for the same reason — it mirrors them as BSBConfig and
-//     DataStoreConfig, whose untagged SDK fields like NetworkPassphrase must
-//     not be file keys.)
+//     and the flag set could drift apart (see DataStoreConfig for the same
+//     concern with embedded SDK structs);
 //   - a tagged struct field recurses with its tag as a path segment;
 //   - a tagged leaf of an unsupported type PANICS at BindFlags time — adding a
 //     config field of a new type must extend leafKind, not silently lose its flag.
@@ -235,8 +229,8 @@ func walkLeaves(v reflect.Value, prefix string, visit func(path string, f reflec
 		tag := field.Tag.Get("toml")
 		if tag == "" {
 			panic(fmt.Sprintf("config flags: exported field %s.%s has no toml tag — go-toml would "+
-				"still accept it as a file key (matched by field name) but it would get no flag; "+
-				"tag it, or mark it `toml:\"-\"` to exclude it from the file schema", t.Name(), field.Name))
+				"accept it as a file key by field name, but it would get no flag; "+
+				"tag it, or mark it toml:\"-\"", t.Name(), field.Name))
 		}
 		if tag == "-" {
 			continue

--- a/cmd/stellar-rpc/internal/rpcv2/config/flags.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/flags.go
@@ -71,8 +71,11 @@ func BindFlags(fs *pflag.FlagSet) {
 }
 
 // ApplyFlags writes every flag the user actually set (fs.Changed) into cfg,
-// allocating pointer fields as needed. Run it AFTER DecodeConfig and BEFORE
-// WithDefaults so the overlay participates in defaulting at its own tier.
+// allocating pointer fields as needed. Map-valued flags merge into the file's
+// map key by key (a flag can set an entry, never delete one); slice-valued
+// flags replace the file's slice wholesale (a list has no per-element identity
+// to merge on). Run it AFTER DecodeConfig and BEFORE WithDefaults so the
+// overlay participates in defaulting at its own tier.
 func ApplyFlags(cfg *Config, fs FlagOverrides) error {
 	var firstErr error
 	walkLeaves(reflect.ValueOf(cfg).Elem(), "", func(path string, f reflect.Value) {
@@ -131,7 +134,17 @@ func setLeaf(f reflect.Value, path string, fs FlagOverrides) error {
 		if err != nil {
 			return fail(err)
 		}
-		setPossiblyPointer(f, reflect.ValueOf(v))
+		// Merge per key instead of replacing the file's map: a map flag names
+		// individual entries (--backfill.datastore.params=region=x), and
+		// clobbering the sibling entries the file set is never what the
+		// operator meant. Like every other flag, a map flag can set values but
+		// never remove them.
+		if f.IsNil() {
+			f.Set(reflect.MakeMap(f.Type()))
+		}
+		for k, val := range v {
+			f.SetMapIndex(reflect.ValueOf(k), reflect.ValueOf(val))
+		}
 	case kindUnsupported:
 		// unreachable: walkLeaves panics on an unsupported leaf before visiting
 	}

--- a/cmd/stellar-rpc/internal/rpcv2/config/flags_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/flags_test.go
@@ -114,6 +114,68 @@ func TestApplyFlags_OverridesFileValues(t *testing.T) {
 	assert.Equal(t, 7*time.Second, *cfg.Backfill.BSB.RetryWait)
 }
 
+func TestApplyFlags_MapFlagMergesPerKey(t *testing.T) {
+	fs := newBoundFlagSet(t)
+	require.NoError(t, fs.Parse([]string{"--backfill.datastore.params=region=us-west-1"}))
+
+	cfg, err := DecodeConfig([]byte(minimalValidConfig))
+	require.NoError(t, err)
+	require.NoError(t, ApplyFlags(&cfg, fs))
+
+	assert.Equal(t, "us-west-1", cfg.Backfill.DataStore.Params["region"])
+	assert.Equal(t, "bucket/path", cfg.Backfill.DataStore.Params["destination_bucket_path"],
+		"a one-key map flag must not clobber the file's other entries")
+}
+
+func TestApplyFlags_MapFlagOverwritesExistingKey(t *testing.T) {
+	fs := newBoundFlagSet(t)
+	require.NoError(t, fs.Parse([]string{"--backfill.datastore.params=destination_bucket_path=other/bucket"}))
+
+	cfg, err := DecodeConfig([]byte(minimalValidConfig))
+	require.NoError(t, err)
+	require.NoError(t, ApplyFlags(&cfg, fs))
+
+	assert.Equal(t, "other/bucket", cfg.Backfill.DataStore.Params["destination_bucket_path"])
+	assert.Len(t, cfg.Backfill.DataStore.Params, 1)
+}
+
+func TestApplyFlags_MapFlagAllocatesAbsentMap(t *testing.T) {
+	fs := newBoundFlagSet(t)
+	require.NoError(t, fs.Parse([]string{"--backfill.datastore.params=region=eu-west-1"}))
+
+	cfg, err := DecodeConfig([]byte(`
+[storage]
+default_data_dir = "/d"
+
+[ingestion]
+captive_core_config = "/cc"
+`))
+	require.NoError(t, err)
+	require.Nil(t, cfg.Backfill.DataStore.Params)
+	require.NoError(t, ApplyFlags(&cfg, fs))
+
+	assert.Equal(t, map[string]string{"region": "eu-west-1"}, cfg.Backfill.DataStore.Params)
+}
+
+func TestApplyFlags_SliceFlagReplacesWholesale(t *testing.T) {
+	fs := newBoundFlagSet(t)
+	require.NoError(t, fs.Parse([]string{"--ingestion.history_archive_urls=https://c.example"}))
+
+	cfg, err := DecodeConfig([]byte(`
+[storage]
+default_data_dir = "/d"
+
+[ingestion]
+captive_core_config = "/cc"
+history_archive_urls = ["https://a.example", "https://b.example"]
+`))
+	require.NoError(t, err)
+	require.NoError(t, ApplyFlags(&cfg, fs))
+
+	assert.Equal(t, []string{"https://c.example"}, cfg.Ingestion.HistoryArchiveURLs,
+		"a slice flag replaces the file's list; it does not append")
+}
+
 func TestApplyFlags_Precedence(t *testing.T) {
 	const fileWithTiers = `
 [storage]

--- a/cmd/stellar-rpc/internal/rpcv2/config/flags_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/flags_test.go
@@ -88,11 +88,9 @@ func TestApplyFlags_OverridesFileValues(t *testing.T) {
 	assert.Equal(t, uint32(33), *cfg.Service.FeeStats.ClassicFeeWindowLedgers)
 	assert.Equal(t, 3, *cfg.Backfill.Workers)
 	assert.Equal(t, []string{"https://a.example", "https://b.example"}, cfg.Ingestion.HistoryArchiveURLs)
-	assert.Equal(t, 7*time.Second, cfg.Backfill.BSB.RetryWait)
+	assert.Equal(t, 7*time.Second, *cfg.Backfill.BSB.RetryWait)
 }
 
-// The precedence examples from issue #882: specificity beats source; within a
-// tier, CLI beats file; compiled defaults are the last tier.
 func TestApplyFlags_Precedence(t *testing.T) {
 	const fileWithTiers = `
 [storage]

--- a/cmd/stellar-rpc/internal/rpcv2/config/flags_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/flags_test.go
@@ -57,6 +57,29 @@ func TestBindFlags_LockstepWithTOMLSchema(t *testing.T) {
 	}
 }
 
+func TestWalkLeaves_PanicsOnUntaggedExportedField(t *testing.T) {
+	type bad struct {
+		Tagged   string `toml:"tagged"`
+		Untagged string
+	}
+	assert.Panics(t, func() {
+		walkLeaves(reflect.ValueOf(&bad{}).Elem(), "", func(string, reflect.Value) {})
+	})
+}
+
+func TestWalkLeaves_SkipsUnexportedAndOptedOutFields(t *testing.T) {
+	type ok struct {
+		Tagged   string `toml:"tagged"`
+		Excluded string `toml:"-"`
+		hidden   string //nolint:unused // exists to prove unexported fields are skipped
+	}
+	var paths []string
+	walkLeaves(reflect.ValueOf(&ok{}).Elem(), "", func(path string, _ reflect.Value) {
+		paths = append(paths, path)
+	})
+	assert.Equal(t, []string{"tagged"}, paths)
+}
+
 func TestApplyFlags_NoFlagsSetIsANoOp(t *testing.T) {
 	fs := newBoundFlagSet(t)
 	cfg, err := DecodeConfig([]byte(minimalValidConfig))

--- a/cmd/stellar-rpc/internal/rpcv2/config/flags_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/flags_test.go
@@ -1,0 +1,158 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newBoundFlagSet(t *testing.T) *pflag.FlagSet {
+	t.Helper()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	BindFlags(fs)
+	return fs
+}
+
+func TestBindFlags_LockstepWithTOMLSchema(t *testing.T) {
+	fs := newBoundFlagSet(t)
+
+	// Every TOML leaf has a flag — walked from the same struct BindFlags walks,
+	// so this can only fail if BindFlags skipped a visit (or panicked on an
+	// unsupported type, which is its own guard).
+	count := 0
+	walkLeaves(reflect.ValueOf(&Config{}).Elem(), "", func(path string, _ reflect.Value) {
+		count++
+		assert.NotNil(t, fs.Lookup(path), "TOML leaf %s has no flag", path)
+	})
+	assert.Greater(t, count, 40, "the schema has dozens of leaves; a tiny count means the walk broke")
+
+	// Spot-check names across every section and nesting depth.
+	for _, name := range []string{
+		"storage.default_data_dir",
+		"storage.hot",
+		"retention.earliest_ledger",
+		"retention.retention_chunks",
+		"backfill.workers",
+		"backfill.datastore.type",
+		"backfill.datastore.params",
+		"backfill.datastore.schema.ledgers_per_file",
+		"backfill.bsb.retry_wait",
+		"ingestion.captive_core_config",
+		"ingestion.history_archive_urls",
+		"logging.level",
+		"service.endpoint",
+		"service.max_concurrent_requests",
+		"service.fee_stats.classic_fee_window_ledgers",
+		"service.methods.queue_limit",
+		"service.methods.getLedgers.queue_limit",
+		"service.methods.getLedgers.max_items_per_response",
+		"service.methods.getHealth.max_healthy_ledger_latency",
+		"service.methods.getFeeStats.max_execution_duration",
+	} {
+		assert.NotNil(t, fs.Lookup(name), "expected flag --%s", name)
+	}
+}
+
+func TestApplyFlags_NoFlagsSetIsANoOp(t *testing.T) {
+	fs := newBoundFlagSet(t)
+	cfg, err := DecodeConfig([]byte(minimalValidConfig))
+	require.NoError(t, err)
+	before := cfg
+
+	require.NoError(t, ApplyFlags(&cfg, fs))
+	assert.Equal(t, before, cfg)
+}
+
+func TestApplyFlags_OverridesFileValues(t *testing.T) {
+	fs := newBoundFlagSet(t)
+	require.NoError(t, fs.Parse([]string{
+		"--storage.default_data_dir=/flag/data",
+		"--service.endpoint=0.0.0.0:7777",
+		"--service.fee_stats.classic_fee_window_ledgers=33",
+		"--backfill.workers=3",
+		"--ingestion.history_archive_urls=https://a.example,https://b.example",
+		"--backfill.bsb.retry_wait=7s",
+	}))
+
+	cfg, err := DecodeConfig([]byte(minimalValidConfig))
+	require.NoError(t, err)
+	require.NoError(t, ApplyFlags(&cfg, fs))
+	cfg = cfg.WithDefaults()
+
+	assert.Equal(t, "/flag/data", cfg.Storage.DefaultDataDir)
+	assert.Equal(t, "0.0.0.0:7777", cfg.Service.Endpoint)
+	assert.Equal(t, uint32(33), *cfg.Service.FeeStats.ClassicFeeWindowLedgers)
+	assert.Equal(t, 3, *cfg.Backfill.Workers)
+	assert.Equal(t, []string{"https://a.example", "https://b.example"}, cfg.Ingestion.HistoryArchiveURLs)
+	assert.Equal(t, 7*time.Second, cfg.Backfill.BSB.RetryWait)
+}
+
+// The precedence examples from issue #882: specificity beats source; within a
+// tier, CLI beats file; compiled defaults are the last tier.
+func TestApplyFlags_Precedence(t *testing.T) {
+	const fileWithTiers = `
+[storage]
+default_data_dir = "/d"
+[service.methods]
+queue_limit = 10
+[service.methods.getLedgers]
+queue_limit = 5
+[ingestion]
+captive_core_config = "/cc"
+`
+
+	load := func(t *testing.T, text string, args ...string) Config {
+		t.Helper()
+		fs := newBoundFlagSet(t)
+		require.NoError(t, fs.Parse(args))
+		cfg, err := DecodeConfig([]byte(text))
+		require.NoError(t, err)
+		require.NoError(t, ApplyFlags(&cfg, fs))
+		return cfg.WithDefaults()
+	}
+
+	t.Run("example A: CLI raises the default tier; explicit per-method file value survives", func(t *testing.T) {
+		cfg := load(t, fileWithTiers, "--service.methods.queue_limit=30")
+		m := cfg.Service.Methods
+
+		assert.Equal(t, uint(5), *m.GetLedgers.QueueLimit, "tier 1 (file) beats a tier-2 CLI value")
+		assert.Equal(t, uint(30), *m.GetHealth.QueueLimit, "tier 2: CLI beats file's 10")
+		assert.Equal(t, uint(30), *m.GetFeeStats.QueueLimit, "tier 2 also beats getFeeStats' compiled 100")
+	})
+
+	t.Run("example B: CLI overrides one method only", func(t *testing.T) {
+		cfg := load(t, `
+[storage]
+default_data_dir = "/d"
+[service.methods.getLedgers]
+queue_limit = 5
+[ingestion]
+captive_core_config = "/cc"
+`, "--service.methods.getLedgers.queue_limit=50")
+		m := cfg.Service.Methods
+
+		assert.Equal(t, uint(50), *m.GetLedgers.QueueLimit, "tier 1: CLI beats file within the tier")
+		assert.Equal(t, DefaultMethodQueueLimit, *m.GetHealth.QueueLimit, "tier 3: compiled default")
+		assert.Equal(t, DefaultGetFeeStatsQueueLimit, *m.GetFeeStats.QueueLimit, "tier 3: compiled default")
+	})
+
+	t.Run("example D: durations cascade the same way", func(t *testing.T) {
+		cfg := load(t, `
+[storage]
+default_data_dir = "/d"
+[service.methods]
+max_execution_duration = "8s"
+[ingestion]
+captive_core_config = "/cc"
+`, "--service.methods.getEvents.max_execution_duration=20s")
+		m := cfg.Service.Methods
+
+		assert.Equal(t, 20*time.Second, *m.GetEvents.MaxExecutionDuration, "tier 1 (CLI)")
+		assert.Equal(t, 8*time.Second, *m.GetLedgers.MaxExecutionDuration, "tier 2 (file) beats compiled 10s")
+		assert.Equal(t, 8*time.Second, *m.GetHealth.MaxExecutionDuration, "tier 2 (file)")
+	})
+}

--- a/cmd/stellar-rpc/internal/rpcv2/config_validate.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config_validate.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"time"
 
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/limits"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/catalog"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/config"
@@ -46,6 +48,9 @@ func validateConfig(
 	if err := validateEarliestForm(cfg.Retention.EarliestLedger); err != nil {
 		return 0, err
 	}
+	if err := validateService(cfg.Service); err != nil {
+		return 0, err
+	}
 
 	earliestStored, earliestPinned, err := cat.EarliestLedger()
 	if err != nil {
@@ -69,6 +74,106 @@ func validateConfig(
 		return 0, fmt.Errorf("pin earliest ledger (earliest=%d): %w", earliest, err)
 	}
 	return earliest, nil
+}
+
+// minConfiguredDuration guards go-toml v1's nanosecond trap: a bare integer
+// duration decodes as NANOSECONDS (max_execution_duration = 10 → 10ns), so any
+// configured duration under 1ms is a near-certain typo for the string form
+// ("10s"). Zero is rejected by the same check — a zero execution budget or
+// warning threshold is never intended.
+const minConfiguredDuration = time.Millisecond
+
+// validateService form-validates the [service] section. It runs AFTER
+// WithDefaults, so every pointer is non-nil and the checks cover all three
+// tiers of the methods cascade (an explicit zero at any tier lands here).
+func validateService(svc config.ServiceConfig) error {
+	if *svc.MaxConcurrentRequests < 1 {
+		return errors.New("[service].max_concurrent_requests must be >= 1")
+	}
+	durations := []struct {
+		name string
+		d    time.Duration
+	}{
+		{"[service].max_request_execution_duration", *svc.MaxRequestExecutionDuration},
+		{"[service].request_execution_warning_threshold", *svc.RequestExecutionWarningThreshold},
+		{"[service.methods.getHealth].max_healthy_ledger_latency", *svc.Methods.GetHealth.MaxHealthyLedgerLatency},
+	}
+	m := svc.Methods
+	if m.QueueLimit != nil && *m.QueueLimit < 1 {
+		return errors.New("[service.methods].queue_limit must be >= 1")
+	}
+	if m.MaxExecutionDuration != nil {
+		durations = append(durations, struct {
+			name string
+			d    time.Duration
+		}{"[service.methods].max_execution_duration", *m.MaxExecutionDuration})
+	}
+
+	methods := []struct {
+		name  string
+		queue uint
+		dur   time.Duration
+	}{
+		{"getHealth", *m.GetHealth.QueueLimit, *m.GetHealth.MaxExecutionDuration},
+		{"getNetwork", *m.GetNetwork.QueueLimit, *m.GetNetwork.MaxExecutionDuration},
+		{"getVersionInfo", *m.GetVersionInfo.QueueLimit, *m.GetVersionInfo.MaxExecutionDuration},
+		{"getLatestLedger", *m.GetLatestLedger.QueueLimit, *m.GetLatestLedger.MaxExecutionDuration},
+		{"getTransaction", *m.GetTransaction.QueueLimit, *m.GetTransaction.MaxExecutionDuration},
+		{"getTransactions", *m.GetTransactions.QueueLimit, *m.GetTransactions.MaxExecutionDuration},
+		{"getLedgers", *m.GetLedgers.QueueLimit, *m.GetLedgers.MaxExecutionDuration},
+		{"getEvents", *m.GetEvents.QueueLimit, *m.GetEvents.MaxExecutionDuration},
+		{"getFeeStats", *m.GetFeeStats.QueueLimit, *m.GetFeeStats.MaxExecutionDuration},
+	}
+	for _, mm := range methods {
+		if mm.queue < 1 {
+			return fmt.Errorf("[service.methods.%s].queue_limit must be >= 1", mm.name)
+		}
+		durations = append(durations, struct {
+			name string
+			d    time.Duration
+		}{"[service.methods." + mm.name + "].max_execution_duration", mm.dur})
+	}
+	for _, dd := range durations {
+		if dd.d < minConfiguredDuration {
+			return fmt.Errorf("%s is %v — durations below 1ms are rejected; "+
+				"a bare TOML integer parses as nanoseconds, write a string like \"10s\"", dd.name, dd.d)
+		}
+	}
+
+	paginated := []struct {
+		name string
+		p    config.PaginatedMethodConfig
+	}{
+		{"getTransactions", m.GetTransactions},
+		{"getLedgers", m.GetLedgers},
+		{"getEvents", m.GetEvents},
+	}
+	for _, pp := range paginated {
+		if *pp.p.MaxItemsPerResponse < 1 {
+			return fmt.Errorf("[service.methods.%s].max_items_per_response must be >= 1", pp.name)
+		}
+		if *pp.p.DefaultItemsPerResponse > *pp.p.MaxItemsPerResponse {
+			return fmt.Errorf("[service.methods.%s].default_items_per_response (%d) cannot exceed max_items_per_response (%d)",
+				pp.name, *pp.p.DefaultItemsPerResponse, *pp.p.MaxItemsPerResponse)
+		}
+	}
+
+	feeWindows := []struct {
+		name string
+		v    uint32
+	}{
+		{"[service.fee_stats].classic_fee_window_ledgers", *svc.FeeStats.ClassicFeeWindowLedgers},
+		{"[service.fee_stats].soroban_inclusion_fee_window_ledgers", *svc.FeeStats.SorobanInclusionFeeWindowLedgers},
+	}
+	for _, fw := range feeWindows {
+		if fw.v < 1 {
+			return fmt.Errorf("%s must be >= 1", fw.name)
+		}
+		if err := limits.ValidateFeeStatsRetentionWindow(fw.name, fw.v); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // confirmEarliestUnchanged enforces earliest_ledger's restart immutability: genesis or

--- a/cmd/stellar-rpc/internal/rpcv2/config_validate.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config_validate.go
@@ -27,31 +27,11 @@ func validateConfig(
 		return 0, errors.New("validateConfig requires a non-nil Catalog")
 	}
 
-	workers := deref(cfg.Backfill.Workers)
-	maxRetries := deref(cfg.Backfill.MaxRetries)
-
-	// --- 1. Form validation. ---
-	if workers < 1 {
-		return 0, fmt.Errorf("workers must be >= 1 (got %d) — a zero pool deadlocks executePlan", workers)
-	}
-	if maxRetries < 0 {
-		return 0, fmt.Errorf("max_retries must be >= 0 (got %d) — 0 means run once, no retry", maxRetries)
-	}
-	if err := validateBSB(cfg.Backfill.BSB); err != nil {
-		return 0, err
-	}
-	// logging.format silently means text unless it is exactly "json", so reject any
-	// other value rather than let a typo drop the operator to text logging. Empty is
-	// the unset sentinel WithDefaults resolves to text, so it is not a typo.
-	if f := cfg.Logging.Format; f != "" && f != config.DefaultLogFormat && f != config.LogFormatJSON {
-		return 0, fmt.Errorf("logging.format must be %q or %q; got %q",
-			config.DefaultLogFormat, config.LogFormatJSON, f)
-	}
-	// Form-validate here so the numeric case avoids chunk.IDFromLedger's sub-genesis panic below.
-	if err := validateEarliestForm(cfg.Retention.EarliestLedger); err != nil {
-		return 0, err
-	}
-	if err := validateService(cfg.Service); err != nil {
+	// --- 1. Form validation. runDaemonWith already ran this right after config
+	// load (so a malformed config is rejected before the catalog, captive core,
+	// or datastore are touched); re-running here keeps validateConfig a complete
+	// gate for callers and tests that enter through it directly. ---
+	if err := validateForm(cfg); err != nil {
 		return 0, err
 	}
 
@@ -79,6 +59,35 @@ func validateConfig(
 	return earliest, nil
 }
 
+// validateForm runs every check that needs only the parsed config — no catalog,
+// no backend, no filesystem. It runs AFTER WithDefaults (pointers non-nil) and
+// BEFORE the daemon opens anything, so a malformed config is rejected without
+// side effects.
+func validateForm(cfg config.Config) error {
+	if workers := deref(cfg.Backfill.Workers); workers < 1 {
+		return fmt.Errorf("workers must be >= 1 (got %d) — a zero pool deadlocks executePlan", workers)
+	}
+	if maxRetries := deref(cfg.Backfill.MaxRetries); maxRetries < 0 {
+		return fmt.Errorf("max_retries must be >= 0 (got %d) — 0 means run once, no retry", maxRetries)
+	}
+	if err := validateBSB(cfg.Backfill.BSB); err != nil {
+		return err
+	}
+	// logging.format silently means text unless it is exactly "json", so reject any
+	// other value rather than let a typo drop the operator to text logging. Empty is
+	// the unset sentinel WithDefaults resolves to text, so it is not a typo.
+	if f := cfg.Logging.Format; f != "" && f != config.DefaultLogFormat && f != config.LogFormatJSON {
+		return fmt.Errorf("logging.format must be %q or %q; got %q",
+			config.DefaultLogFormat, config.LogFormatJSON, f)
+	}
+	// Form-validate here so validateConfig's numeric path can't hit
+	// chunk.IDFromLedger's sub-genesis panic.
+	if err := validateEarliestForm(cfg.Retention.EarliestLedger); err != nil {
+		return err
+	}
+	return validateService(cfg.Service)
+}
+
 // minConfiguredDuration guards go-toml v1's nanosecond trap: a bare integer
 // duration decodes as NANOSECONDS (max_execution_duration = 10 → 10ns), so any
 // configured duration under 1ms is a near-certain typo for the string form
@@ -95,6 +104,10 @@ func validateBSB(bsb config.BSBConfig) error {
 	}
 	if *bsb.NumWorkers < 1 {
 		return errors.New("[backfill.bsb].num_workers must be >= 1")
+	}
+	if *bsb.NumWorkers > *bsb.BufferSize {
+		return fmt.Errorf("[backfill.bsb].num_workers (%d) cannot exceed buffer_size (%d) — "+
+			"each worker needs a buffer slot to download into", *bsb.NumWorkers, *bsb.BufferSize)
 	}
 	if *bsb.RetryWait < minConfiguredDuration {
 		return fmt.Errorf("[backfill.bsb].retry_wait is %v — durations below 1ms are rejected; "+
@@ -160,6 +173,13 @@ func validateService(svc config.ServiceConfig) error {
 		}
 	}
 
+	if err := validatePaginatedMethods(m); err != nil {
+		return err
+	}
+	return validateFeeWindows(svc.FeeStats)
+}
+
+func validatePaginatedMethods(m config.MethodsConfig) error {
 	paginated := []struct {
 		name string
 		p    config.PaginatedMethodConfig
@@ -172,18 +192,24 @@ func validateService(svc config.ServiceConfig) error {
 		if *pp.p.MaxItemsPerResponse < 1 {
 			return fmt.Errorf("[service.methods.%s].max_items_per_response must be >= 1", pp.name)
 		}
+		if *pp.p.DefaultItemsPerResponse < 1 {
+			return fmt.Errorf("[service.methods.%s].default_items_per_response must be >= 1", pp.name)
+		}
 		if *pp.p.DefaultItemsPerResponse > *pp.p.MaxItemsPerResponse {
 			return fmt.Errorf("[service.methods.%s].default_items_per_response (%d) cannot exceed max_items_per_response (%d)",
 				pp.name, *pp.p.DefaultItemsPerResponse, *pp.p.MaxItemsPerResponse)
 		}
 	}
+	return nil
+}
 
+func validateFeeWindows(fs config.FeeStatsConfig) error {
 	feeWindows := []struct {
 		name string
 		v    uint32
 	}{
-		{"[service.fee_stats].classic_fee_window_ledgers", *svc.FeeStats.ClassicFeeWindowLedgers},
-		{"[service.fee_stats].soroban_inclusion_fee_window_ledgers", *svc.FeeStats.SorobanInclusionFeeWindowLedgers},
+		{"[service.fee_stats].classic_fee_window_ledgers", *fs.ClassicFeeWindowLedgers},
+		{"[service.fee_stats].soroban_inclusion_fee_window_ledgers", *fs.SorobanInclusionFeeWindowLedgers},
 	}
 	for _, fw := range feeWindows {
 		if fw.v < 1 {

--- a/cmd/stellar-rpc/internal/rpcv2/config_validate.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config_validate.go
@@ -27,10 +27,8 @@ func validateConfig(
 		return 0, errors.New("validateConfig requires a non-nil Catalog")
 	}
 
-	// --- 1. Form validation. runDaemonWith already ran this right after config
-	// load (so a malformed config is rejected before the catalog, captive core,
-	// or datastore are touched); re-running here keeps validateConfig a complete
-	// gate for callers and tests that enter through it directly. ---
+	// --- 1. Form validation (runDaemonWith already ran this right after config
+	// load; re-run so validateConfig stays a complete gate on its own). ---
 	if err := validateForm(cfg); err != nil {
 		return 0, err
 	}

--- a/cmd/stellar-rpc/internal/rpcv2/config_validate.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config_validate.go
@@ -37,6 +37,9 @@ func validateConfig(
 	if maxRetries < 0 {
 		return 0, fmt.Errorf("max_retries must be >= 0 (got %d) — 0 means run once, no retry", maxRetries)
 	}
+	if err := validateBSB(cfg.Backfill.BSB); err != nil {
+		return 0, err
+	}
 	// logging.format silently means text unless it is exactly "json", so reject any
 	// other value rather than let a typo drop the operator to text logging. Empty is
 	// the unset sentinel WithDefaults resolves to text, so it is not a typo.
@@ -82,6 +85,23 @@ func validateConfig(
 // ("10s"). Zero is rejected by the same check — a zero execution budget or
 // warning threshold is never intended.
 const minConfiguredDuration = time.Millisecond
+
+// validateBSB form-validates [backfill.bsb]. It runs AFTER WithDefaults, so
+// every pointer is non-nil. max_retries needs no check — any uint32 is valid,
+// including 0 (no retries).
+func validateBSB(bsb config.BSBConfig) error {
+	if *bsb.BufferSize < 1 {
+		return errors.New("[backfill.bsb].buffer_size must be >= 1")
+	}
+	if *bsb.NumWorkers < 1 {
+		return errors.New("[backfill.bsb].num_workers must be >= 1")
+	}
+	if *bsb.RetryWait < minConfiguredDuration {
+		return fmt.Errorf("[backfill.bsb].retry_wait is %v — durations below 1ms are rejected; "+
+			"a bare TOML integer parses as nanoseconds, write a string like \"5s\"", *bsb.RetryWait)
+	}
+	return nil
+}
 
 // validateService form-validates the [service] section. It runs AFTER
 // WithDefaults, so every pointer is non-nil and the checks cover all three

--- a/cmd/stellar-rpc/internal/rpcv2/config_validate_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config_validate_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,13 +15,15 @@ import (
 )
 
 // validCfg builds a valid Config; callers mutate one field to drive a rejection.
+// Defaults are applied, matching production (validateConfig's contract is a
+// post-WithDefaults config — every [service] pointer non-nil).
 func validCfg(workers, maxRetries int, earliest string) config.Config {
 	return config.Config{
-		Service:   config.ServiceConfig{DefaultDataDir: "/data"},
+		Storage:   config.StorageConfig{DefaultDataDir: "/data"},
 		Retention: config.RetentionConfig{EarliestLedger: earliest},
 		Backfill:  config.BackfillConfig{Workers: &workers, MaxRetries: &maxRetries},
 		Ingestion: config.IngestionConfig{CaptiveCoreConfig: "/cc"},
-	}
+	}.WithDefaults()
 }
 
 // readyTip returns a tip backend that always reports the given ledger.
@@ -123,6 +126,73 @@ func TestValidateConfig_RejectsMalformed(t *testing.T) {
 			// A rejected config pins nothing.
 			_, ok, _ := cat.EarliestLedger()
 			assert.False(t, ok, "no earliest pin on a rejected config")
+		})
+	}
+}
+
+func TestValidateConfig_RejectsMalformedService(t *testing.T) {
+	uintPtr := func(v uint) *uint { return &v }
+	uint32Ptr := func(v uint32) *uint32 { return &v }
+	durPtr := func(v time.Duration) *time.Duration { return &v }
+
+	tests := []struct {
+		name   string
+		mutate func(*config.Config)
+		want   string
+	}{
+		{
+			"zero max_concurrent_requests",
+			func(c *config.Config) { c.Service.MaxConcurrentRequests = uintPtr(0) },
+			"max_concurrent_requests",
+		},
+		{
+			"zero per-method queue_limit",
+			func(c *config.Config) { c.Service.Methods.GetLedgers.QueueLimit = uintPtr(0) },
+			"[service.methods.getLedgers].queue_limit",
+		},
+		{
+			"zero wide-tier queue_limit",
+			func(c *config.Config) { c.Service.Methods.QueueLimit = uintPtr(0) },
+			"queue_limit",
+		},
+		{
+			// The nanosecond trap: a bare TOML integer 10 decodes as 10ns.
+			"sub-millisecond duration",
+			func(c *config.Config) { c.Service.Methods.GetEvents.MaxExecutionDuration = durPtr(10) },
+			"nanoseconds",
+		},
+		{
+			"zero global execution duration",
+			func(c *config.Config) { c.Service.MaxRequestExecutionDuration = durPtr(0) },
+			"max_request_execution_duration",
+		},
+		{
+			"default items above max",
+			func(c *config.Config) {
+				c.Service.Methods.GetLedgers.MaxItemsPerResponse = uintPtr(10)
+				c.Service.Methods.GetLedgers.DefaultItemsPerResponse = uintPtr(11)
+			},
+			"default_items_per_response",
+		},
+		{
+			"fee window above the cap",
+			func(c *config.Config) { c.Service.FeeStats.ClassicFeeWindowLedgers = uint32Ptr(1001) },
+			"classic_fee_window_ledgers",
+		},
+		{
+			"zero fee window",
+			func(c *config.Config) { c.Service.FeeStats.SorobanInclusionFeeWindowLedgers = uint32Ptr(0) },
+			"soroban_inclusion_fee_window_ledgers",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cat, _ := testCatalog(t)
+			cfg := validCfg(4, 3, "genesis")
+			tc.mutate(&cfg)
+			_, err := callValidate(t, cfg, cat, downTip())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
 		})
 	}
 }

--- a/cmd/stellar-rpc/internal/rpcv2/config_validate_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config_validate_test.go
@@ -175,6 +175,11 @@ func TestValidateConfig_RejectsMalformedService(t *testing.T) {
 			"default_items_per_response",
 		},
 		{
+			"zero default items",
+			func(c *config.Config) { c.Service.Methods.GetEvents.DefaultItemsPerResponse = uintPtr(0) },
+			"default_items_per_response",
+		},
+		{
 			"fee window above the cap",
 			func(c *config.Config) { c.Service.FeeStats.ClassicFeeWindowLedgers = uint32Ptr(1001) },
 			"classic_fee_window_ledgers",
@@ -221,6 +226,14 @@ func TestValidateConfig_RejectsMalformedBSB(t *testing.T) {
 			"sub-millisecond retry_wait",
 			func(c *config.Config) { c.Backfill.BSB.RetryWait = durPtr(10) },
 			"nanoseconds",
+		},
+		{
+			"num_workers above buffer_size",
+			func(c *config.Config) {
+				c.Backfill.BSB.BufferSize = uint32Ptr(10)
+				c.Backfill.BSB.NumWorkers = uint32Ptr(50)
+			},
+			"num_workers",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/stellar-rpc/internal/rpcv2/config_validate_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config_validate_test.go
@@ -197,6 +197,53 @@ func TestValidateConfig_RejectsMalformedService(t *testing.T) {
 	}
 }
 
+func TestValidateConfig_RejectsMalformedBSB(t *testing.T) {
+	uint32Ptr := func(v uint32) *uint32 { return &v }
+	durPtr := func(v time.Duration) *time.Duration { return &v }
+
+	tests := []struct {
+		name   string
+		mutate func(*config.Config)
+		want   string
+	}{
+		{
+			"zero buffer_size",
+			func(c *config.Config) { c.Backfill.BSB.BufferSize = uint32Ptr(0) },
+			"[backfill.bsb].buffer_size",
+		},
+		{
+			"zero num_workers",
+			func(c *config.Config) { c.Backfill.BSB.NumWorkers = uint32Ptr(0) },
+			"[backfill.bsb].num_workers",
+		},
+		{
+			// The nanosecond trap again: retry_wait = 10 decodes as 10ns.
+			"sub-millisecond retry_wait",
+			func(c *config.Config) { c.Backfill.BSB.RetryWait = durPtr(10) },
+			"nanoseconds",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cat, _ := testCatalog(t)
+			cfg := validCfg(4, 3, "genesis")
+			tc.mutate(&cfg)
+			_, err := callValidate(t, cfg, cat, downTip())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+func TestValidateConfig_AcceptsZeroBSBMaxRetries(t *testing.T) {
+	uint32Ptr := func(v uint32) *uint32 { return &v }
+	cat, _ := testCatalog(t)
+	cfg := validCfg(4, 3, "genesis")
+	cfg.Backfill.BSB.MaxRetries = uint32Ptr(0)
+	_, err := callValidate(t, cfg, cat, downTip())
+	require.NoError(t, err)
+}
+
 // ---------------------------------------------------------------------------
 // First start pins earliest_ledger.
 // ---------------------------------------------------------------------------

--- a/cmd/stellar-rpc/internal/rpcv2/daemon.go
+++ b/cmd/stellar-rpc/internal/rpcv2/daemon.go
@@ -30,9 +30,11 @@ import (
 
 // RunDaemon is the full-history daemon's process entrypoint: load config, lock
 // storage roots, open the catalog, validateConfig, build boundaries, then run
-// the supervised run loop.
-func RunDaemon(ctx context.Context, configPath string) error {
-	return runDaemonWith(ctx, configPath, daemonOptions{})
+// the supervised run loop. flags carries the CLI overrides main registered via
+// config.BindFlags (nil = none); each set flag overlays its TOML key before
+// defaults resolve.
+func RunDaemon(ctx context.Context, configPath string, flags config.FlagOverrides) error {
+	return runDaemonWith(ctx, configPath, daemonOptions{Flags: flags})
 }
 
 // daemonOptions carries the daemon's injectable seams; production leaves every field zero.
@@ -64,6 +66,9 @@ type daemonOptions struct {
 	// IngestSink is the per-type cold-path ingest sink; nil ⇒ a *ingest.PrometheusSink.
 	IngestSink ingest.MetricSink
 
+	// Flags carries the CLI overrides registered by config.BindFlags; nil = none.
+	Flags config.FlagOverrides
+
 	// chunksPerTxhashIndex overrides the tx-hash index width (test-only). 0 ⇒ the
 	// fixed geometry.ChunksPerTxhashIndex. Tests set it to 1 so a single chunk's
 	// freeze is a terminal index (exercising the index rebuild + prune path cheaply).
@@ -77,12 +82,12 @@ const defaultRestartBackoff = 5 * time.Second
 //nolint:cyclop,funlen // linear startup sequence; each branch is one wiring step
 func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) error {
 	// --- Load + form-validate the config. ---
-	cfg, err := config.LoadConfig(configPath)
+	cfg, err := config.LoadConfigWithFlags(configPath, opts.Flags)
 	if err != nil {
 		return err
 	}
-	if cfg.Service.DefaultDataDir == "" {
-		return errors.New("[service].default_data_dir is required")
+	if cfg.Storage.DefaultDataDir == "" {
+		return errors.New("[storage].default_data_dir is required")
 	}
 
 	logger := opts.Logger
@@ -216,7 +221,7 @@ func resolveCore(opts daemonOptions, cfg config.Config, logger *supportlog.Entry
 	if opts.Core != nil {
 		return opts.Core, nil
 	}
-	built, err := newCaptiveCoreOpener(cfg.Ingestion, cfg.Service.DefaultDataDir, logger)
+	built, err := newCaptiveCoreOpener(cfg.Ingestion, cfg.Storage.DefaultDataDir, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/stellar-rpc/internal/rpcv2/daemon.go
+++ b/cmd/stellar-rpc/internal/rpcv2/daemon.go
@@ -126,7 +126,7 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	// ingestion loop, and the no-lake backfill source is built from its stream. A
 	// bad [ingestion] config therefore surfaces before validateConfig's errors —
 	// cosmetic, both are fatal startup errors. ---
-	core, err := resolveCore(opts, cfg, logger)
+	core, networkPassphrase, err := resolveCore(opts, cfg, logger)
 	if err != nil {
 		return err
 	}
@@ -148,7 +148,7 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	// (which needs the tip) runs after this. ---
 	backend := opts.Backend
 	if backend == nil {
-		built, cleanup, berr := buildBackfillBackend(ctx, cfg, core, pool, logger)
+		built, cleanup, berr := buildBackfillBackend(ctx, cfg, core, pool, networkPassphrase, logger)
 		if berr != nil {
 			return fmt.Errorf("build backfill backend: %w", berr)
 		}
@@ -216,16 +216,18 @@ func openCatalog(paths config.Paths, opts daemonOptions, logger *supportlog.Entr
 }
 
 // resolveCore returns the injected CoreOpener (tests) or a production captive-core
-// opener built from [ingestion].
-func resolveCore(opts daemonOptions, cfg config.Config, logger *supportlog.Entry) (CoreOpener, error) {
+// opener built from [ingestion], plus the NETWORK_PASSPHRASE read back from the
+// captive-core file. An injected opener carries no passphrase — the empty string
+// means "unknown", which skips the datastore's wrong-network check.
+func resolveCore(opts daemonOptions, cfg config.Config, logger *supportlog.Entry) (CoreOpener, string, error) {
 	if opts.Core != nil {
-		return opts.Core, nil
+		return opts.Core, "", nil
 	}
 	built, err := newCaptiveCoreOpener(cfg.Ingestion, cfg.Storage.DefaultDataDir, logger)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	return built, nil
+	return built, built.config.NetworkPassphrase, nil
 }
 
 // startConfig assembles the StartConfig run consumes. run() builds the
@@ -322,11 +324,18 @@ func sleepCtx(ctx context.Context, d time.Duration) error {
 // pinnable (#833). With neither it returns (nil, nil, nil) and runDaemonWith fails
 // startup with the config-shaped message. core must be non-nil (runDaemonWith
 // resolves the opener first).
+//
+// networkPassphrase is the one read back from the captive-core file; it is
+// copied into the SDK datastore config so a lake whose manifest names a
+// DIFFERENT network is rejected at startup (NewBSBBackendFromConfig's manifest
+// check). Empty means unknown and skips the check.
 func buildBackfillBackend(
-	ctx context.Context, cfg config.Config, core CoreOpener, pool rootHASGetter, logger *supportlog.Entry,
+	ctx context.Context, cfg config.Config, core CoreOpener, pool rootHASGetter,
+	networkPassphrase string, logger *supportlog.Entry,
 ) (backfill.Backend, func(), error) {
 	if cfg.Backfill.DataStore.Type != "" {
-		backend, cleanup, err := backfill.NewBSBBackendFromConfig(ctx, cfg.Backfill.DataStore, cfg.Backfill.BSB)
+		dsCfg := cfg.Backfill.DataStore.SDKConfig(networkPassphrase)
+		backend, cleanup, err := backfill.NewBSBBackendFromConfig(ctx, dsCfg, cfg.Backfill.BSB.SDKConfig())
 		if err != nil {
 			return nil, nil, err
 		}

--- a/cmd/stellar-rpc/internal/rpcv2/daemon.go
+++ b/cmd/stellar-rpc/internal/rpcv2/daemon.go
@@ -89,6 +89,13 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	if cfg.Storage.DefaultDataDir == "" {
 		return errors.New("[storage].default_data_dir is required")
 	}
+	// Reject a malformed config NOW, before anything is opened — no catalog, no
+	// stellar-core lookup, no datastore client or remote reads for a config that
+	// was never going to run. validateConfig re-runs these form checks as part
+	// of its gate, which is harmless (they are pure).
+	if err := validateForm(cfg); err != nil {
+		return err
+	}
 
 	logger := opts.Logger
 	if logger == nil {

--- a/cmd/stellar-rpc/internal/rpcv2/daemon.go
+++ b/cmd/stellar-rpc/internal/rpcv2/daemon.go
@@ -89,10 +89,8 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	if cfg.Storage.DefaultDataDir == "" {
 		return errors.New("[storage].default_data_dir is required")
 	}
-	// Reject a malformed config NOW, before anything is opened — no catalog, no
-	// stellar-core lookup, no datastore client or remote reads for a config that
-	// was never going to run. validateConfig re-runs these form checks as part
-	// of its gate, which is harmless (they are pure).
+	// Reject a malformed config before anything is opened (catalog, core,
+	// datastore). validateConfig re-runs these pure checks as part of its gate.
 	if err := validateForm(cfg); err != nil {
 		return err
 	}

--- a/cmd/stellar-rpc/internal/rpcv2/daemon_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/daemon_test.go
@@ -48,7 +48,7 @@ func writeTempConfig(t *testing.T, extra string) (string, string) {
 	dataDir := t.TempDir()
 	configPath := filepath.Join(t.TempDir(), "daemon.toml")
 	body := fmt.Sprintf(`
-[service]
+[storage]
 default_data_dir = %q
 
 [retention]
@@ -280,14 +280,14 @@ func TestRunDaemon_StoragePathOverridesHonored(t *testing.T) {
 	catalogOverride := filepath.Join(overrideRoot, "meta")
 
 	cfg := config.Config{
-		Service: config.ServiceConfig{DefaultDataDir: dataDir},
 		Storage: config.StorageConfig{
-			Catalog:     catalogOverride,
-			Ledgers:     ledgersOverride,
-			Events:      eventsOverride,
-			TxhashRaw:   txhashRawOverride,
-			TxhashIndex: txhashIndexOverride,
-			Hot:         hotOverride,
+			DefaultDataDir: dataDir,
+			Catalog:        catalogOverride,
+			Ledgers:        ledgersOverride,
+			Events:         eventsOverride,
+			TxhashRaw:      txhashRawOverride,
+			TxhashIndex:    txhashIndexOverride,
+			Hot:            hotOverride,
 		},
 	}.WithDefaults()
 
@@ -367,7 +367,7 @@ func writeTempConfigNow(t *testing.T) (string, string) {
 	dataDir := t.TempDir()
 	configPath := filepath.Join(t.TempDir(), "daemon.toml")
 	body := fmt.Sprintf(`
-[service]
+[storage]
 default_data_dir = %q
 [retention]
 earliest_ledger = "now"
@@ -602,7 +602,7 @@ func TestRunDaemon_NoLakeBackfillsThroughCaptiveCore(t *testing.T) {
 	dataDir := t.TempDir()
 	configPath := filepath.Join(t.TempDir(), "daemon.toml")
 	body := fmt.Sprintf(`
-[service]
+[storage]
 default_data_dir = %q
 
 [retention]

--- a/cmd/stellar-rpc/internal/rpcv2/daemon_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/daemon_test.go
@@ -475,7 +475,7 @@ func TestSupervise_FirstStartNoTipRetries(t *testing.T) {
 // returns no backend (runDaemonWith then fails startup).
 func TestBuildBackfillBackend_NoSourcesNoBackend(t *testing.T) {
 	cfg := config.Config{}.WithDefaults()
-	backend, cleanup, err := buildBackfillBackend(context.Background(), cfg, &fakeCore{}, nil, silentLogger())
+	backend, cleanup, err := buildBackfillBackend(context.Background(), cfg, &fakeCore{}, nil, "", silentLogger())
 	require.NoError(t, err)
 	require.Nil(t, backend, "no datastore and no archives ⇒ no bulk source")
 	require.Nil(t, cleanup, "nothing to release when no backend was opened")
@@ -501,7 +501,7 @@ func TestBuildBackfillBackend_NoLakeBuildsCaptiveSource(t *testing.T) {
 	cfg := config.Config{}.WithDefaults()
 	core := &fakeCore{}
 	backend, cleanup, err := buildBackfillBackend(
-		context.Background(), cfg, core, fakeRootHAS{current: 70_000}, silentLogger())
+		context.Background(), cfg, core, fakeRootHAS{current: 70_000}, "", silentLogger())
 	require.NoError(t, err)
 	require.Nil(t, cleanup, "no datastore handle to release")
 	require.IsType(t, &captiveSource{}, backend)

--- a/cmd/stellar-rpc/internal/rpcv2/e2e_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/e2e_test.go
@@ -185,7 +185,7 @@ func e2eConfigPath(t *testing.T, dataDir string, retentionChunks uint32) string 
 	t.Helper()
 	cfgPath := filepath.Join(t.TempDir(), "daemon.toml")
 	body := fmt.Sprintf(`
-[service]
+[storage]
 default_data_dir = %q
 
 [retention]
@@ -504,7 +504,7 @@ func TestE2E_DaemonLifecycle_FirstStartIngestFreezeLookupRestartPrune(t *testing
 // MUST be closed via the returned close func before the next daemon run).
 func e2eReadCatalog(t *testing.T, dataDir string) (*catalog.Catalog, func()) {
 	t.Helper()
-	paths := config.Config{Service: config.ServiceConfig{DefaultDataDir: dataDir}}.WithDefaults().ResolvePaths()
+	paths := config.Config{Storage: config.StorageConfig{DefaultDataDir: dataDir}}.WithDefaults().ResolvePaths()
 	windows, err := geometry.NewTxHashIndexLayout(1) // matches chunksPerTxhashIndex = 1
 	require.NoError(t, err)
 	cat, err := catalog.Open(paths.Catalog, config.NewLayoutFromPaths(paths), windows, silentLogger())

--- a/cmd/stellar-rpc/rpcv2/main.go
+++ b/cmd/stellar-rpc/rpcv2/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/bench"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/config"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/version"
 )
 
@@ -19,11 +20,11 @@ func main() {
 	rootCmd := &cobra.Command{
 		Use:   "stellar-rpc-v2",
 		Short: "Run the full-history streaming ingestion daemon",
-		Run: func(_ *cobra.Command, _ []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			// Cancel the supervised run loop on SIGINT/SIGTERM for a clean shutdown.
 			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 			defer stop()
-			if err := rpcv2.RunDaemon(ctx, configPath); err != nil {
+			if err := rpcv2.RunDaemon(ctx, configPath, cmd.Flags()); err != nil {
 				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
 			}
@@ -31,6 +32,10 @@ func main() {
 	}
 	rootCmd.Flags().StringVar(&configPath, "config", "",
 		"path to the full-history streaming daemon TOML config")
+	// Every TOML key is also a flag named by its dotted path
+	// (--storage.default_data_dir, --service.methods.getLedgers.queue_limit);
+	// set flags override the file.
+	config.BindFlags(rootCmd.Flags())
 	if err := rootCmd.MarkFlagRequired("config"); err != nil {
 		fmt.Fprintf(os.Stderr, "could not configure root command: %v\n", err)
 		os.Exit(1)

--- a/cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml
+++ b/cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml
@@ -63,9 +63,10 @@ retention_chunks = 0
 # -----------------------------------------------------------------------------
 # [service] — the JSON-RPC read-serving policy (issue #882)
 # -----------------------------------------------------------------------------
-# Dormant until the v2 read server exists, EXCEPT [service.fee_stats], which
-# live ingestion consumes today (issue #881). Naming rule: camelCase table
-# keys only where the key IS a JSON-RPC method name; snake_case elsewhere.
+# Dormant today: the v2 read server does not exist yet, and live ingestion
+# starts consuming [service.fee_stats] when issue #881 lands. Naming rule:
+# camelCase table keys only where the key IS a JSON-RPC method name;
+# snake_case elsewhere.
 [service]
 
 # Address the JSON-RPC server listens on.
@@ -83,7 +84,7 @@ max_concurrent_requests = 5000
 max_request_execution_duration = "25s"    # global 504 timeout
 request_execution_warning_threshold = "5s" # slower requests log a warning
 
-# --- Fee statistics windows (consumed by live ingestion, issue #881) --------
+# --- Fee statistics windows (to be consumed by live ingestion — issue #881) --
 # Sizes, in LEDGERS, of the two in-memory windows behind getFeeStats. They
 # live here — not under getFeeStats — because they size ingestion-time
 # memory, not request handling. Both must be 1..1000; larger windows slow

--- a/cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml
+++ b/cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml
@@ -17,6 +17,10 @@
 #     source, so --service.methods.queue_limit=30 (the methods-wide default)
 #     never overrides an explicit [service.methods.getLedgers] value from this
 #     file. There are no environment variables.
+#   * Map-valued keys ([backfill.datastore.params]) merge from the command
+#     line PER ENTRY: --backfill.datastore.params=region=x sets that one entry
+#     and keeps the file's others. List-valued keys (history_archive_urls) are
+#     replaced wholesale.
 #   * Durations are strings like "10s", "500ms", "1m30s". Do NOT write bare
 #     integers — TOML integers decode as NANOSECONDS and any duration under
 #     1ms is rejected at startup.

--- a/cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml
+++ b/cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml
@@ -1,0 +1,238 @@
+# =============================================================================
+# stellar-rpc-v2 sample configuration
+# =============================================================================
+#
+# Usage:
+#   stellar-rpc-v2 --config /etc/stellar/rpc-v2.toml
+#
+# Rules this file lives by (they differ from v1 — see issue #882):
+#
+#   * Parsing is ALWAYS STRICT: any unknown or misspelled key is a hard
+#     startup error, never silently ignored.
+#   * Every key below is also settable from the command line as a flag named
+#     by its dotted TOML path, e.g.
+#         --storage.default_data_dir=/var/stellar
+#         --service.methods.getLedgers.queue_limit=500
+#     A set flag overrides the file AT THE SAME SPECIFICITY: specificity beats
+#     source, so --service.methods.queue_limit=30 (the methods-wide default)
+#     never overrides an explicit [service.methods.getLedgers] value from this
+#     file. There are no environment variables.
+#   * Durations are strings like "10s", "500ms", "1m30s". Do NOT write bare
+#     integers — TOML integers decode as NANOSECONDS and any duration under
+#     1ms is rejected at startup.
+#   * Every key is optional unless marked required; absent keys take the
+#     defaults shown.
+
+# -----------------------------------------------------------------------------
+# [storage] — where the daemon's data lives
+# -----------------------------------------------------------------------------
+[storage]
+
+# REQUIRED. The data root: the catalog and every store below defaults to a
+# tree under this directory. Also the base for captive core's scratch dir.
+default_data_dir = "/var/stellar/rpc-v2"
+
+# Optional per-store overrides, for splitting trees across disks (e.g. the hot
+# RocksDB on fast local NVMe, cold packs on bulk storage). An empty/absent key
+# derives the path under default_data_dir (shown in the trailing comments).
+# Any two overrides resolving to the same tree are rejected at startup.
+#catalog = ""        # {default_data_dir}/catalog/rocksdb — the catalog RocksDB
+#ledgers = ""        # {default_data_dir}/ledgers         — immutable ledger .pack files
+#events = ""         # {default_data_dir}/events          — immutable events segments
+#txhash_raw = ""     # {default_data_dir}/txhash/raw      — transient txhash .bin files
+#txhash_index = ""   # {default_data_dir}/txhash/index    — frozen per-window .idx files
+#hot = ""            # {default_data_dir}/hot             — per-chunk hot RocksDB databases
+
+# -----------------------------------------------------------------------------
+# [retention] — how much history this daemon keeps
+# -----------------------------------------------------------------------------
+[retention]
+
+# The earliest ledger this daemon will EVER have data for. One of:
+#   "genesis"  — full history from the network's first ledger (the default)
+#   "now"      — start from the chunk containing the network tip at first boot
+#   <number>   — a chunk-aligned ledger sequence (e.g. 50002)
+# PINNED: written immutably on first start and checked on every restart —
+# changing it once data exists aborts startup (wipe the data dir to change it).
+earliest_ledger = "genesis"
+
+# Sliding retention window in CHUNKS (10,000 ledgers each); 0 = keep
+# everything (full history, the default).
+retention_chunks = 0
+
+# -----------------------------------------------------------------------------
+# [service] — the JSON-RPC read-serving policy (issue #882)
+# -----------------------------------------------------------------------------
+# Dormant until the v2 read server exists, EXCEPT [service.fee_stats], which
+# live ingestion consumes today (issue #881). Naming rule: camelCase table
+# keys only where the key IS a JSON-RPC method name; snake_case elsewhere.
+[service]
+
+# Address the JSON-RPC server listens on.
+endpoint = "localhost:8000"
+
+# Admin endpoint (pprof, Prometheus metrics) over plaintext HTTP. "" (the
+# default) disables it. Never expose this to the internet.
+admin_endpoint = ""
+
+# The three keys below are the HTTP-LAYER GATE wrapped around the whole
+# server, exactly as in v1. They always act, on every request, IN ADDITION to
+# the per-method limits: max_concurrent_requests bounds the SUM of in-flight
+# requests across all methods, which no per-method limit can.
+max_concurrent_requests = 5000
+max_request_execution_duration = "25s"    # global 504 timeout
+request_execution_warning_threshold = "5s" # slower requests log a warning
+
+# --- Fee statistics windows (consumed by live ingestion, issue #881) --------
+# Sizes, in LEDGERS, of the two in-memory windows behind getFeeStats. They
+# live here — not under getFeeStats — because they size ingestion-time
+# memory, not request handling. Both must be 1..1000; larger windows slow
+# startup replay without improving fee estimates.
+[service.fee_stats]
+classic_fee_window_ledgers = 10
+soroban_inclusion_fee_window_ledgers = 50
+
+# --- Per-method serving limits ----------------------------------------------
+# Bare keys directly on [service.methods] are the OPTIONAL methods-wide
+# default tier for the two fields every method has. Resolution per method and
+# field: explicit per-method value → methods-wide default → compiled default
+# (the values shown in the tables below, identical to v1's).
+[service.methods]
+#queue_limit = 200              # default queue_limit for all nine methods
+#max_execution_duration = "8s"  # default execution budget for all nine methods
+
+# Each method's table, keyed by the method's wire name:
+#   queue_limit             — max outstanding requests for this method
+#   max_execution_duration  — per-request budget; exceeding it aborts with -32001
+
+[service.methods.getHealth]
+queue_limit = 1000
+max_execution_duration = "5s"
+# getHealth only: the daemon reports healthy while the last committed ledger's
+# close time is within this latency of now.
+max_healthy_ledger_latency = "30s"
+
+[service.methods.getNetwork]
+queue_limit = 1000
+max_execution_duration = "5s"
+
+[service.methods.getVersionInfo]
+queue_limit = 1000
+max_execution_duration = "5s"
+
+[service.methods.getLatestLedger]
+queue_limit = 1000
+max_execution_duration = "5s"
+
+[service.methods.getTransaction]
+queue_limit = 1000
+max_execution_duration = "5s"
+
+# The three paginated methods also carry the page-size caps:
+#   max_items_per_response     — hard cap on the client's pagination limit
+#   default_items_per_response — page size when the request omits a limit
+# (No methods-wide default tier for these two — they exist on only three methods.)
+
+[service.methods.getTransactions]
+queue_limit = 1000
+max_execution_duration = "5s"
+max_items_per_response = 200
+default_items_per_response = 50
+
+[service.methods.getLedgers]
+queue_limit = 1000
+max_execution_duration = "10s"
+max_items_per_response = 200
+default_items_per_response = 50
+
+[service.methods.getEvents]
+queue_limit = 1000
+max_execution_duration = "10s"
+max_items_per_response = 10000
+default_items_per_response = 100
+
+[service.methods.getFeeStats]
+queue_limit = 100
+max_execution_duration = "5s"
+
+# NOT here (by design): sendTransaction, simulateTransaction, getLedgerEntries
+# and the preflight worker settings — those methods are captive-core-backed
+# and arrive with the captive-core-endpoints work. friendbot_url arrives with
+# the getNetwork handler.
+
+# -----------------------------------------------------------------------------
+# [backfill] — bulk history download into local storage
+# -----------------------------------------------------------------------------
+[backfill]
+
+# Concurrent chunk-task slots; >= 1. Default: GOMAXPROCS.
+#workers = 8
+
+# Per-task retries before the daemon aborts; 0 = run once, no retry. Default 3.
+max_retries = 3
+
+# --- The bulk ledger source (a "lake") ---------------------------------------
+# Any SDK datastore works (GCS, S3, filesystem, ...). OMIT this whole block
+# (or leave type = "") for NO lake: backfill then replays history through
+# captive core from [ingestion].history_archive_urls — correct but much slower.
+[backfill.datastore]
+
+# SDK datastore type: "GCS", "S3", ... Empty = no lake.
+type = "GCS"
+
+# Datastore-specific parameters; keys depend on type. For GCS:
+[backfill.datastore.params]
+destination_bucket_path = "my-bucket/path/to/ledgers"
+
+# How the lake's files are laid out. Must match how the lake was exported.
+[backfill.datastore.schema]
+ledgers_per_file = 1
+files_per_partition = 64000
+
+# --- Buffered reads over the datastore ---------------------------------------
+# Tunes the SDK's buffered-storage stream over [backfill.datastore]. Any field
+# left zero/absent falls back to the backfill defaults applied in code.
+[backfill.bsb]
+buffer_size = 100    # ledgers buffered in memory
+num_workers = 10     # concurrent object fetchers
+retry_limit = 0      # per-object retries (0 = none)
+retry_wait = "0s"    # wait between object retries
+
+# -----------------------------------------------------------------------------
+# [ingestion] — live-network ingestion via captive stellar-core
+# -----------------------------------------------------------------------------
+# The captive-core config FILE is the single source of truth for everything
+# core-side — this differs from v1, where NETWORK_PASSPHRASE was an RPC config
+# key of its own. Here the daemon READS the passphrase back from the file
+# below at startup (it must define NETWORK_PASSPHRASE). v1's `network`
+# convenience macro and the captive-core HTTP-port knobs do not exist in v2.
+[ingestion]
+
+# REQUIRED for live ingestion. Path to the stellar-core config used by captive
+# core. Must define NETWORK_PASSPHRASE and at least a quorum set; the daemon
+# passes it to the SDK in strict mode with unified events and soroban
+# diagnostic/meta enforcement ON (same params as the v1 daemon).
+captive_core_config = "/etc/stellar/captive-core.toml"
+
+# REQUIRED for live ingestion. Plain history-archive URLs the SDK reads
+# checkpoints from — not derivable from the core file's [HISTORY.*] entries
+# (those are shell commands, not URLs). Also the no-lake backfill source.
+history_archive_urls = ["https://history.stellar.org/prd/core-live/core_live_001"]
+
+# Path to the stellar-core binary. Default: the "stellar-core" found on PATH.
+#stellar_core_binary_path = "/usr/local/bin/stellar-core"
+
+# Captive core's working/bucket directory. Default: {default_data_dir}/captive-core.
+#captive_core_storage_path = ""
+
+# -----------------------------------------------------------------------------
+# [logging]
+# -----------------------------------------------------------------------------
+[logging]
+
+# Minimum severity: "debug", "info", "warn", "error". Default "info".
+level = "info"
+
+# "text" or "json". Anything else is rejected (a typo must not silently drop
+# you to text logging). Default "text".
+format = "text"

--- a/cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml
+++ b/cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml
@@ -175,6 +175,11 @@ max_retries = 3
 # Any SDK datastore works (GCS, S3, filesystem, ...). OMIT this whole block
 # (or leave type = "") for NO lake: backfill then replays history through
 # captive core from [ingestion].history_archive_urls — correct but much slower.
+#
+# The network passphrase is deliberately NOT a key here (or anywhere in this
+# file): the daemon copies it from the captive-core config at startup and, when
+# the lake carries a manifest (.config.json), verifies the lake was exported
+# from the same network — a wrong-network lake fails startup.
 [backfill.datastore]
 
 # SDK datastore type: "GCS", "S3", ... Empty = no lake.
@@ -190,13 +195,16 @@ ledgers_per_file = 1
 files_per_partition = 64000
 
 # --- Buffered reads over the datastore ---------------------------------------
-# Tunes the SDK's buffered-storage stream over [backfill.datastore]. Any field
-# left zero/absent falls back to the backfill defaults applied in code.
+# Tunes the buffered-storage stream that downloads ledger objects from
+# [backfill.datastore]. max_retries here retries ONE object download (a single
+# ledger file) after a transient datastore error, waiting retry_wait between
+# attempts — a different knob from [backfill].max_retries above, which re-runs
+# a whole chunk task.
 [backfill.bsb]
-buffer_size = 100    # ledgers buffered in memory
-num_workers = 10     # concurrent object fetchers
-retry_limit = 0      # per-object retries (0 = none)
-retry_wait = "0s"    # wait between object retries
+buffer_size = 100    # downloaded ledgers buffered in memory; >= 1
+num_workers = 10     # concurrent object downloads; >= 1
+max_retries = 3      # retries per object download; 0 = fail on first error
+retry_wait = "5s"    # pause between retries of one object download
 
 # -----------------------------------------------------------------------------
 # [ingestion] — live-network ingestion via captive stellar-core

--- a/cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml
+++ b/cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml
@@ -55,9 +55,13 @@ default_data_dir = "/var/stellar/rpc-v2"
 # The earliest ledger this daemon will EVER have data for. One of:
 #   "genesis"  — full history from the network's first ledger (the default)
 #   "now"      — start from the chunk containing the network tip at first boot
-#   <number>   — a chunk-aligned ledger sequence (e.g. 50002)
+#   "<number>" — a chunk-aligned ledger sequence, IN QUOTES (e.g. "50002";
+#                a bare integer fails to parse — the key is a string)
 # PINNED: written immutably on first start and checked on every restart —
 # changing it once data exists aborts startup (wipe the data dir to change it).
+# Set pinned keys HERE, not via one-off CLI flags: a node first started with
+# --retention.earliest_ledger and later restarted without it aborts on the
+# pin mismatch.
 earliest_ledger = "genesis"
 
 # Sliding retention window in CHUNKS (10,000 ledgers each); 0 = keep
@@ -147,13 +151,16 @@ default_items_per_response = 50
 [service.methods.getLedgers]
 queue_limit = 1000
 max_execution_duration = "10s"
-max_items_per_response = 200
-default_items_per_response = 50
+# Smaller than v1's 200/50 on purpose: one item is a full ledger's meta,
+# megabytes each on a busy ledger.
+max_items_per_response = 20
+default_items_per_response = 5
 
 [service.methods.getEvents]
 queue_limit = 1000
 max_execution_duration = "10s"
-max_items_per_response = 10000
+# The getEvents v2 API caps pages at 1,000 (spec constant), unlike v1's 10000.
+max_items_per_response = 1000
 default_items_per_response = 100
 
 [service.methods.getFeeStats]

--- a/cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml
+++ b/cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml
@@ -213,8 +213,8 @@ files_per_partition = 64000
 # attempts — a different knob from [backfill].max_retries above, which re-runs
 # a whole chunk task.
 [backfill.bsb]
-buffer_size = 100    # downloaded ledgers buffered in memory; >= 1
-num_workers = 10     # concurrent object downloads; >= 1
+buffer_size = 5000   # downloaded ledgers buffered in memory; >= 1
+num_workers = 50     # concurrent object downloads; >= 1 and <= buffer_size
 max_retries = 3      # retries per object download; 0 = fail on first error
 retry_wait = "5s"    # pause between retries of one object download
 

--- a/cmd/stellar-rpc/rpcv2/sample_config_test.go
+++ b/cmd/stellar-rpc/rpcv2/sample_config_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/config"
+)
+
+// The shipped sample config must always parse under the strict decoder — every
+// key it documents is thereby proven to exist in the schema. A schema rename
+// that orphans a sample key fails here, not in a user's deploy.
+func TestSampleConfig_ParsesStrict(t *testing.T) {
+	data, err := os.ReadFile("rpc-v2-sample-config.toml")
+	require.NoError(t, err)
+
+	cfg, err := config.ParseConfig(data)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/var/stellar/rpc-v2", cfg.Storage.DefaultDataDir)
+	assert.Equal(t, config.DefaultEndpoint, cfg.Service.Endpoint)
+	assert.Equal(t, "GCS", cfg.Backfill.DataStore.Type)
+	assert.Equal(t, "/etc/stellar/captive-core.toml", cfg.Ingestion.CaptiveCoreConfig)
+
+	// The sample spells out the compiled defaults; drift between the two would
+	// make the sample lie about what an absent key means.
+	assert.Equal(t, config.DefaultMaxConcurrentRequests, *cfg.Service.MaxConcurrentRequests)
+	assert.Equal(t, config.DefaultMethodQueueLimit, *cfg.Service.Methods.GetLedgers.QueueLimit)
+	assert.Equal(t, config.DefaultScanMethodMaxExecutionDuration, *cfg.Service.Methods.GetLedgers.MaxExecutionDuration)
+	assert.Equal(t, config.DefaultGetFeeStatsQueueLimit, *cfg.Service.Methods.GetFeeStats.QueueLimit)
+	assert.Equal(t, config.DefaultClassicFeeWindowLedgers, *cfg.Service.FeeStats.ClassicFeeWindowLedgers)
+	assert.Equal(t, config.DefaultMaxHealthyLedgerLatency, *cfg.Service.Methods.GetHealth.MaxHealthyLedgerLatency)
+	assert.Equal(t, 30*time.Second, *cfg.Service.Methods.GetHealth.MaxHealthyLedgerLatency)
+}

--- a/cmd/stellar-rpc/rpcv2/sample_config_test.go
+++ b/cmd/stellar-rpc/rpcv2/sample_config_test.go
@@ -8,12 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/backfill"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/config"
 )
 
-// The shipped sample config must always parse under the strict decoder — every
-// key it documents is thereby proven to exist in the schema. A schema rename
-// that orphans a sample key fails here, not in a user's deploy.
 func TestSampleConfig_ParsesStrict(t *testing.T) {
 	data, err := os.ReadFile("rpc-v2-sample-config.toml")
 	require.NoError(t, err)
@@ -35,4 +33,9 @@ func TestSampleConfig_ParsesStrict(t *testing.T) {
 	assert.Equal(t, config.DefaultClassicFeeWindowLedgers, *cfg.Service.FeeStats.ClassicFeeWindowLedgers)
 	assert.Equal(t, config.DefaultMaxHealthyLedgerLatency, *cfg.Service.Methods.GetHealth.MaxHealthyLedgerLatency)
 	assert.Equal(t, 30*time.Second, *cfg.Service.Methods.GetHealth.MaxHealthyLedgerLatency)
+
+	assert.Equal(t, uint32(backfill.DefaultBSBBufferSize), *cfg.Backfill.BSB.BufferSize)
+	assert.Equal(t, uint32(backfill.DefaultBSBNumWorkers), *cfg.Backfill.BSB.NumWorkers)
+	assert.Equal(t, uint32(backfill.DefaultBSBMaxRetries), *cfg.Backfill.BSB.MaxRetries)
+	assert.Equal(t, backfill.DefaultBSBRetryWait, *cfg.Backfill.BSB.RetryWait)
 }

--- a/cmd/stellar-rpc/rpcv2/sample_config_test.go
+++ b/cmd/stellar-rpc/rpcv2/sample_config_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"regexp"
 	"testing"
 	"time"
 
@@ -38,4 +39,20 @@ func TestSampleConfig_ParsesStrict(t *testing.T) {
 	assert.Equal(t, uint32(backfill.DefaultBSBNumWorkers), *cfg.Backfill.BSB.NumWorkers)
 	assert.Equal(t, uint32(backfill.DefaultBSBMaxRetries), *cfg.Backfill.BSB.MaxRetries)
 	assert.Equal(t, backfill.DefaultBSBRetryWait, *cfg.Backfill.BSB.RetryWait)
+}
+
+func TestSampleConfig_CommentedOptionalKeysParseStrict(t *testing.T) {
+	data, err := os.ReadFile("rpc-v2-sample-config.toml")
+	require.NoError(t, err)
+
+	// Optional keys are documented as `#key = value` lines (no space after #,
+	// unlike prose comments). Uncomment them all: every documented-but-disabled
+	// key must still exist in the schema, or this strict parse fails.
+	re := regexp.MustCompile(`(?m)^#([a-z_]+ = )`)
+	uncommented := re.ReplaceAll(data, []byte("$1"))
+	require.NotEqual(t, string(data), string(uncommented),
+		"expected '#key = value' optional-key lines in the sample")
+
+	_, err = config.ParseConfig(uncommented)
+	require.NoError(t, err)
 }

--- a/design-docs/full-history-streaming-workflow.md
+++ b/design-docs/full-history-streaming-workflow.md
@@ -42,13 +42,28 @@ All chunk and window ids use uniform `%08d` zero-padding. Example (window = 1,00
 
 ## Configuration
 
-One TOML file configures the daemon, passed as `--config` to the v2 binary (`stellar-rpc-v2 --config <path>`). Decoding is strict: an unknown key or section is a startup error, so a stale or mistyped config fails loudly instead of being half-read.
+One TOML file configures the daemon, passed as `--config` to the v2 binary (`stellar-rpc-v2 --config <path>`). Decoding is strict: an unknown key or section is a startup error, so a stale or mistyped config fails loudly instead of being half-read. A fully-commented sample lives at `cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml`.
 
-**[service]**
+Every TOML leaf is also settable from the command line as a flag named by its dotted TOML path (`--storage.default_data_dir`, `--service.methods.getLedgers.queue_limit`); the flag set is derived from the config structs by reflection, so it can never drift from the file schema. Precedence: specificity beats source; within a tier, a set flag beats the file; compiled defaults are the last tier. `--config` stays required — the file is the source of truth, flags are one-off overrides. No environment variables.
+
+**[service]** — the JSON-RPC read-serving policy (#882; dormant until the read server exists, except `[service.fee_stats]`, which live ingestion consumes — #881). Key naming: camelCase only for the JSON-RPC method table names, snake_case elsewhere. Durations are strings (`"10s"`); any duration under 1ms is rejected (a bare TOML integer parses as nanoseconds).
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `default_data_dir` | string | **required** | Base directory for the catalog and default storage paths. |
+| `endpoint` | string | `localhost:8000` | JSON-RPC listen address. |
+| `admin_endpoint` | string | `""` (disabled) | pprof/metrics endpoint, plaintext HTTP. |
+| `max_concurrent_requests` | uint | `5000` | HTTP-layer gate: bounds total in-flight requests across ALL methods, in addition to per-method limits. |
+| `max_request_execution_duration` | duration | `"25s"` | HTTP-layer global timeout. |
+| `request_execution_warning_threshold` | duration | `"5s"` | Slower requests log a warning. |
+
+**[service.fee_stats]** — sizes (in ledgers, 1..1000) of the in-memory fee windows behind getFeeStats; fed by live ingestion, hence not method config:
+
+| Key | Default |
+|---|---|
+| `classic_fee_window_ledgers` | `10` |
+| `soroban_inclusion_fee_window_ledgers` | `50` |
+
+**[service.methods.\<methodName\>]** — one table per served method (getHealth, getNetwork, getVersionInfo, getLatestLedger, getTransaction, getTransactions, getLedgers, getEvents, getFeeStats), each with `queue_limit` and `max_execution_duration` (v1's defaults: 1000 / 5s, except getFeeStats 100, and 10s for getLedgers/getEvents). The three paginated methods add `max_items_per_response` / `default_items_per_response`; getHealth adds `max_healthy_ledger_latency` (default `"30s"`). Bare `queue_limit` / `max_execution_duration` keys directly on `[service.methods]` form an optional methods-wide default tier: per-method value → wide default → compiled default. (sendTransaction, simulateTransaction, getLedgerEntries and the preflight knobs arrive with the captive-core-endpoints work.)
 
 **[retention]** — the two inputs to the retention floor; the effective floor is the higher of the two:
 
@@ -57,10 +72,11 @@ One TOML file configures the daemon, passed as `--config` to the v2 binary (`ste
 | `retention_chunks` | uint32 | `0` | Retention window in chunks. `0` = full history. |
 | `earliest_ledger` | uint32 \| `"genesis"` \| `"now"` | `"genesis"` | Earliest ledger this daemon will ever have data for — a fixed lower floor on history. Must be chunk-aligned; `"now"` resolves to the backfill backend's frontier chunk at first start. Resolved and pinned on the first start (a reachable backend is required, to resolve `"now"` and to reject a numeric floor past the tip; see `validateConfig`), immutable thereafter. Setting it above genesis typically skips upfront backfill — useful when no fast backfill source is available and the daemon only follows the live network (`earliest_ledger = "now"`). |
 
-**[storage]** — one optional path per on-disk tree; an unset key defaults under `{default_data_dir}`:
+**[storage]** — the data root plus one optional path per on-disk tree; an unset per-store key defaults under `{default_data_dir}`:
 
 | Key | Default path | Holds |
 |---|---|---|
+| `default_data_dir` | **required** | base directory for the catalog and default storage paths (moved here from `[service]` in #882) |
 | `catalog` | `{default_data_dir}/catalog/rocksdb` | the catalog RocksDB |
 | `ledgers` | `{default_data_dir}/ledgers` | `.pack` files |
 | `events` | `{default_data_dir}/events` | events cold segments |
@@ -95,6 +111,7 @@ One TOML file configures the daemon, passed as `--config` to the v2 binary (`ste
 | Flag | Type | Default | Description |
 |---|---|---|---|
 | `--config` | string | **required** | Path to TOML config file. |
+| `--<section>.<key>` | per key | — | One auto-derived override flag per TOML leaf (see above). |
 
 ---
 

--- a/design-docs/full-history-streaming-workflow.md
+++ b/design-docs/full-history-streaming-workflow.md
@@ -44,7 +44,13 @@ All chunk and window ids use uniform `%08d` zero-padding. Example (window = 1,00
 
 One TOML file configures the daemon, passed as `--config` to the v2 binary (`stellar-rpc-v2 --config <path>`). Decoding is strict: an unknown key or section is a startup error, so a stale or mistyped config fails loudly instead of being half-read. A fully-commented sample lives at `cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml`.
 
-Every TOML leaf is also settable from the command line as a flag named by its dotted TOML path (`--storage.default_data_dir`, `--service.methods.getLedgers.queue_limit`); the flag set is derived from the config structs by reflection, so it can never drift from the file schema. Precedence: specificity beats source; within a tier, a set flag beats the file; compiled defaults are the last tier. `--config` stays required — the file is the source of truth, flags are one-off overrides. No environment variables.
+Every TOML leaf is also settable from the command line:
+
+- One flag per leaf, named by its dotted TOML path: `--storage.default_data_dir`, `--service.methods.getLedgers.queue_limit`.
+- The flag set is derived from the config structs by reflection, so it can never drift from the file schema.
+- Precedence: specificity beats source; within a tier, a set flag beats the file; compiled defaults are the last tier.
+- `--config` stays required — the file is the source of truth, flags are one-off overrides.
+- No environment variables.
 
 **[service]** — the JSON-RPC read-serving policy (#882; dormant until the read server exists, except `[service.fee_stats]`, which live ingestion consumes — #881). Key naming: camelCase only for the JSON-RPC method table names, snake_case elsewhere. Durations are strings (`"10s"`); any duration under 1ms is rejected (a bare TOML integer parses as nanoseconds).
 
@@ -63,7 +69,13 @@ Every TOML leaf is also settable from the command line as a flag named by its do
 | `classic_fee_window_ledgers` | `10` |
 | `soroban_inclusion_fee_window_ledgers` | `50` |
 
-**[service.methods.\<methodName\>]** — one table per served method (getHealth, getNetwork, getVersionInfo, getLatestLedger, getTransaction, getTransactions, getLedgers, getEvents, getFeeStats), each with `queue_limit` and `max_execution_duration` (v1's defaults: 1000 / 5s, except getFeeStats 100, and 10s for getLedgers/getEvents). The three paginated methods add `max_items_per_response` / `default_items_per_response`; getHealth adds `max_healthy_ledger_latency` (default `"30s"`). Bare `queue_limit` / `max_execution_duration` keys directly on `[service.methods]` form an optional methods-wide default tier: per-method value → wide default → compiled default. (sendTransaction, simulateTransaction, getLedgerEntries and the preflight knobs arrive with the captive-core-endpoints work.)
+**[service.methods.\<methodName\>]** — one table per served method (getHealth, getNetwork, getVersionInfo, getLatestLedger, getTransaction, getTransactions, getLedgers, getEvents, getFeeStats):
+
+- Every method: `queue_limit` and `max_execution_duration`. v1's defaults: 1000 / 5s, except getFeeStats's queue is 100, and getLedgers/getEvents get 10s.
+- The three paginated methods (getTransactions, getLedgers, getEvents) add `max_items_per_response` / `default_items_per_response`.
+- getHealth adds `max_healthy_ledger_latency` (default `"30s"`).
+- Bare `queue_limit` / `max_execution_duration` keys directly on `[service.methods]` form an optional methods-wide default tier: per-method value → wide default → compiled default.
+- Not here: sendTransaction, simulateTransaction, getLedgerEntries and the preflight knobs — they arrive with the captive-core-endpoints work.
 
 **[retention]** — the two inputs to the retention floor; the effective floor is the higher of the two:
 
@@ -91,9 +103,19 @@ Every TOML leaf is also settable from the command line as a flag named by its do
 | `workers` | int | `GOMAXPROCS` | Concurrent task slots for backfill. |
 | `max_retries` | int | `3` | Retries per backfill task, after the first attempt, before the task fails the run. |
 
-**[backfill.datastore]** — the bulk ledger source: the SDK's `datastore.DataStoreConfig`, verbatim (`type`, `params`, `schema`), so any SDK datastore (GCS, S3, Filesystem) works. Optional: an empty `type` means no lake, and backfill replays through captive core from the history archives instead.
+**[backfill.datastore]** — the bulk ledger source (`type`, `params`, `schema.ledgers_per_file`, `schema.files_per_partition`; key names match the SDK's `datastore.DataStoreConfig`):
 
-**[backfill.bsb]** — tuning for the buffered-storage stream over the datastore: the SDK's `BufferedStorageBackendConfig`, verbatim. Optional; unset fields take backfill-tuned defaults (`buffer_size` 5000, `num_workers` 50, bounded retries).
+- Any SDK datastore (GCS, S3, Filesystem) works. Optional: an empty `type` means no lake, and backfill replays through captive core from the history archives instead.
+- The network passphrase is deliberately not a key here: the daemon copies it from the captive-core file at startup, and when the lake carries a manifest the SDK verifies the lake was exported from the same network — a wrong-network lake fails startup. A manifest-less lake skips the check.
+
+**[backfill.bsb]** — tuning for the buffered-storage stream that downloads ledger objects from the datastore. Optional:
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `buffer_size` | uint32 | `100` | Downloaded ledgers buffered in memory; >= 1. |
+| `num_workers` | uint32 | `10` | Concurrent object downloads; >= 1. |
+| `max_retries` | uint32 | `3` | Retries of ONE object download after a transient error; `0` = fail on the first error. Distinct from `[backfill].max_retries`, which re-runs a whole chunk task. |
+| `retry_wait` | duration | `"5s"` | Pause between retries of one object download; >= 1ms. |
 
 **[ingestion]** — the live-network (captive core) settings:
 

--- a/design-docs/full-history-streaming-workflow.md
+++ b/design-docs/full-history-streaming-workflow.md
@@ -52,7 +52,7 @@ Every TOML leaf is also settable from the command line:
 - `--config` stays required — the file is the source of truth, flags are one-off overrides.
 - No environment variables.
 
-**[service]** — the JSON-RPC read-serving policy (#882; dormant until the read server exists, except `[service.fee_stats]`, which live ingestion consumes — #881). Key naming: camelCase only for the JSON-RPC method table names, snake_case elsewhere. Durations are strings (`"10s"`); any duration under 1ms is rejected (a bare TOML integer parses as nanoseconds).
+**[service]** — the JSON-RPC read-serving policy (#882; entirely dormant today — the read server arrives with #772, and #881 wires `[service.fee_stats]` into live ingestion). Key naming: camelCase only for the JSON-RPC method table names, snake_case elsewhere. Durations are strings (`"10s"`); any duration under 1ms is rejected (a bare TOML integer parses as nanoseconds).
 
 | Key | Type | Default | Description |
 |---|---|---|---|
@@ -62,7 +62,7 @@ Every TOML leaf is also settable from the command line:
 | `max_request_execution_duration` | duration | `"25s"` | HTTP-layer global timeout. |
 | `request_execution_warning_threshold` | duration | `"5s"` | Slower requests log a warning. |
 
-**[service.fee_stats]** — sizes (in ledgers, 1..1000) of the in-memory fee windows behind getFeeStats; fed by live ingestion, hence not method config:
+**[service.fee_stats]** — sizes (in ledgers, 1..1000) of the in-memory fee windows behind getFeeStats; they will be fed by live ingestion (#881), and size ingestion-time memory rather than request handling, hence not method config:
 
 | Key | Default |
 |---|---|

--- a/design-docs/full-history-streaming-workflow.md
+++ b/design-docs/full-history-streaming-workflow.md
@@ -49,6 +49,7 @@ Every TOML leaf is also settable from the command line:
 - One flag per leaf, named by its dotted TOML path: `--storage.default_data_dir`, `--service.methods.getLedgers.queue_limit`.
 - The flag set is derived from the config structs by reflection, so it can never drift from the file schema.
 - Precedence: specificity beats source; within a tier, a set flag beats the file; compiled defaults are the last tier.
+- Map-valued keys merge per entry (`--backfill.datastore.params=region=x` sets one param and keeps the file's others); list-valued keys are replaced wholesale.
 - `--config` stays required — the file is the source of truth, flags are one-off overrides.
 - No environment variables.
 

--- a/design-docs/full-history-streaming-workflow.md
+++ b/design-docs/full-history-streaming-workflow.md
@@ -107,7 +107,7 @@ Every TOML leaf is also settable from the command line:
 **[backfill.datastore]** — the bulk ledger source (`type`, `params`, `schema.ledgers_per_file`, `schema.files_per_partition`; key names match the SDK's `datastore.DataStoreConfig`):
 
 - Any SDK datastore (GCS, S3, Filesystem) works. Optional: an empty `type` means no lake, and backfill replays through captive core from the history archives instead.
-- The network passphrase is deliberately not a key here: the daemon copies it from the captive-core file at startup, and when the lake carries a manifest the SDK verifies the lake was exported from the same network — a wrong-network lake fails startup. A manifest-less lake skips the check.
+- The network passphrase is deliberately not a key here: the daemon copies it from the captive-core file at startup, and when the lake carries a manifest the SDK verifies the lake was exported from the same network — a wrong-network lake fails startup. A manifest-less lake skips the check, but its `schema` must then be set in the config (the SDK needs one of the two).
 
 **[backfill.bsb]** — tuning for the buffered-storage stream that downloads ledger objects from the datastore. Optional:
 

--- a/design-docs/full-history-streaming-workflow.md
+++ b/design-docs/full-history-streaming-workflow.md
@@ -73,7 +73,7 @@ Every TOML leaf is also settable from the command line:
 **[service.methods.\<methodName\>]** — one table per served method (getHealth, getNetwork, getVersionInfo, getLatestLedger, getTransaction, getTransactions, getLedgers, getEvents, getFeeStats):
 
 - Every method: `queue_limit` and `max_execution_duration`. v1's defaults: 1000 / 5s, except getFeeStats's queue is 100, and getLedgers/getEvents get 10s.
-- The three paginated methods (getTransactions, getLedgers, getEvents) add `max_items_per_response` / `default_items_per_response`.
+- The three paginated methods (getTransactions, getLedgers, getEvents) add `max_items_per_response` / `default_items_per_response`. Two deliberate breaks from v1's page sizes (TODO: revisit under the v2 benchmarking epic): getEvents max is 1000 (the v2 API's spec constant, not v1's 10000), and getLedgers is 20/5 (one item is a full ledger's meta — megabytes each — so v1's 200/50 could produce >100MB responses).
 - getHealth adds `max_healthy_ledger_latency` (default `"30s"`).
 - Bare `queue_limit` / `max_execution_duration` keys directly on `[service.methods]` form an optional methods-wide default tier: per-method value → wide default → compiled default.
 - Not here: sendTransaction, simulateTransaction, getLedgerEntries and the preflight knobs — they arrive with the captive-core-endpoints work.
@@ -83,7 +83,7 @@ Every TOML leaf is also settable from the command line:
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `retention_chunks` | uint32 | `0` | Retention window in chunks. `0` = full history. |
-| `earliest_ledger` | uint32 \| `"genesis"` \| `"now"` | `"genesis"` | Earliest ledger this daemon will ever have data for — a fixed lower floor on history. Must be chunk-aligned; `"now"` resolves to the backfill backend's frontier chunk at first start. Resolved and pinned on the first start (a reachable backend is required, to resolve `"now"` and to reject a numeric floor past the tip; see `validateConfig`), immutable thereafter. Setting it above genesis typically skips upfront backfill — useful when no fast backfill source is available and the daemon only follows the live network (`earliest_ledger = "now"`). |
+| `earliest_ledger` | `"<number>"` \| `"genesis"` \| `"now"` (always a string — a bare TOML integer fails to parse) | `"genesis"` | Earliest ledger this daemon will ever have data for — a fixed lower floor on history. Must be chunk-aligned; `"now"` resolves to the backfill backend's frontier chunk at first start. Resolved and pinned on the first start (a reachable backend is required, to resolve `"now"` and to reject a numeric floor past the tip; see `validateConfig`), immutable thereafter. Setting it above genesis typically skips upfront backfill — useful when no fast backfill source is available and the daemon only follows the live network (`earliest_ledger = "now"`). |
 
 **[storage]** — the data root plus one optional path per on-disk tree; an unset per-store key defaults under `{default_data_dir}`:
 

--- a/design-docs/full-history-streaming-workflow.md
+++ b/design-docs/full-history-streaming-workflow.md
@@ -113,8 +113,8 @@ Every TOML leaf is also settable from the command line:
 
 | Key | Type | Default | Description |
 |---|---|---|---|
-| `buffer_size` | uint32 | `100` | Downloaded ledgers buffered in memory; >= 1. |
-| `num_workers` | uint32 | `10` | Concurrent object downloads; >= 1. |
+| `buffer_size` | uint32 | `5000` | Downloaded ledgers buffered in memory; >= 1. Per BSB instance — each backfill chunk task opens its own stream. |
+| `num_workers` | uint32 | `50` | Concurrent object downloads; >= 1 and <= `buffer_size`. Per BSB instance. |
 | `max_retries` | uint32 | `3` | Retries of ONE object download after a transient error; `0` = fail on the first error. Distinct from `[backfill].max_retries`, which re-runs a whole chunk task. |
 | `retry_wait` | duration | `"5s"` | Pause between retries of one object download; >= 1ms. |
 


### PR DESCRIPTION
Implements #882. Full decision record + precedence examples in the issue.

Below is the complete v2 config reference after this PR: **59 keys, one row each, one table per section** (59 leaves + `--config` = the 60 CLI flags `--help` lists). Each row carries its v1 counterpart; `—` = no counterpart exists.

## `[storage]` — 7 keys

| Key | Type | Default | v1 counterpart | Description |
|---|---|---|---|---|
| `default_data_dir` | string | **required** | — (v1 has single-file `db-path`) | Data root; every store below and the catalog default under it. Moved here from `[service]` in this PR. |
| `catalog` | string | `{data_dir}/catalog/rocksdb` | — | Catalog RocksDB dir override. |
| `ledgers` | string | `{data_dir}/ledgers` | — | Immutable ledger `.pack` root override. |
| `events` | string | `{data_dir}/events` | — | Immutable events segments root override. |
| `txhash_raw` | string | `{data_dir}/txhash/raw` | — | Transient txhash `.bin` root override. |
| `txhash_index` | string | `{data_dir}/txhash/index` | — | Frozen txhash `.idx` root override. |
| `hot` | string | `{data_dir}/hot` | — | Per-chunk hot RocksDB root override. |

## `[retention]` — 2 keys (unchanged by this PR)

| Key | Type | Default | v1 counterpart | Description |
|---|---|---|---|---|
| `earliest_ledger` | `"genesis"` \| `"now"` \| `"<number>"` (always a string — quote numeric values) | `"genesis"` | — | Earliest ledger the daemon will ever hold. Pinned on first start; immutable. |
| `retention_chunks` | uint32 | `0` (full history) | `history-retention-window` (in ledgers) | Sliding retention window, in chunks. |

## `[service]` — 5 keys

| Key | Type | Default | v1 counterpart | Description |
|---|---|---|---|---|
| `endpoint` | string | `localhost:8000` | `endpoint` | JSON-RPC listen address. |
| `admin_endpoint` | string | `""` (disabled) | `admin-endpoint` | pprof/metrics endpoint, plaintext HTTP. |
| `max_concurrent_requests` | uint | `5000` | `request-backlog-global-queue-limit` | HTTP-layer gate: bounds total in-flight requests across ALL methods, in addition to per-method limits. |
| `max_request_execution_duration` | duration | `"25s"` | `max-request-execution-duration` | HTTP-layer global timeout (504). |
| `request_execution_warning_threshold` | duration | `"5s"` | `request-execution-warning-threshold` | Slower requests log a warning. |

## `[service.fee_stats]` — 2 keys

| Key | Type | Default | v1 counterpart | Description |
|---|---|---|---|---|
| `classic_fee_window_ledgers` | uint32 | `10` | `classic-fee-stats-retention-window` | Classic fee window size in ledgers (1..1000). Will be fed by live ingestion when #881 lands; nothing consumes it yet. |
| `soroban_inclusion_fee_window_ledgers` | uint32 | `50` | `soroban-fee-stats-retention-window` | Soroban inclusion-fee window size in ledgers (1..1000). |

## `[service.methods]` — 2 keys (the wide-default tier)

| Key | Type | Default | v1 counterpart | Description |
|---|---|---|---|---|
| `queue_limit` | uint | unset | — | Optional default `queue_limit` for all nine methods; per-method values override it. |
| `max_execution_duration` | duration | unset | — | Optional default execution budget for all nine methods; per-method values override it. |

## `[service.methods.getHealth]` — 3 keys

| Key | Type | Default | v1 counterpart | Description |
|---|---|---|---|---|
| `queue_limit` | uint | `1000` | `request-backlog-get-health-queue-limit` | Max outstanding getHealth requests. |
| `max_execution_duration` | duration | `"5s"` | `max-get-health-execution-duration` | Per-request budget; exceeded → -32001. |
| `max_healthy_ledger_latency` | duration | `"30s"` | `max-healthy-ledger-latency` | Max age of the last committed ledger's close time to report healthy. |

## `[service.methods.getNetwork]` — 2 keys

| Key | Type | Default | v1 counterpart | Description |
|---|---|---|---|---|
| `queue_limit` | uint | `1000` | `request-backlog-get-network-queue-limit` | Max outstanding getNetwork requests. |
| `max_execution_duration` | duration | `"5s"` | `max-get-network-execution-duration` | Per-request budget; exceeded → -32001. |

## `[service.methods.getVersionInfo]` — 2 keys

| Key | Type | Default | v1 counterpart | Description |
|---|---|---|---|---|
| `queue_limit` | uint | `1000` | `request-backlog-get-version-info-queue-limit` | Max outstanding getVersionInfo requests. |
| `max_execution_duration` | duration | `"5s"` | `max-get-version-info-execution-duration` | Per-request budget; exceeded → -32001. |

## `[service.methods.getLatestLedger]` — 2 keys

| Key | Type | Default | v1 counterpart | Description |
|---|---|---|---|---|
| `queue_limit` | uint | `1000` | `request-backlog-get-latest-ledger-queue-limit` | Max outstanding getLatestLedger requests. |
| `max_execution_duration` | duration | `"5s"` | `max-get-latest-ledger-execution-duration` | Per-request budget; exceeded → -32001. |

## `[service.methods.getTransaction]` — 2 keys

| Key | Type | Default | v1 counterpart | Description |
|---|---|---|---|---|
| `queue_limit` | uint | `1000` | `request-backlog-get-transaction-queue-limit` | Max outstanding getTransaction requests. |
| `max_execution_duration` | duration | `"5s"` | `max-get-transaction-execution-duration` | Per-request budget; exceeded → -32001. |

## `[service.methods.getTransactions]` — 4 keys

| Key | Type | Default | v1 counterpart | Description |
|---|---|---|---|---|
| `queue_limit` | uint | `1000` | `request-backlog-get-transactions-queue-limit` | Max outstanding getTransactions requests. |
| `max_execution_duration` | duration | `"5s"` | `max-get-transactions-execution-duration` | Per-request budget; exceeded → -32001. |
| `max_items_per_response` | uint | `200` | `max-transactions-limit` | Hard cap on the client's page size. |
| `default_items_per_response` | uint | `50` | `default-transactions-limit` | Page size when the request omits a limit. |

## `[service.methods.getLedgers]` — 4 keys

| Key | Type | Default | v1 counterpart | Description |
|---|---|---|---|---|
| `queue_limit` | uint | `1000` | `request-backlog-get-ledgers-queue-limit` | Max outstanding getLedgers requests. |
| `max_execution_duration` | duration | `"10s"` | `max-get-ledgers-execution-duration` | Per-request budget; exceeded → -32001. |
| `max_items_per_response` | uint | `20` | `max-ledgers-limit` (v1: 200) | Hard cap on the client's page size. Deliberate break from v1: one item is a full ledger's meta (MBs each), so 200 could exceed 100MB/response. TODO: revisit under the benchmarking epic. |
| `default_items_per_response` | uint | `5` | `default-ledgers-limit` (v1: 50) | Page size when the request omits a limit. Same deliberate break. |

## `[service.methods.getEvents]` — 4 keys

| Key | Type | Default | v1 counterpart | Description |
|---|---|---|---|---|
| `queue_limit` | uint | `1000` | `request-backlog-get-events-queue-limit` | Max outstanding getEvents requests. |
| `max_execution_duration` | duration | `"10s"` | `max-get-events-execution-duration` | Per-request budget; exceeded → -32001. |
| `max_items_per_response` | uint | `1000` | `max-events-limit` (v1: 10000) | Hard cap on the client's page size. Deliberate break from v1: the finalized getEvents v2 API fixes the cap at 1,000 as a spec constant. |
| `default_items_per_response` | uint | `100` | `default-events-limit` | Page size when the request omits a limit. |

## `[service.methods.getFeeStats]` — 2 keys

| Key | Type | Default | v1 counterpart | Description |
|---|---|---|---|---|
| `queue_limit` | uint | `100` | `request-backlog-get-fee-stats-queue-limit` | Max outstanding getFeeStats requests. |
| `max_execution_duration` | duration | `"5s"` | `max-get-fee-stats-execution-duration` | Per-request budget; exceeded → -32001. |

## `[backfill]` — 2 keys (unchanged by this PR)

| Key | Type | Default | v1 counterpart | Description |
|---|---|---|---|---|
| `workers` | int | GOMAXPROCS | — | Concurrent chunk-task slots (≥ 1). |
| `max_retries` | int | `3` | — | Per-task retries before the daemon aborts (0 = run once). |

## `[backfill.datastore]` — 2 keys

| Key | Type | Default | v1 counterpart | Description |
|---|---|---|---|---|
| `type` | string | `""` (no lake) | `datastore_config.type` | SDK datastore type (GCS, S3, ...). Empty = replay via captive core. |
| `params` | map | — | `datastore_config.params` | Datastore-specific params (e.g. `destination_bucket_path`). |

Keys unchanged; two behavior changes:

- This section used to be the SDK's `DataStoreConfig` struct embedded directly. That silently accepted `NetworkPassphrase = "..."` and `Compression = "..."` as file keys, because go-toml fills untagged Go fields whose name matches a key. The section is now our own struct with the same keys, so those spellings fail at startup like any other unknown key.
- The network passphrase is not a config key at all — the captive-core file stays its single source. The daemon already reads `NETWORK_PASSPHRASE` from that file at startup; it now also hands the value to the SDK datastore client, which compares it against the manifest (`.config.json`) the lake was exported with. Pointing a pubnet daemon at a testnet lake now fails at startup with one clear error. A lake that has no manifest skips the check, but its `schema` must then be set in the file (the SDK needs one of the two).

## `[backfill.datastore.schema]` — 2 keys (unchanged by this PR)

| Key | Type | Default | v1 counterpart | Description |
|---|---|---|---|---|
| `ledgers_per_file` | uint32 | — | `datastore_config.schema.ledgers_per_file` | Lake file layout; must match the export. |
| `files_per_partition` | uint32 | — | `datastore_config.schema.files_per_partition` | Lake partition layout; must match the export. |

## `[backfill.bsb]` — 4 keys

| Key | Type | Default | v1 counterpart | Description |
|---|---|---|---|---|
| `buffer_size` | uint32 | `5000` | `buffered_storage_backend_config.buffer_size` | Downloaded ledgers buffered in memory (≥ 1). Per BSB instance — each backfill chunk task opens its own stream. |
| `num_workers` | uint32 | `50` | `buffered_storage_backend_config.num_workers` | Concurrent object downloads (≥ 1, ≤ `buffer_size`). Per BSB instance. |
| `max_retries` | uint32 | `3` | `buffered_storage_backend_config.retry_limit` | Retries of ONE object download after a transient error; `0` = fail on the first error. Distinct from `[backfill].max_retries`, which re-runs a whole chunk task. |
| `retry_wait` | duration | `"5s"` | `buffered_storage_backend_config.retry_wait` | Pause between retries of one object download (≥ 1ms). |

Changes from v1's shape:

- `retry_limit` is renamed `max_retries`, matching `[backfill].max_retries`. The two are different knobs: `[backfill.bsb].max_retries` retries ONE object download, `[backfill].max_retries` re-runs a whole chunk task.
- `max_retries = 0` now really means no retries. This section used to be the SDK's struct, whose plain fields cannot tell "explicitly 0" from "absent" — an explicit 0 silently became 3 retries. The section is now our own struct with pointer fields, so absent → default 3, explicit 0 → 0.

## `[ingestion]` — 4 keys (unchanged by this PR)

| Key | Type | Default | v1 counterpart | Description |
|---|---|---|---|---|
| `captive_core_config` | string | **required** | `captive-core-config-path` | Path to the stellar-core config file. Must define `NETWORK_PASSPHRASE`, read back at startup — v1 instead has a separate required `network-passphrase` key; v2 has none. The read-back passphrase is also checked against the lake's manifest (see `[backfill.datastore]`). |
| `history_archive_urls` | []string | **required** | `history-archive-urls` | Archive URLs for the SDK's client; also the no-lake backfill source. |
| `stellar_core_binary_path` | string | `stellar-core` on PATH | `stellar-core-binary-path` | Core binary path. |
| `captive_core_storage_path` | string | `{data_dir}/captive-core` | `captive-core-storage-path` (v1 default: cwd) | Captive core's working dir. |

## `[logging]` — 2 keys (unchanged by this PR)

| Key | Type | Default | v1 counterpart | Description |
|---|---|---|---|---|
| `level` | string | `"info"` | `log-level` | debug/info/warn/error. |
| `format` | string | `"text"` | `log-format` | text/json; anything else rejected. |

## v1 keys with NO v2 home yet — where each lands

| v1 key | v1 default | Lands in |
|---|---|---|
| `request-backlog-send-transaction-queue-limit` | 500 | #884 |
| `max-send-transaction-execution-duration` | 15s | #884 |
| `request-backlog-simulate-transaction-queue-limit` | 100 | #884 |
| `max-simulate-transaction-execution-duration` | 15s | #884 |
| `request-backlog-get-ledger-entries-queue-limit` | 1000 | #884 |
| `max-get-ledger-entries-execution-duration` | 5s | #884 |
| `preflight-worker-count` | NumCPU | #884 |
| `preflight-worker-queue-size` | NumCPU | #884 |
| `preflight-enable-debug` | true | #884 |
| `stellar-captive-core-http-port` | 11626 | #884 |
| `stellar-captive-core-http-query-port` | 11628 | #884 |
| `stellar-captive-core-http-query-thread-pool-size` | NumCPU | #884 |
| `stellar-captive-core-http-query-snapshot-ledgers` | 4 | #884 |
| `stellar-core-url` | `http://localhost:{http_port}` | #884 |
| `stellar-core-timeout` | 2s | #884 |
| `friendbot-url` | `""` | getNetwork handler ticket |
| `network` macro (pubnet/testnet/futurenet) | — | — dropped: the core file is the single source of truth |
| `ingestion-timeout` | 50m | — v2's supervised-restart model replaces the bootstrap timeout |
| `checkpoint-frequency` | 64 | — v2 derives checkpoint math from chunk geometry |

## Precedence

> Specificity beats source. Within a tier, CLI beats file. Compiled defaults are the last tier.

Example — file: `[service.methods] queue_limit = 10` + `[service.methods.getLedgers] queue_limit = 5`; CLI: `--service.methods.queue_limit=30`:

| Method | Effective | Why |
|---|---|---|
| getLedgers | 5 | more specific tier wins regardless of source |
| other 8 | 30 | same tier: CLI beats file |

Executable as tests in `internal/rpcv2/config/flags_test.go`.

## Other changes

- Every key above gets a `--<dotted.toml.path>` CLI override flag. The flag set is built by walking the config structs' `toml` tags with reflection (`internal/rpcv2/config/flags.go`), so adding a config field automatically creates its flag; a test pins that every TOML key has one. The walk panics on an untagged exported field (go-toml would accept it as a file key by field name, but it would get no flag — the one way file schema and flags could drift). Map-valued flags merge into the file's map per entry (`--backfill.datastore.params=region=x` sets one param, keeps the file's others); slice-valued flags replace the file's list wholesale. `--config` stays required; no env vars.
- Startup validation catches the common traps: `queue_limit` ≥ 1; every duration must be ≥ 1ms, because go-toml reads a bare integer as NANOSECONDS (`timeout = 10` is 10ns) — including `[backfill.bsb].retry_wait`; `buffer_size` / `num_workers` ≥ 1 and `num_workers ≤ buffer_size` (each worker needs a buffer slot); `1 ≤ default_items_per_response ≤ max_items_per_response`; fee windows via `internal/limits`.
- The pure-form checks run immediately after config load (`validateForm`), before the catalog, captive core, or datastore are touched — a malformed config is rejected with zero side effects and no remote reads.
- No SDK structs are embedded in `Config` anymore. `[backfill.datastore]` and `[backfill.bsb]` are our own structs with the same key names, converted to the SDK types where the daemon opens the datastore. Why is explained under each section's table above.
- The wrong-network-lake check runs once, at startup, in `NewBSBBackendFromConfig`. The SDK stream re-runs the same check every time it opens anyway; checking eagerly means a bad lake is one clear startup error instead of a crash-looping chunk task.
- The BSB defaults (100 / 10 / 3 / 5s) are declared once, in the backfill package, and used by config defaulting and the bench-ingest flags. `NewBSBBackend` no longer rewrites zero retry values — an explicit 0 must survive to the SDK.
- One documented caveat: go-toml matches keys case-insensitively, so the camelCase method-table names are a convention the decoder cannot enforce — `[service.methods.getledgers]` (wrong case) is accepted. Misspellings still fail.
- Dead code removed: `config.LoadConfig` (the daemon uses `LoadConfigWithFlags`).
- The sample config (`cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml`) is strict-parsed by a test that also asserts its spelled-out values equal the compiled defaults, so the sample cannot drift into lying about what an absent key means. A second test uncomments every documented-but-disabled `#key = value` line and strict-parses again, so even the optional keys are proven to exist in the schema.
- `design-docs/full-history-streaming-workflow.md` Configuration section updated to match.

## Testing

- `internal/rpcv2/config`: full/minimal documents, defaults, cascade examples, strict-decode rejections (incl. the pre-move `[service].default_data_dir` home, a typo'd method table, and `NetworkPassphrase` under `[backfill.datastore]`), explicit `max_retries = 0` survival, flag lockstep + precedence, walkLeaves panic on untagged fields, and a reflective guard that every pointer leaf is non-nil after `WithDefaults` (so adding a method table and forgetting its default fills fails a test, not startup).
- `internal/rpcv2`: `validateService` + `validateBSB` rejections; full package suite green.
- `cmd/stellar-rpc/rpcv2`: sample-config strict parse; `--help` verified to list all 60 flags.

