### PR TITLE
Boiler blate code to enable  getLedgerEntries, simulateTransaction, sendTransaction on v2 (#884). Wiring comes in (#889)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,9 +124,9 @@ build-rpc-v1: build-libs
 # as part of the package building.
 build-stellar-rpc: build-rpc-v1
 
-# no build-libs prerequisite: nothing under rpcv2 links the rust preflight or
-# xdr2json bindings yet; #884 adds the prerequisite when it first does.
-build-rpc-v2:
+# build-libs is required: rpcv2 wires internal/preflight, which links the rust
+# preflight library through cgo (#884).
+build-rpc-v2: build-libs
 	go build -ldflags="${GOLDFLAGS}" ${MACOS_MIN_VER} -o ${STELLAR_RPC_V2_BINARY} -trimpath -v ./cmd/stellar-rpc/rpcv2
 
 # Override for feature branches, e.g. `make go-check-branch BASE=origin/feature/full-history`.

--- a/cmd/stellar-rpc/docker/Dockerfile.rpcv2
+++ b/cmd/stellar-rpc/docker/Dockerfile.rpcv2
@@ -40,8 +40,8 @@ RUN apt update && apt install -y build-essential curl git jq && apt clean
 RUN curl -sSfL "https://go.dev/dl/go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz" \
     | tar -C /usr/local -xzf -
 
-# build-rpc-v2 doesn't need Rust yet; kept because #884 links the rust
-# preflight bindings into the v2 binary.
+# Rust is required: build-rpc-v2 depends on build-libs, which cargo-builds the
+# preflight library the v2 binary links through cgo.
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_TOOLCHAIN_VERSION
 
 COPY --from=zstd-build /usr/local/include/ /usr/local/include/

--- a/cmd/stellar-rpc/internal/host/host.go
+++ b/cmd/stellar-rpc/internal/host/host.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
 	proto "github.com/stellar/go-stellar-sdk/protocols/stellarcore"
 	"github.com/stellar/go-stellar-sdk/xdr"
 )
@@ -22,7 +21,13 @@ type Daemon interface {
 	MetricsNamespace() string
 	CoreClient() CoreClient
 	FastCoreClient() FastCoreClient
-	GetCore() *ledgerbackend.CaptiveStellarCore
+
+	// CoreVersion is the version string of the stellar-core BINARY this daemon
+	// runs — the first line of `stellar-core version`. It describes the binary,
+	// not a running process, so an implementation can answer it by looking at the
+	// configured binary path alone; getVersionInfo is its only consumer. An
+	// implementation that cannot determine the version returns "".
+	CoreVersion() string
 }
 
 type CoreClient interface {

--- a/cmd/stellar-rpc/internal/host/host.go
+++ b/cmd/stellar-rpc/internal/host/host.go
@@ -22,11 +22,11 @@ type Daemon interface {
 	CoreClient() CoreClient
 	FastCoreClient() FastCoreClient
 
-	// CoreVersion is the version string of the stellar-core BINARY this daemon
-	// runs — the first line of `stellar-core version`. It describes the binary,
-	// not a running process, so an implementation can answer it by looking at the
-	// configured binary path alone; getVersionInfo is its only consumer. An
-	// implementation that cannot determine the version returns "".
+	// CoreVersion is the version of the stellar-core binary this daemon runs —
+	// the first line of `stellar-core version`. It describes the binary, not a
+	// running process, so an implementation can answer from the configured path
+	// alone. Returns "" if the version is unknown. getVersionInfo is its only
+	// consumer.
 	CoreVersion() string
 }
 

--- a/cmd/stellar-rpc/internal/host/noOpDaemon.go
+++ b/cmd/stellar-rpc/internal/host/noOpDaemon.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
 	proto "github.com/stellar/go-stellar-sdk/protocols/stellarcore"
 	"github.com/stellar/go-stellar-sdk/xdr"
 )
@@ -16,7 +15,6 @@ type NoOpDaemon struct {
 	metricsRegistry  *prometheus.Registry
 	metricsNamespace string
 	coreClient       noOpCoreClient
-	core             *ledgerbackend.CaptiveStellarCore
 }
 
 func MakeNoOpDaemon() *NoOpDaemon {
@@ -43,8 +41,10 @@ func (d *NoOpDaemon) FastCoreClient() FastCoreClient {
 	return d.coreClient
 }
 
-func (d *NoOpDaemon) GetCore() *ledgerbackend.CaptiveStellarCore {
-	return d.core
+// CoreVersion reports no version: there is no stellar-core binary behind a
+// no-op daemon.
+func (d *NoOpDaemon) CoreVersion() string {
+	return ""
 }
 
 type noOpCoreClient struct{}

--- a/cmd/stellar-rpc/internal/host/noOpDaemon.go
+++ b/cmd/stellar-rpc/internal/host/noOpDaemon.go
@@ -41,8 +41,7 @@ func (d *NoOpDaemon) FastCoreClient() FastCoreClient {
 	return d.coreClient
 }
 
-// CoreVersion reports no version: there is no stellar-core binary behind a
-// no-op daemon.
+// CoreVersion is empty: there is no core binary behind a no-op daemon.
 func (d *NoOpDaemon) CoreVersion() string {
 	return ""
 }

--- a/cmd/stellar-rpc/internal/methods/get_version_info.go
+++ b/cmd/stellar-rpc/internal/methods/get_version_info.go
@@ -18,11 +18,12 @@ func NewGetVersionInfoHandler(
 	ledgerReader store.LedgerReader,
 	daemon host.Daemon,
 ) jrpc2.Handler {
-	core := daemon.GetCore()
-
 	coreHandler := func(ctx context.Context, _ protocol.GetVersionInfoRequest,
 	) (protocol.GetVersionInfoResponse, error) {
-		captiveCoreVersion := core.GetCoreVersion()
+		// Asked per request, not once at construction: the daemon learns the
+		// version when it starts stellar-core, which is after the handlers are
+		// built, so a value captured here would always be empty.
+		captiveCoreVersion := daemon.CoreVersion()
 		protocolVersion, err := getProtocolVersion(ctx, ledgerReader)
 		if err != nil {
 			logger.WithError(err).Error("failed to fetch protocol version")

--- a/cmd/stellar-rpc/internal/methods/get_version_info.go
+++ b/cmd/stellar-rpc/internal/methods/get_version_info.go
@@ -20,9 +20,8 @@ func NewGetVersionInfoHandler(
 ) jrpc2.Handler {
 	coreHandler := func(ctx context.Context, _ protocol.GetVersionInfoRequest,
 	) (protocol.GetVersionInfoResponse, error) {
-		// Asked per request, not once at construction: the daemon learns the
-		// version when it starts stellar-core, which is after the handlers are
-		// built, so a value captured here would always be empty.
+		// Per request, not captured at construction: the daemon only learns the
+		// version once it starts core, which is after handlers are built.
 		captiveCoreVersion := daemon.CoreVersion()
 		protocolVersion, err := getProtocolVersion(ctx, ledgerReader)
 		if err != nil {

--- a/cmd/stellar-rpc/internal/rpcv1/daemon/metrics.go
+++ b/cmd/stellar-rpc/internal/rpcv1/daemon/metrics.go
@@ -9,7 +9,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/collectors"
 
 	"github.com/stellar/go-stellar-sdk/clients/stellarcore"
-	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
 	proto "github.com/stellar/go-stellar-sdk/protocols/stellarcore"
 	supportlog "github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/go-stellar-sdk/support/logmetrics"
@@ -122,8 +121,8 @@ func (d *Daemon) FastCoreClient() host.FastCoreClient {
 	return d.coreQueryingClient
 }
 
-func (d *Daemon) GetCore() *ledgerbackend.CaptiveStellarCore {
-	return d.core
+func (d *Daemon) CoreVersion() string {
+	return d.core.GetCoreVersion()
 }
 
 func (d *Daemon) Logger() *supportlog.Entry {

--- a/cmd/stellar-rpc/internal/rpcv2/config/config.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/config.go
@@ -44,11 +44,11 @@ type Config struct {
 }
 
 // ServiceConfig is [service] — the JSON-RPC read-serving policy (issue #882).
-// Most of it is dormant today: the read server arrives with #772, and #881
-// wires [service.fee_stats] into live ingestion — until then those values are
-// only parsed, defaulted, and validated. [service.preflight] is the exception:
-// the daemon already sizes the preflight worker pool from it at startup (#884).
-// The whole section is optional: absent keys get v1's defaults in WithDefaults.
+// Most of it is dormant today: the read server arrives with #772, and #881 wires
+// [service.fee_stats] into live ingestion — until then those values are only
+// parsed, defaulted, and validated. [service.preflight] is the exception; the
+// daemon sizes its preflight pool from it at startup. The whole section is
+// optional: absent keys get v1's defaults in WithDefaults.
 //
 // Key naming rule: camelCase table keys ONLY where the key is a wire identifier
 // (the [service.methods.<methodName>] tables, named after the JSON-RPC method);
@@ -76,10 +76,9 @@ type ServiceConfig struct {
 }
 
 // PreflightConfig is [service.preflight] — the worker pool that runs
-// simulateTransaction's preflight (the Rust libpreflight call). It sits under
-// [service] rather than under the simulateTransaction method table for the same
-// reason [service.fee_stats] does: the pool is a process-wide resource sized at
-// startup, not a per-request limit.
+// simulateTransaction's preflights. It sits under [service] rather than under the
+// simulateTransaction method table because the pool is sized once at startup,
+// not per request (the same reason [service.fee_stats] lives where it does).
 type PreflightConfig struct {
 	// WorkerCount is how many goroutines run preflights concurrently; >= 1.
 	// Default NumCPU.
@@ -87,9 +86,8 @@ type PreflightConfig struct {
 	// WorkerQueueSize is how many preflight requests may wait for a free worker
 	// before the pool starts rejecting them; >= 1. Default NumCPU.
 	WorkerQueueSize *uint `toml:"worker_queue_size"`
-	// EnableDebug adds detailed diagnostics to preflight errors. Default true.
-	// v1 warns against it in production deployments (the extra detail is
-	// expensive to produce).
+	// EnableDebug adds detailed diagnostics to preflight errors — expensive to
+	// produce, and v1 warns against it in production. Default true.
 	EnableDebug *bool `toml:"enable_debug"`
 }
 
@@ -131,9 +129,9 @@ type MethodsConfig struct {
 	GetEvents       PaginatedMethodConfig `toml:"getEvents"`
 	GetFeeStats     MethodConfig          `toml:"getFeeStats"`
 
-	// The three captive-core-backed methods (#884). They read live ledger state
-	// through captive core rather than this daemon's stores, so their knobs live
-	// alongside the rest but their [ingestion] core-HTTP settings do not.
+	// The three methods that read current ledger state through captive core
+	// rather than this daemon's stores (#884). Their serving knobs belong here;
+	// the core ports they reach over live in [ingestion].
 	SendTransaction     MethodConfig `toml:"sendTransaction"`
 	SimulateTransaction MethodConfig `toml:"simulateTransaction"`
 	GetLedgerEntries    MethodConfig `toml:"getLedgerEntries"`
@@ -324,38 +322,35 @@ type IngestionConfig struct {
 	// defaults to {default_data_dir}/captive-core.
 	CaptiveCoreStoragePath string `toml:"captive_core_storage_path"`
 
-	// The six keys below govern the HTTP surface of the SAME captive-core process
-	// the keys above configure — the two servers core runs when its toml enables
-	// them. They land in [ingestion] because that is where the core process lives,
-	// even though their consumers are three read/write endpoints (#884):
+	// The six keys below configure the two HTTP servers of the same captive-core
+	// process the keys above describe, which is why they live here even though
+	// their consumers are serving endpoints (#884): the admin server takes
+	// transaction submissions, and the query server answers ledger-entry lookups
+	// for getLedgerEntries and preflight.
 	//
-	//   - the admin server (core_http_port) takes transaction submissions;
-	//   - the query server (core_http_query_port) answers ledger-entry lookups
-	//     for getLedgerEntries and for simulateTransaction's preflight.
-	//
-	// They are set on the LIVE ingestion core's toml only. The backfill cores of a
-	// no-lake deployment run in parallel, so fixed ports there would collide.
+	// They are set on the LIVE core's toml only — the backfill cores of a no-lake
+	// deployment run in parallel, so fixed ports there would collide.
 
 	// CoreHTTPPort is core's admin HTTP port (v1's stellar-captive-core-http-port).
 	// Default 11626. Also the base for the default CoreURL.
 	CoreHTTPPort *uint `toml:"core_http_port"`
-	// CoreURL is the base URL transactions are submitted to (v1's stellar-core-url).
-	// Default "http://localhost:{core_http_port}"; set it only when core's admin
-	// server is reachable somewhere other than localhost.
+	// CoreURL is where transactions are submitted (v1's stellar-core-url). Default
+	// "http://localhost:{core_http_port}"; set it only when core's admin server is
+	// not on localhost.
 	CoreURL string `toml:"core_url"`
 	// CoreRequestTimeout is the HTTP timeout for every request to either core
 	// server (v1's stellar-core-timeout). Default "2s"; >= 1ms.
 	CoreRequestTimeout *time.Duration `toml:"core_request_timeout"`
-	// CoreHTTPQueryPort is core's high-performance query port, serving
-	// /getledgerentry (v1's stellar-captive-core-http-query-port). Default 11628.
-	// Must differ from CoreHTTPPort.
+	// CoreHTTPQueryPort is core's query port, serving /getledgerentry (v1's
+	// stellar-captive-core-http-query-port). Default 11628, and must differ from
+	// CoreHTTPPort.
 	CoreHTTPQueryPort *uint `toml:"core_http_query_port"`
 	// CoreHTTPQueryThreadPoolSize is how many threads core's query server uses.
 	// Default NumCPU.
 	CoreHTTPQueryThreadPoolSize *uint `toml:"core_http_query_thread_pool_size"`
 	// CoreHTTPQuerySnapshotLedgers is how many recent ledgers core's query server
-	// keeps queryable snapshots for. Default 4; leave it alone unless you know
-	// what core does with it.
+	// keeps snapshots for. Default 4; leave it alone unless you know what core
+	// does with it.
 	CoreHTTPQuerySnapshotLedgers *uint `toml:"core_http_query_snapshot_ledgers"`
 }
 
@@ -403,16 +398,13 @@ const (
 	// getEvents and getLedgers, which scan wider ranges.
 	DefaultScanMethodMaxExecutionDuration time.Duration = 10 * time.Second
 
-	// DefaultSendTransactionQueueLimit and DefaultSimulateTransactionQueueLimit
-	// are v1's queue limits for two of the three captive-core-backed methods:
-	// submissions are cheap to hold but must not pile up unbounded, and a
-	// simulation occupies a preflight worker for its whole run. (getLedgerEntries
-	// keeps the ordinary DefaultMethodQueueLimit.)
+	// DefaultSendTransactionQueueLimit and DefaultSimulateTransactionQueueLimit are
+	// v1's values; getLedgerEntries keeps the ordinary DefaultMethodQueueLimit.
 	DefaultSendTransactionQueueLimit     uint = 500
 	DefaultSimulateTransactionQueueLimit uint = 100
 	// DefaultCoreMethodMaxExecutionDuration is v1's wider budget for the two
-	// methods that wait on work outside this process — core's transaction
-	// submission and the Rust preflight call.
+	// methods that wait on work outside this process: core's own submission, and
+	// the Rust preflight call.
 	DefaultCoreMethodMaxExecutionDuration time.Duration = 15 * time.Second
 
 	DefaultMaxHealthyLedgerLatency time.Duration = 30 * time.Second
@@ -446,15 +438,14 @@ const (
 	DefaultCoreHTTPQuerySnapshotLedgers uint          = 4
 	DefaultCoreRequestTimeout           time.Duration = 2 * time.Second
 
-	// MaxPort is the highest legal TCP port. The captive-core toml carries the
-	// query-server settings as uint16, so validateConfig rejects anything above
-	// this before the daemon narrows the configured uint.
+	// MaxPort is the highest legal TCP port. The captive-core toml carries these
+	// settings as uint16, so validateConfig rejects anything above it before the
+	// daemon narrows the configured uint.
 	MaxPort uint = 65535
 )
 
 // NumCPU is the default for the three keys v1 sizes by CPU count: the preflight
-// worker count and queue size, and core's query-server thread pool. Wrapped so
-// the defaulting and the tests that assert it read the same value.
+// worker count and queue size, and core's query-server thread pool.
 func NumCPU() uint {
 	//nolint:gosec // runtime.NumCPU() is always non-negative and realistically well below uint limits
 	return uint(runtime.NumCPU())
@@ -559,8 +550,7 @@ func (cfg Config) WithDefaults() Config {
 	fillUint(&svc.Preflight.WorkerQueueSize, NumCPU())
 	fillBool(&svc.Preflight.EnableDebug, DefaultPreflightEnableDebug)
 
-	// [ingestion] core HTTP: the port fills FIRST, so an operator who sets only
-	// core_http_port gets a core_url that follows it.
+	// The port fills FIRST, so setting only core_http_port moves core_url with it.
 	ing := &cfg.Ingestion
 	fillUint(&ing.CoreHTTPPort, DefaultCoreHTTPPort)
 	if ing.CoreURL == "" {

--- a/cmd/stellar-rpc/internal/rpcv2/config/config.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/config.go
@@ -44,7 +44,7 @@ type Config struct {
 }
 
 // ServiceConfig is [service] — the JSON-RPC read-serving policy (issue #882).
-// Most of it is dormant today: the read server arrives with #772, and #881 wires
+// Most of it is dormant today: the read server arrives with #889, and #881 wires
 // [service.fee_stats] into live ingestion — until then those values are only
 // parsed, defaulted, and validated. [service.preflight] is the exception; the
 // daemon sizes its preflight pool from it at startup. The whole section is

--- a/cmd/stellar-rpc/internal/rpcv2/config/config.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/config.go
@@ -44,7 +44,8 @@ type Config struct {
 }
 
 // ServiceConfig is [service] — the JSON-RPC read-serving policy (issue #882).
-// Most of it is dormant today: the read server arrives with #889, and #881 wires
+// Most of it is dormant today: #889 builds the read server that reads these
+// serving limits (over the store readers its handlers need), and #881 wires
 // [service.fee_stats] into live ingestion — until then those values are only
 // parsed, defaulted, and validated. [service.preflight] is the exception; the
 // daemon sizes its preflight pool from it at startup. The whole section is

--- a/cmd/stellar-rpc/internal/rpcv2/config/config.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/config.go
@@ -456,6 +456,7 @@ const (
 // worker count and queue size, and core's query-server thread pool. Wrapped so
 // the defaulting and the tests that assert it read the same value.
 func NumCPU() uint {
+	//nolint:gosec // runtime.NumCPU() is always non-negative and realistically well below uint limits
 	return uint(runtime.NumCPU())
 }
 

--- a/cmd/stellar-rpc/internal/rpcv2/config/config.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/pelletier/go-toml"
@@ -43,10 +44,11 @@ type Config struct {
 }
 
 // ServiceConfig is [service] — the JSON-RPC read-serving policy (issue #882).
-// Everything here is dormant today: the read server arrives with #772, and
-// #881 wires [service.fee_stats] into live ingestion — until then the values
-// are only parsed, defaulted, and validated. The whole section is optional:
-// absent keys get v1's defaults in WithDefaults.
+// Most of it is dormant today: the read server arrives with #772, and #881
+// wires [service.fee_stats] into live ingestion — until then those values are
+// only parsed, defaulted, and validated. [service.preflight] is the exception:
+// the daemon already sizes the preflight worker pool from it at startup (#884).
+// The whole section is optional: absent keys get v1's defaults in WithDefaults.
 //
 // Key naming rule: camelCase table keys ONLY where the key is a wire identifier
 // (the [service.methods.<methodName>] tables, named after the JSON-RPC method);
@@ -68,8 +70,27 @@ type ServiceConfig struct {
 	MaxRequestExecutionDuration      *time.Duration `toml:"max_request_execution_duration"`
 	RequestExecutionWarningThreshold *time.Duration `toml:"request_execution_warning_threshold"`
 
-	FeeStats FeeStatsConfig `toml:"fee_stats"`
-	Methods  MethodsConfig  `toml:"methods"`
+	FeeStats  FeeStatsConfig  `toml:"fee_stats"`
+	Preflight PreflightConfig `toml:"preflight"`
+	Methods   MethodsConfig   `toml:"methods"`
+}
+
+// PreflightConfig is [service.preflight] — the worker pool that runs
+// simulateTransaction's preflight (the Rust libpreflight call). It sits under
+// [service] rather than under the simulateTransaction method table for the same
+// reason [service.fee_stats] does: the pool is a process-wide resource sized at
+// startup, not a per-request limit.
+type PreflightConfig struct {
+	// WorkerCount is how many goroutines run preflights concurrently; >= 1.
+	// Default NumCPU.
+	WorkerCount *uint `toml:"worker_count"`
+	// WorkerQueueSize is how many preflight requests may wait for a free worker
+	// before the pool starts rejecting them; >= 1. Default NumCPU.
+	WorkerQueueSize *uint `toml:"worker_queue_size"`
+	// EnableDebug adds detailed diagnostics to preflight errors. Default true.
+	// v1 warns against it in production deployments (the extra detail is
+	// expensive to produce).
+	EnableDebug *bool `toml:"enable_debug"`
 }
 
 // FeeStatsConfig is [service.fee_stats] — the sizes, in ledgers, of the two
@@ -109,6 +130,13 @@ type MethodsConfig struct {
 	GetLedgers      PaginatedMethodConfig `toml:"getLedgers"`
 	GetEvents       PaginatedMethodConfig `toml:"getEvents"`
 	GetFeeStats     MethodConfig          `toml:"getFeeStats"`
+
+	// The three captive-core-backed methods (#884). They read live ledger state
+	// through captive core rather than this daemon's stores, so their knobs live
+	// alongside the rest but their [ingestion] core-HTTP settings do not.
+	SendTransaction     MethodConfig `toml:"sendTransaction"`
+	SimulateTransaction MethodConfig `toml:"simulateTransaction"`
+	GetLedgerEntries    MethodConfig `toml:"getLedgerEntries"`
 }
 
 // MethodConfig is one method's serving knobs: the per-method request backlog
@@ -295,6 +323,40 @@ type IngestionConfig struct {
 	// CaptiveCoreStoragePath is captive core's BUCKET_DIR_PATH base; optional,
 	// defaults to {default_data_dir}/captive-core.
 	CaptiveCoreStoragePath string `toml:"captive_core_storage_path"`
+
+	// The six keys below govern the HTTP surface of the SAME captive-core process
+	// the keys above configure — the two servers core runs when its toml enables
+	// them. They land in [ingestion] because that is where the core process lives,
+	// even though their consumers are three read/write endpoints (#884):
+	//
+	//   - the admin server (core_http_port) takes transaction submissions;
+	//   - the query server (core_http_query_port) answers ledger-entry lookups
+	//     for getLedgerEntries and for simulateTransaction's preflight.
+	//
+	// They are set on the LIVE ingestion core's toml only. The backfill cores of a
+	// no-lake deployment run in parallel, so fixed ports there would collide.
+
+	// CoreHTTPPort is core's admin HTTP port (v1's stellar-captive-core-http-port).
+	// Default 11626. Also the base for the default CoreURL.
+	CoreHTTPPort *uint `toml:"core_http_port"`
+	// CoreURL is the base URL transactions are submitted to (v1's stellar-core-url).
+	// Default "http://localhost:{core_http_port}"; set it only when core's admin
+	// server is reachable somewhere other than localhost.
+	CoreURL string `toml:"core_url"`
+	// CoreRequestTimeout is the HTTP timeout for every request to either core
+	// server (v1's stellar-core-timeout). Default "2s"; >= 1ms.
+	CoreRequestTimeout *time.Duration `toml:"core_request_timeout"`
+	// CoreHTTPQueryPort is core's high-performance query port, serving
+	// /getledgerentry (v1's stellar-captive-core-http-query-port). Default 11628.
+	// Must differ from CoreHTTPPort.
+	CoreHTTPQueryPort *uint `toml:"core_http_query_port"`
+	// CoreHTTPQueryThreadPoolSize is how many threads core's query server uses.
+	// Default NumCPU.
+	CoreHTTPQueryThreadPoolSize *uint `toml:"core_http_query_thread_pool_size"`
+	// CoreHTTPQuerySnapshotLedgers is how many recent ledgers core's query server
+	// keeps queryable snapshots for. Default 4; leave it alone unless you know
+	// what core does with it.
+	CoreHTTPQuerySnapshotLedgers *uint `toml:"core_http_query_snapshot_ledgers"`
 }
 
 // LoggingConfig is [logging].
@@ -341,6 +403,18 @@ const (
 	// getEvents and getLedgers, which scan wider ranges.
 	DefaultScanMethodMaxExecutionDuration time.Duration = 10 * time.Second
 
+	// DefaultSendTransactionQueueLimit and DefaultSimulateTransactionQueueLimit
+	// are v1's queue limits for two of the three captive-core-backed methods:
+	// submissions are cheap to hold but must not pile up unbounded, and a
+	// simulation occupies a preflight worker for its whole run. (getLedgerEntries
+	// keeps the ordinary DefaultMethodQueueLimit.)
+	DefaultSendTransactionQueueLimit     uint = 500
+	DefaultSimulateTransactionQueueLimit uint = 100
+	// DefaultCoreMethodMaxExecutionDuration is v1's wider budget for the two
+	// methods that wait on work outside this process — core's transaction
+	// submission and the Rust preflight call.
+	DefaultCoreMethodMaxExecutionDuration time.Duration = 15 * time.Second
+
 	DefaultMaxHealthyLedgerLatency time.Duration = 30 * time.Second
 
 	// DefaultGetEventsMaxItemsPerResponse and the getLedgers pair below are the
@@ -361,7 +435,29 @@ const (
 
 	DefaultClassicFeeWindowLedgers          uint32 = 10
 	DefaultSorobanInclusionFeeWindowLedgers uint32 = 50
+
+	DefaultPreflightEnableDebug = true
 )
+
+// [ingestion] captive-core HTTP defaults — v1's values.
+const (
+	DefaultCoreHTTPPort                 uint          = 11626
+	DefaultCoreHTTPQueryPort            uint          = 11628
+	DefaultCoreHTTPQuerySnapshotLedgers uint          = 4
+	DefaultCoreRequestTimeout           time.Duration = 2 * time.Second
+
+	// MaxPort is the highest legal TCP port. The captive-core toml carries the
+	// query-server settings as uint16, so validateConfig rejects anything above
+	// this before the daemon narrows the configured uint.
+	MaxPort uint = 65535
+)
+
+// NumCPU is the default for the three keys v1 sizes by CPU count: the preflight
+// worker count and queue size, and core's query-server thread pool. Wrapped so
+// the defaulting and the tests that assert it read the same value.
+func NumCPU() uint {
+	return uint(runtime.NumCPU())
+}
 
 // LoadConfigWithFlags reads and parses the TOML config at path, with CLI
 // overrides: decode the file (strict), overlay every flag the user actually set
@@ -458,6 +554,21 @@ func (cfg Config) WithDefaults() Config {
 	fillDuration(&svc.RequestExecutionWarningThreshold, DefaultRequestExecutionWarningThreshold)
 	fillUint32(&svc.FeeStats.ClassicFeeWindowLedgers, DefaultClassicFeeWindowLedgers)
 	fillUint32(&svc.FeeStats.SorobanInclusionFeeWindowLedgers, DefaultSorobanInclusionFeeWindowLedgers)
+	fillUint(&svc.Preflight.WorkerCount, NumCPU())
+	fillUint(&svc.Preflight.WorkerQueueSize, NumCPU())
+	fillBool(&svc.Preflight.EnableDebug, DefaultPreflightEnableDebug)
+
+	// [ingestion] core HTTP: the port fills FIRST, so an operator who sets only
+	// core_http_port gets a core_url that follows it.
+	ing := &cfg.Ingestion
+	fillUint(&ing.CoreHTTPPort, DefaultCoreHTTPPort)
+	if ing.CoreURL == "" {
+		ing.CoreURL = fmt.Sprintf("http://localhost:%d", *ing.CoreHTTPPort)
+	}
+	fillDuration(&ing.CoreRequestTimeout, DefaultCoreRequestTimeout)
+	fillUint(&ing.CoreHTTPQueryPort, DefaultCoreHTTPQueryPort)
+	fillUint(&ing.CoreHTTPQueryThreadPoolSize, NumCPU())
+	fillUint(&ing.CoreHTTPQuerySnapshotLedgers, DefaultCoreHTTPQuerySnapshotLedgers)
 
 	// The methods cascade. queue/dur fill one per-method field: an explicit
 	// per-method value stays; else the [service.methods] wide default applies;
@@ -519,10 +630,25 @@ func (cfg Config) WithDefaults() Config {
 	queue(&m.GetFeeStats.QueueLimit, DefaultGetFeeStatsQueueLimit)
 	dur(&m.GetFeeStats.MaxExecutionDuration, DefaultMethodMaxExecutionDuration)
 
+	queue(&m.SendTransaction.QueueLimit, DefaultSendTransactionQueueLimit)
+	dur(&m.SendTransaction.MaxExecutionDuration, DefaultCoreMethodMaxExecutionDuration)
+
+	queue(&m.SimulateTransaction.QueueLimit, DefaultSimulateTransactionQueueLimit)
+	dur(&m.SimulateTransaction.MaxExecutionDuration, DefaultCoreMethodMaxExecutionDuration)
+
+	queue(&m.GetLedgerEntries.QueueLimit, DefaultMethodQueueLimit)
+	dur(&m.GetLedgerEntries.MaxExecutionDuration, DefaultMethodMaxExecutionDuration)
+
 	return cfg
 }
 
 func fillUint(p **uint, v uint) {
+	if *p == nil {
+		*p = &v
+	}
+}
+
+func fillBool(p **bool, v bool) {
 	if *p == nil {
 		*p = &v
 	}

--- a/cmd/stellar-rpc/internal/rpcv2/config/config_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/config_test.go
@@ -227,6 +227,70 @@ func TestParseConfig_ServiceDefaults(t *testing.T) {
 	assert.Equal(t, DefaultGetEventsDefaultItemsPerResponse, *m.GetEvents.DefaultItemsPerResponse)
 	assert.Equal(t, DefaultGetTransactionsMaxItemsPerResponse, *m.GetTransactions.MaxItemsPerResponse)
 	assert.Equal(t, DefaultGetLedgersMaxItemsPerResponse, *m.GetLedgers.MaxItemsPerResponse)
+
+	assert.Equal(t, DefaultSendTransactionQueueLimit, *m.SendTransaction.QueueLimit)
+	assert.Equal(t, DefaultCoreMethodMaxExecutionDuration, *m.SendTransaction.MaxExecutionDuration)
+	assert.Equal(t, DefaultSimulateTransactionQueueLimit, *m.SimulateTransaction.QueueLimit)
+	assert.Equal(t, DefaultCoreMethodMaxExecutionDuration, *m.SimulateTransaction.MaxExecutionDuration)
+	assert.Equal(t, DefaultMethodQueueLimit, *m.GetLedgerEntries.QueueLimit)
+	assert.Equal(t, DefaultMethodMaxExecutionDuration, *m.GetLedgerEntries.MaxExecutionDuration)
+}
+
+func TestParseConfig_PreflightDefaults(t *testing.T) {
+	cfg, err := ParseConfig([]byte(minimalValidConfig))
+	require.NoError(t, err)
+
+	p := cfg.Service.Preflight
+	assert.Equal(t, NumCPU(), *p.WorkerCount)
+	assert.Equal(t, NumCPU(), *p.WorkerQueueSize)
+	assert.True(t, *p.EnableDebug)
+}
+
+func TestParseConfig_PreflightExplicitValues(t *testing.T) {
+	cfg, err := ParseConfig([]byte(minimalValidConfig + `
+[service.preflight]
+worker_count = 3
+worker_queue_size = 7
+enable_debug = false
+`))
+	require.NoError(t, err)
+
+	p := cfg.Service.Preflight
+	assert.Equal(t, uint(3), *p.WorkerCount)
+	assert.Equal(t, uint(7), *p.WorkerQueueSize)
+	assert.False(t, *p.EnableDebug, "an explicit false must survive the true default")
+}
+
+func TestParseConfig_CoreHTTPDefaults(t *testing.T) {
+	cfg, err := ParseConfig([]byte(minimalValidConfig))
+	require.NoError(t, err)
+
+	ing := cfg.Ingestion
+	assert.Equal(t, DefaultCoreHTTPPort, *ing.CoreHTTPPort)
+	assert.Equal(t, "http://localhost:11626", ing.CoreURL)
+	assert.Equal(t, DefaultCoreRequestTimeout, *ing.CoreRequestTimeout)
+	assert.Equal(t, DefaultCoreHTTPQueryPort, *ing.CoreHTTPQueryPort)
+	assert.Equal(t, NumCPU(), *ing.CoreHTTPQueryThreadPoolSize)
+	assert.Equal(t, DefaultCoreHTTPQuerySnapshotLedgers, *ing.CoreHTTPQuerySnapshotLedgers)
+}
+
+func TestParseConfig_CoreURLFollowsCoreHTTPPort(t *testing.T) {
+	cfg, err := ParseConfig([]byte(minimalValidConfig + "\ncore_http_port = 21626\n"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "http://localhost:21626", cfg.Ingestion.CoreURL,
+		"moving the admin port alone must move the submission URL with it")
+}
+
+func TestParseConfig_ExplicitCoreURLWins(t *testing.T) {
+	cfg, err := ParseConfig([]byte(minimalValidConfig + `
+core_http_port = 21626
+core_url = "http://core.internal:8080"
+`))
+	require.NoError(t, err)
+
+	assert.Equal(t, "http://core.internal:8080", cfg.Ingestion.CoreURL)
+	assert.Equal(t, uint(21626), *cfg.Ingestion.CoreHTTPPort)
 }
 
 func TestParseConfig_MethodsCascade(t *testing.T) {
@@ -247,6 +311,11 @@ func TestParseConfig_MethodsCascade(t *testing.T) {
 		// getLedgers' duration was not set per-method, so the wide tier wins over
 		// its compiled 10s default.
 		assert.Equal(t, 8*time.Second, *m.GetLedgers.MaxExecutionDuration)
+		// Same for the captive-core-backed methods: the wide tier beats their
+		// compiled 500/15s and 100/15s.
+		assert.Equal(t, uint(200), *m.SendTransaction.QueueLimit)
+		assert.Equal(t, 8*time.Second, *m.SimulateTransaction.MaxExecutionDuration)
+		assert.Equal(t, uint(200), *m.GetLedgerEntries.QueueLimit)
 	})
 
 	t.Run("no wide tier: compiled per-method defaults", func(t *testing.T) {

--- a/cmd/stellar-rpc/internal/rpcv2/config/flags.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/flags.go
@@ -34,6 +34,7 @@ import (
 type FlagOverrides interface {
 	Changed(name string) bool
 	GetString(name string) (string, error)
+	GetBool(name string) (bool, error)
 	GetUint(name string) (uint, error)
 	GetUint32(name string) (uint32, error)
 	GetInt(name string) (int, error)
@@ -50,6 +51,12 @@ func BindFlags(fs *pflag.FlagSet) {
 		switch leafKind(f.Type()) {
 		case kindString:
 			fs.String(path, "", usage)
+		case kindBool:
+			// Registered as a normal (non-shorthand) bool flag, so both
+			// --service.preflight.enable_debug and the explicit
+			// --service.preflight.enable_debug=false work. The false default here
+			// is irrelevant: ApplyFlags reads a flag only when the user set it.
+			fs.Bool(path, false, usage)
 		case kindUint:
 			fs.Uint(path, 0, usage)
 		case kindUint32:
@@ -93,6 +100,12 @@ func setLeaf(f reflect.Value, path string, fs FlagOverrides) error {
 	switch leafKind(f.Type()) {
 	case kindString:
 		v, err := fs.GetString(path)
+		if err != nil {
+			return fail(err)
+		}
+		setPossiblyPointer(f, reflect.ValueOf(v))
+	case kindBool:
+		v, err := fs.GetBool(path)
 		if err != nil {
 			return fail(err)
 		}
@@ -165,6 +178,7 @@ type kind int
 const (
 	kindUnsupported kind = iota
 	kindString
+	kindBool
 	kindUint
 	kindUint32
 	kindInt
@@ -189,6 +203,8 @@ func leafKind(t reflect.Type) kind {
 	switch t.Kind() {
 	case reflect.String:
 		return kindString
+	case reflect.Bool:
+		return kindBool
 	case reflect.Uint:
 		return kindUint
 	case reflect.Uint32:

--- a/cmd/stellar-rpc/internal/rpcv2/config/flags.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/flags.go
@@ -52,10 +52,9 @@ func BindFlags(fs *pflag.FlagSet) {
 		case kindString:
 			fs.String(path, "", usage)
 		case kindBool:
-			// Registered as a normal (non-shorthand) bool flag, so both
-			// --service.preflight.enable_debug and the explicit
-			// --service.preflight.enable_debug=false work. The false default here
-			// is irrelevant: ApplyFlags reads a flag only when the user set it.
+			// The false default is irrelevant — ApplyFlags reads a flag only when
+			// the user set it. Turning a true-by-default key off needs --key=false,
+			// since a bare --key sets true.
 			fs.Bool(path, false, usage)
 		case kindUint:
 			fs.Uint(path, 0, usage)

--- a/cmd/stellar-rpc/internal/rpcv2/config/flags_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config/flags_test.go
@@ -52,6 +52,15 @@ func TestBindFlags_LockstepWithTOMLSchema(t *testing.T) {
 		"service.methods.getLedgers.max_items_per_response",
 		"service.methods.getHealth.max_healthy_ledger_latency",
 		"service.methods.getFeeStats.max_execution_duration",
+		"service.methods.sendTransaction.queue_limit",
+		"service.methods.simulateTransaction.max_execution_duration",
+		"service.methods.getLedgerEntries.queue_limit",
+		"service.preflight.worker_count",
+		"service.preflight.enable_debug",
+		"ingestion.core_http_port",
+		"ingestion.core_url",
+		"ingestion.core_request_timeout",
+		"ingestion.core_http_query_port",
 	} {
 		assert.NotNil(t, fs.Lookup(name), "expected flag --%s", name)
 	}
@@ -112,6 +121,49 @@ func TestApplyFlags_OverridesFileValues(t *testing.T) {
 	assert.Equal(t, 3, *cfg.Backfill.Workers)
 	assert.Equal(t, []string{"https://a.example", "https://b.example"}, cfg.Ingestion.HistoryArchiveURLs)
 	assert.Equal(t, 7*time.Second, *cfg.Backfill.BSB.RetryWait)
+}
+
+func TestApplyFlags_BoolOverride(t *testing.T) {
+	// enable_debug defaults to true, so the only override worth testing is the
+	// one that turns it off — and it has to be spelled --flag=false, since a bare
+	// --flag sets a bool to true.
+	fs := newBoundFlagSet(t)
+	require.NoError(t, fs.Parse([]string{"--service.preflight.enable_debug=false"}))
+
+	cfg, err := DecodeConfig([]byte(minimalValidConfig))
+	require.NoError(t, err)
+	require.Nil(t, cfg.Service.Preflight.EnableDebug)
+	require.NoError(t, ApplyFlags(&cfg, fs))
+	cfg = cfg.WithDefaults()
+
+	assert.False(t, *cfg.Service.Preflight.EnableDebug)
+}
+
+func TestApplyFlags_BoolLeftAloneKeepsTheDefault(t *testing.T) {
+	fs := newBoundFlagSet(t)
+	require.NoError(t, fs.Parse(nil))
+
+	cfg, err := DecodeConfig([]byte(minimalValidConfig))
+	require.NoError(t, err)
+	require.NoError(t, ApplyFlags(&cfg, fs))
+	cfg = cfg.WithDefaults()
+
+	assert.True(t, *cfg.Service.Preflight.EnableDebug,
+		"the flag's own false default must not leak in when the user never set it")
+}
+
+func TestApplyFlags_CoreHTTPPortMovesTheDerivedURL(t *testing.T) {
+	fs := newBoundFlagSet(t)
+	require.NoError(t, fs.Parse([]string{"--ingestion.core_http_port=31626"}))
+
+	cfg, err := DecodeConfig([]byte(minimalValidConfig))
+	require.NoError(t, err)
+	require.NoError(t, ApplyFlags(&cfg, fs))
+	cfg = cfg.WithDefaults()
+
+	assert.Equal(t, uint(31626), *cfg.Ingestion.CoreHTTPPort)
+	assert.Equal(t, "http://localhost:31626", cfg.Ingestion.CoreURL,
+		"the URL is derived after flags are overlaid, so a port flag moves it")
 }
 
 func TestApplyFlags_MapFlagMergesPerKey(t *testing.T) {

--- a/cmd/stellar-rpc/internal/rpcv2/config_validate.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config_validate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"strconv"
 	"time"
@@ -103,8 +104,8 @@ const (
 // validateIngestion form-validates the [ingestion] captive-core HTTP settings.
 // It runs after WithDefaults, so every pointer is non-nil.
 //
-// The four counts are uint here but uint16 in the captive-core toml, so each is
-// range-checked; newCaptiveCoreOpeners narrows them on the strength of it.
+// The four counts are uint here but 16-bit fields in core's toml, so each is
+// range-checked to fail as a config error rather than inside core.
 func validateIngestion(ing config.IngestionConfig) error {
 	// Both ports must be usable. v1 read port 0 as "don't run core's HTTP
 	// server"; v2 always serves sendTransaction off the admin port and
@@ -142,7 +143,28 @@ func validateIngestion(ing config.IngestionConfig) error {
 	case u.Host == "":
 		return fmt.Errorf("[ingestion].core_url %q names no host", ing.CoreURL)
 	}
+	// This daemon starts the core it submits to, and that core binds
+	// core_http_port, so a local core_url on any other port reaches something
+	// else — often a second daemon's captive core, which would accept the
+	// transaction — with neither startup nor getHealth reporting a problem. A
+	// non-local core_url is left alone: that is the reason to set it at all.
+	if isLoopbackHost(u.Hostname()) && u.Port() != strconv.FormatUint(uint64(*ing.CoreHTTPPort), 10) {
+		return fmt.Errorf("[ingestion].core_url %q points at this host but not at %s (%d) — "+
+			"the captive core this daemon starts listens on that port. Leave core_url unset to "+
+			"derive it, or give it a non-local address if core's admin server really is elsewhere",
+			ing.CoreURL, keyCoreHTTPPort, *ing.CoreHTTPPort)
+	}
 	return nil
+}
+
+// isLoopbackHost reports whether host refers to this machine. url.URL.Hostname
+// has already stripped an IPv6 literal's brackets, so "[::1]" arrives as "::1".
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 // minConfiguredDuration guards go-toml v1's nanosecond trap: a bare integer

--- a/cmd/stellar-rpc/internal/rpcv2/config_validate.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config_validate.go
@@ -90,10 +90,9 @@ func validateForm(cfg config.Config) error {
 	return validateService(cfg.Service)
 }
 
-// The [ingestion] core-HTTP key names, spelled once. Both the range checks in
-// validateIngestion and newCaptiveCoreOpeners' file-conflict check name these in
-// operator-facing errors, and a reader who greps an error message should land on
-// one definition. They mirror the toml tags on config.IngestionConfig.
+// The [ingestion] core-HTTP key names, spelled once: validateIngestion and
+// newCaptiveCoreOpeners both name them in errors. They mirror the toml tags on
+// config.IngestionConfig.
 const (
 	keyCoreHTTPPort             = "core_http_port"
 	keyCoreHTTPQueryPort        = "core_http_query_port"
@@ -102,16 +101,14 @@ const (
 )
 
 // validateIngestion form-validates the [ingestion] captive-core HTTP settings.
-// It runs AFTER WithDefaults, so every pointer is non-nil.
+// It runs after WithDefaults, so every pointer is non-nil.
 //
-// The four counts are configured as uint but reach the captive-core toml as
-// uint16, so each is range-checked here — this is the single place that rule
-// lives, and newCaptiveCoreOpeners narrows the values on the strength of it.
+// The four counts are uint here but uint16 in the captive-core toml, so each is
+// range-checked; newCaptiveCoreOpeners narrows them on the strength of it.
 func validateIngestion(ing config.IngestionConfig) error {
-	// Both ports must be usable: unlike v1, where port 0 meant "don't run core's
-	// HTTP server", v2 always serves sendTransaction off the admin port and
-	// getLedgerEntries off the query port, so a disabled server is a broken
-	// deployment rather than a mode.
+	// Both ports must be usable. v1 read port 0 as "don't run core's HTTP
+	// server"; v2 always serves sendTransaction off the admin port and
+	// getLedgerEntries off the query port, so 0 is a broken deployment, not a mode.
 	ports := []struct {
 		name string
 		v    uint
@@ -134,10 +131,8 @@ func validateIngestion(ing config.IngestionConfig) error {
 		return fmt.Errorf("[ingestion].core_request_timeout is %v — durations below 1ms are rejected; "+
 			"a bare TOML integer parses as nanoseconds, write a string like \"2s\"", *ing.CoreRequestTimeout)
 	}
-	// core_url is the one new key that is not a number, and an unusable one fails
-	// only later, per request, while the daemon still reports healthy. The easy
-	// mistake is omitting the scheme ("core.internal:11626"), which the HTTP
-	// client rejects at send time with "unsupported protocol scheme".
+	// A bad core_url otherwise fails per request, while the daemon reports
+	// healthy. The easy mistake is omitting the scheme ("core.internal:11626").
 	u, err := url.Parse(ing.CoreURL)
 	switch {
 	case err != nil:
@@ -247,9 +242,9 @@ func validateService(svc config.ServiceConfig) error {
 	return validateFeeWindows(svc.FeeStats)
 }
 
-// validatePreflight form-validates [service.preflight]. A zero worker count
-// means no goroutine ever picks a request up, and a zero queue size means the
-// pool is full the moment it is built — both reject every simulateTransaction.
+// validatePreflight form-validates [service.preflight]. Zero workers means
+// nothing picks requests up; a zero queue means the pool is full from the start.
+// Either rejects every simulateTransaction.
 func validatePreflight(p config.PreflightConfig) error {
 	if *p.WorkerCount < 1 {
 		return errors.New("[service.preflight].worker_count must be >= 1")

--- a/cmd/stellar-rpc/internal/rpcv2/config_validate.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config_validate.go
@@ -83,7 +83,46 @@ func validateForm(cfg config.Config) error {
 	if err := validateEarliestForm(cfg.Retention.EarliestLedger); err != nil {
 		return err
 	}
+	if err := validateIngestion(cfg.Ingestion); err != nil {
+		return err
+	}
 	return validateService(cfg.Service)
+}
+
+// validateIngestion form-validates the [ingestion] captive-core HTTP settings.
+// It runs AFTER WithDefaults, so every pointer is non-nil.
+//
+// The four counts are configured as uint but reach the captive-core toml as
+// uint16, so each is range-checked here — this is the single place that rule
+// lives, and newCaptiveCoreOpeners narrows the values on the strength of it.
+func validateIngestion(ing config.IngestionConfig) error {
+	// Both ports must be usable: unlike v1, where port 0 meant "don't run core's
+	// HTTP server", v2 always serves sendTransaction off the admin port and
+	// getLedgerEntries off the query port, so a disabled server is a broken
+	// deployment rather than a mode.
+	ports := []struct {
+		name string
+		v    uint
+	}{
+		{"core_http_port", *ing.CoreHTTPPort},
+		{"core_http_query_port", *ing.CoreHTTPQueryPort},
+		{"core_http_query_thread_pool_size", *ing.CoreHTTPQueryThreadPoolSize},
+		{"core_http_query_snapshot_ledgers", *ing.CoreHTTPQuerySnapshotLedgers},
+	}
+	for _, p := range ports {
+		if p.v < 1 || p.v > config.MaxPort {
+			return fmt.Errorf("[ingestion].%s must be between 1 and %d (got %d)", p.name, config.MaxPort, p.v)
+		}
+	}
+	if *ing.CoreHTTPPort == *ing.CoreHTTPQueryPort {
+		return fmt.Errorf("[ingestion].core_http_port and core_http_query_port are both %d — "+
+			"core runs two servers and cannot bind one port twice", *ing.CoreHTTPPort)
+	}
+	if *ing.CoreRequestTimeout < minConfiguredDuration {
+		return fmt.Errorf("[ingestion].core_request_timeout is %v — durations below 1ms are rejected; "+
+			"a bare TOML integer parses as nanoseconds, write a string like \"2s\"", *ing.CoreRequestTimeout)
+	}
+	return nil
 }
 
 // minConfiguredDuration guards go-toml v1's nanosecond trap: a bare integer
@@ -154,6 +193,9 @@ func validateService(svc config.ServiceConfig) error {
 		{"getLedgers", *m.GetLedgers.QueueLimit, *m.GetLedgers.MaxExecutionDuration},
 		{"getEvents", *m.GetEvents.QueueLimit, *m.GetEvents.MaxExecutionDuration},
 		{"getFeeStats", *m.GetFeeStats.QueueLimit, *m.GetFeeStats.MaxExecutionDuration},
+		{"sendTransaction", *m.SendTransaction.QueueLimit, *m.SendTransaction.MaxExecutionDuration},
+		{"simulateTransaction", *m.SimulateTransaction.QueueLimit, *m.SimulateTransaction.MaxExecutionDuration},
+		{"getLedgerEntries", *m.GetLedgerEntries.QueueLimit, *m.GetLedgerEntries.MaxExecutionDuration},
 	}
 	for _, mm := range methods {
 		if mm.queue < 1 {
@@ -174,7 +216,23 @@ func validateService(svc config.ServiceConfig) error {
 	if err := validatePaginatedMethods(m); err != nil {
 		return err
 	}
+	if err := validatePreflight(svc.Preflight); err != nil {
+		return err
+	}
 	return validateFeeWindows(svc.FeeStats)
+}
+
+// validatePreflight form-validates [service.preflight]. A zero worker count
+// means no goroutine ever picks a request up, and a zero queue size means the
+// pool is full the moment it is built — both reject every simulateTransaction.
+func validatePreflight(p config.PreflightConfig) error {
+	if *p.WorkerCount < 1 {
+		return errors.New("[service.preflight].worker_count must be >= 1")
+	}
+	if *p.WorkerQueueSize < 1 {
+		return errors.New("[service.preflight].worker_queue_size must be >= 1")
+	}
+	return nil
 }
 
 func validatePaginatedMethods(m config.MethodsConfig) error {

--- a/cmd/stellar-rpc/internal/rpcv2/config_validate.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config_validate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -89,6 +90,17 @@ func validateForm(cfg config.Config) error {
 	return validateService(cfg.Service)
 }
 
+// The [ingestion] core-HTTP key names, spelled once. Both the range checks in
+// validateIngestion and newCaptiveCoreOpeners' file-conflict check name these in
+// operator-facing errors, and a reader who greps an error message should land on
+// one definition. They mirror the toml tags on config.IngestionConfig.
+const (
+	keyCoreHTTPPort             = "core_http_port"
+	keyCoreHTTPQueryPort        = "core_http_query_port"
+	keyCoreQueryThreadPoolSize  = "core_http_query_thread_pool_size"
+	keyCoreQuerySnapshotLedgers = "core_http_query_snapshot_ledgers"
+)
+
 // validateIngestion form-validates the [ingestion] captive-core HTTP settings.
 // It runs AFTER WithDefaults, so every pointer is non-nil.
 //
@@ -104,10 +116,10 @@ func validateIngestion(ing config.IngestionConfig) error {
 		name string
 		v    uint
 	}{
-		{"core_http_port", *ing.CoreHTTPPort},
-		{"core_http_query_port", *ing.CoreHTTPQueryPort},
-		{"core_http_query_thread_pool_size", *ing.CoreHTTPQueryThreadPoolSize},
-		{"core_http_query_snapshot_ledgers", *ing.CoreHTTPQuerySnapshotLedgers},
+		{keyCoreHTTPPort, *ing.CoreHTTPPort},
+		{keyCoreHTTPQueryPort, *ing.CoreHTTPQueryPort},
+		{keyCoreQueryThreadPoolSize, *ing.CoreHTTPQueryThreadPoolSize},
+		{keyCoreQuerySnapshotLedgers, *ing.CoreHTTPQuerySnapshotLedgers},
 	}
 	for _, p := range ports {
 		if p.v < 1 || p.v > config.MaxPort {
@@ -121,6 +133,19 @@ func validateIngestion(ing config.IngestionConfig) error {
 	if *ing.CoreRequestTimeout < minConfiguredDuration {
 		return fmt.Errorf("[ingestion].core_request_timeout is %v — durations below 1ms are rejected; "+
 			"a bare TOML integer parses as nanoseconds, write a string like \"2s\"", *ing.CoreRequestTimeout)
+	}
+	// core_url is the one new key that is not a number, and an unusable one fails
+	// only later, per request, while the daemon still reports healthy. The easy
+	// mistake is omitting the scheme ("core.internal:11626"), which the HTTP
+	// client rejects at send time with "unsupported protocol scheme".
+	u, err := url.Parse(ing.CoreURL)
+	switch {
+	case err != nil:
+		return fmt.Errorf("[ingestion].core_url %q is not a URL: %w", ing.CoreURL, err)
+	case u.Scheme != "http" && u.Scheme != "https":
+		return fmt.Errorf("[ingestion].core_url %q must start with http:// or https://", ing.CoreURL)
+	case u.Host == "":
+		return fmt.Errorf("[ingestion].core_url %q names no host", ing.CoreURL)
 	}
 	return nil
 }

--- a/cmd/stellar-rpc/internal/rpcv2/config_validate.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config_validate.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/limits"
@@ -132,35 +133,59 @@ func validateIngestion(ing config.IngestionConfig) error {
 		return fmt.Errorf("[ingestion].core_request_timeout is %v — durations below 1ms are rejected; "+
 			"a bare TOML integer parses as nanoseconds, write a string like \"2s\"", *ing.CoreRequestTimeout)
 	}
-	// A bad core_url otherwise fails per request, while the daemon reports
-	// healthy. The easy mistake is omitting the scheme ("core.internal:11626").
-	u, err := url.Parse(ing.CoreURL)
+	return validateCoreURL(ing.CoreURL, *ing.CoreHTTPPort)
+}
+
+// validateCoreURL form-validates [ingestion].core_url against the admin port the
+// captive core will bind. A bad core_url otherwise fails per request, while the
+// daemon reports healthy. The easy mistake is omitting the scheme
+// ("core.internal:11626").
+func validateCoreURL(coreURL string, adminPort uint) error {
+	u, err := url.Parse(coreURL)
 	switch {
 	case err != nil:
-		return fmt.Errorf("[ingestion].core_url %q is not a URL: %w", ing.CoreURL, err)
+		return fmt.Errorf("[ingestion].core_url %q is not a URL: %w", coreURL, err)
 	case u.Scheme != "http" && u.Scheme != "https":
-		return fmt.Errorf("[ingestion].core_url %q must start with http:// or https://", ing.CoreURL)
+		return fmt.Errorf("[ingestion].core_url %q must start with http:// or https://", coreURL)
 	case u.Host == "":
-		return fmt.Errorf("[ingestion].core_url %q names no host", ing.CoreURL)
+		return fmt.Errorf("[ingestion].core_url %q names no host", coreURL)
+	}
+	// url.Parse only checks that an explicit port is numeric, so a port past
+	// 65535 parses fine here and fails at dial time on every submission.
+	if p := u.Port(); p != "" {
+		if n, err := strconv.Atoi(p); err != nil || n < 1 || n > int(config.MaxPort) {
+			return fmt.Errorf("[ingestion].core_url %q has port %s — ports run 1 to %d",
+				coreURL, p, config.MaxPort)
+		}
 	}
 	// This daemon starts the core it submits to, and that core binds
 	// core_http_port, so a local core_url on any other port reaches something
 	// else — often a second daemon's captive core, which would accept the
 	// transaction — with neither startup nor getHealth reporting a problem. A
 	// non-local core_url is left alone: that is the reason to set it at all.
-	if isLoopbackHost(u.Hostname()) && u.Port() != strconv.FormatUint(uint64(*ing.CoreHTTPPort), 10) {
-		return fmt.Errorf("[ingestion].core_url %q points at this host but not at %s (%d) — "+
-			"the captive core this daemon starts listens on that port. Leave core_url unset to "+
-			"derive it, or give it a non-local address if core's admin server really is elsewhere",
-			ing.CoreURL, keyCoreHTTPPort, *ing.CoreHTTPPort)
+	if isLoopbackHost(u.Hostname()) {
+		if u.Scheme == "https" {
+			return fmt.Errorf("[ingestion].core_url %q is https to this host, but the captive core "+
+				"this daemon starts serves plain HTTP — every submission would fail its TLS handshake. "+
+				"Use http://, or a non-local address if core's admin server really is elsewhere",
+				coreURL)
+		}
+		if u.Port() != strconv.FormatUint(uint64(adminPort), 10) {
+			return fmt.Errorf("[ingestion].core_url %q points at this host but not at %s (%d) — "+
+				"the captive core this daemon starts listens on that port. Leave core_url unset to "+
+				"derive it, or give it a non-local address if core's admin server really is elsewhere",
+				coreURL, keyCoreHTTPPort, adminPort)
+		}
 	}
 	return nil
 }
 
 // isLoopbackHost reports whether host refers to this machine. url.URL.Hostname
 // has already stripped an IPv6 literal's brackets, so "[::1]" arrives as "::1".
+// DNS names are case-insensitive and may carry a trailing root dot, so
+// "LOCALHOST" and "localhost." count too.
 func isLoopbackHost(host string) bool {
-	if host == "localhost" {
+	if strings.EqualFold(strings.TrimSuffix(host, "."), "localhost") {
 		return true
 	}
 	ip := net.ParseIP(host)

--- a/cmd/stellar-rpc/internal/rpcv2/config_validate_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config_validate_test.go
@@ -14,6 +14,11 @@ import (
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/config"
 )
 
+// wantNanosecondHint is the fragment every sub-millisecond-duration rejection
+// carries: a bare TOML integer decodes as nanoseconds, so the error tells the
+// operator to write the string form instead.
+const wantNanosecondHint = "nanoseconds"
+
 // validCfg builds a valid Config; callers mutate one field to drive a rejection.
 // Defaults are applied, matching production (validateConfig's contract is a
 // post-WithDefaults config — every [service] pointer non-nil).
@@ -159,7 +164,7 @@ func TestValidateConfig_RejectsMalformedService(t *testing.T) {
 			// The nanosecond trap: a bare TOML integer 10 decodes as 10ns.
 			"sub-millisecond duration",
 			func(c *config.Config) { c.Service.Methods.GetEvents.MaxExecutionDuration = durPtr(10) },
-			"nanoseconds",
+			wantNanosecondHint,
 		},
 		{
 			"zero global execution duration",
@@ -188,6 +193,31 @@ func TestValidateConfig_RejectsMalformedService(t *testing.T) {
 			"zero fee window",
 			func(c *config.Config) { c.Service.FeeStats.SorobanInclusionFeeWindowLedgers = uint32Ptr(0) },
 			"soroban_inclusion_fee_window_ledgers",
+		},
+		{
+			"zero sendTransaction queue_limit",
+			func(c *config.Config) { c.Service.Methods.SendTransaction.QueueLimit = uintPtr(0) },
+			"[service.methods.sendTransaction].queue_limit",
+		},
+		{
+			"sub-millisecond simulateTransaction duration",
+			func(c *config.Config) { c.Service.Methods.SimulateTransaction.MaxExecutionDuration = durPtr(15) },
+			wantNanosecondHint,
+		},
+		{
+			"zero getLedgerEntries queue_limit",
+			func(c *config.Config) { c.Service.Methods.GetLedgerEntries.QueueLimit = uintPtr(0) },
+			"[service.methods.getLedgerEntries].queue_limit",
+		},
+		{
+			"zero preflight worker_count",
+			func(c *config.Config) { c.Service.Preflight.WorkerCount = uintPtr(0) },
+			"[service.preflight].worker_count",
+		},
+		{
+			"zero preflight worker_queue_size",
+			func(c *config.Config) { c.Service.Preflight.WorkerQueueSize = uintPtr(0) },
+			"[service.preflight].worker_queue_size",
 		},
 	}
 	for _, tc := range tests {
@@ -225,7 +255,7 @@ func TestValidateConfig_RejectsMalformedBSB(t *testing.T) {
 			// The nanosecond trap again: retry_wait = 10 decodes as 10ns.
 			"sub-millisecond retry_wait",
 			func(c *config.Config) { c.Backfill.BSB.RetryWait = durPtr(10) },
-			"nanoseconds",
+			wantNanosecondHint,
 		},
 		{
 			"num_workers above buffer_size",
@@ -234,6 +264,65 @@ func TestValidateConfig_RejectsMalformedBSB(t *testing.T) {
 				c.Backfill.BSB.NumWorkers = uint32Ptr(50)
 			},
 			"num_workers",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cat, _ := testCatalog(t)
+			cfg := validCfg(4, 3, "genesis")
+			tc.mutate(&cfg)
+			_, err := callValidate(t, cfg, cat, downTip())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+func TestValidateConfig_RejectsMalformedCoreHTTP(t *testing.T) {
+	uintPtr := func(v uint) *uint { return &v }
+	durPtr := func(v time.Duration) *time.Duration { return &v }
+
+	tests := []struct {
+		name   string
+		mutate func(*config.Config)
+		want   string
+	}{
+		{
+			// v1 read 0 as "don't run core's HTTP server"; v2 serves
+			// sendTransaction off it, so 0 is a broken deployment.
+			"zero core_http_port",
+			func(c *config.Config) { c.Ingestion.CoreHTTPPort = uintPtr(0) },
+			"[ingestion].core_http_port",
+		},
+		{
+			// The captive-core toml carries these as uint16.
+			"core_http_query_port above 65535",
+			func(c *config.Config) { c.Ingestion.CoreHTTPQueryPort = uintPtr(70000) },
+			"[ingestion].core_http_query_port",
+		},
+		{
+			"thread pool above 65535",
+			func(c *config.Config) { c.Ingestion.CoreHTTPQueryThreadPoolSize = uintPtr(65536) },
+			"core_http_query_thread_pool_size",
+		},
+		{
+			"zero snapshot ledgers",
+			func(c *config.Config) { c.Ingestion.CoreHTTPQuerySnapshotLedgers = uintPtr(0) },
+			"core_http_query_snapshot_ledgers",
+		},
+		{
+			"both servers on one port",
+			func(c *config.Config) {
+				c.Ingestion.CoreHTTPPort = uintPtr(11626)
+				c.Ingestion.CoreHTTPQueryPort = uintPtr(11626)
+			},
+			"cannot bind one port twice",
+		},
+		{
+			// The nanosecond trap once more: core_request_timeout = 2 is 2ns.
+			"sub-millisecond core_request_timeout",
+			func(c *config.Config) { c.Ingestion.CoreRequestTimeout = durPtr(2) },
+			wantNanosecondHint,
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/stellar-rpc/internal/rpcv2/config_validate_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config_validate_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 // wantNanosecondHint is the fragment every sub-millisecond-duration rejection
-// carries: a bare TOML integer decodes as nanoseconds, so the error tells the
-// operator to write the string form instead.
+// carries, telling the operator to write the string form instead.
 const wantNanosecondHint = "nanoseconds"
 
 // validCfg builds a valid Config; callers mutate one field to drive a rejection.
@@ -288,8 +287,7 @@ func TestValidateConfig_RejectsMalformedCoreHTTP(t *testing.T) {
 		want   string
 	}{
 		{
-			// v1 read 0 as "don't run core's HTTP server"; v2 serves
-			// sendTransaction off it, so 0 is a broken deployment.
+			// v1 read 0 as "don't run core's HTTP server".
 			"zero core_http_port",
 			func(c *config.Config) { c.Ingestion.CoreHTTPPort = uintPtr(0) },
 			"[ingestion]." + keyCoreHTTPPort,
@@ -325,8 +323,7 @@ func TestValidateConfig_RejectsMalformedCoreHTTP(t *testing.T) {
 			wantNanosecondHint,
 		},
 		{
-			// Easy to write, given the sibling key is a bare port. Without this
-			// check every submission fails at request time, not at startup.
+			// Otherwise every submission fails at request time, not at startup.
 			"core_url without a scheme",
 			func(c *config.Config) { c.Ingestion.CoreURL = "core.internal:11626" },
 			"must start with http:// or https://",

--- a/cmd/stellar-rpc/internal/rpcv2/config_validate_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config_validate_test.go
@@ -338,6 +338,21 @@ func TestValidateConfig_RejectsMalformedCoreHTTP(t *testing.T) {
 			func(c *config.Config) { c.Ingestion.CoreURL = "http://[::1" },
 			"core_url",
 		},
+		{
+			"core_url on this host but not on core_http_port",
+			func(c *config.Config) { c.Ingestion.CoreURL = "http://localhost:21626" },
+			"points at this host but not at " + keyCoreHTTPPort,
+		},
+		{
+			"core_url on a loopback address but not on core_http_port",
+			func(c *config.Config) { c.Ingestion.CoreURL = "http://127.0.0.1:8080" },
+			"points at this host but not at " + keyCoreHTTPPort,
+		},
+		{
+			"core_url on this host with no port",
+			func(c *config.Config) { c.Ingestion.CoreURL = "http://localhost" },
+			"points at this host but not at " + keyCoreHTTPPort,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -347,6 +362,26 @@ func TestValidateConfig_RejectsMalformedCoreHTTP(t *testing.T) {
 			_, err := callValidate(t, cfg, cat, downTip())
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+func TestValidateConfig_AcceptsCoreURLsThatCannotMisroute(t *testing.T) {
+	corePort := strconv.FormatUint(uint64(config.DefaultCoreHTTPPort), 10)
+	urls := []string{
+		"http://core.internal:8080",
+		"https://core.internal",
+		"http://localhost:" + corePort,
+		"http://127.0.0.1:" + corePort,
+		"http://[::1]:" + corePort,
+	}
+	for _, u := range urls {
+		t.Run(u, func(t *testing.T) {
+			cat, _ := testCatalog(t)
+			cfg := validCfg(4, 3, "genesis")
+			cfg.Ingestion.CoreURL = u
+			_, err := callValidate(t, cfg, cat, downTip())
+			require.NoError(t, err)
 		})
 	}
 }

--- a/cmd/stellar-rpc/internal/rpcv2/config_validate_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config_validate_test.go
@@ -292,23 +292,23 @@ func TestValidateConfig_RejectsMalformedCoreHTTP(t *testing.T) {
 			// sendTransaction off it, so 0 is a broken deployment.
 			"zero core_http_port",
 			func(c *config.Config) { c.Ingestion.CoreHTTPPort = uintPtr(0) },
-			"[ingestion].core_http_port",
+			"[ingestion]." + keyCoreHTTPPort,
 		},
 		{
 			// The captive-core toml carries these as uint16.
 			"core_http_query_port above 65535",
 			func(c *config.Config) { c.Ingestion.CoreHTTPQueryPort = uintPtr(70000) },
-			"[ingestion].core_http_query_port",
+			"[ingestion]." + keyCoreHTTPQueryPort,
 		},
 		{
 			"thread pool above 65535",
 			func(c *config.Config) { c.Ingestion.CoreHTTPQueryThreadPoolSize = uintPtr(65536) },
-			"core_http_query_thread_pool_size",
+			keyCoreQueryThreadPoolSize,
 		},
 		{
 			"zero snapshot ledgers",
 			func(c *config.Config) { c.Ingestion.CoreHTTPQuerySnapshotLedgers = uintPtr(0) },
-			"core_http_query_snapshot_ledgers",
+			keyCoreQuerySnapshotLedgers,
 		},
 		{
 			"both servers on one port",
@@ -323,6 +323,23 @@ func TestValidateConfig_RejectsMalformedCoreHTTP(t *testing.T) {
 			"sub-millisecond core_request_timeout",
 			func(c *config.Config) { c.Ingestion.CoreRequestTimeout = durPtr(2) },
 			wantNanosecondHint,
+		},
+		{
+			// Easy to write, given the sibling key is a bare port. Without this
+			// check every submission fails at request time, not at startup.
+			"core_url without a scheme",
+			func(c *config.Config) { c.Ingestion.CoreURL = "core.internal:11626" },
+			"must start with http:// or https://",
+		},
+		{
+			"core_url with no host",
+			func(c *config.Config) { c.Ingestion.CoreURL = "http://" },
+			"names no host",
+		},
+		{
+			"core_url that is not a URL at all",
+			func(c *config.Config) { c.Ingestion.CoreURL = "http://[::1" },
+			"core_url",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/stellar-rpc/internal/rpcv2/config_validate_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/config_validate_test.go
@@ -322,37 +322,6 @@ func TestValidateConfig_RejectsMalformedCoreHTTP(t *testing.T) {
 			func(c *config.Config) { c.Ingestion.CoreRequestTimeout = durPtr(2) },
 			wantNanosecondHint,
 		},
-		{
-			// Otherwise every submission fails at request time, not at startup.
-			"core_url without a scheme",
-			func(c *config.Config) { c.Ingestion.CoreURL = "core.internal:11626" },
-			"must start with http:// or https://",
-		},
-		{
-			"core_url with no host",
-			func(c *config.Config) { c.Ingestion.CoreURL = "http://" },
-			"names no host",
-		},
-		{
-			"core_url that is not a URL at all",
-			func(c *config.Config) { c.Ingestion.CoreURL = "http://[::1" },
-			"core_url",
-		},
-		{
-			"core_url on this host but not on core_http_port",
-			func(c *config.Config) { c.Ingestion.CoreURL = "http://localhost:21626" },
-			"points at this host but not at " + keyCoreHTTPPort,
-		},
-		{
-			"core_url on a loopback address but not on core_http_port",
-			func(c *config.Config) { c.Ingestion.CoreURL = "http://127.0.0.1:8080" },
-			"points at this host but not at " + keyCoreHTTPPort,
-		},
-		{
-			"core_url on this host with no port",
-			func(c *config.Config) { c.Ingestion.CoreURL = "http://localhost" },
-			"points at this host but not at " + keyCoreHTTPPort,
-		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -366,12 +335,85 @@ func TestValidateConfig_RejectsMalformedCoreHTTP(t *testing.T) {
 	}
 }
 
+// A bad core_url otherwise fails per request, not at startup.
+func TestValidateConfig_RejectsMisroutableCoreURLs(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			"without a scheme",
+			"core.internal:11626",
+			"must start with http:// or https://",
+		},
+		{
+			"no host",
+			"http://",
+			"names no host",
+		},
+		{
+			"not a URL at all",
+			"http://[::1",
+			"core_url",
+		},
+		{
+			"this host but not core_http_port",
+			"http://localhost:21626",
+			"points at this host but not at " + keyCoreHTTPPort,
+		},
+		{
+			"a loopback address but not core_http_port",
+			"http://127.0.0.1:8080",
+			"points at this host but not at " + keyCoreHTTPPort,
+		},
+		{
+			"this host with no port",
+			"http://localhost",
+			"points at this host but not at " + keyCoreHTTPPort,
+		},
+		{
+			"this host in uppercase but not core_http_port",
+			"http://LOCALHOST:21626",
+			"points at this host but not at " + keyCoreHTTPPort,
+		},
+		{
+			"this host with a trailing dot but not core_http_port",
+			"http://localhost.:21626",
+			"points at this host but not at " + keyCoreHTTPPort,
+		},
+		{
+			// The local captive core serves plain HTTP, so https can never work.
+			"https to this host",
+			"https://localhost:11626",
+			"TLS handshake",
+		},
+		{
+			"a port past 65535",
+			"http://core.internal:70000",
+			"ports run 1 to",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cat, _ := testCatalog(t)
+			cfg := validCfg(4, 3, "genesis")
+			cfg.Ingestion.CoreURL = tc.url
+			_, err := callValidate(t, cfg, cat, downTip())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
 func TestValidateConfig_AcceptsCoreURLsThatCannotMisroute(t *testing.T) {
 	corePort := strconv.FormatUint(uint64(config.DefaultCoreHTTPPort), 10)
 	urls := []string{
 		"http://core.internal:8080",
 		"https://core.internal",
 		"http://localhost:" + corePort,
+		"http://LOCALHOST:" + corePort,
+		"http://localhost.:" + corePort,
 		"http://127.0.0.1:" + corePort,
 		"http://[::1]:" + corePort,
 	}

--- a/cmd/stellar-rpc/internal/rpcv2/corestate/corestate.go
+++ b/cmd/stellar-rpc/internal/rpcv2/corestate/corestate.go
@@ -1,0 +1,193 @@
+// Package corestate is the full-history daemon's window onto the CURRENT
+// ledger state, which lives in captive core's bucket list rather than in any of
+// this daemon's stores.
+//
+// Three JSON-RPC methods need that state, and all three reach it over HTTP:
+//
+//   - sendTransaction submits to core's admin server (the only path that floods
+//     a transaction to the network);
+//   - getLedgerEntries reads entries from core's high-performance query server;
+//   - simulateTransaction runs the Rust preflight library in-process, and the
+//     library fetches every entry it touches back through that same query
+//     server.
+//
+// Daemon is the concrete host.Daemon those handlers are written against. It is
+// deliberately thin: two HTTP clients pointed at the two ports, the metrics
+// registry the handlers register on, and the stellar-core binary's version
+// string. It holds no reference to the running core process — nothing the
+// handlers need requires one, and the ingestion stream owns that process's
+// lifecycle (a fresh core per supervised run).
+//
+// Both clients assume core is up. Before ingestion starts nothing has launched
+// core yet, so calls fail at the HTTP layer (connection refused) and surface as
+// handler errors.
+package corestate
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/stellar/go-stellar-sdk/clients/stellarcore"
+	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/host"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/ledgerentries"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/store"
+)
+
+// Config is what New needs to build a Daemon. Every field comes from the
+// daemon's [ingestion] config section except Registry and Logger.
+type Config struct {
+	// CoreURL is the base URL of core's admin HTTP server, where transactions
+	// are submitted ([ingestion].core_url). Required.
+	CoreURL string
+
+	// QueryPort is the port of core's high-performance query server on localhost
+	// ([ingestion].core_http_query_port). Required. Unlike CoreURL this is a bare
+	// port: the query server is only ever the local captive-core process, because
+	// this daemon is what configured and launched it.
+	QueryPort uint
+
+	// RequestTimeout bounds every HTTP request to either server
+	// ([ingestion].core_request_timeout). Required — a zero value would mean "no
+	// timeout at all", so New rejects it.
+	RequestTimeout time.Duration
+
+	// StellarCoreBinaryPath is the RESOLVED path to the stellar-core binary (an
+	// explicit [ingestion].stellar_core_binary_path, or whatever was found on
+	// PATH). New runs `stellar-core version` against it once. Optional: when it is
+	// empty CoreVersion reports "".
+	StellarCoreBinaryPath string
+
+	// Registry is where handlers register their collectors. Required, and it must
+	// be the daemon's own registry — the one its metrics endpoint serves.
+	Registry *prometheus.Registry
+
+	// Namespace prefixes those collectors' names; empty means
+	// host.PrometheusNamespace.
+	Namespace string
+
+	// Logger is optional; it only records whether the version lookup worked.
+	Logger *supportlog.Entry
+}
+
+// Daemon implements host.Daemon for the full-history daemon. Build it with New.
+type Daemon struct {
+	registry       *prometheus.Registry
+	namespace      string
+	coreClient     *stellarcore.Client
+	fastCoreClient *stellarcore.Client
+	coreVersion    string
+}
+
+// New builds the Daemon: one HTTP client per core server, and one up-front read
+// of the binary's version.
+//
+// A failed version lookup is NOT an error. The version is a cosmetic field of
+// getVersionInfo's response, so a daemon that cannot run `stellar-core version`
+// (no binary on this host yet, wrong permissions) still starts, logs the
+// failure, and reports an empty version.
+func New(cfg Config) (*Daemon, error) {
+	if cfg.CoreURL == "" {
+		return nil, errors.New("corestate: CoreURL is required (default http://localhost:{core_http_port})")
+	}
+	if cfg.QueryPort == 0 {
+		return nil, errors.New("corestate: QueryPort is required")
+	}
+	if cfg.RequestTimeout <= 0 {
+		return nil, fmt.Errorf("corestate: RequestTimeout must be positive, got %v", cfg.RequestTimeout)
+	}
+	if cfg.Registry == nil {
+		return nil, errors.New("corestate: Registry is required")
+	}
+
+	namespace := cfg.Namespace
+	if namespace == "" {
+		namespace = host.PrometheusNamespace
+	}
+
+	// One client per server, each with its own http.Client so a slow submission
+	// cannot consume a connection the query path needs.
+	return &Daemon{
+		registry:  cfg.Registry,
+		namespace: namespace,
+		coreClient: &stellarcore.Client{
+			URL:  cfg.CoreURL,
+			HTTP: &http.Client{Timeout: cfg.RequestTimeout},
+		},
+		fastCoreClient: &stellarcore.Client{
+			URL:  fmt.Sprintf("http://localhost:%d", cfg.QueryPort),
+			HTTP: &http.Client{Timeout: cfg.RequestTimeout},
+		},
+		coreVersion: readCoreVersion(cfg.StellarCoreBinaryPath, cfg.Logger),
+	}, nil
+}
+
+// MetricsRegistry returns the daemon's registry — the real one, so a collector
+// registered by a handler shows up on the metrics endpoint.
+func (d *Daemon) MetricsRegistry() *prometheus.Registry {
+	return d.registry
+}
+
+func (d *Daemon) MetricsNamespace() string {
+	return d.namespace
+}
+
+// CoreClient is the client for core's admin server: sendTransaction's submission
+// path.
+func (d *Daemon) CoreClient() host.CoreClient {
+	return d.coreClient
+}
+
+// FastCoreClient is the client for core's query server: getLedgerEntries and
+// every entry lookup a preflight makes.
+func (d *Daemon) FastCoreClient() host.FastCoreClient {
+	return d.fastCoreClient
+}
+
+// CoreVersion returns the version string read from the stellar-core binary at
+// startup, or "" if it could not be read.
+func (d *Daemon) CoreVersion() string {
+	return d.coreVersion
+}
+
+// LedgerEntryGetter builds the entry reader getLedgerEntries and
+// simulateTransaction share: it fetches from core's query server, at the ledger
+// this daemon has most recently committed.
+//
+// The ledger matters. Passing core the daemon's latest sequence — rather than
+// letting core answer from its own latest — keeps a read consistent with what
+// the rest of this daemon's responses report, even while core runs ahead.
+//
+// Typical use, from the handler wiring:
+//
+//	getter := coreDaemon.LedgerEntryGetter(ledgerReader)
+//	entries, atLedger, err := getter.GetLedgerEntries(ctx, keys)
+func (d *Daemon) LedgerEntryGetter(latestLedgerReader store.LedgerReader) ledgerentries.LedgerEntryGetter {
+	return ledgerentries.NewLedgerEntryGetter(d.FastCoreClient(), latestLedgerReader)
+}
+
+// readCoreVersion runs `stellar-core version` against the binary once. An empty
+// path (no binary configured or found) skips the call entirely.
+func readCoreVersion(binaryPath string, logger *supportlog.Entry) string {
+	if binaryPath == "" {
+		return ""
+	}
+	version, err := ledgerbackend.CoreBuildVersion(binaryPath)
+	if err != nil {
+		if logger != nil {
+			logger.WithError(err).WithField("binary_path", binaryPath).
+				Warn("could not read the stellar-core version; getVersionInfo will report it as empty")
+		}
+		return ""
+	}
+	if logger != nil {
+		logger.WithField("stellar_core_version", version).Info("read stellar-core version")
+	}
+	return version
+}

--- a/cmd/stellar-rpc/internal/rpcv2/corestate/corestate.go
+++ b/cmd/stellar-rpc/internal/rpcv2/corestate/corestate.go
@@ -176,7 +176,12 @@ func readCoreVersion(ctx context.Context, binaryPath string, logger *supportlog.
 	ctx, cancel := context.WithTimeout(ctx, coreVersionTimeout)
 	defer cancel()
 
-	out, err := exec.CommandContext(ctx, binaryPath, "version").Output()
+	cmd := exec.CommandContext(ctx, binaryPath, "version")
+	// The timeout kills only the direct process. If that was a wrapper whose
+	// child inherited stdout, Output would still wait for pipe EOF — WaitDelay
+	// forces the pipe closed so the hang stays bounded.
+	cmd.WaitDelay = time.Second
+	out, err := cmd.Output()
 	version, _, _ := strings.Cut(string(out), "\n")
 	if err == nil && version == "" {
 		err = errors.New("stellar-core version printed no output")

--- a/cmd/stellar-rpc/internal/rpcv2/corestate/corestate.go
+++ b/cmd/stellar-rpc/internal/rpcv2/corestate/corestate.go
@@ -1,26 +1,17 @@
-// Package corestate is the full-history daemon's window onto the CURRENT
-// ledger state, which lives in captive core's bucket list rather than in any of
-// this daemon's stores.
+// Package corestate reads current ledger state from captive core, which is
+// where it lives — the bucket list, not this daemon's stores.
 //
-// Three JSON-RPC methods need that state, and all three reach it over HTTP:
+// Three methods need it, all over HTTP: sendTransaction submits to core's admin
+// server, getLedgerEntries reads from core's query server, and
+// simulateTransaction runs the Rust preflight library in-process, which fetches
+// the entries it touches from that same query server.
 //
-//   - sendTransaction submits to core's admin server (the only path that floods
-//     a transaction to the network);
-//   - getLedgerEntries reads entries from core's high-performance query server;
-//   - simulateTransaction runs the Rust preflight library in-process, and the
-//     library fetches every entry it touches back through that same query
-//     server.
+// Daemon is the host.Daemon those handlers take. It holds two HTTP clients, a
+// metrics registry, and the core binary's version string — no reference to the
+// running core process, because nothing here needs one.
 //
-// Daemon is the concrete host.Daemon those handlers are written against. It is
-// deliberately thin: two HTTP clients pointed at the two ports, the metrics
-// registry the handlers register on, and the stellar-core binary's version
-// string. It holds no reference to the running core process — nothing the
-// handlers need requires one, and the ingestion stream owns that process's
-// lifecycle (a fresh core per supervised run).
-//
-// Both clients assume core is up. Before ingestion starts nothing has launched
-// core yet, so calls fail at the HTTP layer (connection refused) and surface as
-// handler errors.
+// Both clients assume core is up. Before ingestion starts it isn't, so calls
+// fail with connection refused.
 package corestate
 
 import (
@@ -47,29 +38,25 @@ type Config struct {
 	// are submitted ([ingestion].core_url). Required.
 	CoreURL string
 
-	// QueryPort is the port of core's high-performance query server on localhost
-	// ([ingestion].core_http_query_port). Required. Unlike CoreURL this is a bare
-	// port: the query server is only ever the local captive-core process, because
-	// this daemon is what configured and launched it.
+	// QueryPort is the port of core's query server ([ingestion].core_http_query_port).
+	// Required. A bare port, not a URL: that server is always the local
+	// captive-core process this daemon launched.
 	QueryPort uint
 
-	// RequestTimeout bounds every HTTP request to either server
-	// ([ingestion].core_request_timeout). Required — a zero value would mean "no
-	// timeout at all", so New rejects it.
+	// RequestTimeout bounds every request to either server
+	// ([ingestion].core_request_timeout). Required: zero would mean no timeout.
 	RequestTimeout time.Duration
 
-	// StellarCoreBinaryPath is the RESOLVED path to the stellar-core binary (an
-	// explicit [ingestion].stellar_core_binary_path, or whatever was found on
-	// PATH). New runs `stellar-core version` against it once. Optional: when it is
-	// empty CoreVersion reports "".
+	// StellarCoreBinaryPath is the resolved stellar-core binary — an explicit
+	// [ingestion].stellar_core_binary_path, or the one found on PATH. New runs
+	// `stellar-core version` against it once. Empty ⇒ CoreVersion reports "".
 	StellarCoreBinaryPath string
 
 	// Registry is where handlers register their collectors. Required, and it must
-	// be the daemon's own registry — the one its metrics endpoint serves.
+	// be the registry the daemon's metrics endpoint serves.
 	Registry *prometheus.Registry
 
-	// Namespace prefixes those collectors' names; empty means
-	// host.PrometheusNamespace.
+	// Namespace prefixes those collectors' names; empty ⇒ host.PrometheusNamespace.
 	Namespace string
 
 	// Logger is optional; it only records whether the version lookup worked.
@@ -85,13 +72,11 @@ type Daemon struct {
 	coreVersion    string
 }
 
-// New builds the Daemon: one HTTP client per core server, and one up-front read
-// of the binary's version.
+// New builds the Daemon: one HTTP client per core server, plus one read of the
+// binary's version.
 //
-// A failed version lookup is NOT an error. The version is a cosmetic field of
-// getVersionInfo's response, so a daemon that cannot run `stellar-core version`
-// (no binary on this host yet, wrong permissions) still starts, logs the
-// failure, and reports an empty version.
+// A failed version lookup is not an error — the version is only a field in
+// getVersionInfo's response, so the daemon starts anyway and reports "".
 func New(cfg Config) (*Daemon, error) {
 	if cfg.CoreURL == "" {
 		return nil, errors.New("corestate: CoreURL is required (default http://localhost:{core_http_port})")
@@ -111,13 +96,12 @@ func New(cfg Config) (*Daemon, error) {
 		namespace = host.PrometheusNamespace
 	}
 
-	// One client per server, each with its own http.Client so a slow submission
-	// cannot consume a connection the query path needs.
+	// Separate http.Clients so a slow submission cannot tie up a connection the
+	// query path needs.
 	//
 	// TODO(#889): the submission client is unwrapped, so v2 does not yet publish
-	// v1's two txsub metrics (soroban_rpc_txsub_submission_duration_seconds and
-	// _operation_count). v1's wrapper for them lives in internal/rpcv1/daemon and
-	// has to move to a shared package before sendTransaction is served.
+	// v1's txsub metrics. v1's wrapper for them lives in internal/rpcv1/daemon and
+	// must move to a shared package before sendTransaction is served.
 	return &Daemon{
 		registry:  cfg.Registry,
 		namespace: namespace,
@@ -133,8 +117,8 @@ func New(cfg Config) (*Daemon, error) {
 	}, nil
 }
 
-// MetricsRegistry returns the daemon's registry — the real one, so a collector
-// registered by a handler shows up on the metrics endpoint.
+// MetricsRegistry returns the daemon's own registry, so collectors a handler
+// registers show up on the metrics endpoint.
 func (d *Daemon) MetricsRegistry() *prometheus.Registry {
 	return d.registry
 }
@@ -143,33 +127,27 @@ func (d *Daemon) MetricsNamespace() string {
 	return d.namespace
 }
 
-// CoreClient is the client for core's admin server: sendTransaction's submission
-// path.
+// CoreClient talks to core's admin server: sendTransaction's submission path.
 func (d *Daemon) CoreClient() host.CoreClient {
 	return d.coreClient
 }
 
-// FastCoreClient is the client for core's query server: getLedgerEntries and
-// every entry lookup a preflight makes.
+// FastCoreClient talks to core's query server: getLedgerEntries and preflight's
+// entry lookups.
 func (d *Daemon) FastCoreClient() host.FastCoreClient {
 	return d.fastCoreClient
 }
 
-// CoreVersion returns the version string read from the stellar-core binary at
-// startup, or "" if it could not be read.
+// CoreVersion returns the version read from the core binary at startup, or "".
 func (d *Daemon) CoreVersion() string {
 	return d.coreVersion
 }
 
 // LedgerEntryGetter builds the entry reader getLedgerEntries and
-// simulateTransaction share: it fetches from core's query server, at the ledger
-// this daemon has most recently committed.
-//
-// The ledger matters. Passing core the daemon's latest sequence — rather than
-// letting core answer from its own latest — keeps a read consistent with what
-// the rest of this daemon's responses report, even while core runs ahead.
-//
-// Typical use, from the handler wiring:
+// simulateTransaction share. It reads from core's query server at the ledger
+// this daemon last committed, rather than letting core answer from its own
+// latest, so a read agrees with what the daemon's other responses report even
+// while core runs ahead.
 //
 //	getter := coreDaemon.LedgerEntryGetter(ledgerReader)
 //	entries, atLedger, err := getter.GetLedgerEntries(ctx, keys)
@@ -177,8 +155,7 @@ func (d *Daemon) LedgerEntryGetter(latestLedgerReader store.LedgerReader) ledger
 	return ledgerentries.NewLedgerEntryGetter(d.FastCoreClient(), latestLedgerReader)
 }
 
-// readCoreVersion runs `stellar-core version` against the binary once. An empty
-// path (no binary configured or found) skips the call entirely.
+// readCoreVersion runs `stellar-core version` once; an empty path skips it.
 func readCoreVersion(binaryPath string, logger *supportlog.Entry) string {
 	if binaryPath == "" {
 		return ""

--- a/cmd/stellar-rpc/internal/rpcv2/corestate/corestate.go
+++ b/cmd/stellar-rpc/internal/rpcv2/corestate/corestate.go
@@ -113,6 +113,11 @@ func New(cfg Config) (*Daemon, error) {
 
 	// One client per server, each with its own http.Client so a slow submission
 	// cannot consume a connection the query path needs.
+	//
+	// TODO(#889): the submission client is unwrapped, so v2 does not yet publish
+	// v1's two txsub metrics (soroban_rpc_txsub_submission_duration_seconds and
+	// _operation_count). v1's wrapper for them lives in internal/rpcv1/daemon and
+	// has to move to a shared package before sendTransaction is served.
 	return &Daemon{
 		registry:  cfg.Registry,
 		namespace: namespace,

--- a/cmd/stellar-rpc/internal/rpcv2/corestate/corestate.go
+++ b/cmd/stellar-rpc/internal/rpcv2/corestate/corestate.go
@@ -15,15 +15,17 @@
 package corestate
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
+	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/stellar/go-stellar-sdk/clients/stellarcore"
-	"github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
 	supportlog "github.com/stellar/go-stellar-sdk/support/log"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/host"
@@ -76,8 +78,9 @@ type Daemon struct {
 // binary's version.
 //
 // A failed version lookup is not an error — the version is only a field in
-// getVersionInfo's response, so the daemon starts anyway and reports "".
-func New(cfg Config) (*Daemon, error) {
+// getVersionInfo's response, so the daemon starts anyway and reports "". ctx
+// bounds that lookup and nothing else; the Daemon does not retain it.
+func New(ctx context.Context, cfg Config) (*Daemon, error) {
 	if cfg.CoreURL == "" {
 		return nil, errors.New("corestate: CoreURL is required (default http://localhost:{core_http_port})")
 	}
@@ -96,8 +99,12 @@ func New(cfg Config) (*Daemon, error) {
 		namespace = host.PrometheusNamespace
 	}
 
-	// Separate http.Clients so a slow submission cannot tie up a connection the
-	// query path needs.
+	// One http.Client per server. This is not connection-pool isolation: both
+	// leave Transport nil, so both use http.DefaultTransport and share its single
+	// pool. That pool keys idle connections by host:port, and the two servers are
+	// different host:port pairs, so submissions and queries already stay off each
+	// other's connections — one shared Client would behave the same way. The two
+	// Clients exist so the submission path can be wrapped on its own.
 	//
 	// TODO(#889): the submission client is unwrapped, so v2 does not yet publish
 	// v1's txsub metrics. v1's wrapper for them lives in internal/rpcv1/daemon and
@@ -113,7 +120,7 @@ func New(cfg Config) (*Daemon, error) {
 			URL:  fmt.Sprintf("http://localhost:%d", cfg.QueryPort),
 			HTTP: &http.Client{Timeout: cfg.RequestTimeout},
 		},
-		coreVersion: readCoreVersion(cfg.StellarCoreBinaryPath, cfg.Logger),
+		coreVersion: readCoreVersion(ctx, cfg.StellarCoreBinaryPath, cfg.Logger),
 	}, nil
 }
 
@@ -155,12 +162,25 @@ func (d *Daemon) LedgerEntryGetter(latestLedgerReader store.LedgerReader) ledger
 	return ledgerentries.NewLedgerEntryGetter(d.FastCoreClient(), latestLedgerReader)
 }
 
+const coreVersionTimeout = 5 * time.Second
+
 // readCoreVersion runs `stellar-core version` once; an empty path skips it.
-func readCoreVersion(binaryPath string, logger *supportlog.Entry) string {
+//
+// Not ledgerbackend.CoreBuildVersion, which execs with no context: this runs at
+// startup before anything is logged, so a binary that never returns (a wrapper
+// script, a stalled mount) would freeze the daemon silently and ignore Ctrl-C.
+func readCoreVersion(ctx context.Context, binaryPath string, logger *supportlog.Entry) string {
 	if binaryPath == "" {
 		return ""
 	}
-	version, err := ledgerbackend.CoreBuildVersion(binaryPath)
+	ctx, cancel := context.WithTimeout(ctx, coreVersionTimeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, binaryPath, "version").Output()
+	version, _, _ := strings.Cut(string(out), "\n")
+	if err == nil && version == "" {
+		err = errors.New("stellar-core version printed no output")
+	}
 	if err != nil {
 		if logger != nil {
 			logger.WithError(err).WithField("binary_path", binaryPath).

--- a/cmd/stellar-rpc/internal/rpcv2/corestate/corestate_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/corestate/corestate_test.go
@@ -1,0 +1,207 @@
+package corestate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/go-stellar-sdk/clients/stellarcore"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/host"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/store"
+)
+
+func validConfig() Config {
+	return Config{
+		CoreURL:        "http://localhost:11626",
+		QueryPort:      11628,
+		RequestTimeout: 2 * time.Second,
+		Registry:       prometheus.NewRegistry(),
+	}
+}
+
+func TestNew_WiresBothClientsAtTheirPorts(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	cfg := validConfig()
+	cfg.CoreURL = "http://core.internal:8080"
+	cfg.QueryPort = 21628
+	cfg.RequestTimeout = 7 * time.Second
+	cfg.Registry = registry
+
+	d, err := New(cfg)
+	require.NoError(t, err)
+
+	submit, ok := d.CoreClient().(*stellarcore.Client)
+	require.True(t, ok)
+	assert.Equal(t, "http://core.internal:8080", submit.URL,
+		"submissions go to the configured admin URL")
+	assert.Equal(t, 7*time.Second, submit.HTTP.(*http.Client).Timeout) //nolint:forcetypeassert
+
+	query, ok := d.FastCoreClient().(*stellarcore.Client)
+	require.True(t, ok)
+	assert.Equal(t, "http://localhost:21628", query.URL,
+		"entry lookups go to the local query port")
+	assert.Equal(t, 7*time.Second, query.HTTP.(*http.Client).Timeout) //nolint:forcetypeassert
+
+	assert.NotSame(t, submit.HTTP, query.HTTP,
+		"one http.Client per server, so a slow submission cannot starve the query path")
+	assert.Same(t, registry, d.MetricsRegistry(),
+		"handlers must register on the daemon's real registry, not a throwaway")
+	assert.Equal(t, host.PrometheusNamespace, d.MetricsNamespace())
+}
+
+func TestNew_NamespaceOverride(t *testing.T) {
+	cfg := validConfig()
+	cfg.Namespace = "custom_ns"
+	d, err := New(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "custom_ns", d.MetricsNamespace())
+}
+
+func TestNew_RejectsIncompleteConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Config)
+		want   string
+	}{
+		{"no core URL", func(c *Config) { c.CoreURL = "" }, "CoreURL"},
+		{"no query port", func(c *Config) { c.QueryPort = 0 }, "QueryPort"},
+		{"zero timeout means no timeout at all", func(c *Config) { c.RequestTimeout = 0 }, "RequestTimeout"},
+		{"negative timeout", func(c *Config) { c.RequestTimeout = -time.Second }, "RequestTimeout"},
+		{"no registry", func(c *Config) { c.Registry = nil }, "Registry"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validConfig()
+			tc.mutate(&cfg)
+			_, err := New(cfg)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+// fakeCoreBinary writes an executable that answers `version` like stellar-core
+// does — the first line of stdout is the version string.
+func fakeCoreBinary(t *testing.T, script string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "stellar-core")
+	require.NoError(t, os.WriteFile(path, []byte(script), 0o755))
+	return path
+}
+
+func TestCoreVersion_ReadFromTheBinary(t *testing.T) {
+	cfg := validConfig()
+	cfg.StellarCoreBinaryPath = fakeCoreBinary(t, "#!/bin/sh\necho 'stellar-core 22.1.0 (deadbeef)'\n")
+
+	d, err := New(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "stellar-core 22.1.0 (deadbeef)", d.CoreVersion())
+}
+
+func TestCoreVersion_EmptyWhenNoBinaryPath(t *testing.T) {
+	d, err := New(validConfig())
+	require.NoError(t, err)
+	assert.Empty(t, d.CoreVersion())
+}
+
+// A binary that cannot be run is not a startup failure: the version is a
+// cosmetic field of getVersionInfo, so the daemon still comes up.
+func TestCoreVersion_UnreadableBinaryIsNotFatal(t *testing.T) {
+	cfg := validConfig()
+	cfg.StellarCoreBinaryPath = filepath.Join(t.TempDir(), "does-not-exist")
+
+	d, err := New(cfg)
+	require.NoError(t, err)
+	assert.Empty(t, d.CoreVersion())
+}
+
+// stubLedgerReader answers only GetLatestLedgerSequence; the entry getter needs
+// nothing else from the store.
+type stubLedgerReader struct{ latest uint32 }
+
+func (s stubLedgerReader) GetLatestLedgerSequence(context.Context) (uint32, error) {
+	return s.latest, nil
+}
+
+func (s stubLedgerReader) GetLedger(context.Context, uint32) (xdr.LedgerCloseMeta, bool, error) {
+	return xdr.LedgerCloseMeta{}, false, errors.New("unused")
+}
+
+func (s stubLedgerReader) GetLedgerRange(context.Context) (store.LedgerRange, error) {
+	return store.LedgerRange{}, errors.New("unused")
+}
+
+func (s stubLedgerReader) StreamLedgerRange(
+	context.Context, uint32, uint32, store.StreamLedgerFn,
+) error {
+	return errors.New("unused")
+}
+
+func (s stubLedgerReader) NewTx(context.Context) (store.LedgerReaderTx, error) {
+	return nil, errors.New("unused")
+}
+
+// The entry getter must reach core's QUERY server (not the admin URL) and must
+// ask for the ledger this daemon last committed, so a read agrees with what the
+// daemon's other responses report even while core runs ahead.
+func TestLedgerEntryGetter_QueriesTheQueryPortAtTheDaemonsLedger(t *testing.T) {
+	var gotPath, gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotPath, gotBody = r.URL.Path, string(body)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"ledgerSeq":1234,"entries":[]}`)
+	}))
+	defer srv.Close()
+
+	cfg := validConfig()
+	cfg.QueryPort = serverPort(t, srv)
+	// A deliberately unroutable admin URL: any request that lands here instead of
+	// on the query port fails the test rather than passing by accident.
+	cfg.CoreURL = "http://127.0.0.1:1"
+
+	d, err := New(cfg)
+	require.NoError(t, err)
+
+	getter := d.LedgerEntryGetter(stubLedgerReader{latest: 1234})
+	key := xdr.LedgerKey{
+		Type: xdr.LedgerEntryTypeAccount,
+		Account: &xdr.LedgerKeyAccount{
+			AccountId: xdr.MustAddress("GDKXE2OZMJIPOSLNA6N6F2BVCI3O777I2OOC4BV7VOYUEHYX7RTRYA7Y"),
+		},
+	}
+
+	entries, atLedger, err := getter.GetLedgerEntries(context.Background(), []xdr.LedgerKey{key})
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+	assert.Equal(t, uint32(1234), atLedger)
+	assert.Equal(t, "/getledgerentry", gotPath)
+	assert.Contains(t, gotBody, "ledgerSeq=1234",
+		"the daemon's own latest ledger is what core is asked about")
+}
+
+// serverPort is the port an httptest server bound, so a client built from a bare
+// port number can be pointed at it.
+func serverPort(t *testing.T, srv *httptest.Server) uint {
+	t.Helper()
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	port, err := strconv.ParseUint(u.Port(), 10, 32)
+	require.NoError(t, err)
+	return uint(port)
+}

--- a/cmd/stellar-rpc/internal/rpcv2/corestate/corestate_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/corestate/corestate_test.go
@@ -133,12 +133,29 @@ func TestCoreVersion_UnreadableBinaryIsNotFatal(t *testing.T) {
 func TestCoreVersion_HangingBinaryDoesNotBlockStartup(t *testing.T) {
 	cfg := validConfig()
 	cfg.StellarCoreBinaryPath = fakeCoreBinary(t, "#!/bin/sh\nsleep 300\n")
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
 
+	start := time.Now()
 	d, err := New(ctx, cfg)
 	require.NoError(t, err)
 	assert.Empty(t, d.CoreVersion())
+	assert.Less(t, time.Since(start), 30*time.Second,
+		"a binary that never exits must be killed at the deadline, not waited out")
+}
+
+func TestCoreVersion_WrapperChildHoldingStdoutDoesNotBlockStartup(t *testing.T) {
+	cfg := validConfig()
+	// The wrapper exits at once, but its background child inherits stdout and
+	// holds the pipe open — only WaitDelay unblocks the read.
+	cfg.StellarCoreBinaryPath = fakeCoreBinary(t, "#!/bin/sh\necho 'stellar-core 99.0.0'\nsleep 300 &\n")
+
+	start := time.Now()
+	d, err := New(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Empty(t, d.CoreVersion())
+	assert.Less(t, time.Since(start), 30*time.Second,
+		"a grandchild holding the stdout pipe must not stall startup")
 }
 
 // stubLedgerReader answers only GetLatestLedgerSequence; the entry getter needs

--- a/cmd/stellar-rpc/internal/rpcv2/corestate/corestate_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/corestate/corestate_test.go
@@ -42,7 +42,7 @@ func TestNew_WiresBothClientsAtTheirPorts(t *testing.T) {
 	cfg.RequestTimeout = 7 * time.Second
 	cfg.Registry = registry
 
-	d, err := New(cfg)
+	d, err := New(context.Background(), cfg)
 	require.NoError(t, err)
 
 	submit, ok := d.CoreClient().(*stellarcore.Client)
@@ -58,7 +58,7 @@ func TestNew_WiresBothClientsAtTheirPorts(t *testing.T) {
 	assert.Equal(t, 7*time.Second, query.HTTP.(*http.Client).Timeout) //nolint:forcetypeassert
 
 	assert.NotSame(t, submit.HTTP, query.HTTP,
-		"one http.Client per server, so a slow submission cannot starve the query path")
+		"one http.Client per server, so the submission path can be wrapped without touching queries")
 	assert.Same(t, registry, d.MetricsRegistry(),
 		"handlers must register on the daemon's real registry, not a throwaway")
 	assert.Equal(t, host.PrometheusNamespace, d.MetricsNamespace())
@@ -67,7 +67,7 @@ func TestNew_WiresBothClientsAtTheirPorts(t *testing.T) {
 func TestNew_NamespaceOverride(t *testing.T) {
 	cfg := validConfig()
 	cfg.Namespace = "custom_ns"
-	d, err := New(cfg)
+	d, err := New(context.Background(), cfg)
 	require.NoError(t, err)
 	assert.Equal(t, "custom_ns", d.MetricsNamespace())
 }
@@ -88,7 +88,7 @@ func TestNew_RejectsIncompleteConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := validConfig()
 			tc.mutate(&cfg)
-			_, err := New(cfg)
+			_, err := New(context.Background(), cfg)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.want)
 		})
@@ -108,13 +108,13 @@ func TestCoreVersion_ReadFromTheBinary(t *testing.T) {
 	cfg := validConfig()
 	cfg.StellarCoreBinaryPath = fakeCoreBinary(t, "#!/bin/sh\necho 'stellar-core 22.1.0 (deadbeef)'\n")
 
-	d, err := New(cfg)
+	d, err := New(context.Background(), cfg)
 	require.NoError(t, err)
 	assert.Equal(t, "stellar-core 22.1.0 (deadbeef)", d.CoreVersion())
 }
 
 func TestCoreVersion_EmptyWhenNoBinaryPath(t *testing.T) {
-	d, err := New(validConfig())
+	d, err := New(context.Background(), validConfig())
 	require.NoError(t, err)
 	assert.Empty(t, d.CoreVersion())
 }
@@ -125,7 +125,18 @@ func TestCoreVersion_UnreadableBinaryIsNotFatal(t *testing.T) {
 	cfg := validConfig()
 	cfg.StellarCoreBinaryPath = filepath.Join(t.TempDir(), "does-not-exist")
 
-	d, err := New(cfg)
+	d, err := New(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Empty(t, d.CoreVersion())
+}
+
+func TestCoreVersion_HangingBinaryDoesNotBlockStartup(t *testing.T) {
+	cfg := validConfig()
+	cfg.StellarCoreBinaryPath = fakeCoreBinary(t, "#!/bin/sh\nsleep 300\n")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	d, err := New(ctx, cfg)
 	require.NoError(t, err)
 	assert.Empty(t, d.CoreVersion())
 }
@@ -175,7 +186,7 @@ func TestLedgerEntryGetter_QueriesTheQueryPortAtTheDaemonsLedger(t *testing.T) {
 	// on the query port fails the test rather than passing by accident.
 	cfg.CoreURL = "http://127.0.0.1:1"
 
-	d, err := New(cfg)
+	d, err := New(context.Background(), cfg)
 	require.NoError(t, err)
 
 	getter := d.LedgerEntryGetter(stubLedgerReader{latest: 1234})

--- a/cmd/stellar-rpc/internal/rpcv2/daemon.go
+++ b/cmd/stellar-rpc/internal/rpcv2/daemon.go
@@ -203,7 +203,7 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	// simulateTransaction's preflight pool. Built once, outside the supervised
 	// loop: the pool registers collectors on the registry above, and registering
 	// the same collector twice panics. #889 hands both to the method table. ---
-	coreDaemon, err := corestate.New(corestate.Config{
+	coreDaemon, err := corestate.New(ctx, corestate.Config{
 		CoreURL:               cfg.Ingestion.CoreURL,
 		QueryPort:             deref(cfg.Ingestion.CoreHTTPQueryPort),
 		RequestTimeout:        deref(cfg.Ingestion.CoreRequestTimeout),
@@ -481,7 +481,8 @@ type captiveCoreOpener struct {
 // PATH. Only the history-archive URLs come from [ingestion], since the file's
 // [HISTORY.*] entries are shell commands, not URLs. The toml params mirror the
 // v1 daemon (strict, unified events, soroban diagnostic/meta enforcement) so the
-// ingested meta suits the events + txhash stores.
+// ingested meta suits the events + txhash stores. Core's four HTTP-server
+// settings are the exception: [ingestion] owns those, see applyHTTPServers.
 //
 // It returns two openers over one read of the file, differing only in whether
 // core's HTTP servers are enabled — see resolvedCore.
@@ -508,9 +509,7 @@ func newCaptiveCoreOpeners(
 	if peek.NetworkPassphrase == "" {
 		return resolvedCore{}, fmt.Errorf("captive_core_config %q must define NETWORK_PASSPHRASE", ing.CaptiveCoreConfig)
 	}
-	if cerr := peek.checkNoHTTPConflict(ing); cerr != nil {
-		return resolvedCore{}, cerr
-	}
+	peek.warnHTTPSettingsOverridden(ing, logger)
 
 	// stellar-core binary: explicit path, else the one on PATH (RPC daemon default).
 	binaryPath := ing.StellarCoreBinaryPath
@@ -528,7 +527,8 @@ func newCaptiveCoreOpeners(
 		storagePath = filepath.Join(dataDir, "captive-core")
 	}
 
-	// Shared params; the live opener then adds the HTTP ports.
+	// One set of params for both openers; the HTTP settings are applied per toml
+	// below, not passed here.
 	params := ledgerbackend.CaptiveCoreTomlParams{
 		HistoryArchiveURLs:                 ing.HistoryArchiveURLs,
 		NetworkPassphrase:                  peek.NetworkPassphrase,
@@ -546,21 +546,12 @@ func newCaptiveCoreOpeners(
 	}
 	disableHTTPServers(backfillOpener.config.Toml)
 
-	httpPort := *ing.CoreHTTPPort
-	params.HTTPPort = &httpPort
-	params.HTTPQueryServerParams = &ledgerbackend.HTTPQueryServerParams{
-		//nolint:gosec // validateIngestion rejects any of these above 65535
-		Port: uint16(*ing.CoreHTTPQueryPort),
-		//nolint:gosec // same range check
-		ThreadPoolSize: uint16(*ing.CoreHTTPQueryThreadPoolSize),
-		//nolint:gosec // same range check
-		SnapshotLedgers: uint16(*ing.CoreHTTPQuerySnapshotLedgers),
-	}
 	liveOpener, err := newCaptiveCoreOpener(
 		ing, data, params, binaryPath, storagePath, peek.NetworkPassphrase, logger)
 	if err != nil {
 		return resolvedCore{}, err
 	}
+	applyHTTPServers(liveOpener.config.Toml, ing)
 
 	return resolvedCore{
 		live:              liveOpener,
@@ -587,7 +578,7 @@ func disableHTTPServers(coreToml *ledgerbackend.CaptiveCoreToml) {
 
 // coreFilePeek is the captive-core file keys the daemon reads itself before
 // handing the file to the SDK: the network, and the four HTTP-server settings
-// [ingestion] also owns. go-toml ignores every other key.
+// [ingestion] overrides. go-toml ignores every other key.
 type coreFilePeek struct {
 	NetworkPassphrase    string `toml:"NETWORK_PASSPHRASE"`
 	HTTPPort             *uint  `toml:"HTTP_PORT"`
@@ -596,21 +587,16 @@ type coreFilePeek struct {
 	QuerySnapshotLedgers *uint  `toml:"QUERY_SNAPSHOT_LEDGERS"`
 }
 
-// checkNoHTTPConflict rejects a captive-core file that sets one of core's four
-// HTTP keys to a different value than the matching [ingestion] key. A value that
-// agrees is fine, so configs carried over from v1 (which commonly set these in
-// the core file) still start.
-//
-// The SDK checks this too, but unusably: its three query-server mismatch
-// branches format the error with params.PeerPort, which this daemon never sets,
-// so they panic on a nil pointer instead of reporting the conflict. Checking
-// here turns that crash into an error naming both sides.
-func (p coreFilePeek) checkNoHTTPConflict(ing config.IngestionConfig) error {
-	conflicts := []struct {
-		fileKey    string
-		configKey  string
-		inFile     *uint
-		configured uint
+// warnHTTPSettingsOverridden logs each of core's four HTTP keys the captive-core
+// file sets to something other than what core will run with. Overriding silently
+// would be the trap: an operator carrying a v1 file with HTTP_PORT = 11625 may
+// have firewall rules or a monitoring scrape pointed at 11625.
+func (p coreFilePeek) warnHTTPSettingsOverridden(ing config.IngestionConfig, logger *supportlog.Entry) {
+	settings := []struct {
+		fileKey   string
+		configKey string
+		inFile    *uint
+		used      uint
 	}{
 		{"HTTP_PORT", keyCoreHTTPPort, p.HTTPPort, *ing.CoreHTTPPort},
 		{"HTTP_QUERY_PORT", keyCoreHTTPQueryPort, p.HTTPQueryPort, *ing.CoreHTTPQueryPort},
@@ -623,16 +609,34 @@ func (p coreFilePeek) checkNoHTTPConflict(ing config.IngestionConfig) error {
 			p.QuerySnapshotLedgers, *ing.CoreHTTPQuerySnapshotLedgers,
 		},
 	}
-	for _, c := range conflicts {
-		if c.inFile == nil || *c.inFile == c.configured {
+	for _, s := range settings {
+		if s.inFile == nil || *s.inFile == s.used {
 			continue
 		}
-		return fmt.Errorf("captive_core_config sets %s = %d, but [ingestion].%s is %d — "+
-			"core's HTTP settings are configured in [ingestion]; remove %s from the "+
-			"captive-core file or set the two to the same value",
-			c.fileKey, *c.inFile, c.configKey, c.configured, c.fileKey)
+		logger.Warnf("captive_core_config sets %s = %d, but [ingestion].%s owns core's HTTP "+
+			"settings — running core with %d. Remove %s from the captive-core file to silence this.",
+			s.fileKey, *s.inFile, s.configKey, s.used, s.fileKey)
 	}
-	return nil
+}
+
+// applyHTTPServers points the live core's two HTTP servers at the [ingestion]
+// settings, overriding whatever the captive-core file said.
+//
+// The values are written onto the generated toml instead of passed in
+// CaptiveCoreTomlParams because the SDK treats params as a cross-check, not an
+// override: it rejects a file that disagrees rather than preferring the params,
+// and its three query-server mismatch branches format that error with
+// params.PeerPort, which this daemon never sets, so they panic on a nil pointer.
+// Passing no HTTP params leaves those branches unreachable.
+func applyHTTPServers(coreToml *ledgerbackend.CaptiveCoreToml, ing config.IngestionConfig) {
+	queryPort := *ing.CoreHTTPQueryPort
+	threadPoolSize := *ing.CoreHTTPQueryThreadPoolSize
+	snapshotLedgers := *ing.CoreHTTPQuerySnapshotLedgers
+
+	coreToml.HTTPPort = *ing.CoreHTTPPort
+	coreToml.HTTPQueryPort = &queryPort
+	coreToml.QueryThreadPoolSize = &threadPoolSize
+	coreToml.QuerySnapshotLedgers = &snapshotLedgers
 }
 
 // newCaptiveCoreOpener builds one opener from the captive-core file's bytes.

--- a/cmd/stellar-rpc/internal/rpcv2/daemon.go
+++ b/cmd/stellar-rpc/internal/rpcv2/daemon.go
@@ -53,8 +53,10 @@ type daemonOptions struct {
 	Core CoreOpener
 
 	// ServeReads launches the RPC read server; it must return promptly, not block.
-	// nil ⇒ a no-op placeholder until #889 builds v2's read server. Reads come from
-	// the v1 SQLite daemon until the #772 cutover.
+	// nil ⇒ a no-op placeholder, which is what production uses today: v2 serves
+	// nothing. Serving arrives across #772's sub-tasks — #889 builds the server and
+	// the method table, over the router-backed store readers (#885-#887) the
+	// handlers need. Reads stay on the v1 SQLite daemon until the #772 cutover.
 	ServeReads func(ctx context.Context) error
 
 	// RestartBackoff is the supervised loop's inter-restart sleep; zero ⇒ defaultRestartBackoff.
@@ -176,7 +178,8 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	serveReads := opts.ServeReads
 	if serveReads == nil {
 		// TODO(#889): build v2's read server — the method table, the listener on
-		// [service].endpoint, and the admin endpoint. No-op until then.
+		// [service].endpoint, and the admin endpoint. The handlers it registers also
+		// need the router-backed store readers (#885-#887). No-op until then.
 		serveReads = func(context.Context) error { return nil }
 	}
 

--- a/cmd/stellar-rpc/internal/rpcv2/daemon.go
+++ b/cmd/stellar-rpc/internal/rpcv2/daemon.go
@@ -53,7 +53,8 @@ type daemonOptions struct {
 	Core CoreOpener
 
 	// ServeReads launches the RPC read server; it must return promptly, not block.
-	// nil ⇒ the #772 no-op placeholder (reads still come from the v1 SQLite daemon).
+	// nil ⇒ a no-op placeholder until #889 builds v2's read server. Reads come from
+	// the v1 SQLite daemon until the #772 cutover.
 	ServeReads func(ctx context.Context) error
 
 	// RestartBackoff is the supervised loop's inter-restart sleep; zero ⇒ defaultRestartBackoff.
@@ -108,7 +109,7 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	// Readiness/health signal, fed by the ingestion loop per commit; both signals
 	// derive from the last committed ledger. Created outside the supervised run
 	// loop so it survives restarts (readiness stays latched across them).
-	// TODO(#772): serve it from the read server (as HealthSignal).
+	// TODO(#889): serve it from the read server (as HealthSignal).
 	hs := &healthState{}
 
 	paths := cfg.ResolvePaths()
@@ -174,7 +175,8 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 
 	serveReads := opts.ServeReads
 	if serveReads == nil {
-		// TODO(#772): wire the full-history RPC read server; no-op until the cutover.
+		// TODO(#889): build v2's read server — the method table, the listener on
+		// [service].endpoint, and the admin endpoint. No-op until then.
 		serveReads = func(context.Context) error { return nil }
 	}
 
@@ -190,7 +192,7 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 
 	// Control-plane Metrics and the ingest sink share ONE registry, built after the
 	// validateConfig gate (it registers Prometheus collectors).
-	// TODO(#772): expose it on the read server's /metrics.
+	// TODO(#889): expose it on the read server's /metrics.
 	registry := prometheus.NewRegistry()
 	metrics, sink := buildSinks(opts, registry)
 

--- a/cmd/stellar-rpc/internal/rpcv2/daemon.go
+++ b/cmd/stellar-rpc/internal/rpcv2/daemon.go
@@ -194,11 +194,10 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	registry := prometheus.NewRegistry()
 	metrics, sink := buildSinks(opts, registry)
 
-	// --- The current-ledger-state boundary the three captive-core-backed
-	// endpoints read through, plus the preflight pool simulateTransaction runs
-	// on. Built ONCE here, outside the supervised loop: the pool registers
-	// collectors on the registry above, and a second registration of the same
-	// collector panics. #889 hands both to the read server's method table. ---
+	// --- Captive-core state access for the three endpoints that need it, plus
+	// simulateTransaction's preflight pool. Built once, outside the supervised
+	// loop: the pool registers collectors on the registry above, and registering
+	// the same collector twice panics. #889 hands both to the method table. ---
 	coreDaemon, err := corestate.New(corestate.Config{
 		CoreURL:               cfg.Ingestion.CoreURL,
 		QueryPort:             deref(cfg.Ingestion.CoreHTTPQueryPort),
@@ -249,33 +248,30 @@ func openCatalog(paths config.Paths, opts daemonOptions, logger *supportlog.Entr
 	return cat, nil
 }
 
-// resolvedCore is everything runDaemonWith gets out of resolving captive core:
-// the two openers, and the two facts read off the resolution that other wiring
-// needs (the network the core runs on, and where its binary is).
+// resolvedCore is the result of resolving captive core: two openers, plus the
+// network and binary path read off the resolution.
 type resolvedCore struct {
 	// live opens the stream the ingestion loop follows. Its toml enables core's
 	// two HTTP servers, because the serving endpoints query them.
 	live CoreOpener
 
 	// backfill opens the bounded per-chunk replays of a no-lake deployment. Its
-	// toml is PORTLESS: those replays run in parallel, one core per chunk, so a
-	// fixed port in the toml would have every one of them fight over binding it.
-	// (Nothing queries a backfill core — only the live one is ever addressed.)
+	// toml has no ports: those replays run one core per chunk in parallel, so a
+	// fixed port would have them all fight over binding it. Nothing queries a
+	// backfill core.
 	backfill CoreOpener
 
-	// networkPassphrase is read back from the captive-core file. Empty means
-	// "unknown" (an injected opener), which skips the datastore's wrong-network
-	// check.
+	// networkPassphrase comes from the captive-core file. Empty means unknown (an
+	// injected opener) and skips the datastore's wrong-network check.
 	networkPassphrase string
 
-	// binaryPath is the resolved stellar-core binary — an explicit
-	// stellar_core_binary_path, or the one found on PATH. Empty for an injected
-	// opener; corestate then reports no core version.
+	// binaryPath is the resolved stellar-core binary. Empty for an injected
+	// opener, which makes corestate report no core version.
 	binaryPath string
 }
 
-// resolveCore returns the injected CoreOpener (tests, used for both roles) or
-// the production pair built from [ingestion].
+// resolveCore returns the injected opener (tests use it for both roles) or the
+// production pair built from [ingestion].
 func resolveCore(opts daemonOptions, cfg config.Config, logger *supportlog.Entry) (resolvedCore, error) {
 	if opts.Core != nil {
 		return resolvedCore{live: opts.Core, backfill: opts.Core}, nil
@@ -311,12 +307,9 @@ func startConfig(
 	}
 }
 
-// newPreflightPool starts the worker pool simulateTransaction's preflights run
-// on, sized by [service.preflight]. The caller owns Close.
-//
-// networkPassphrase is the one read back from the captive-core file. It is empty
-// only when the core opener was injected by a test, which also means no request
-// ever reaches the pool; a real deployment always has it.
+// newPreflightPool starts simulateTransaction's worker pool, sized by
+// [service.preflight]. The caller owns Close. networkPassphrase is empty only
+// for an injected (test) opener, where nothing reaches the pool anyway.
 func newPreflightPool(
 	cfg config.Config, coreDaemon *corestate.Daemon, networkPassphrase string, logger *supportlog.Entry,
 ) *preflight.WorkerPool {
@@ -477,17 +470,16 @@ type captiveCoreOpener struct {
 	config ledgerbackend.CaptiveCoreConfig
 }
 
-// newCaptiveCoreOpeners resolves the captive-core config, treating the
-// captive_core_config FILE as the single source of truth: NETWORK_PASSPHRASE is
-// read back from it, and the stellar-core binary defaults to the one on PATH.
-// Only the plain history-archive URLs (not derivable from the file's [HISTORY.*]
-// get-commands) come from [ingestion].history_archive_urls. The toml params
-// mirror the RPC daemon (strict, unified events, soroban diagnostic/meta
-// enforcement) so the ingested meta is what the events + txhash stores need.
+// newCaptiveCoreOpeners resolves the captive-core config. The
+// captive_core_config file is the source of truth for core-side settings:
+// NETWORK_PASSPHRASE is read back from it, and the binary defaults to the one on
+// PATH. Only the history-archive URLs come from [ingestion], since the file's
+// [HISTORY.*] entries are shell commands, not URLs. The toml params mirror the
+// v1 daemon (strict, unified events, soroban diagnostic/meta enforcement) so the
+// ingested meta suits the events + txhash stores.
 //
-// It returns TWO openers over one read of the file, differing only in whether
-// core's HTTP servers are enabled — see resolvedCore for why the backfill one
-// must stay portless.
+// It returns two openers over one read of the file, differing only in whether
+// core's HTTP servers are enabled — see resolvedCore.
 func newCaptiveCoreOpeners(
 	ing config.IngestionConfig, dataDir string, logger *supportlog.Entry,
 ) (resolvedCore, error) {
@@ -498,10 +490,8 @@ func newCaptiveCoreOpeners(
 		return resolvedCore{}, errors.New("[ingestion].history_archive_urls is required for live ingestion")
 	}
 
-	// NETWORK_PASSPHRASE lives in the captive-core file; read it back so the
-	// operator configures it in one place. (go-toml v1 ignores the other fields.)
-	// Read ONCE: both openers are built from these bytes, so they cannot end up
-	// describing two different networks if the file changes underneath us.
+	// Read the file ONCE: both openers are built from these bytes, so they cannot
+	// describe two different networks if the file changes underneath us.
 	data, err := os.ReadFile(ing.CaptiveCoreConfig)
 	if err != nil {
 		return resolvedCore{}, fmt.Errorf("read captive_core_config %q: %w", ing.CaptiveCoreConfig, err)
@@ -533,7 +523,7 @@ func newCaptiveCoreOpeners(
 		storagePath = filepath.Join(dataDir, "captive-core")
 	}
 
-	// The params both openers share; the live one then adds the HTTP ports.
+	// Shared params; the live opener then adds the HTTP ports.
 	params := ledgerbackend.CaptiveCoreTomlParams{
 		HistoryArchiveURLs:                 ing.HistoryArchiveURLs,
 		NetworkPassphrase:                  peek.NetworkPassphrase,
@@ -575,28 +565,24 @@ func newCaptiveCoreOpeners(
 	}, nil
 }
 
-// disableHTTPServers strips core's two HTTP servers from a toml, so a core
-// started with it binds no ports at all. This is what makes the backfill cores
-// of a no-lake deployment safe to run in parallel — several of them replaying
-// different chunks at once cannot all bind the same two ports.
+// disableHTTPServers strips core's two HTTP servers from a toml, so a core run
+// with it binds no ports — what makes parallel backfill replays safe.
 //
-// Simply not asking for the servers is NOT enough, which is why this exists:
-// when the operator's captive-core file declares HTTP_QUERY_PORT itself, the SDK
-// keeps that value (it only overwrites the query keys when the caller passes
-// query-server params), and the bounded-replay config it generates clears
-// HTTP_PORT but never the query port. Clearing the fields on the built toml is
-// how the SDK itself disables ports (see CaptiveCoreToml.CatchupToml).
+// Not asking for the servers is not enough: when the operator's captive-core
+// file declares HTTP_QUERY_PORT itself, the SDK keeps that value (it overwrites
+// the query keys only when given query-server params), and the bounded-replay
+// config it generates clears HTTP_PORT but never the query port. Clearing the
+// fields is how the SDK disables ports itself (CaptiveCoreToml.CatchupToml).
 func disableHTTPServers(coreToml *ledgerbackend.CaptiveCoreToml) {
-	coreToml.HTTPPort = 0 // 0 means "no admin server", the same value CatchupToml writes
+	coreToml.HTTPPort = 0 // no admin server, the value CatchupToml writes
 	coreToml.HTTPQueryPort = nil
 	coreToml.QueryThreadPoolSize = nil
 	coreToml.QuerySnapshotLedgers = nil
 }
 
-// coreFilePeek is the handful of captive-core file keys the daemon reads for
-// itself before handing the file to the SDK: the network it describes, and the
-// four HTTP-server settings that [ingestion] also owns. (go-toml ignores every
-// other key in the file.)
+// coreFilePeek is the captive-core file keys the daemon reads itself before
+// handing the file to the SDK: the network, and the four HTTP-server settings
+// [ingestion] also owns. go-toml ignores every other key.
 type coreFilePeek struct {
 	NetworkPassphrase    string `toml:"NETWORK_PASSPHRASE"`
 	HTTPPort             *uint  `toml:"HTTP_PORT"`
@@ -606,16 +592,14 @@ type coreFilePeek struct {
 }
 
 // checkNoHTTPConflict rejects a captive-core file that sets one of core's four
-// HTTP-server keys to a DIFFERENT value than the matching [ingestion] key. A
-// value that agrees is left alone, so a config carried over from v1 (where these
-// were commonly written into the core file) still starts.
+// HTTP keys to a different value than the matching [ingestion] key. A value that
+// agrees is fine, so configs carried over from v1 (which commonly set these in
+// the core file) still start.
 //
-// The SDK checks this too, but two of its checks are unusable: its three
-// query-server mismatch branches format the error with params.PeerPort, which
-// this daemon never sets, so they panic on a nil pointer instead of reporting
-// the conflict (go-stellar-sdk ingest/ledgerbackend/toml.go). Catching the
-// conflict here turns a nil-pointer stack trace into a startup error naming both
-// sides of the disagreement.
+// The SDK checks this too, but unusably: its three query-server mismatch
+// branches format the error with params.PeerPort, which this daemon never sets,
+// so they panic on a nil pointer instead of reporting the conflict. Checking
+// here turns that crash into an error naming both sides.
 func (p coreFilePeek) checkNoHTTPConflict(ing config.IngestionConfig) error {
 	conflicts := []struct {
 		fileKey    string
@@ -647,12 +631,11 @@ func (p coreFilePeek) checkNoHTTPConflict(ing config.IngestionConfig) error {
 }
 
 // newCaptiveCoreOpener builds one opener from the captive-core file's bytes.
-// data is what was read from ing.CaptiveCoreConfig; params carries the caller's
-// choice of whether core's HTTP servers are enabled.
+// params decides whether core's HTTP servers are enabled.
 //
-// The toml is built from the bytes rather than the path: NewCaptiveCoreTomlFromFile
-// would read the file again and could observe a different NETWORK_PASSPHRASE than
-// the caller peeked, surfacing as the SDK's confusing mismatch error.
+// It builds from the bytes, not the path: NewCaptiveCoreTomlFromFile would read
+// the file again and could see a different NETWORK_PASSPHRASE than the caller
+// peeked, surfacing as the SDK's confusing mismatch error.
 func newCaptiveCoreOpener(
 	ing config.IngestionConfig, data []byte, params ledgerbackend.CaptiveCoreTomlParams,
 	binaryPath, storagePath, networkPassphrase string, logger *supportlog.Entry,

--- a/cmd/stellar-rpc/internal/rpcv2/daemon.go
+++ b/cmd/stellar-rpc/internal/rpcv2/daemon.go
@@ -215,7 +215,7 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	defer preflightPool.Close()
 	logger.WithFields(supportlog.F{
 		"core_url":             cfg.Ingestion.CoreURL,
-		"core_http_query_port": deref(cfg.Ingestion.CoreHTTPQueryPort),
+		keyCoreHTTPQueryPort:   deref(cfg.Ingestion.CoreHTTPQueryPort),
 		"preflight_workers":    deref(cfg.Service.Preflight.WorkerCount),
 		"stellar_core_version": coreDaemon.CoreVersion(),
 	}).Info("wired the captive-core-backed endpoints")
@@ -506,14 +506,15 @@ func newCaptiveCoreOpeners(
 	if err != nil {
 		return resolvedCore{}, fmt.Errorf("read captive_core_config %q: %w", ing.CaptiveCoreConfig, err)
 	}
-	var peek struct {
-		NetworkPassphrase string `toml:"NETWORK_PASSPHRASE"`
-	}
+	var peek coreFilePeek
 	if perr := toml.Unmarshal(data, &peek); perr != nil {
 		return resolvedCore{}, fmt.Errorf("parse captive_core_config %q: %w", ing.CaptiveCoreConfig, perr)
 	}
 	if peek.NetworkPassphrase == "" {
 		return resolvedCore{}, fmt.Errorf("captive_core_config %q must define NETWORK_PASSPHRASE", ing.CaptiveCoreConfig)
+	}
+	if cerr := peek.checkNoHTTPConflict(ing); cerr != nil {
+		return resolvedCore{}, cerr
 	}
 
 	// stellar-core binary: explicit path, else the one on PATH (RPC daemon default).
@@ -548,6 +549,7 @@ func newCaptiveCoreOpeners(
 	if err != nil {
 		return resolvedCore{}, err
 	}
+	disableHTTPServers(backfillOpener.config.Toml)
 
 	httpPort := *ing.CoreHTTPPort
 	params.HTTPPort = &httpPort
@@ -571,6 +573,77 @@ func newCaptiveCoreOpeners(
 		networkPassphrase: peek.NetworkPassphrase,
 		binaryPath:        binaryPath,
 	}, nil
+}
+
+// disableHTTPServers strips core's two HTTP servers from a toml, so a core
+// started with it binds no ports at all. This is what makes the backfill cores
+// of a no-lake deployment safe to run in parallel — several of them replaying
+// different chunks at once cannot all bind the same two ports.
+//
+// Simply not asking for the servers is NOT enough, which is why this exists:
+// when the operator's captive-core file declares HTTP_QUERY_PORT itself, the SDK
+// keeps that value (it only overwrites the query keys when the caller passes
+// query-server params), and the bounded-replay config it generates clears
+// HTTP_PORT but never the query port. Clearing the fields on the built toml is
+// how the SDK itself disables ports (see CaptiveCoreToml.CatchupToml).
+func disableHTTPServers(coreToml *ledgerbackend.CaptiveCoreToml) {
+	coreToml.HTTPPort = 0 // 0 means "no admin server", the same value CatchupToml writes
+	coreToml.HTTPQueryPort = nil
+	coreToml.QueryThreadPoolSize = nil
+	coreToml.QuerySnapshotLedgers = nil
+}
+
+// coreFilePeek is the handful of captive-core file keys the daemon reads for
+// itself before handing the file to the SDK: the network it describes, and the
+// four HTTP-server settings that [ingestion] also owns. (go-toml ignores every
+// other key in the file.)
+type coreFilePeek struct {
+	NetworkPassphrase    string `toml:"NETWORK_PASSPHRASE"`
+	HTTPPort             *uint  `toml:"HTTP_PORT"`
+	HTTPQueryPort        *uint  `toml:"HTTP_QUERY_PORT"`
+	QueryThreadPoolSize  *uint  `toml:"QUERY_THREAD_POOL_SIZE"`
+	QuerySnapshotLedgers *uint  `toml:"QUERY_SNAPSHOT_LEDGERS"`
+}
+
+// checkNoHTTPConflict rejects a captive-core file that sets one of core's four
+// HTTP-server keys to a DIFFERENT value than the matching [ingestion] key. A
+// value that agrees is left alone, so a config carried over from v1 (where these
+// were commonly written into the core file) still starts.
+//
+// The SDK checks this too, but two of its checks are unusable: its three
+// query-server mismatch branches format the error with params.PeerPort, which
+// this daemon never sets, so they panic on a nil pointer instead of reporting
+// the conflict (go-stellar-sdk ingest/ledgerbackend/toml.go). Catching the
+// conflict here turns a nil-pointer stack trace into a startup error naming both
+// sides of the disagreement.
+func (p coreFilePeek) checkNoHTTPConflict(ing config.IngestionConfig) error {
+	conflicts := []struct {
+		fileKey    string
+		configKey  string
+		inFile     *uint
+		configured uint
+	}{
+		{"HTTP_PORT", keyCoreHTTPPort, p.HTTPPort, *ing.CoreHTTPPort},
+		{"HTTP_QUERY_PORT", keyCoreHTTPQueryPort, p.HTTPQueryPort, *ing.CoreHTTPQueryPort},
+		{
+			"QUERY_THREAD_POOL_SIZE", keyCoreQueryThreadPoolSize,
+			p.QueryThreadPoolSize, *ing.CoreHTTPQueryThreadPoolSize,
+		},
+		{
+			"QUERY_SNAPSHOT_LEDGERS", keyCoreQuerySnapshotLedgers,
+			p.QuerySnapshotLedgers, *ing.CoreHTTPQuerySnapshotLedgers,
+		},
+	}
+	for _, c := range conflicts {
+		if c.inFile == nil || *c.inFile == c.configured {
+			continue
+		}
+		return fmt.Errorf("captive_core_config sets %s = %d, but [ingestion].%s is %d — "+
+			"core's HTTP settings are configured in [ingestion]; remove %s from the "+
+			"captive-core file or set the two to the same value",
+			c.fileKey, *c.inFile, c.configKey, c.configured, c.fileKey)
+	}
+	return nil
 }
 
 // newCaptiveCoreOpener builds one opener from the captive-core file's bytes.

--- a/cmd/stellar-rpc/internal/rpcv2/daemon.go
+++ b/cmd/stellar-rpc/internal/rpcv2/daemon.go
@@ -19,10 +19,12 @@ import (
 	"github.com/stellar/go-stellar-sdk/support/storage"
 
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/host"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/preflight"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/backfill"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/catalog"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/chunk"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/config"
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/corestate"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/geometry"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/ingest"
 	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/observability"
@@ -131,7 +133,7 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	// ingestion loop, and the no-lake backfill source is built from its stream. A
 	// bad [ingestion] config therefore surfaces before validateConfig's errors —
 	// cosmetic, both are fatal startup errors. ---
-	core, networkPassphrase, err := resolveCore(opts, cfg, logger)
+	core, err := resolveCore(opts, cfg, logger)
 	if err != nil {
 		return err
 	}
@@ -153,7 +155,8 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	// (which needs the tip) runs after this. ---
 	backend := opts.Backend
 	if backend == nil {
-		built, cleanup, berr := buildBackfillBackend(ctx, cfg, core, pool, networkPassphrase, logger)
+		built, cleanup, berr := buildBackfillBackend(
+			ctx, cfg, core.backfill, pool, core.networkPassphrase, logger)
 		if berr != nil {
 			return fmt.Errorf("build backfill backend: %w", berr)
 		}
@@ -163,7 +166,7 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 		backend = built
 	}
 	if backend == nil {
-		// In production newCaptiveCoreOpener already rejects missing archive URLs;
+		// In production newCaptiveCoreOpeners already rejects missing archive URLs;
 		// this config-shaped message covers an injected Core bypassing that gate.
 		return errors.New("no bulk ledger source configured: set [backfill.datastore] " +
 			"or [ingestion].history_archive_urls")
@@ -191,9 +194,35 @@ func runDaemonWith(ctx context.Context, configPath string, opts daemonOptions) e
 	registry := prometheus.NewRegistry()
 	metrics, sink := buildSinks(opts, registry)
 
+	// --- The current-ledger-state boundary the three captive-core-backed
+	// endpoints read through, plus the preflight pool simulateTransaction runs
+	// on. Built ONCE here, outside the supervised loop: the pool registers
+	// collectors on the registry above, and a second registration of the same
+	// collector panics. #889 hands both to the read server's method table. ---
+	coreDaemon, err := corestate.New(corestate.Config{
+		CoreURL:               cfg.Ingestion.CoreURL,
+		QueryPort:             deref(cfg.Ingestion.CoreHTTPQueryPort),
+		RequestTimeout:        deref(cfg.Ingestion.CoreRequestTimeout),
+		StellarCoreBinaryPath: core.binaryPath,
+		Registry:              registry,
+		Namespace:             host.PrometheusNamespace,
+		Logger:                logger,
+	})
+	if err != nil {
+		return err
+	}
+	preflightPool := newPreflightPool(cfg, coreDaemon, core.networkPassphrase, logger)
+	defer preflightPool.Close()
+	logger.WithFields(supportlog.F{
+		"core_url":             cfg.Ingestion.CoreURL,
+		"core_http_query_port": deref(cfg.Ingestion.CoreHTTPQueryPort),
+		"preflight_workers":    deref(cfg.Service.Preflight.WorkerCount),
+		"stellar_core_version": coreDaemon.CoreVersion(),
+	}).Info("wired the captive-core-backed endpoints")
+
 	// --- Assemble the StartConfig and run the supervised run loop. ---
 	start := startConfig(
-		cfg, cat, logger, backend, core, serveReads, metrics, sink, hs, retention)
+		cfg, cat, logger, backend, core.live, serveReads, metrics, sink, hs, retention)
 
 	backoff := opts.RestartBackoff
 	if backoff <= 0 {
@@ -220,19 +249,38 @@ func openCatalog(paths config.Paths, opts daemonOptions, logger *supportlog.Entr
 	return cat, nil
 }
 
-// resolveCore returns the injected CoreOpener (tests) or a production captive-core
-// opener built from [ingestion], plus the NETWORK_PASSPHRASE read back from the
-// captive-core file. An injected opener carries no passphrase — the empty string
-// means "unknown", which skips the datastore's wrong-network check.
-func resolveCore(opts daemonOptions, cfg config.Config, logger *supportlog.Entry) (CoreOpener, string, error) {
+// resolvedCore is everything runDaemonWith gets out of resolving captive core:
+// the two openers, and the two facts read off the resolution that other wiring
+// needs (the network the core runs on, and where its binary is).
+type resolvedCore struct {
+	// live opens the stream the ingestion loop follows. Its toml enables core's
+	// two HTTP servers, because the serving endpoints query them.
+	live CoreOpener
+
+	// backfill opens the bounded per-chunk replays of a no-lake deployment. Its
+	// toml is PORTLESS: those replays run in parallel, one core per chunk, so a
+	// fixed port in the toml would have every one of them fight over binding it.
+	// (Nothing queries a backfill core — only the live one is ever addressed.)
+	backfill CoreOpener
+
+	// networkPassphrase is read back from the captive-core file. Empty means
+	// "unknown" (an injected opener), which skips the datastore's wrong-network
+	// check.
+	networkPassphrase string
+
+	// binaryPath is the resolved stellar-core binary — an explicit
+	// stellar_core_binary_path, or the one found on PATH. Empty for an injected
+	// opener; corestate then reports no core version.
+	binaryPath string
+}
+
+// resolveCore returns the injected CoreOpener (tests, used for both roles) or
+// the production pair built from [ingestion].
+func resolveCore(opts daemonOptions, cfg config.Config, logger *supportlog.Entry) (resolvedCore, error) {
 	if opts.Core != nil {
-		return opts.Core, "", nil
+		return resolvedCore{live: opts.Core, backfill: opts.Core}, nil
 	}
-	built, err := newCaptiveCoreOpener(cfg.Ingestion, cfg.Storage.DefaultDataDir, logger)
-	if err != nil {
-		return nil, "", err
-	}
-	return built, built.config.NetworkPassphrase, nil
+	return newCaptiveCoreOpeners(cfg.Ingestion, cfg.Storage.DefaultDataDir, logger)
 }
 
 // startConfig assembles the StartConfig run consumes. run() builds the
@@ -261,6 +309,26 @@ func startConfig(
 		ServeReads: serveReads,
 		health:     hs,
 	}
+}
+
+// newPreflightPool starts the worker pool simulateTransaction's preflights run
+// on, sized by [service.preflight]. The caller owns Close.
+//
+// networkPassphrase is the one read back from the captive-core file. It is empty
+// only when the core opener was injected by a test, which also means no request
+// ever reaches the pool; a real deployment always has it.
+func newPreflightPool(
+	cfg config.Config, coreDaemon *corestate.Daemon, networkPassphrase string, logger *supportlog.Entry,
+) *preflight.WorkerPool {
+	p := cfg.Service.Preflight
+	return preflight.NewPreflightWorkerPool(preflight.WorkerPoolConfig{
+		Daemon:            coreDaemon,
+		WorkerCount:       deref(p.WorkerCount),
+		JobQueueCapacity:  deref(p.WorkerQueueSize),
+		EnableDebug:       deref(p.EnableDebug),
+		NetworkPassphrase: networkPassphrase,
+		Logger:            logger,
+	})
 }
 
 // buildSinks resolves the control-plane Metrics + per-type ingest sink, defaulting
@@ -409,37 +477,43 @@ type captiveCoreOpener struct {
 	config ledgerbackend.CaptiveCoreConfig
 }
 
-// newCaptiveCoreOpener resolves the captive-core config, treating the
+// newCaptiveCoreOpeners resolves the captive-core config, treating the
 // captive_core_config FILE as the single source of truth: NETWORK_PASSPHRASE is
 // read back from it, and the stellar-core binary defaults to the one on PATH.
 // Only the plain history-archive URLs (not derivable from the file's [HISTORY.*]
 // get-commands) come from [ingestion].history_archive_urls. The toml params
 // mirror the RPC daemon (strict, unified events, soroban diagnostic/meta
 // enforcement) so the ingested meta is what the events + txhash stores need.
-func newCaptiveCoreOpener(
+//
+// It returns TWO openers over one read of the file, differing only in whether
+// core's HTTP servers are enabled — see resolvedCore for why the backfill one
+// must stay portless.
+func newCaptiveCoreOpeners(
 	ing config.IngestionConfig, dataDir string, logger *supportlog.Entry,
-) (*captiveCoreOpener, error) {
+) (resolvedCore, error) {
 	if ing.CaptiveCoreConfig == "" {
-		return nil, errors.New("[ingestion].captive_core_config is required for live ingestion")
+		return resolvedCore{}, errors.New("[ingestion].captive_core_config is required for live ingestion")
 	}
 	if len(ing.HistoryArchiveURLs) == 0 {
-		return nil, errors.New("[ingestion].history_archive_urls is required for live ingestion")
+		return resolvedCore{}, errors.New("[ingestion].history_archive_urls is required for live ingestion")
 	}
 
 	// NETWORK_PASSPHRASE lives in the captive-core file; read it back so the
 	// operator configures it in one place. (go-toml v1 ignores the other fields.)
+	// Read ONCE: both openers are built from these bytes, so they cannot end up
+	// describing two different networks if the file changes underneath us.
 	data, err := os.ReadFile(ing.CaptiveCoreConfig)
 	if err != nil {
-		return nil, fmt.Errorf("read captive_core_config %q: %w", ing.CaptiveCoreConfig, err)
+		return resolvedCore{}, fmt.Errorf("read captive_core_config %q: %w", ing.CaptiveCoreConfig, err)
 	}
 	var peek struct {
 		NetworkPassphrase string `toml:"NETWORK_PASSPHRASE"`
 	}
 	if perr := toml.Unmarshal(data, &peek); perr != nil {
-		return nil, fmt.Errorf("parse captive_core_config %q: %w", ing.CaptiveCoreConfig, perr)
+		return resolvedCore{}, fmt.Errorf("parse captive_core_config %q: %w", ing.CaptiveCoreConfig, perr)
 	}
 	if peek.NetworkPassphrase == "" {
-		return nil, fmt.Errorf("captive_core_config %q must define NETWORK_PASSPHRASE", ing.CaptiveCoreConfig)
+		return resolvedCore{}, fmt.Errorf("captive_core_config %q must define NETWORK_PASSPHRASE", ing.CaptiveCoreConfig)
 	}
 
 	// stellar-core binary: explicit path, else the one on PATH (RPC daemon default).
@@ -447,7 +521,7 @@ func newCaptiveCoreOpener(
 	if binaryPath == "" {
 		found, lerr := exec.LookPath("stellar-core")
 		if lerr != nil {
-			return nil, fmt.Errorf(
+			return resolvedCore{}, fmt.Errorf(
 				"[ingestion].stellar_core_binary_path unset and stellar-core not found on PATH: %w", lerr)
 		}
 		binaryPath = found
@@ -458,11 +532,8 @@ func newCaptiveCoreOpener(
 		storagePath = filepath.Join(dataDir, "captive-core")
 	}
 
-	// Build the toml from the bytes already read, not the path — re-reading via
-	// NewCaptiveCoreTomlFromFile would parse the file twice and, worse, could
-	// observe a different NETWORK_PASSPHRASE than the one peeked above if the file
-	// changed between the two reads (surfacing as the SDK's confusing mismatch error).
-	coreToml, err := ledgerbackend.NewCaptiveCoreTomlFromData(data, ledgerbackend.CaptiveCoreTomlParams{
+	// The params both openers share; the live one then adds the HTTP ports.
+	params := ledgerbackend.CaptiveCoreTomlParams{
 		HistoryArchiveURLs:                 ing.HistoryArchiveURLs,
 		NetworkPassphrase:                  peek.NetworkPassphrase,
 		Strict:                             true,
@@ -470,16 +541,58 @@ func newCaptiveCoreOpener(
 		EnforceSorobanTransactionMetaExtV1: true,
 		EmitUnifiedEvents:                  true,
 		CoreBinaryPath:                     binaryPath,
-	})
+	}
+
+	backfillOpener, err := newCaptiveCoreOpener(
+		ing, data, params, binaryPath, storagePath, peek.NetworkPassphrase, logger)
+	if err != nil {
+		return resolvedCore{}, err
+	}
+
+	httpPort := *ing.CoreHTTPPort
+	params.HTTPPort = &httpPort
+	params.HTTPQueryServerParams = &ledgerbackend.HTTPQueryServerParams{
+		//nolint:gosec // validateIngestion rejects any of these above 65535
+		Port: uint16(*ing.CoreHTTPQueryPort),
+		//nolint:gosec // same range check
+		ThreadPoolSize: uint16(*ing.CoreHTTPQueryThreadPoolSize),
+		//nolint:gosec // same range check
+		SnapshotLedgers: uint16(*ing.CoreHTTPQuerySnapshotLedgers),
+	}
+	liveOpener, err := newCaptiveCoreOpener(
+		ing, data, params, binaryPath, storagePath, peek.NetworkPassphrase, logger)
+	if err != nil {
+		return resolvedCore{}, err
+	}
+
+	return resolvedCore{
+		live:              liveOpener,
+		backfill:          backfillOpener,
+		networkPassphrase: peek.NetworkPassphrase,
+		binaryPath:        binaryPath,
+	}, nil
+}
+
+// newCaptiveCoreOpener builds one opener from the captive-core file's bytes.
+// data is what was read from ing.CaptiveCoreConfig; params carries the caller's
+// choice of whether core's HTTP servers are enabled.
+//
+// The toml is built from the bytes rather than the path: NewCaptiveCoreTomlFromFile
+// would read the file again and could observe a different NETWORK_PASSPHRASE than
+// the caller peeked, surfacing as the SDK's confusing mismatch error.
+func newCaptiveCoreOpener(
+	ing config.IngestionConfig, data []byte, params ledgerbackend.CaptiveCoreTomlParams,
+	binaryPath, storagePath, networkPassphrase string, logger *supportlog.Entry,
+) (*captiveCoreOpener, error) {
+	coreToml, err := ledgerbackend.NewCaptiveCoreTomlFromData(data, params)
 	if err != nil {
 		return nil, fmt.Errorf("invalid captive-core toml %q: %w", ing.CaptiveCoreConfig, err)
 	}
-
 	return &captiveCoreOpener{
 		config: ledgerbackend.CaptiveCoreConfig{
 			BinaryPath:         binaryPath,
 			StoragePath:        storagePath,
-			NetworkPassphrase:  peek.NetworkPassphrase,
+			NetworkPassphrase:  networkPassphrase,
 			HistoryArchiveURLs: ing.HistoryArchiveURLs,
 			Log:                logger.WithField("subservice", "stellar-core"),
 			Toml:               coreToml,

--- a/cmd/stellar-rpc/internal/rpcv2/daemon_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/daemon_test.go
@@ -472,12 +472,15 @@ func TestSupervise_FirstStartNoTipRetries(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // writeCaptiveCoreFile writes a captive-core config with the network passphrase
-// and a quorum set — the minimum the SDK's toml builder accepts.
-func writeCaptiveCoreFile(t *testing.T) string {
+// and a quorum set — the minimum the SDK's toml builder accepts. extra is
+// appended as top-level keys, for the cases where the operator's file also sets
+// one of core's HTTP keys.
+func writeCaptiveCoreFile(t *testing.T, extra string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "captive-core.toml")
 	body := fmt.Sprintf(`
 NETWORK_PASSPHRASE = %q
+%s
 
 [[HOME_DOMAINS]]
 HOME_DOMAIN = "testnet.stellar.org"
@@ -488,9 +491,22 @@ NAME = "sdf_testnet_1"
 HOME_DOMAIN = "testnet.stellar.org"
 PUBLIC_KEY = "GDKXE2OZMJIPOSLNA6N6F2BVCI3O777I2OOC4BV7VOYUEHYX7RTRYA7Y"
 ADDRESS = "core-testnet1.stellar.org"
-`, network.TestNetworkPassphrase)
+`, network.TestNetworkPassphrase, extra)
 	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
 	return path
+}
+
+// coreFileIngestion is a defaulted [ingestion] section pointed at corePath. The
+// binary path is one that does not exist: nothing execs it in these tests (the
+// SDK's version probe ignores a failed lookup), and it keeps them off whatever
+// stellar-core happens to be on PATH.
+func coreFileIngestion(t *testing.T, corePath string) config.IngestionConfig {
+	t.Helper()
+	return config.Config{Ingestion: config.IngestionConfig{
+		CaptiveCoreConfig:     corePath,
+		HistoryArchiveURLs:    []string{"https://archive.example"},
+		StellarCoreBinaryPath: filepath.Join(t.TempDir(), "stellar-core"),
+	}}.WithDefaults().Ingestion
 }
 
 // The live ingestion core gets core's two HTTP servers; the backfill cores must
@@ -499,14 +515,7 @@ ADDRESS = "core-testnet1.stellar.org"
 // — and nothing ever queries a backfill core.
 func TestNewCaptiveCoreOpeners_PortsOnLiveCoreOnly(t *testing.T) {
 	uintPtr := func(v uint) *uint { return &v }
-	ing := config.IngestionConfig{
-		CaptiveCoreConfig:  writeCaptiveCoreFile(t),
-		HistoryArchiveURLs: []string{"https://archive.example"},
-		// A path that does not exist: nothing execs it here (the SDK's version
-		// probe ignores a failed lookup), and it keeps the test off whatever
-		// stellar-core happens to be on PATH.
-		StellarCoreBinaryPath: filepath.Join(t.TempDir(), "stellar-core"),
-	}
+	ing := coreFileIngestion(t, writeCaptiveCoreFile(t, ""))
 	ing.CoreHTTPPort = uintPtr(21626)
 	ing.CoreHTTPQueryPort = uintPtr(21628)
 	ing.CoreHTTPQueryThreadPoolSize = uintPtr(7)
@@ -544,6 +553,82 @@ func TestNewCaptiveCoreOpeners_PortsOnLiveCoreOnly(t *testing.T) {
 	assert.Equal(t, ing.StellarCoreBinaryPath, core.binaryPath)
 	assert.Equal(t, live.config.NetworkPassphrase, backfill.config.NetworkPassphrase)
 	assert.Equal(t, live.config.StoragePath, backfill.config.StoragePath)
+}
+
+// A captive-core file that declares core's ports ITSELF must not leak them into
+// the backfill cores. The SDK keeps a file-declared HTTP_QUERY_PORT (it
+// overwrites the query keys only when the caller passes query-server params),
+// and its bounded-replay config clears HTTP_PORT but never the query port — so
+// without disableHTTPServers every parallel replay would try to bind it.
+func TestNewCaptiveCoreOpeners_BackfillPortlessEvenWhenCoreFileDeclaresPorts(t *testing.T) {
+	// The values must AGREE with [ingestion] or startup is rejected outright; the
+	// point here is that agreeing values still do not reach a backfill core.
+	extra := "HTTP_PORT = 11626\nHTTP_QUERY_PORT = 11628\nQUERY_THREAD_POOL_SIZE = 2\n"
+	ing := coreFileIngestion(t, writeCaptiveCoreFile(t, extra))
+	poolSize := uint(2)
+	ing.CoreHTTPQueryThreadPoolSize = &poolSize
+
+	core, err := newCaptiveCoreOpeners(ing, t.TempDir(), silentLogger())
+	require.NoError(t, err)
+
+	backfill, ok := core.backfill.(*captiveCoreOpener)
+	require.True(t, ok)
+	assert.Nil(t, backfill.config.Toml.HTTPQueryPort)
+	assert.Nil(t, backfill.config.Toml.QueryThreadPoolSize)
+	assert.Nil(t, backfill.config.Toml.QuerySnapshotLedgers)
+	assert.Zero(t, backfill.config.Toml.HTTPPort)
+
+	// The generated file is what core actually reads, so assert on it too — for
+	// both the direct and the bounded-replay (catchup) form.
+	raw, err := backfill.config.Toml.Marshal()
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "HTTP_QUERY_PORT")
+	catchup, err := backfill.config.Toml.CatchupToml()
+	require.NoError(t, err)
+	rawCatchup, err := catchup.Marshal()
+	require.NoError(t, err)
+	assert.NotContains(t, string(rawCatchup), "HTTP_QUERY_PORT")
+
+	// The live core still gets both servers.
+	live, ok := core.live.(*captiveCoreOpener)
+	require.True(t, ok)
+	require.NotNil(t, live.config.Toml.HTTPQueryPort)
+	assert.Equal(t, uint(11628), *live.config.Toml.HTTPQueryPort)
+}
+
+// A captive-core file that sets one of core's HTTP keys to a DIFFERENT value
+// than [ingestion] is rejected with a message naming both sides. Without this
+// check the SDK's own comparison is reached instead, and three of its branches
+// format the error with a params field this daemon never sets — a nil-pointer
+// panic in place of an error.
+func TestNewCaptiveCoreOpeners_RejectsCoreFileHTTPConflict(t *testing.T) {
+	tests := []struct {
+		name  string
+		extra string
+		want  string
+	}{
+		{"admin port", "HTTP_PORT = 11625\n", keyCoreHTTPPort},
+		{"query port", "HTTP_QUERY_PORT = 11111\n", keyCoreHTTPQueryPort},
+		{"thread pool", "QUERY_THREAD_POOL_SIZE = 999\n", keyCoreQueryThreadPoolSize},
+		{"snapshot ledgers", "QUERY_SNAPSHOT_LEDGERS = 77\n", keyCoreQuerySnapshotLedgers},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ing := coreFileIngestion(t, writeCaptiveCoreFile(t, tc.extra))
+			_, err := newCaptiveCoreOpeners(ing, t.TempDir(), silentLogger())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+			assert.Contains(t, err.Error(), "captive_core_config sets")
+		})
+	}
+}
+
+// A file value that AGREES with [ingestion] is fine — configs carried over from
+// v1, where these keys commonly lived in the core file, still start.
+func TestNewCaptiveCoreOpeners_AcceptsAgreeingCoreFileHTTPKeys(t *testing.T) {
+	ing := coreFileIngestion(t, writeCaptiveCoreFile(t, "HTTP_PORT = 11626\n"))
+	_, err := newCaptiveCoreOpeners(ing, t.TempDir(), silentLogger())
+	require.NoError(t, err)
 }
 
 // An injected opener (every rpcv2 test) serves both roles, so nothing in the

--- a/cmd/stellar-rpc/internal/rpcv2/daemon_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/daemon_test.go
@@ -548,8 +548,6 @@ func TestNewCaptiveCoreOpeners_PortsOnLiveCoreOnly(t *testing.T) {
 }
 
 func TestNewCaptiveCoreOpeners_BackfillPortlessEvenWhenCoreFileDeclaresPorts(t *testing.T) {
-	// These must agree with [ingestion] or startup is rejected; the point is that
-	// agreeing values still do not reach a backfill core.
 	extra := "HTTP_PORT = 11626\nHTTP_QUERY_PORT = 11628\nQUERY_THREAD_POOL_SIZE = 2\n"
 	ing := coreFileIngestion(t, writeCaptiveCoreFile(t, extra))
 	poolSize := uint(2)
@@ -582,34 +580,68 @@ func TestNewCaptiveCoreOpeners_BackfillPortlessEvenWhenCoreFileDeclaresPorts(t *
 	assert.Equal(t, uint(11628), *live.config.Toml.HTTPQueryPort)
 }
 
-// Without this check the SDK's own comparison is reached, where three branches
-// panic on a nil pointer instead of reporting the conflict.
-func TestNewCaptiveCoreOpeners_RejectsCoreFileHTTPConflict(t *testing.T) {
+func TestNewCaptiveCoreOpeners_OverridesCoreFileHTTPSettings(t *testing.T) {
 	tests := []struct {
-		name  string
-		extra string
-		want  string
+		name    string
+		extra   string
+		fileKey string
+		read    func(*ledgerbackend.CaptiveCoreToml) uint
+		want    uint
 	}{
-		{"admin port", "HTTP_PORT = 11625\n", keyCoreHTTPPort},
-		{"query port", "HTTP_QUERY_PORT = 11111\n", keyCoreHTTPQueryPort},
-		{"thread pool", "QUERY_THREAD_POOL_SIZE = 999\n", keyCoreQueryThreadPoolSize},
-		{"snapshot ledgers", "QUERY_SNAPSHOT_LEDGERS = 77\n", keyCoreQuerySnapshotLedgers},
+		{
+			"admin port", "HTTP_PORT = 11625\n", keyCoreHTTPPort,
+			func(c *ledgerbackend.CaptiveCoreToml) uint { return c.HTTPPort },
+			config.DefaultCoreHTTPPort,
+		},
+		{
+			"query port", "HTTP_QUERY_PORT = 11111\n", keyCoreHTTPQueryPort,
+			func(c *ledgerbackend.CaptiveCoreToml) uint { return *c.HTTPQueryPort },
+			config.DefaultCoreHTTPQueryPort,
+		},
+		{
+			"snapshot ledgers", "QUERY_SNAPSHOT_LEDGERS = 77\n", keyCoreQuerySnapshotLedgers,
+			func(c *ledgerbackend.CaptiveCoreToml) uint { return *c.QuerySnapshotLedgers },
+			config.DefaultCoreHTTPQuerySnapshotLedgers,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			logger, logs := capturingLogger()
 			ing := coreFileIngestion(t, writeCaptiveCoreFile(t, tc.extra))
-			_, err := newCaptiveCoreOpeners(ing, t.TempDir(), silentLogger())
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tc.want)
-			assert.Contains(t, err.Error(), "captive_core_config sets")
+
+			core, err := newCaptiveCoreOpeners(ing, t.TempDir(), logger)
+			require.NoError(t, err)
+
+			live, ok := core.live.(*captiveCoreOpener)
+			require.True(t, ok)
+			assert.Equal(t, tc.want, tc.read(live.config.Toml))
+			assert.Contains(t, logs.String(), tc.fileKey)
 		})
 	}
 }
 
-func TestNewCaptiveCoreOpeners_AcceptsAgreeingCoreFileHTTPKeys(t *testing.T) {
-	ing := coreFileIngestion(t, writeCaptiveCoreFile(t, "HTTP_PORT = 11626\n"))
-	_, err := newCaptiveCoreOpeners(ing, t.TempDir(), silentLogger())
+func TestNewCaptiveCoreOpeners_OverridesCoreFileThreadPoolSize(t *testing.T) {
+	logger, logs := capturingLogger()
+	ing := coreFileIngestion(t, writeCaptiveCoreFile(t, "QUERY_THREAD_POOL_SIZE = 999\n"))
+
+	core, err := newCaptiveCoreOpeners(ing, t.TempDir(), logger)
 	require.NoError(t, err)
+
+	live, ok := core.live.(*captiveCoreOpener)
+	require.True(t, ok)
+	require.NotNil(t, live.config.Toml.QueryThreadPoolSize)
+	assert.Equal(t, config.NumCPU(), *live.config.Toml.QueryThreadPoolSize)
+	assert.Contains(t, logs.String(), keyCoreQueryThreadPoolSize)
+}
+
+func TestNewCaptiveCoreOpeners_SilentWhenCoreFileAgrees(t *testing.T) {
+	logger, logs := capturingLogger()
+	extra := fmt.Sprintf("HTTP_PORT = %d\n", config.DefaultCoreHTTPPort)
+	ing := coreFileIngestion(t, writeCaptiveCoreFile(t, extra))
+
+	_, err := newCaptiveCoreOpeners(ing, t.TempDir(), logger)
+	require.NoError(t, err)
+	assert.NotContains(t, logs.String(), keyCoreHTTPPort)
 }
 
 func TestResolveCore_InjectedOpenerServesBothRoles(t *testing.T) {

--- a/cmd/stellar-rpc/internal/rpcv2/daemon_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/daemon_test.go
@@ -471,10 +471,9 @@ func TestSupervise_FirstStartNoTipRetries(t *testing.T) {
 // Captive-core resolution: HTTP ports on the live core only.
 // ---------------------------------------------------------------------------
 
-// writeCaptiveCoreFile writes a captive-core config with the network passphrase
-// and a quorum set — the minimum the SDK's toml builder accepts. extra is
-// appended as top-level keys, for the cases where the operator's file also sets
-// one of core's HTTP keys.
+// writeCaptiveCoreFile writes the minimum captive-core config the SDK's toml
+// builder accepts: a network passphrase and a quorum set. extra is appended as
+// top-level keys.
 func writeCaptiveCoreFile(t *testing.T, extra string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "captive-core.toml")
@@ -497,9 +496,8 @@ ADDRESS = "core-testnet1.stellar.org"
 }
 
 // coreFileIngestion is a defaulted [ingestion] section pointed at corePath. The
-// binary path is one that does not exist: nothing execs it in these tests (the
-// SDK's version probe ignores a failed lookup), and it keeps them off whatever
-// stellar-core happens to be on PATH.
+// binary path does not exist, keeping these tests off whatever stellar-core is
+// on PATH; nothing execs it (the SDK's version probe ignores a failed lookup).
 func coreFileIngestion(t *testing.T, corePath string) config.IngestionConfig {
 	t.Helper()
 	return config.Config{Ingestion: config.IngestionConfig{
@@ -509,10 +507,6 @@ func coreFileIngestion(t *testing.T, corePath string) config.IngestionConfig {
 	}}.WithDefaults().Ingestion
 }
 
-// The live ingestion core gets core's two HTTP servers; the backfill cores must
-// not. A no-lake backfill runs one bounded-replay core per chunk IN PARALLEL, so
-// a fixed port in their toml would have every one of them contend on binding it
-// — and nothing ever queries a backfill core.
 func TestNewCaptiveCoreOpeners_PortsOnLiveCoreOnly(t *testing.T) {
 	uintPtr := func(v uint) *uint { return &v }
 	ing := coreFileIngestion(t, writeCaptiveCoreFile(t, ""))
@@ -529,7 +523,7 @@ func TestNewCaptiveCoreOpeners_PortsOnLiveCoreOnly(t *testing.T) {
 	backfill, ok := core.backfill.(*captiveCoreOpener)
 	require.True(t, ok)
 
-	// Live: both servers enabled, on the configured ports.
+	// Live: both servers, on the configured ports.
 	assert.Equal(t, uint(21626), live.config.Toml.HTTPPort)
 	require.NotNil(t, live.config.Toml.HTTPQueryPort)
 	assert.Equal(t, uint(21628), *live.config.Toml.HTTPQueryPort)
@@ -538,31 +532,24 @@ func TestNewCaptiveCoreOpeners_PortsOnLiveCoreOnly(t *testing.T) {
 	require.NotNil(t, live.config.Toml.QuerySnapshotLedgers)
 	assert.Equal(t, uint(9), *live.config.Toml.QuerySnapshotLedgers)
 
-	// Backfill: the query server is never configured at all...
+	// Backfill: no query server, and no admin server either.
 	assert.Nil(t, backfill.config.Toml.HTTPQueryPort,
 		"a backfill core must not bind the query port")
 	assert.Nil(t, backfill.config.Toml.QueryThreadPoolSize)
-	// ...and its admin port is dropped by the bounded-replay (catchup) mode those
-	// cores run in — which is what makes the parallel replays safe.
 	catchup, err := backfill.config.Toml.CatchupToml()
 	require.NoError(t, err)
 	assert.Zero(t, catchup.HTTPPort, "bounded replay runs core with no admin server")
 
-	// Both openers describe the same core on the same network.
+	// Both openers describe the same core.
 	assert.Equal(t, network.TestNetworkPassphrase, core.networkPassphrase)
 	assert.Equal(t, ing.StellarCoreBinaryPath, core.binaryPath)
 	assert.Equal(t, live.config.NetworkPassphrase, backfill.config.NetworkPassphrase)
 	assert.Equal(t, live.config.StoragePath, backfill.config.StoragePath)
 }
 
-// A captive-core file that declares core's ports ITSELF must not leak them into
-// the backfill cores. The SDK keeps a file-declared HTTP_QUERY_PORT (it
-// overwrites the query keys only when the caller passes query-server params),
-// and its bounded-replay config clears HTTP_PORT but never the query port — so
-// without disableHTTPServers every parallel replay would try to bind it.
 func TestNewCaptiveCoreOpeners_BackfillPortlessEvenWhenCoreFileDeclaresPorts(t *testing.T) {
-	// The values must AGREE with [ingestion] or startup is rejected outright; the
-	// point here is that agreeing values still do not reach a backfill core.
+	// These must agree with [ingestion] or startup is rejected; the point is that
+	// agreeing values still do not reach a backfill core.
 	extra := "HTTP_PORT = 11626\nHTTP_QUERY_PORT = 11628\nQUERY_THREAD_POOL_SIZE = 2\n"
 	ing := coreFileIngestion(t, writeCaptiveCoreFile(t, extra))
 	poolSize := uint(2)
@@ -578,8 +565,7 @@ func TestNewCaptiveCoreOpeners_BackfillPortlessEvenWhenCoreFileDeclaresPorts(t *
 	assert.Nil(t, backfill.config.Toml.QuerySnapshotLedgers)
 	assert.Zero(t, backfill.config.Toml.HTTPPort)
 
-	// The generated file is what core actually reads, so assert on it too — for
-	// both the direct and the bounded-replay (catchup) form.
+	// The generated file is what core reads, so assert on that too.
 	raw, err := backfill.config.Toml.Marshal()
 	require.NoError(t, err)
 	assert.NotContains(t, string(raw), "HTTP_QUERY_PORT")
@@ -596,11 +582,8 @@ func TestNewCaptiveCoreOpeners_BackfillPortlessEvenWhenCoreFileDeclaresPorts(t *
 	assert.Equal(t, uint(11628), *live.config.Toml.HTTPQueryPort)
 }
 
-// A captive-core file that sets one of core's HTTP keys to a DIFFERENT value
-// than [ingestion] is rejected with a message naming both sides. Without this
-// check the SDK's own comparison is reached instead, and three of its branches
-// format the error with a params field this daemon never sets — a nil-pointer
-// panic in place of an error.
+// Without this check the SDK's own comparison is reached, where three branches
+// panic on a nil pointer instead of reporting the conflict.
 func TestNewCaptiveCoreOpeners_RejectsCoreFileHTTPConflict(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -623,16 +606,12 @@ func TestNewCaptiveCoreOpeners_RejectsCoreFileHTTPConflict(t *testing.T) {
 	}
 }
 
-// A file value that AGREES with [ingestion] is fine — configs carried over from
-// v1, where these keys commonly lived in the core file, still start.
 func TestNewCaptiveCoreOpeners_AcceptsAgreeingCoreFileHTTPKeys(t *testing.T) {
 	ing := coreFileIngestion(t, writeCaptiveCoreFile(t, "HTTP_PORT = 11626\n"))
 	_, err := newCaptiveCoreOpeners(ing, t.TempDir(), silentLogger())
 	require.NoError(t, err)
 }
 
-// An injected opener (every rpcv2 test) serves both roles, so nothing in the
-// test suite depends on a real core process or a resolvable binary.
 func TestResolveCore_InjectedOpenerServesBothRoles(t *testing.T) {
 	injected := &fakeCore{}
 	core, err := resolveCore(daemonOptions{Core: injected}, config.Config{}, silentLogger())

--- a/cmd/stellar-rpc/internal/rpcv2/daemon_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/daemon_test.go
@@ -468,6 +468,98 @@ func TestSupervise_FirstStartNoTipRetries(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Captive-core resolution: HTTP ports on the live core only.
+// ---------------------------------------------------------------------------
+
+// writeCaptiveCoreFile writes a captive-core config with the network passphrase
+// and a quorum set — the minimum the SDK's toml builder accepts.
+func writeCaptiveCoreFile(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "captive-core.toml")
+	body := fmt.Sprintf(`
+NETWORK_PASSPHRASE = %q
+
+[[HOME_DOMAINS]]
+HOME_DOMAIN = "testnet.stellar.org"
+QUALITY = "HIGH"
+
+[[VALIDATORS]]
+NAME = "sdf_testnet_1"
+HOME_DOMAIN = "testnet.stellar.org"
+PUBLIC_KEY = "GDKXE2OZMJIPOSLNA6N6F2BVCI3O777I2OOC4BV7VOYUEHYX7RTRYA7Y"
+ADDRESS = "core-testnet1.stellar.org"
+`, network.TestNetworkPassphrase)
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+	return path
+}
+
+// The live ingestion core gets core's two HTTP servers; the backfill cores must
+// not. A no-lake backfill runs one bounded-replay core per chunk IN PARALLEL, so
+// a fixed port in their toml would have every one of them contend on binding it
+// — and nothing ever queries a backfill core.
+func TestNewCaptiveCoreOpeners_PortsOnLiveCoreOnly(t *testing.T) {
+	uintPtr := func(v uint) *uint { return &v }
+	ing := config.IngestionConfig{
+		CaptiveCoreConfig:  writeCaptiveCoreFile(t),
+		HistoryArchiveURLs: []string{"https://archive.example"},
+		// A path that does not exist: nothing execs it here (the SDK's version
+		// probe ignores a failed lookup), and it keeps the test off whatever
+		// stellar-core happens to be on PATH.
+		StellarCoreBinaryPath: filepath.Join(t.TempDir(), "stellar-core"),
+	}
+	ing.CoreHTTPPort = uintPtr(21626)
+	ing.CoreHTTPQueryPort = uintPtr(21628)
+	ing.CoreHTTPQueryThreadPoolSize = uintPtr(7)
+	ing.CoreHTTPQuerySnapshotLedgers = uintPtr(9)
+
+	core, err := newCaptiveCoreOpeners(ing, t.TempDir(), silentLogger())
+	require.NoError(t, err)
+
+	live, ok := core.live.(*captiveCoreOpener)
+	require.True(t, ok, "the live opener is the production captive-core opener")
+	backfill, ok := core.backfill.(*captiveCoreOpener)
+	require.True(t, ok)
+
+	// Live: both servers enabled, on the configured ports.
+	assert.Equal(t, uint(21626), live.config.Toml.HTTPPort)
+	require.NotNil(t, live.config.Toml.HTTPQueryPort)
+	assert.Equal(t, uint(21628), *live.config.Toml.HTTPQueryPort)
+	require.NotNil(t, live.config.Toml.QueryThreadPoolSize)
+	assert.Equal(t, uint(7), *live.config.Toml.QueryThreadPoolSize)
+	require.NotNil(t, live.config.Toml.QuerySnapshotLedgers)
+	assert.Equal(t, uint(9), *live.config.Toml.QuerySnapshotLedgers)
+
+	// Backfill: the query server is never configured at all...
+	assert.Nil(t, backfill.config.Toml.HTTPQueryPort,
+		"a backfill core must not bind the query port")
+	assert.Nil(t, backfill.config.Toml.QueryThreadPoolSize)
+	// ...and its admin port is dropped by the bounded-replay (catchup) mode those
+	// cores run in — which is what makes the parallel replays safe.
+	catchup, err := backfill.config.Toml.CatchupToml()
+	require.NoError(t, err)
+	assert.Zero(t, catchup.HTTPPort, "bounded replay runs core with no admin server")
+
+	// Both openers describe the same core on the same network.
+	assert.Equal(t, network.TestNetworkPassphrase, core.networkPassphrase)
+	assert.Equal(t, ing.StellarCoreBinaryPath, core.binaryPath)
+	assert.Equal(t, live.config.NetworkPassphrase, backfill.config.NetworkPassphrase)
+	assert.Equal(t, live.config.StoragePath, backfill.config.StoragePath)
+}
+
+// An injected opener (every rpcv2 test) serves both roles, so nothing in the
+// test suite depends on a real core process or a resolvable binary.
+func TestResolveCore_InjectedOpenerServesBothRoles(t *testing.T) {
+	injected := &fakeCore{}
+	core, err := resolveCore(daemonOptions{Core: injected}, config.Config{}, silentLogger())
+	require.NoError(t, err)
+
+	assert.Same(t, injected, core.live)
+	assert.Same(t, injected, core.backfill)
+	assert.Empty(t, core.networkPassphrase, "an injected opener carries no passphrase")
+	assert.Empty(t, core.binaryPath, "and no binary path, so no core version is reported")
+}
+
+// ---------------------------------------------------------------------------
 // buildBackfillBackend — the no-lake (no datastore) paths.
 // ---------------------------------------------------------------------------
 
@@ -482,7 +574,7 @@ func TestBuildBackfillBackend_NoSourcesNoBackend(t *testing.T) {
 }
 
 // A daemon with no bulk source at all (no datastore, no archives; the injected
-// Core bypasses newCaptiveCoreOpener's own archive-URL requirement) fails fast at
+// Core bypasses newCaptiveCoreOpeners' own archive-URL requirement) fails fast at
 // startup with the config-shaped message — not at the first backfill pass.
 func TestRunDaemon_NoBulkSourceFailsFast(t *testing.T) {
 	configPath, _ := writeTempConfig(t, "")

--- a/cmd/stellar-rpc/internal/rpcv2/health.go
+++ b/cmd/stellar-rpc/internal/rpcv2/health.go
@@ -6,7 +6,7 @@ import (
 )
 
 // HealthSignal is the read side of the daemon's readiness/health signal — the
-// seam #772's read server consumes (the way v1's getHealth is a method on the
+// seam #889's read server consumes (the way v1's getHealth is a method on the
 // main server). It exposes exactly the raw signal: the readiness latch and the
 // last committed ledger's close time. The staleness judgment (close-time age vs
 // a latency threshold, the v1 getHealth semantic) is check policy that lives

--- a/cmd/stellar-rpc/internal/rpcv2/helpers_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/helpers_test.go
@@ -32,11 +32,17 @@ const testCPI = geometry.ChunksPerTxhashIndex
 const preGenesisLedger = uint32(chunk.FirstLedgerSeq - 1)
 
 func silentLogger() *supportlog.Entry {
-	var buf bytes.Buffer
+	logger, _ := capturingLogger()
+	return logger
+}
+
+// capturingLogger is silentLogger plus access to what was logged.
+func capturingLogger() (*supportlog.Entry, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
 	log := supportlog.New()
 	log.SetLevel(logrus.DebugLevel)
-	log.SetOutput(&buf)
-	return log
+	log.SetOutput(buf)
+	return log, buf
 }
 
 // newTestCatalog builds a Catalog over a real KV store on temp dirs with

--- a/cmd/stellar-rpc/internal/rpcv2/startup.go
+++ b/cmd/stellar-rpc/internal/rpcv2/startup.go
@@ -313,7 +313,7 @@ type StartConfig struct {
 	runBackfill func(ctx context.Context, exec backfill.ExecConfig, lo, hi chunk.ID) error
 
 	// health is the readiness/health signal the ingestion loop feeds per commit;
-	// #772's read server consumes it (as HealthSignal). nil ⇒ observe is a no-op.
+	// #889's read server consumes it (as HealthSignal). nil ⇒ observe is a no-op.
 	health *healthState
 }
 

--- a/cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml
+++ b/cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml
@@ -71,10 +71,11 @@ retention_chunks = 0
 # -----------------------------------------------------------------------------
 # [service] — the JSON-RPC read-serving policy (issue #882)
 # -----------------------------------------------------------------------------
-# Dormant today: the v2 read server does not exist yet, and live ingestion
-# starts consuming [service.fee_stats] when issue #881 lands. Naming rule:
-# camelCase table keys only where the key IS a JSON-RPC method name;
-# snake_case elsewhere.
+# Mostly dormant today: the v2 read server does not exist yet, and live
+# ingestion starts consuming [service.fee_stats] when issue #881 lands.
+# [service.preflight] is already live — the daemon sizes its preflight worker
+# pool from it at startup. Naming rule: camelCase table keys only where the key
+# IS a JSON-RPC method name; snake_case elsewhere.
 [service]
 
 # Address the JSON-RPC server listens on.
@@ -107,8 +108,8 @@ soroban_inclusion_fee_window_ledgers = 50
 # field: explicit per-method value → methods-wide default → compiled default
 # (the values shown in the tables below, identical to v1's).
 [service.methods]
-#queue_limit = 200              # default queue_limit for all nine methods
-#max_execution_duration = "8s"  # default execution budget for all nine methods
+#queue_limit = 200              # default queue_limit for every method below
+#max_execution_duration = "8s"  # default execution budget for every method below
 
 # Each method's table, keyed by the method's wire name:
 #   queue_limit             — max outstanding requests for this method
@@ -167,10 +168,41 @@ default_items_per_response = 100
 queue_limit = 100
 max_execution_duration = "5s"
 
-# NOT here (by design): sendTransaction, simulateTransaction, getLedgerEntries
-# and the preflight worker settings — those methods are captive-core-backed
-# and arrive with the captive-core-endpoints work. friendbot_url arrives with
-# the getNetwork handler.
+# The three captive-core-backed methods. They read CURRENT ledger state from
+# captive core (the bucket list) over the HTTP ports set in [ingestion] below,
+# not from this daemon's stores. sendTransaction and simulateTransaction get
+# v1's wider 15s budget because each waits on work outside this process — core's
+# own transaction submission, and the Rust preflight library.
+
+[service.methods.sendTransaction]
+queue_limit = 500
+max_execution_duration = "15s"
+
+[service.methods.simulateTransaction]
+queue_limit = 100
+max_execution_duration = "15s"
+
+[service.methods.getLedgerEntries]
+queue_limit = 1000
+max_execution_duration = "5s"
+
+# --- The preflight worker pool (simulateTransaction) -------------------------
+# Preflights run the Rust libpreflight in a pool of goroutines, sized once at
+# startup. The pool lives here rather than under simulateTransaction for the
+# same reason [service.fee_stats] does: it is a process-wide resource, not a
+# per-request limit.
+[service.preflight]
+
+# Concurrent preflights, and how many requests may wait for a free worker
+# before the pool rejects them; both >= 1. Default: the CPU count.
+#worker_count = 8
+#worker_queue_size = 8
+
+# Include detailed diagnostics in preflight errors. Costly to produce — v1
+# advises against it in production. Default true.
+enable_debug = true
+
+# NOT here (by design): friendbot_url, which arrives with the getNetwork handler.
 
 # -----------------------------------------------------------------------------
 # [backfill] — bulk history download into local storage
@@ -225,7 +257,7 @@ retry_wait = "5s"    # pause between retries of one object download
 # core-side — this differs from v1, where NETWORK_PASSPHRASE was an RPC config
 # key of its own. Here the daemon READS the passphrase back from the file
 # below at startup (it must define NETWORK_PASSPHRASE). v1's `network`
-# convenience macro and the captive-core HTTP-port knobs do not exist in v2.
+# convenience macro does not exist in v2.
 [ingestion]
 
 # REQUIRED for live ingestion. Path to the stellar-core config used by captive
@@ -244,6 +276,37 @@ history_archive_urls = ["https://history.stellar.org/prd/core-live/core_live_001
 
 # Captive core's working/bucket directory. Default: {default_data_dir}/captive-core.
 #captive_core_storage_path = ""
+
+# --- Core's HTTP surface ------------------------------------------------------
+# The keys below govern the two HTTP servers the captive-core process above runs,
+# and they are what the three captive-core-backed methods talk to:
+#
+#   * the admin server (core_http_port) accepts transaction submissions —
+#     sendTransaction's only path to the network;
+#   * the query server (core_http_query_port) answers ledger-entry lookups for
+#     getLedgerEntries and for every entry a preflight touches.
+#
+# Both ports must be free on this host and must differ from each other. They are
+# written into the LIVE ingestion core's config only: the bounded replay cores a
+# no-lake backfill runs are started in parallel, so a fixed port would have them
+# all fight over binding it.
+
+core_http_port = 11626
+core_http_query_port = 11628
+
+# Where transactions are submitted. Default: http://localhost:{core_http_port},
+# so setting core_http_port alone is enough. Set this only if core's admin
+# server is reachable somewhere other than localhost.
+#core_url = "http://localhost:11626"
+
+# Timeout for every request to either server above.
+core_request_timeout = "2s"
+
+# Threads core's query server uses (default: the CPU count), and how many recent
+# ledgers it keeps queryable snapshots of. Leave snapshot_ledgers alone unless
+# you know what core does with it.
+#core_http_query_thread_pool_size = 8
+core_http_query_snapshot_ledgers = 4
 
 # -----------------------------------------------------------------------------
 # [logging]

--- a/cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml
+++ b/cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml
@@ -199,8 +199,9 @@ max_execution_duration = "5s"
 #worker_queue_size = 8
 
 # Include detailed diagnostics in preflight errors. Costly to produce — v1
-# advises against it in production. Default true.
-enable_debug = true
+# advises against it in production. The default is true; this sample is a
+# production starting point, so it turns it off.
+enable_debug = false
 
 # NOT here (by design): friendbot_url, which arrives with the getNetwork handler.
 
@@ -294,14 +295,16 @@ history_archive_urls = ["https://history.stellar.org/prd/core-live/core_live_001
 # These four keys are owned HERE, not by the captive-core file — the opposite of
 # NETWORK_PASSPHRASE, which the captive-core file owns. If that file also sets
 # HTTP_PORT, HTTP_QUERY_PORT, QUERY_THREAD_POOL_SIZE or QUERY_SNAPSHOT_LEDGERS,
-# the two must agree; a disagreement is a startup error naming both sides.
+# the values below win and core is run with them; the daemon logs a warning
+# naming both, so nothing about the override is silent.
 
 core_http_port = 11626
 core_http_query_port = 11628
 
 # Where transactions are submitted. Default: http://localhost:{core_http_port},
 # so setting core_http_port alone is enough. Set this only if core's admin
-# server is reachable somewhere other than localhost.
+# server is reachable somewhere other than localhost — a core_url pointing at
+# this host must name core_http_port, and startup rejects it otherwise.
 #core_url = "http://localhost:11626"
 
 # Timeout for every request to either server above.

--- a/cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml
+++ b/cmd/stellar-rpc/rpcv2/rpc-v2-sample-config.toml
@@ -290,6 +290,11 @@ history_archive_urls = ["https://history.stellar.org/prd/core-live/core_live_001
 # written into the LIVE ingestion core's config only: the bounded replay cores a
 # no-lake backfill runs are started in parallel, so a fixed port would have them
 # all fight over binding it.
+#
+# These four keys are owned HERE, not by the captive-core file — the opposite of
+# NETWORK_PASSPHRASE, which the captive-core file owns. If that file also sets
+# HTTP_PORT, HTTP_QUERY_PORT, QUERY_THREAD_POOL_SIZE or QUERY_SNAPSHOT_LEDGERS,
+# the two must agree; a disagreement is a startup error naming both sides.
 
 core_http_port = 11626
 core_http_query_port = 11628

--- a/cmd/stellar-rpc/rpcv2/sample_config_test.go
+++ b/cmd/stellar-rpc/rpcv2/sample_config_test.go
@@ -35,6 +35,19 @@ func TestSampleConfig_ParsesStrict(t *testing.T) {
 	assert.Equal(t, config.DefaultMaxHealthyLedgerLatency, *cfg.Service.Methods.GetHealth.MaxHealthyLedgerLatency)
 	assert.Equal(t, 30*time.Second, *cfg.Service.Methods.GetHealth.MaxHealthyLedgerLatency)
 
+	assert.Equal(t, config.DefaultSendTransactionQueueLimit, *cfg.Service.Methods.SendTransaction.QueueLimit)
+	assert.Equal(t, config.DefaultCoreMethodMaxExecutionDuration,
+		*cfg.Service.Methods.SimulateTransaction.MaxExecutionDuration)
+	assert.Equal(t, config.DefaultMethodQueueLimit, *cfg.Service.Methods.GetLedgerEntries.QueueLimit)
+	assert.True(t, *cfg.Service.Preflight.EnableDebug)
+
+	assert.Equal(t, config.DefaultCoreHTTPPort, *cfg.Ingestion.CoreHTTPPort)
+	assert.Equal(t, config.DefaultCoreHTTPQueryPort, *cfg.Ingestion.CoreHTTPQueryPort)
+	assert.Equal(t, config.DefaultCoreRequestTimeout, *cfg.Ingestion.CoreRequestTimeout)
+	assert.Equal(t, config.DefaultCoreHTTPQuerySnapshotLedgers, *cfg.Ingestion.CoreHTTPQuerySnapshotLedgers)
+	assert.Equal(t, "http://localhost:11626", cfg.Ingestion.CoreURL,
+		"the sample leaves core_url commented out, so it derives from core_http_port")
+
 	assert.Equal(t, uint32(backfill.DefaultBSBBufferSize), *cfg.Backfill.BSB.BufferSize)
 	assert.Equal(t, uint32(backfill.DefaultBSBNumWorkers), *cfg.Backfill.BSB.NumWorkers)
 	assert.Equal(t, uint32(backfill.DefaultBSBMaxRetries), *cfg.Backfill.BSB.MaxRetries)

--- a/cmd/stellar-rpc/rpcv2/sample_config_test.go
+++ b/cmd/stellar-rpc/rpcv2/sample_config_test.go
@@ -39,7 +39,8 @@ func TestSampleConfig_ParsesStrict(t *testing.T) {
 	assert.Equal(t, config.DefaultCoreMethodMaxExecutionDuration,
 		*cfg.Service.Methods.SimulateTransaction.MaxExecutionDuration)
 	assert.Equal(t, config.DefaultMethodQueueLimit, *cfg.Service.Methods.GetLedgerEntries.QueueLimit)
-	assert.True(t, *cfg.Service.Preflight.EnableDebug)
+	assert.False(t, *cfg.Service.Preflight.EnableDebug,
+		"the sample deliberately departs from the true default: it is a production starting point")
 
 	assert.Equal(t, config.DefaultCoreHTTPPort, *cfg.Ingestion.CoreHTTPPort)
 	assert.Equal(t, config.DefaultCoreHTTPQueryPort, *cfg.Ingestion.CoreHTTPQueryPort)

--- a/design-docs/full-history-streaming-workflow.md
+++ b/design-docs/full-history-streaming-workflow.md
@@ -53,7 +53,7 @@ Every TOML leaf is also settable from the command line:
 - `--config` stays required — the file is the source of truth, flags are one-off overrides.
 - No environment variables.
 
-**[service]** — the JSON-RPC read-serving policy (#882; entirely dormant today — the read server arrives with #772, and #881 wires `[service.fee_stats]` into live ingestion). Key naming: camelCase only for the JSON-RPC method table names, snake_case elsewhere. Durations are strings (`"10s"`); any duration under 1ms is rejected (a bare TOML integer parses as nanoseconds).
+**[service]** — the JSON-RPC read-serving policy (#882; mostly dormant today — the read server arrives with #772, and #881 wires `[service.fee_stats]` into live ingestion; `[service.preflight]` already sizes the preflight worker pool at startup). Key naming: camelCase only for the JSON-RPC method table names, snake_case elsewhere. Durations are strings (`"10s"`); any duration under 1ms is rejected (a bare TOML integer parses as nanoseconds).
 
 | Key | Type | Default | Description |
 |---|---|---|---|
@@ -70,13 +70,22 @@ Every TOML leaf is also settable from the command line:
 | `classic_fee_window_ledgers` | `10` |
 | `soroban_inclusion_fee_window_ledgers` | `50` |
 
-**[service.methods.\<methodName\>]** — one table per served method (getHealth, getNetwork, getVersionInfo, getLatestLedger, getTransaction, getTransactions, getLedgers, getEvents, getFeeStats):
+**[service.methods.\<methodName\>]** — one table per served method (getHealth, getNetwork, getVersionInfo, getLatestLedger, getTransaction, getTransactions, getLedgers, getEvents, getFeeStats, sendTransaction, simulateTransaction, getLedgerEntries):
 
 - Every method: `queue_limit` and `max_execution_duration`. v1's defaults: 1000 / 5s, except getFeeStats's queue is 100, and getLedgers/getEvents get 10s.
+- The three captive-core-backed methods (#884) keep v1's values too: sendTransaction 500 / `"15s"`, simulateTransaction 100 / `"15s"`, getLedgerEntries 1000 / `"5s"`. The two 15s budgets are wider because both wait on work outside this process — core's own submission, and the Rust preflight library.
 - The three paginated methods (getTransactions, getLedgers, getEvents) add `max_items_per_response` / `default_items_per_response`. Two deliberate breaks from v1's page sizes (TODO: revisit under the v2 benchmarking epic): getEvents max is 1000 (the v2 API's spec constant, not v1's 10000), and getLedgers is 20/5 (one item is a full ledger's meta — megabytes each — so v1's 200/50 could produce >100MB responses).
 - getHealth adds `max_healthy_ledger_latency` (default `"30s"`).
 - Bare `queue_limit` / `max_execution_duration` keys directly on `[service.methods]` form an optional methods-wide default tier: per-method value → wide default → compiled default.
-- Not here: sendTransaction, simulateTransaction, getLedgerEntries and the preflight knobs — they arrive with the captive-core-endpoints work.
+- Not here: `friendbot_url`, which arrives with the getNetwork handler.
+
+**[service.preflight]** — the worker pool that runs simulateTransaction's preflights (the Rust libpreflight call). It sits under `[service]`, not under the simulateTransaction method table, for the same reason `[service.fee_stats]` does: it is a process-wide resource sized once at startup, not a per-request limit.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `worker_count` | uint | `NumCPU` | Concurrent preflights; >= 1. |
+| `worker_queue_size` | uint | `NumCPU` | Requests that may wait for a free worker before the pool rejects them; >= 1. |
+| `enable_debug` | bool | `true` | Detailed diagnostics in preflight errors. Costly to produce; v1 advises against it in production. The config schema's first bool — `leafKind`/`BindFlags`/`setLeaf`/`FlagOverrides` gained bool support with it. |
 
 **[retention]** — the two inputs to the retention floor; the effective floor is the higher of the two:
 
@@ -124,8 +133,18 @@ Every TOML leaf is also settable from the command line:
 |---|---|---|---|
 | `captive_core_config` | string | **required** | Path to the CaptiveStellarCore config file. Must define `NETWORK_PASSPHRASE`. |
 | `history_archive_urls` | []string | **required** | History-archive URLs for the SDK's archive client. Not derivable from the captive-core file, whose `[HISTORY.*]` entries are shell commands. |
-| `stellar_core_binary_path` | string | `stellar-core` on `PATH` | Path to the stellar-core binary. |
+| `stellar_core_binary_path` | string | `stellar-core` on `PATH` | Path to the stellar-core binary. Also what `getVersionInfo`'s captive-core version string is read from (`stellar-core version`, once at startup). |
 | `captive_core_storage_path` | string | `{default_data_dir}/captive-core` | Captive core's working directory. |
+| `core_http_port` | uint | `11626` | Core's admin HTTP port — sendTransaction's submission target. Also the base for `core_url`. |
+| `core_url` | string | `http://localhost:{core_http_port}` | Base URL transactions are submitted to. Set it only when core's admin server is reachable somewhere other than localhost. |
+| `core_request_timeout` | duration | `"2s"` | HTTP timeout for every request to either core server; >= 1ms. |
+| `core_http_query_port` | uint | `11628` | Core's high-performance query port, serving `/getledgerentry` for getLedgerEntries and for preflight's entry lookups. |
+| `core_http_query_thread_pool_size` | uint | `NumCPU` | Threads core's query server uses. |
+| `core_http_query_snapshot_ledgers` | uint | `4` | Recent ledgers core's query server keeps queryable snapshots of. |
+
+- The six `core_*` keys govern the HTTP surface of the same captive-core process the keys above configure, which is why they live here rather than under `[service]` (#884).
+- Both ports must be in `1..65535` and must differ from each other. Unlike v1, `0` is not accepted as "disable core's HTTP server": v2 always serves sendTransaction off the admin port and getLedgerEntries off the query port, so a disabled server is a broken deployment rather than a mode.
+- They are written into the **live** ingestion core's toml only. A no-lake backfill starts one bounded-replay core per chunk, in parallel, so a fixed port there would have every one of them contend on binding it — and nothing ever queries a backfill core.
 
 **[logging]** — optional `level` (`debug`/`info`/`warn`/`error`, default `info`) and `format` (`text`/`json`, default `text`).
 

--- a/design-docs/full-history-streaming-workflow.md
+++ b/design-docs/full-history-streaming-workflow.md
@@ -53,7 +53,7 @@ Every TOML leaf is also settable from the command line:
 - `--config` stays required — the file is the source of truth, flags are one-off overrides.
 - No environment variables.
 
-**[service]** — the JSON-RPC read-serving policy (#882; mostly dormant today — the read server arrives with #772, and #881 wires `[service.fee_stats]` into live ingestion; `[service.preflight]` already sizes the preflight worker pool at startup). Key naming: camelCase only for the JSON-RPC method table names, snake_case elsewhere. Durations are strings (`"10s"`); any duration under 1ms is rejected (a bare TOML integer parses as nanoseconds).
+**[service]** — the JSON-RPC read-serving policy (#882; mostly dormant today — the read server arrives with #772, and #881 wires `[service.fee_stats]` into live ingestion). Key naming: camelCase only for the JSON-RPC method table names, snake_case elsewhere. Durations are strings (`"10s"`); any duration under 1ms is rejected (a bare TOML integer parses as nanoseconds).
 
 | Key | Type | Default | Description |
 |---|---|---|---|
@@ -72,20 +72,19 @@ Every TOML leaf is also settable from the command line:
 
 **[service.methods.\<methodName\>]** — one table per served method (getHealth, getNetwork, getVersionInfo, getLatestLedger, getTransaction, getTransactions, getLedgers, getEvents, getFeeStats, sendTransaction, simulateTransaction, getLedgerEntries):
 
-- Every method: `queue_limit` and `max_execution_duration`. v1's defaults: 1000 / 5s, except getFeeStats's queue is 100, and getLedgers/getEvents get 10s.
-- The three captive-core-backed methods (#884) keep v1's values too: sendTransaction 500 / `"15s"`, simulateTransaction 100 / `"15s"`, getLedgerEntries 1000 / `"5s"`. The two 15s budgets are wider because both wait on work outside this process — core's own submission, and the Rust preflight library.
+- Every method: `queue_limit` and `max_execution_duration`. v1's defaults: 1000 / 5s, except getFeeStats's queue is 100, getLedgers/getEvents get 10s, and sendTransaction (500) / simulateTransaction (100) get 15s.
 - The three paginated methods (getTransactions, getLedgers, getEvents) add `max_items_per_response` / `default_items_per_response`. Two deliberate breaks from v1's page sizes (TODO: revisit under the v2 benchmarking epic): getEvents max is 1000 (the v2 API's spec constant, not v1's 10000), and getLedgers is 20/5 (one item is a full ledger's meta — megabytes each — so v1's 200/50 could produce >100MB responses).
 - getHealth adds `max_healthy_ledger_latency` (default `"30s"`).
 - Bare `queue_limit` / `max_execution_duration` keys directly on `[service.methods]` form an optional methods-wide default tier: per-method value → wide default → compiled default.
 - Not here: `friendbot_url`, which arrives with the getNetwork handler.
 
-**[service.preflight]** — the worker pool that runs simulateTransaction's preflights (the Rust libpreflight call). It sits under `[service]`, not under the simulateTransaction method table, for the same reason `[service.fee_stats]` does: it is a process-wide resource sized once at startup, not a per-request limit.
+**[service.preflight]** — simulateTransaction's preflight worker pool. It sits under `[service]` rather than under the method table because it is sized once at startup, not per request:
 
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `worker_count` | uint | `NumCPU` | Concurrent preflights; >= 1. |
-| `worker_queue_size` | uint | `NumCPU` | Requests that may wait for a free worker before the pool rejects them; >= 1. |
-| `enable_debug` | bool | `true` | Detailed diagnostics in preflight errors. Costly to produce; v1 advises against it in production. The config schema's first bool — `leafKind`/`BindFlags`/`setLeaf`/`FlagOverrides` gained bool support with it. |
+| `worker_queue_size` | uint | `NumCPU` | Requests that may wait for a free worker; >= 1. |
+| `enable_debug` | bool | `true` | Detailed diagnostics in preflight errors; not advised in production. |
 
 **[retention]** — the two inputs to the retention floor; the effective floor is the higher of the two:
 
@@ -133,19 +132,16 @@ Every TOML leaf is also settable from the command line:
 |---|---|---|---|
 | `captive_core_config` | string | **required** | Path to the CaptiveStellarCore config file. Must define `NETWORK_PASSPHRASE`. |
 | `history_archive_urls` | []string | **required** | History-archive URLs for the SDK's archive client. Not derivable from the captive-core file, whose `[HISTORY.*]` entries are shell commands. |
-| `stellar_core_binary_path` | string | `stellar-core` on `PATH` | Path to the stellar-core binary. Also what `getVersionInfo`'s captive-core version string is read from (`stellar-core version`, once at startup). |
+| `stellar_core_binary_path` | string | `stellar-core` on `PATH` | Path to the stellar-core binary. |
 | `captive_core_storage_path` | string | `{default_data_dir}/captive-core` | Captive core's working directory. |
-| `core_http_port` | uint | `11626` | Core's admin HTTP port — sendTransaction's submission target. Also the base for `core_url`. |
-| `core_url` | string | `http://localhost:{core_http_port}` | Base URL transactions are submitted to. Set it only when core's admin server is reachable somewhere other than localhost. |
-| `core_request_timeout` | duration | `"2s"` | HTTP timeout for every request to either core server; >= 1ms. |
-| `core_http_query_port` | uint | `11628` | Core's high-performance query port, serving `/getledgerentry` for getLedgerEntries and for preflight's entry lookups. |
+| `core_http_port` | uint | `11626` | Core's admin HTTP port, where sendTransaction submits. Base for `core_url`. |
+| `core_url` | string | `http://localhost:{core_http_port}` | Where transactions are submitted; set it only if core's admin server is not on localhost. |
+| `core_request_timeout` | duration | `"2s"` | Timeout for requests to either core server. |
+| `core_http_query_port` | uint | `11628` | Core's query port, serving ledger-entry reads for getLedgerEntries and preflight. |
 | `core_http_query_thread_pool_size` | uint | `NumCPU` | Threads core's query server uses. |
-| `core_http_query_snapshot_ledgers` | uint | `4` | Recent ledgers core's query server keeps queryable snapshots of. |
+| `core_http_query_snapshot_ledgers` | uint | `4` | Recent ledgers core's query server keeps snapshots of. |
 
-- The six `core_*` keys govern the HTTP surface of the same captive-core process the keys above configure, which is why they live here rather than under `[service]` (#884).
-- Both ports must be in `1..65535` and must differ from each other. Unlike v1, `0` is not accepted as "disable core's HTTP server": v2 always serves sendTransaction off the admin port and getLedgerEntries off the query port, so a disabled server is a broken deployment rather than a mode.
-- These four keys are owned by `[ingestion]`, the opposite of `NETWORK_PASSPHRASE`, which the captive-core file owns. A captive-core file that also sets `HTTP_PORT` / `HTTP_QUERY_PORT` / `QUERY_THREAD_POOL_SIZE` / `QUERY_SNAPSHOT_LEDGERS` must agree with it; a disagreement is a startup error naming both sides (the daemon checks this itself — the SDK's own comparison panics rather than reporting, since it formats the message with a field this daemon never sets).
-- They are written into the **live** ingestion core's toml only. A no-lake backfill starts one bounded-replay core per chunk, in parallel, so a fixed port there would have every one of them contend on binding it — and nothing ever queries a backfill core.
+- The `core_*` keys are written into the **live** ingestion core's config only. A no-lake backfill runs one bounded-replay core per chunk in parallel, so fixed ports there would collide; nothing queries a backfill core.
 
 **[logging]** — optional `level` (`debug`/`info`/`warn`/`error`, default `info`) and `format` (`text`/`json`, default `text`).
 

--- a/design-docs/full-history-streaming-workflow.md
+++ b/design-docs/full-history-streaming-workflow.md
@@ -144,6 +144,7 @@ Every TOML leaf is also settable from the command line:
 
 - The six `core_*` keys govern the HTTP surface of the same captive-core process the keys above configure, which is why they live here rather than under `[service]` (#884).
 - Both ports must be in `1..65535` and must differ from each other. Unlike v1, `0` is not accepted as "disable core's HTTP server": v2 always serves sendTransaction off the admin port and getLedgerEntries off the query port, so a disabled server is a broken deployment rather than a mode.
+- These four keys are owned by `[ingestion]`, the opposite of `NETWORK_PASSPHRASE`, which the captive-core file owns. A captive-core file that also sets `HTTP_PORT` / `HTTP_QUERY_PORT` / `QUERY_THREAD_POOL_SIZE` / `QUERY_SNAPSHOT_LEDGERS` must agree with it; a disagreement is a startup error naming both sides (the daemon checks this itself — the SDK's own comparison panics rather than reporting, since it formats the message with a field this daemon never sets).
 - They are written into the **live** ingestion core's toml only. A no-lake backfill starts one bounded-replay core per chunk, in parallel, so a fixed port there would have every one of them contend on binding it — and nothing ever queries a backfill core.
 
 **[logging]** — optional `level` (`debug`/`info`/`warn`/`error`, default `info`) and `format` (`text`/`json`, default `text`).


### PR DESCRIPTION
## TL;DR

- **Nothing becomes callable here.** v2 still binds no port; `serveReads` is a no-op stub. This PR builds the plumbing the three captive-core endpoints need. Registering them is #889, and their handlers also need the router-backed `store.LedgerReader` (#885–#887).
- v2 gets a real `host.Daemon` over its **own** captive core (new `internal/rpcv2/corestate`), so #889 can run v1's existing `internal/preflight` and `internal/ledgerentries` code unmodified.
- `host.Daemon.GetCore() *ledgerbackend.CaptiveStellarCore` narrows to `CoreVersion() string` — the whole SDK core object was being handed out for one version string.
- Config grows three method tables, six `[ingestion]` core-HTTP keys, and `[service.preflight]` — including the flag machinery's first **bool**.
- ⚠️ **This diverges from v1 on purpose.** v1 *rejects* a captive-core file that disagrees about core's HTTP settings; v2 *overrides* it and warns. Details immediately below.

## ⚠️ Divergence from v1: core's HTTP settings

v1 and v2 both take these four settings from RPC config and write them into the captive-core toml. **They differ in what happens when the operator's captive-core file also names them.**

| | v1 | v2 (this PR) |
|---|---|---|
| File silent | RPC's value is used | RPC's value is used |
| File agrees with RPC config | starts | starts |
| **File disagrees** | **startup fails** | **RPC config wins, warning logged** |
| Who enforces it | the SDK, inside `NewCaptiveCoreTomlFromFile` | this daemon, before the SDK sees the params |

- v1's rejection is `toml.go`'s `validate`: `HTTP_PORT in captive core config file: %d does not match passed configuration (%d)`. It is never a silent override.
- **Why v2 differs:** `core_http_query_thread_pool_size` defaults to `NumCPU()`. Under a conflict check, a core file with `QUERY_THREAD_POOL_SIZE = 8` and no `[ingestion]` value starts on an 8-CPU host and **refuses to start on a 16-CPU host** — the operator set one value, and a default disagreed with them. Only this key is machine-dependent; the other three compare against fixed defaults.
- **Second reason:** the SDK's three *query-server* mismatch branches format their error with `params.PeerPort`, which this daemon never sets, so a disagreeing file **panics** rather than reporting the conflict. v2 passes no HTTP params at all, which makes those branches unreachable.
- **What operators must know:** a value in the captive-core file no longer has any effect on these four keys. Carrying a v1 file with `HTTP_PORT = 11625` moves core to `11626`, so firewall rules or monitoring scrapes pointed at the old port need updating. The warning names both values:

```
captive_core_config sets HTTP_PORT = 11625, but [ingestion].core_http_port owns core's
HTTP settings — running core with 11626. Remove HTTP_PORT from the captive-core file
to silence this.
```

- `NETWORK_PASSPHRASE` is unchanged and still owned by the captive-core file — the ownership split is deliberate, not blanket.

## What a running daemon actually does differently

| Change | Operational effect |
|---|---|
| Core's HTTP ports are written into the live core's toml | The captive core this daemon launches binds **11626** (admin) and **11628** (query). Both must be free on the host. |
| `[ingestion]` overrides the captive-core file | A file setting `HTTP_PORT`, `HTTP_QUERY_PORT`, `QUERY_THREAD_POOL_SIZE` or `QUERY_SNAPSHOT_LEDGERS` is **overridden**, with a warning naming both values. Startup is not blocked. |
| New config validation | Bad ports, a sub-1ms `core_request_timeout`, a malformed `core_url`, a local `core_url` that doesn't match `core_http_port` (or uses `https` — the local core speaks plain HTTP), a `core_url` port past 65535, or a zero preflight worker count all fail startup. |
| `corestate.New` | Builds two HTTP clients and reads `stellar-core version` once, under a 5s timeout tied to the daemon's context (plus a 1s `WaitDelay`, so a wrapper's child holding stdout can't stall past the kill). |
| Preflight worker pool | Starts `worker_count` idle goroutines and registers 5 Prometheus collectors. |

**Inert until #889** — the request paths. Nothing calls `CoreClient()`, `FastCoreClient()`, `LedgerEntryGetter()` or `pool.GetPreflight()`, so the clients never issue a request and the pool never gets a job.

## Why a Daemon and not three handlers

| Endpoint | Path to core | What core does |
|---|---|---|
| `sendTransaction` | `CoreClient` → admin port | validation + flooding; the only real submit path |
| `getLedgerEntries` | `FastCoreClient` → query port | bucket-list entry reads |
| `simulateTransaction` | preflight pool → Rust `libpreflight` in-process | the Rust host fetches each entry back through `FastCoreClient` |

All three already sit behind `internal/host`'s interfaces. This PR supplies the missing implementation; #889 assembles the method table over #885's reader.

<details>
<summary><b>New config keys</b> (15 keys, all with v1 counterparts)</summary>

**`[service.methods.<method>]`** — three new tables, same `MethodConfig` shape:

| Key | Default | v1 flag |
|---|---|---|
| `sendTransaction.queue_limit` | `500` | `request-backlog-send-transaction-queue-limit` |
| `sendTransaction.max_execution_duration` | `"15s"` | `max-send-transaction-execution-duration` |
| `simulateTransaction.queue_limit` | `100` | `request-backlog-simulate-transaction-queue-limit` |
| `simulateTransaction.max_execution_duration` | `"15s"` | `max-simulate-transaction-execution-duration` |
| `getLedgerEntries.queue_limit` | `1000` | `request-backlog-get-ledger-entries-queue-limit` |
| `getLedgerEntries.max_execution_duration` | `"5s"` | `max-get_ledger-entries-execution-duration` |

**`[ingestion]`** — core's HTTP surface, placed with the process it configures:

| Key | Default | v1 flag |
|---|---|---|
| `core_http_port` | `11626` | `stellar-captive-core-http-port` |
| `core_url` | `http://localhost:{core_http_port}` | `stellar-core-url` |
| `core_request_timeout` | `"2s"` | `stellar-core-timeout` |
| `core_http_query_port` | `11628` | `stellar-captive-core-http-query-port` |
| `core_http_query_thread_pool_size` | `NumCPU` | `…-http-query-thread-pool-size` |
| `core_http_query_snapshot_ledgers` | `4` | `…-http-query-snapshot-ledgers` |

**`[service.preflight]`** — serving policy, like `[service.fee_stats]`:

| Key | Default | v1 flag |
|---|---|---|
| `worker_count` | `NumCPU` | `preflight-worker-count` |
| `worker_queue_size` | `NumCPU` | `preflight-worker-queue-size` |
| `enable_debug` | `true` | `preflight-enable-debug` |

- Every key is also a `--dotted.path` CLI flag, free from the reflection-derived flag set.
- `core_request_timeout` joins the ≥1ms nanosecond-typo guard next to `[backfill.bsb].retry_wait`.
- `core_url` is derived **after** flags are overlaid, so `--ingestion.core_http_port=31626` alone moves the submission URL with it.
- The sample toml sets `enable_debug = false` — a deliberate departure from the `true` default, since the sample is a production starting point.

</details>

<details>
<summary><b>What changed where</b></summary>

| Area | Change |
|---|---|
| `internal/host/host.go`, `noOpDaemon.go` | `GetCore()` → `CoreVersion() string`; the `ledgerbackend` dependency leaves the interface |
| `internal/methods/get_version_info.go` | reads `daemon.CoreVersion()` **inside** the handler closure |
| `internal/rpcv1/daemon/metrics.go` | one-line adapter to `d.core.GetCoreVersion()` |
| `internal/rpcv2/corestate/` (new) | `Daemon`: two `*stellarcore.Client`s at the two ports, registry/namespace, version string. `LedgerEntryGetter(store.LedgerReader)` is the seam #889 calls, pinning entry reads to the ledger v2 last committed |
| `internal/rpcv2/config/config.go` | three method tables, `[service.preflight]`, six `[ingestion]` core keys, shared `NumCPU()` helper |
| `internal/rpcv2/config/flags.go` | `kindBool` in `leafKind`/`BindFlags`/`setLeaf`, `GetBool` on `FlagOverrides` |
| `internal/rpcv2/config_validate.go` | new `validateIngestion` + `validatePreflight`; the three methods join `validateService` |
| `internal/rpcv2/daemon.go` | `resolveCore` returns `resolvedCore{live, backfill, networkPassphrase, binaryPath}`; both openers come from ONE read of the captive-core file; corestate + preflight pool built once, outside the supervised loop |
| `Makefile`, `docker/Dockerfile.rpcv2` | `build-rpc-v2: build-libs`; the rust stage's now-wrong "not needed yet" comments are gone |
| sample toml + design doc | all new keys documented; "NOT here (by design)" is down to `friendbot_url` |

</details>

<details>
<summary><b>Why core's HTTP ports land on the live core only</b></summary>

- `runDaemonWith` hands one `CoreOpener` to two consumers: the live ingestion loop, and (with no lake) `captiveSource`, which starts a fresh bounded-replay core **per chunk, in parallel**.
- Ports in that shared toml would have every backfill core contend on binding them. Offline/catchup mode zeroes `HTTP_PORT` but **not** `HTTP_QUERY_PORT`, so the collision is real.
- Hence two openers: `applyHTTPServers` sets all four settings on the live toml, `disableHTTPServers` clears them on the backfill toml.
- Neither is passed through `CaptiveCoreTomlParams`. The SDK treats params as a cross-check rather than an override, and its three query-server mismatch branches format the error with `params.PeerPort` — always nil here — so they panic instead of reporting. Passing no HTTP params leaves those branches unreachable.

</details>

<details>
<summary><b>Design decisions</b></summary>

| Decision | Reasoning |
|---|---|
| `[ingestion]` overrides the captive-core file's four HTTP keys, with a warning, rather than rejecting the config | • one owner per setting, so operators don't reconcile two files<br>• `core_http_query_thread_pool_size` defaults to `NumCPU`, so a conflict check would refuse to start on a host with a different CPU count than the one the config was written on<br>• the warning keeps the override visible: a v1 file with `HTTP_PORT = 11625` may have firewall rules pointed at 11625 |
| Ports must be `1..65535` and must differ; v1's "`0` disables core's HTTP server" is rejected | • v2 always serves sendTransaction off the admin port and getLedgerEntries off the query port<br>• a disabled server is a broken deployment, not a mode |
| A local `core_url` must name `core_http_port` | • this daemon starts the core it submits to, so any other local port is not that core — often another daemon's captive core, which would accept the transaction<br>• non-local `core_url`s are left alone; that's the reason to set one |
| `getVersionInfo` calls `daemon.CoreVersion()` per request | • the version is only known once core starts, which is after handlers are built |
| Plain `stellarcore.Client`s; v1's `CoreClientWithMetrics` txsub summaries not reproduced | • that wrapper lives in `internal/rpcv1/daemon`, not a shared package<br>• `TODO(#889)` at the client, since #889 is what wires sendTransaction |
| A failed `stellar-core version` lookup logs and yields `""` | • cosmetic response field; mirrors the SDK's own `setCoreVersion`<br>• bounded by `exec.CommandContext` + 5s, so a wrapper script or stalled mount can't freeze startup before anything is logged |
| `resolveCore` returns two openers instead of widening `CoreOpener` | • the interface stays one method, so all three existing test fakes are untouched |
| corestate + preflight pool are locals in `runDaemonWith` with `defer Close()` | • "construction only" per the issue<br>• built outside `supervise`, since re-registering the pool's collectors panics |
| Two `http.Client`s, one per core server | • not pool isolation — both share `http.DefaultTransport`, whose pool already keys connections by `host:port`<br>• kept separate so #889 can wrap the submission client alone for v1's txsub metrics |
| `enable_debug` is an ordinary pflag bool | • `--service.preflight.enable_debug=false` turns it off; a bare flag sets true<br>• the flag's own `false` default never leaks in, since `ApplyFlags` reads only flags the user set |

</details>

<details>
<summary><b>Fixes from the branch code review</b></summary>

| Finding | Verdict | Resolution |
|---|---|---|
| Passing `HTTPQueryServerParams` makes an SDK path reachable that **panics** on a nil `*params.PeerPort` | CONFIRMED — real `SIGSEGV` at `ledgerbackend/toml.go:728` with a core file declaring `HTTP_QUERY_PORT = 11111` | The HTTP settings are no longer passed as params at all; they are written onto each generated toml, leaving those branches unreachable |
| The backfill opener was only portless because the fixture declared no ports: the SDK keeps a file-declared `HTTP_QUERY_PORT`, and `CatchupToml()` clears `HTTP_PORT` but never the query port | CONFIRMED — the generated catchup toml contained `HTTP_QUERY_PORT` | `disableHTTPServers` clears all four fields, the same mechanism `CatchupToml` uses. Test asserts on the **marshalled** toml, direct and catchup |
| `core_url` had no form validation, so `core.internal:11626` started fine and failed per request while health looked green | CONFIRMED | `validateIngestion` requires an `http`/`https` scheme and a host, and rejects a loopback `core_url` whose port isn't `core_http_port` |
| The conflict check compared against post-default values, so `QUERY_THREAD_POOL_SIZE` in a core file could start on one host and fail on another purely by CPU count | CONFIRMED | Replaced with override-plus-warning; no default is compared against anything |
| `readCoreVersion` ran `stellar-core version` with no context or timeout, on the startup path before any log line | CONFIRMED | `exec.CommandContext` with a 5s cap, bound to the daemon's context |
| "Separate `http.Client`s so a slow submission cannot tie up a connection the query path needs" — both share `http.DefaultTransport`, so that isn't what the split buys | CONFIRMED | Comment and test rationale corrected to what actually holds |
| v1's two txsub metrics aren't published by the unwrapped submission client | Real, out of scope | `TODO(#889)` — needs v1's wrapper lifted out of `internal/rpcv1/daemon` first |

</details>

<details>
<summary><b>Fixes from the Copilot review</b></summary>

| Finding | Resolution |
|---|---|
| `CommandContext` kills only the direct process; a wrapper's child holding stdout keeps `Output` waiting past the 5s timeout | `cmd.WaitDelay = time.Second` forces the pipes closed after the kill |
| The hanging-binary test cancelled its context before `New`, so the script never started and the timeout was never exercised | Live 100ms deadline so the script starts and is killed; a second test covers a wrapper whose backgrounded child holds stdout |
| `isLoopbackHost` missed `LOCALHOST` and `localhost.` | Case-insensitive compare, trailing root dot stripped |
| `https://localhost:11626` passed validation but the local core speaks plain HTTP, so every submission would fail its TLS handshake | Rejected: `https` to a loopback `core_url` is a startup error |
| An explicit remote port past 65535 (`http://core.internal:70000`) parsed fine and failed only at dial time | Explicit `core_url` ports are range-checked 1–65535 |

</details>

## Testing

| What | Result |
|---|---|
| `go build ./...` | passes |
| `go test ./cmd/stellar-rpc/...` (incl. the ~3min goleak-guarded rpcv2 suite) | passes |
| `golangci-lint run ./cmd/stellar-rpc/...` | clean, bar one local-only artifact: my 2.12.2's gosec no longer flags `int → uint`, so nolintlint calls the `//nolint:gosec` on `uint(runtime.NumCPU())` unused. CI's pinned 2.11.3 needs the directive; v1 carries the identical line at `rpcv1/config/options.go:40` with the same skew |
| `make build-rpc-v2` | links; `nm stellar-rpc-v2` shows `_preflight_invoke_hf_op`, so the rust bindings are really in the binary |

New tests:

- **`corestate`** — client URLs/timeouts per port, registry identity, incomplete-config rejection, version read from a fake `stellar-core version` binary, empty on a missing binary, a live deadline proving a hanging binary is killed rather than waited out, and a wrapper whose backgrounded child holds stdout open (the `WaitDelay` case). An `httptest` server proves `LedgerEntryGetter` hits the **query** port asking for the daemon's own latest ledger.
- **`rpcv2`** — the live-vs-backfill port split (including when the core file declares ports itself), four override cases asserting the live toml's value plus the warning, no warning when the file already agrees, injected-opener-serves-both-roles, and the `[ingestion]`/`[service.preflight]`/`core_url` rejection cases.
- **`config`** — defaults and cascade participation for the three new tables, preflight defaults incl. an explicit `false`, core-HTTP defaults, `core_url` derivation, and the bool flag override.

