### PR TITLE
bench(full-history): add run metadata to benchmarks

### DIFF
--- a/cmd/stellar-rpc/internal/rpcv2/bench/command.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/command.go
@@ -100,12 +100,14 @@ func writePartialCSVs(logger *supportlog.Entry, sink *csvSink, outDir string) {
 }
 
 // newBenchCommand builds one bench-ingest subcommand skeleton — no positional
-// args, SIGINT-canceled context, Info-level logger, profiling around run —
-// with the source and profile flag sets bound.
+// args, SIGINT-canceled context, Info-level logger, profiling around run, an
+// invocation.json record written to --out after the run — with the source,
+// profile, and --out flags bound.
 func newBenchCommand(
 	use, short string, src *sourceFlags, prof *profileFlags,
-	run func(ctx context.Context, logger *supportlog.Entry) error,
+	run func(ctx context.Context, logger *supportlog.Entry, outDir string) error,
 ) *cobra.Command {
+	var outDir string
 	cmd := &cobra.Command{
 		Use:   use,
 		Short: short,
@@ -114,9 +116,24 @@ func newBenchCommand(
 			cmd.SilenceUsage = true
 			ctx, stop, logger := benchContext()
 			defer stop()
-			return prof.around(logger, func() error { return run(ctx, logger) })
+			startedAt := time.Now().UTC()
+			runErr := prof.around(logger, func() error { return run(ctx, logger, outDir) })
+			// The --out dir is created by the run itself, so a run that
+			// failed early (e.g. in validation) leaves nowhere to write the
+			// record and this write fails too. In that case only warn about
+			// the write: the error the user needs to see is the run's own.
+			if err := writeInvocationJSON(
+				outDir, cmd, captureFlags(cmd), startedAt, time.Now().UTC(), runErr,
+			); err != nil {
+				if runErr == nil {
+					return err
+				}
+				logger.Warnf("writing invocation.json: %v", err)
+			}
+			return runErr
 		},
 	}
+	cmd.Flags().StringVar(&outDir, "out", "bench-out", "output dir for the CSV report and invocation.json")
 	src.bind(cmd)
 	prof.bind(cmd)
 	return cmd
@@ -130,13 +147,12 @@ func newColdCommand() *cobra.Command {
 		workers    int
 		coldOutDir string
 		catalogDir string
-		outDir     string
 		prof       profileFlags
 	)
 	cmd := newBenchCommand("cold",
 		"Benchmark cold ingestion: the daemon's backfill (chunk freezes + txhash index builds) over a chunk range",
 		&src, &prof,
-		func(ctx context.Context, logger *supportlog.Entry) error {
+		func(ctx context.Context, logger *supportlog.Entry, outDir string) error {
 			return runCold(ctx, logger, coldOptions{
 				Source:     src.config(),
 				StartChunk: chunk.ID(startChunk),
@@ -156,7 +172,6 @@ func newColdCommand() *cobra.Command {
 			"re-runs overwrite, but leftovers from other ranges are never swept)")
 	fs.StringVar(&catalogDir, "catalog-dir", "",
 		"base dir for the run's scratch catalog; default: --cold-out-dir")
-	fs.StringVar(&outDir, "out", "bench-out", "CSV output dir")
 	markRequired(cmd, "start-chunk", "cold-out-dir")
 	return cmd
 }
@@ -170,13 +185,12 @@ func newHotCommand() *cobra.Command {
 		hotDir        string
 		catalogDir    string
 		closeInterval time.Duration
-		outDir        string
 		prof          profileFlags
 	)
 	cmd := newBenchCommand("hot",
 		"Benchmark hot ingestion: the daemon's live ingestion loop over a chunk range",
 		&src, &prof,
-		func(ctx context.Context, logger *supportlog.Entry) error {
+		func(ctx context.Context, logger *supportlog.Entry, outDir string) error {
 			return runHot(ctx, logger, hotOptions{
 				Source:        src.config(),
 				StartChunk:    chunk.ID(startChunk),
@@ -200,7 +214,6 @@ func newHotCommand() *cobra.Command {
 	fs.DurationVar(&closeInterval, "close-interval", 0,
 		"assumed time between ledger closes; >0 paces ingestion to that steady-state cadence "+
 			"and reports pace_lag (0 = ingest back-to-back, catch-up throughput)")
-	fs.StringVar(&outDir, "out", "bench-out", "CSV output dir")
 	markRequired(cmd, "start-chunk", "hot-dir")
 	return cmd
 }

--- a/cmd/stellar-rpc/internal/rpcv2/bench/csvsink.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/csvsink.go
@@ -367,13 +367,14 @@ type row struct {
 
 // aggregate reduces a series to a row, filtering out zero-duration samples so
 // work too fast for the timer (an empty ledger's stage) doesn't skew the
-// percentiles. ok is false when no sample survives the filter — the row is
-// suppressed.
-func aggregate(name string, s *series) (row, bool) {
+// percentiles. For pace_lag, zeros are always included (they represent
+// on-time ledgers and are part of the lag distribution). ok is false when no
+// sample survives the filter — the row is suppressed.
+func aggregate(name string, s *series, includeZeros bool) (row, bool) {
 	durs := make([]time.Duration, 0, len(s.samples))
 	items := 0
 	for _, sm := range s.samples {
-		if sm.d > 0 {
+		if sm.d > 0 || includeZeros {
 			durs = append(durs, sm.d)
 			items += sm.items
 		}
@@ -450,7 +451,8 @@ func (s *csvSink) files() []file {
 		var rows []row
 		for _, label := range withUnknown(rowOrders[name], byRow) {
 			if sr := byRow[label]; sr != nil {
-				if r, ok := aggregate(label, sr); ok {
+				// pace_lag is for paced runs; include zero-lag samples (on-time ledgers).
+				if r, ok := aggregate(label, sr, label == driverPaceLag); ok {
 					rows = append(rows, r)
 				}
 			}

--- a/cmd/stellar-rpc/internal/rpcv2/bench/csvsink_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/csvsink_test.go
@@ -181,9 +181,9 @@ func TestCSVSinkPaceLag(t *testing.T) {
 }
 
 // TestCSVSinkPaceLagClampedToZero: a ledger committing before its due time (its
-// lag would be negative) records a zero-lag sample, which the aggregated row
-// then drops as sub-tick — so a paced run whose only sample is on-time writes no
-// pace_lag row.
+// lag would be negative) records a zero-lag sample. Zero-lag samples are part
+// of the lag distribution (an on-time ledger), so a paced run whose only
+// sample is on-time still writes a pace_lag row, with all percentiles 0.
 func TestCSVSinkPaceLagClampedToZero(t *testing.T) {
 	clock := &fakeClock{t: time.Unix(0, 0)}
 	sched := &paceSchedule{interval: 100 * time.Millisecond, firstSeq: 2, clock: clock.now}
@@ -194,9 +194,38 @@ func TestCSVSinkPaceLagClampedToZero(t *testing.T) {
 	sink.LastCommitted(5) // pos 3, due t0+300, clock still t0 → lag −300ms → clamped 0
 
 	assert.Equal(t, []time.Duration{0}, paceLagSamples(sink)) // the raw (zero) sample is recorded
-	written, err := sink.writeCSVs(t.TempDir())
-	require.NoError(t, err)
-	assert.Empty(t, written) // the lone zero-duration sample is suppressed
+	driver := readCSV(t, filepath.Join(mustWriteCSVs(t, sink), "driver.csv"))
+	require.Contains(t, driver, "pace_lag")
+	assert.EqualValues(t, 1, driver["pace_lag"]["n"])
+	assert.EqualValues(t, 1, driver["pace_lag"]["n_items"])
+	assert.EqualValues(t, 0, driver["pace_lag"]["p50_ns"])
+	assert.EqualValues(t, 0, driver["pace_lag"]["p99_ns"])
+}
+
+// TestCSVSinkPaceLagMixed: on-time (zero-lag) and late ledgers aggregate into
+// one pace_lag row that counts every committed ledger, so the percentiles
+// reflect how often the run kept pace, not just how late the late ledgers were.
+func TestCSVSinkPaceLagMixed(t *testing.T) {
+	clock := &fakeClock{t: time.Unix(0, 0)}
+	sched := &paceSchedule{interval: 100 * time.Millisecond, firstSeq: 2, clock: clock.now}
+	sched.dueForPos(0)
+	sink := newCSVSink()
+	sink.schedule = sched
+
+	sink.LastCommitted(2) // due t0, commits at t0 → lag 0
+	clock.advance(100 * time.Millisecond)
+	sink.LastCommitted(3) // due t0+100, commits at t0+100 → lag 0
+	clock.advance(200 * time.Millisecond)
+	sink.LastCommitted(4) // due t0+200, commits at t0+300 → lag 100ms
+
+	assert.Equal(t, []time.Duration{0, 0, 100 * time.Millisecond}, paceLagSamples(sink))
+
+	driver := readCSV(t, filepath.Join(mustWriteCSVs(t, sink), "driver.csv"))
+	require.Contains(t, driver, "pace_lag")
+	assert.EqualValues(t, 3, driver["pace_lag"]["n"])
+	assert.EqualValues(t, 3, driver["pace_lag"]["n_items"])
+	assert.EqualValues(t, 0, driver["pace_lag"]["p50_ns"]) // 2 of 3 ledgers on time
+	assert.Equal(t, (100 * time.Millisecond).Nanoseconds(), driver["pace_lag"]["max_ns"])
 }
 
 // TestCSVSinkPaceLagUnanchored: a commit arriving before the schedule anchors

--- a/cmd/stellar-rpc/internal/rpcv2/bench/invocation.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/invocation.go
@@ -1,0 +1,94 @@
+package bench
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/version"
+)
+
+// invocationRecord holds metadata about a benchmark invocation. The JSON
+// keys are a versioned schema (schemaVersion) that downstream tooling
+// consumes; treat key renames as breaking changes.
+type invocationRecord struct {
+	SchemaVersion int               `json:"schemaVersion"`
+	Command       string            `json:"command"`
+	Flags         map[string]string `json:"flags"`
+	Binary        binaryInfo        `json:"binary"`
+	Hostname      string            `json:"hostname"`
+	StartedAt     string            `json:"startedAt"`
+	FinishedAt    string            `json:"finishedAt"`
+	// Error carries a failed run's error message; absent on a successful run.
+	Error string `json:"error,omitempty"`
+}
+
+// binaryInfo holds build-time information about the binary.
+type binaryInfo struct {
+	Version        string `json:"version"`
+	CommitHash     string `json:"commitHash"`
+	BuildTimestamp string `json:"buildTimestamp"`
+	Branch         string `json:"branch"`
+}
+
+// writeInvocationJSON writes an invocation record as JSON to outDir/invocation.json.
+// startedAt and finishedAt should be UTC times. runErr is the run's outcome: nil
+// for a successful run, otherwise its message lands in the record's error field.
+// The JSON is formatted with indentation and a trailing newline.
+func writeInvocationJSON(
+	outDir string,
+	cmd *cobra.Command,
+	flags map[string]string,
+	startedAt, finishedAt time.Time,
+	runErr error,
+) error {
+	hostname, _ := os.Hostname() // empty string on error
+
+	var errMsg string
+	if runErr != nil {
+		errMsg = runErr.Error()
+	}
+
+	record := invocationRecord{
+		SchemaVersion: 1,
+		Command:       cmd.CommandPath(),
+		Flags:         flags,
+		Binary: binaryInfo{
+			Version:        version.Version,
+			CommitHash:     version.CommitHash,
+			BuildTimestamp: version.BuildTimestamp,
+			Branch:         version.Branch,
+		},
+		Hostname:   hostname,
+		StartedAt:  startedAt.UTC().Format(time.RFC3339),
+		FinishedAt: finishedAt.UTC().Format(time.RFC3339),
+		Error:      errMsg,
+	}
+
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal invocation record: %w", err)
+	}
+
+	path := filepath.Join(outDir, "invocation.json")
+	if err := os.WriteFile(path, append(data, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write invocation.json: %w", err)
+	}
+	return nil
+}
+
+// captureFlags extracts all flag values from a cobra command's flag set,
+// returning them as a map of flag name to string value. Uses VisitAll to
+// capture all flags (default and explicitly-set).
+func captureFlags(cmd *cobra.Command) map[string]string {
+	flags := make(map[string]string)
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		flags[f.Name] = f.Value.String()
+	})
+	return flags
+}

--- a/cmd/stellar-rpc/internal/rpcv2/bench/invocation_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/bench/invocation_test.go
@@ -1,0 +1,146 @@
+package bench
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCommandRecordsFailedRun drives the real bench-ingest hot command through
+// cobra against an empty pack tree: the run fails at the first ledger read, and
+// the newBenchCommand wrapper still writes invocation.json into --out with the
+// command path, the parsed flag values, and the run's error.
+func TestCommandRecordsFailedRun(t *testing.T) {
+	outDir := filepath.Join(t.TempDir(), "csv")
+	packDir := t.TempDir() // no pack file for chunk 0
+
+	cmd := NewCommand()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{
+		"hot",
+		"--pack-dir", packDir,
+		"--start-chunk", "0",
+		"--hot-dir", t.TempDir(),
+		"--out", outDir,
+	})
+	err := cmd.Execute()
+	require.Error(t, err)
+
+	data, readErr := os.ReadFile(filepath.Join(outDir, "invocation.json"))
+	require.NoError(t, readErr)
+	var record invocationRecord
+	require.NoError(t, json.Unmarshal(data, &record))
+	assert.Equal(t, "bench-ingest hot", record.Command)
+	assert.Equal(t, err.Error(), record.Error)
+	assert.Equal(t, packDir, record.Flags["pack-dir"])
+	assert.Equal(t, outDir, record.Flags["out"])
+	assert.NotEmpty(t, record.StartedAt)
+	assert.NotEmpty(t, record.FinishedAt)
+}
+
+// TestWriteInvocationJSON verifies that writeInvocationJSON produces a valid
+// invocation.json file with the expected schema and content.
+func TestWriteInvocationJSON(t *testing.T) {
+	outDir := t.TempDir()
+
+	// Create a minimal cobra command for testing with proper hierarchy
+	parent := &cobra.Command{Use: "bench-ingest"}
+	cmd := &cobra.Command{Use: "cold"}
+	parent.AddCommand(cmd)
+
+	flags := map[string]string{
+		"start-chunk": "1000",
+		"num-chunks":  "10",
+		"workers":     "4",
+	}
+
+	startedAt := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	finishedAt := time.Date(2026, 7, 21, 12, 5, 30, 0, time.UTC)
+
+	err := writeInvocationJSON(outDir, cmd, flags, startedAt, finishedAt, nil)
+	require.NoError(t, err)
+
+	// Verify the file exists and is readable
+	filePath := filepath.Join(outDir, "invocation.json")
+	data, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+
+	// Unmarshal and verify the content
+	var record invocationRecord
+	err = json.Unmarshal(data, &record)
+	require.NoError(t, err)
+
+	// Verify schema version and command
+	assert.Equal(t, 1, record.SchemaVersion)
+	assert.Equal(t, "bench-ingest cold", record.Command) // CommandPath returns "parent child"
+
+	// Verify flags are captured
+	assert.Contains(t, record.Flags, "start-chunk")
+	assert.Equal(t, "1000", record.Flags["start-chunk"])
+	assert.Contains(t, record.Flags, "num-chunks")
+	assert.Equal(t, "10", record.Flags["num-chunks"])
+
+	// Verify timestamps
+	assert.Equal(t, "2026-07-21T12:00:00Z", record.StartedAt)
+	assert.Equal(t, "2026-07-21T12:05:30Z", record.FinishedAt)
+
+	// Verify binary info fields are present (even if empty during test)
+	assert.NotNil(t, record.Binary)
+
+	// Verify trailing newline
+	assert.Equal(t, byte('\n'), data[len(data)-1])
+
+	// A successful run's record carries no error key at all, so consumers can
+	// tell success from failure by the key's presence.
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &raw))
+	assert.NotContains(t, raw, "error")
+}
+
+// TestWriteInvocationJSONWithError verifies that a failed run's record carries
+// the run error's message in the error field.
+func TestWriteInvocationJSONWithError(t *testing.T) {
+	outDir := t.TempDir()
+	cmd := &cobra.Command{Use: "cold"}
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+
+	runErr := errors.New("backfill [chunk 3, chunk 3]: boom")
+	require.NoError(t, writeInvocationJSON(outDir, cmd, nil, now, now, runErr))
+
+	data, err := os.ReadFile(filepath.Join(outDir, "invocation.json"))
+	require.NoError(t, err)
+
+	var record invocationRecord
+	require.NoError(t, json.Unmarshal(data, &record))
+	assert.Equal(t, runErr.Error(), record.Error)
+	assert.Equal(t, 1, record.SchemaVersion)
+}
+
+// TestCaptureFlags verifies that captureFlags extracts all flag values from
+// a cobra command's flag set.
+func TestCaptureFlags(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("string-flag", "default-val", "a string")
+	cmd.Flags().Int("int-flag", 42, "an int")
+	cmd.Flags().Bool("bool-flag", false, "a bool")
+
+	// Set some flags
+	require.NoError(t, cmd.Flags().Set("string-flag", "custom-val"))
+	require.NoError(t, cmd.Flags().Set("int-flag", "100"))
+	require.NoError(t, cmd.Flags().Set("bool-flag", "true"))
+
+	flags := captureFlags(cmd)
+
+	assert.Equal(t, "custom-val", flags["string-flag"])
+	assert.Equal(t, "100", flags["int-flag"])
+	assert.Equal(t, "true", flags["bool-flag"])
+}


### PR DESCRIPTION
## Why

Two fixes to the RPC's benchmarking cmd:

- **Record run metadata:** Every `bench-ingest cold` / `hot` run now writes an `invocation.json` into its `--out` directory (on success and on failure ) recording the command path, all resolved flag values, binary build identity (version, commit, build timestamp, branch), hostname, and started/finished timestamps, plus an `error` field on failed runs. 

- **pace_lag percentiles record 0 values for on-time ledgers in paced runs.** `aggregate()` drops zero-duration samples as sub-timer-tick noise, but for `pace_lag` a zero sample is data — an on-time ledger. Dropping them made the percentiles describe only the late ledgers rather than the whole paced run.

## What changed

- New `invocation.go` which manages the metadata about a benchmark invocation.
- `aggregate()` adds  a new `includeZeros` parameter, enabled only for the `pace_lag` label. A fully on-time paced run now writes a `pace_lag` row with all-zero percentiles instead of no row.

Closes #896 