### PR TITLE
rpcv2: add the getEvents v2 event cursor and codec

### DIFF
--- a/cmd/stellar-rpc/internal/rpcv2/query/event_cursor.go
+++ b/cmd/stellar-rpc/internal/rpcv2/query/event_cursor.go
@@ -1,0 +1,320 @@
+package query
+
+// The getEvents v2 cursor envelope and its codec: the versioned, opaque,
+// self-contained structure behind a response's cursor string. Only the server
+// creates or decodes it; clients hold the encoded string and send it
+// back unchanged. The codec checks well-formedness only; validating a query
+// against the serving window and budgets is the handler's job.
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/event"
+)
+
+// ErrCursorMalformed rejects a cursor string that does not decode to a
+// well-formed envelope.
+var ErrCursorMalformed = errors.New("query: malformed cursor")
+
+// ErrCursorUnknownVersion rejects a cursor whose version byte this build does
+// not implement. Distinct from ErrCursorMalformed so the handler can tell a
+// corrupt cursor from one minted by a newer server.
+var ErrCursorUnknownVersion = errors.New("query: unknown cursor version")
+
+// cursorVersion is the envelope's format version. The byte sits outside the
+// JSON so a future body format is a clean version bump.
+const cursorVersion = 1
+
+// maxCursorBytes caps the encoded string length DecodeEventCursor accepts,
+// bounding decode work on hostile input. Encode enforces the same cap so an
+// oversized envelope fails at mint rather than on the resume that follows.
+// Sized above anything the request pipeline can produce: the serving stack
+// caps request bodies at 512 KiB (internal/jsonrpc), and an envelope
+// re-wraps roughly the request's filter content.
+const maxCursorBytes = 1 << 20
+
+// maxCursorFilters caps the filter count in both codec directions. It
+// matches the getEvents v2 proposal's 256-filter request cap: no encoder
+// mints more, so a cursor beyond it is forged or corrupt. Cursors never
+// expire, so this constant can only grow; lowering it would reject
+// outstanding cursors minted at the old cap.
+const maxCursorFilters = 256
+
+const contractIDLen = 32
+
+// EventPosition is the ledger-denominated identity of a delivered event: the
+// TOID fields (Ledger, Tx, Op) plus the event index within the operation, and
+// K, the within-ledger index over all stored events of the ledger. K is
+// portable across nodes only while ingest preserves the close meta's
+// within-ledger stream order and the store's inclusion rule stays fixed.
+type EventPosition struct {
+	Ledger, Tx, Op, Event, K uint32
+}
+
+// EventCursorQuery is the canonical (engine) form of the original query the
+// cursor pins: ledger bounds, direction, and the engine's filters.
+type EventCursorQuery struct {
+	MinLedger, MaxLedger uint32
+	Dir                  Direction
+	Filters              []event.Filter
+}
+
+// EventCursor is the envelope: the server-minted structure inside the opaque
+// cursor string, holding the original query, the position of the last
+// delivered event, and the scanned-ledger watermark. A nil Position means no
+// event has been delivered yet, so resume starts from the watermark alone.
+type EventCursor struct {
+	Query         EventCursorQuery
+	Position      *EventPosition
+	ScannedLedger uint32
+}
+
+// The structs below define the envelope's JSON body. Their tags are the
+// version-1 format: cursors never expire, so once v1 ships the key names are
+// frozen and any change to them is a version bump. event.Filter carries no
+// JSON tags and stays serialization-free; these conversions own the body
+// shape instead. []byte fields serialize as standard base64 via
+// encoding/json.
+
+type envelopeJSON struct {
+	Query    queryJSON     `json:"query"`
+	Position *positionJSON `json:"position,omitempty"`
+	Scanned  uint32        `json:"scanned"`
+}
+
+type queryJSON struct {
+	Min     uint32       `json:"min"`
+	Max     uint32       `json:"max"`
+	Dir     string       `json:"dir"`
+	Filters []filterJSON `json:"filters"`
+}
+
+// filterJSON is event.Filter in the body: "contract" is the raw 32-byte
+// contract ID, omitted when unconstrained; "topics" is always MaxTopicCount
+// entries with null for wildcard positions. A filter with no constraints at
+// all is legal (match-all).
+//
+// Reserved key for the #904 filter fields: "type" (event type), omitempty,
+// to be mapped when that PR merges since v2 filters carry it. #904's
+// TopicCount is v1-only arity semantics that no envelope producer sets;
+// when the coverage tripwire fires at the rebase, either map it for
+// completeness (it needs two keys, "count" and "exact") or reject a set
+// TopicCount at Encode. Decide then; do not drop it silently.
+type filterJSON struct {
+	Contract []byte                         `json:"contract,omitempty"`
+	Topics   [protocol.MaxTopicCount][]byte `json:"topics"`
+}
+
+type positionJSON struct {
+	Ledger uint32 `json:"ledger"`
+	Tx     uint32 `json:"tx"`
+	Op     uint32 `json:"op"`
+	Event  uint32 `json:"event"`
+	K      uint32 `json:"k"`
+}
+
+// Direction's serialized spelling. The Direction int values never
+// serialize, so reordering the constants cannot silently break minted
+// cursors.
+const (
+	directionAsc  = "asc"
+	directionDesc = "desc"
+)
+
+// Encode serializes the envelope as base64url over (version byte ||
+// JSON). Encode fails on an invalid Direction, a wrong-length ContractID,
+// more than maxCursorFilters filters, or output beyond maxCursorBytes.
+//
+// Absent values must be nil: the wire format cannot tell nil from empty, so
+// empty non-nil values decode back as nil (no exact round-trip). Inverted
+// ledger bounds encode without error but fail the next decode.
+func (e *EventCursor) Encode() (string, error) {
+	dir, err := directionToJSON(e.Query.Dir)
+	if err != nil {
+		return "", err
+	}
+	if len(e.Query.Filters) > maxCursorFilters {
+		return "", fmt.Errorf("query: encode cursor: %d filters exceeds the %d-filter cap",
+			len(e.Query.Filters), maxCursorFilters)
+	}
+	w := envelopeJSON{
+		Query: queryJSON{
+			Min:     e.Query.MinLedger,
+			Max:     e.Query.MaxLedger,
+			Dir:     dir,
+			Filters: make([]filterJSON, 0, len(e.Query.Filters)),
+		},
+		Scanned: e.ScannedLedger,
+	}
+	for i := range e.Query.Filters {
+		f, err := filterToJSON(&e.Query.Filters[i])
+		if err != nil {
+			return "", fmt.Errorf("query: encode cursor filter %d: %w", i, err)
+		}
+		w.Query.Filters = append(w.Query.Filters, f)
+	}
+	if e.Position != nil {
+		w.Position = &positionJSON{
+			Ledger: e.Position.Ledger,
+			Tx:     e.Position.Tx,
+			Op:     e.Position.Op,
+			Event:  e.Position.Event,
+			K:      e.Position.K,
+		}
+	}
+	body, err := json.Marshal(w)
+	if err != nil {
+		return "", fmt.Errorf("query: encode cursor: %w", err)
+	}
+	buf := make([]byte, 0, 1+len(body))
+	buf = append(buf, cursorVersion)
+	buf = append(buf, body...)
+	enc := base64.RawURLEncoding.EncodeToString(buf)
+	if len(enc) > maxCursorBytes {
+		return "", fmt.Errorf("query: encode cursor: %d bytes exceeds the %d-byte decode cap",
+			len(enc), maxCursorBytes)
+	}
+	return enc, nil
+}
+
+// DecodeEventCursor parses a cursor string into its envelope. Malformed
+// input returns an error matching ErrCursorMalformed; a cursor whose version
+// byte this build cannot decode returns one matching ErrCursorUnknownVersion.
+func DecodeEventCursor(s string) (*EventCursor, error) {
+	if s == "" {
+		return nil, fmt.Errorf("%w: empty input", ErrCursorMalformed)
+	}
+	if len(s) > maxCursorBytes {
+		return nil, fmt.Errorf("%w: %d bytes exceeds the %d-byte cap",
+			ErrCursorMalformed, len(s), maxCursorBytes)
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("%w: base64: %w", ErrCursorMalformed, err)
+	}
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("%w: missing version byte", ErrCursorMalformed)
+	}
+	if raw[0] != cursorVersion {
+		return nil, fmt.Errorf("%w: %d", ErrCursorUnknownVersion, raw[0])
+	}
+	// Bound unmarshal allocation before parsing: every legal string value in
+	// the body is base64 or a direction token, none of which contain '{', so
+	// the brace count equals the object count (envelope + query + optional
+	// position + one per filter). The post-unmarshal filter cap below stays
+	// the authoritative check.
+	if bytes.Count(raw[1:], []byte("{")) > maxCursorFilters+3 {
+		return nil, fmt.Errorf("%w: object count exceeds the %d-filter cap",
+			ErrCursorMalformed, maxCursorFilters)
+	}
+	var w envelopeJSON
+	if err := json.Unmarshal(raw[1:], &w); err != nil {
+		return nil, fmt.Errorf("%w: json: %w", ErrCursorMalformed, err)
+	}
+
+	dir, err := directionFromJSON(w.Query.Dir)
+	if err != nil {
+		return nil, err
+	}
+	if w.Query.Min > w.Query.Max {
+		return nil, fmt.Errorf("%w: min ledger %d > max ledger %d",
+			ErrCursorMalformed, w.Query.Min, w.Query.Max)
+	}
+	if len(w.Query.Filters) > maxCursorFilters {
+		return nil, fmt.Errorf("%w: %d filters exceeds the %d-filter cap",
+			ErrCursorMalformed, len(w.Query.Filters), maxCursorFilters)
+	}
+	env := &EventCursor{
+		Query: EventCursorQuery{
+			MinLedger: w.Query.Min,
+			MaxLedger: w.Query.Max,
+			Dir:       dir,
+		},
+		ScannedLedger: w.Scanned,
+	}
+	if len(w.Query.Filters) > 0 {
+		env.Query.Filters = make([]event.Filter, len(w.Query.Filters))
+		for i := range w.Query.Filters {
+			f, err := filterFromJSON(&w.Query.Filters[i])
+			if err != nil {
+				return nil, fmt.Errorf("filter %d: %w", i, err)
+			}
+			env.Query.Filters[i] = f
+		}
+	}
+	if w.Position != nil {
+		env.Position = &EventPosition{
+			Ledger: w.Position.Ledger,
+			Tx:     w.Position.Tx,
+			Op:     w.Position.Op,
+			Event:  w.Position.Event,
+			K:      w.Position.K,
+		}
+	}
+	return env, nil
+}
+
+// filterToJSON and filterFromJSON normalize zero-length values to nil in
+// both directions, keeping the absent-means-nil contract exact even for
+// bodies a legitimate encoder never produces.
+
+func filterToJSON(f *event.Filter) (filterJSON, error) {
+	var j filterJSON
+	if n := len(f.ContractID); n > 0 {
+		if n != contractIDLen {
+			return filterJSON{}, fmt.Errorf("contract ID is %d bytes, want %d", n, contractIDLen)
+		}
+		j.Contract = f.ContractID
+	}
+	for i, topic := range f.Topics {
+		if len(topic) > 0 {
+			j.Topics[i] = topic
+		}
+	}
+	return j, nil
+}
+
+func filterFromJSON(j *filterJSON) (event.Filter, error) {
+	var f event.Filter
+	if n := len(j.Contract); n > 0 {
+		if n != contractIDLen {
+			return event.Filter{}, fmt.Errorf("%w: contract ID is %d bytes, want %d",
+				ErrCursorMalformed, n, contractIDLen)
+		}
+		f.ContractID = j.Contract
+	}
+	for i, topic := range j.Topics {
+		if len(topic) > 0 {
+			f.Topics[i] = topic
+		}
+	}
+	return f, nil
+}
+
+func directionToJSON(d Direction) (string, error) {
+	switch d {
+	case Ascending:
+		return directionAsc, nil
+	case Descending:
+		return directionDesc, nil
+	default:
+		return "", fmt.Errorf("query: encode cursor: invalid direction %d", d)
+	}
+}
+
+func directionFromJSON(s string) (Direction, error) {
+	switch s {
+	case directionAsc:
+		return Ascending, nil
+	case directionDesc:
+		return Descending, nil
+	default:
+		return 0, fmt.Errorf("%w: dir %q", ErrCursorMalformed, s)
+	}
+}

--- a/cmd/stellar-rpc/internal/rpcv2/query/event_cursor.go
+++ b/cmd/stellar-rpc/internal/rpcv2/query/event_cursor.go
@@ -5,13 +5,19 @@ package query
 // creates or decodes it; clients hold the encoded string and send it
 // back unchanged. The codec checks well-formedness only; validating a query
 // against the serving window and budgets is the handler's job.
+//
+// A token is "gec" (getEvents cursor), the format version in cleartext
+// digits, "_", then the base64url body without padding. The cleartext
+// version makes version skew visible in logs without decoding. Cursors
+// never expire, so every version's decoder stays supported forever.
 
 import (
-	"bytes"
 	"encoding/base64"
-	"encoding/json"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
+	"strings"
 
 	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
 
@@ -22,21 +28,19 @@ import (
 // well-formed envelope.
 var ErrCursorMalformed = errors.New("query: malformed cursor")
 
-// ErrCursorUnknownVersion rejects a cursor whose version byte this build does
+// ErrCursorUnknownVersion rejects a cursor whose version this build does
 // not implement. Distinct from ErrCursorMalformed so the handler can tell a
 // corrupt cursor from one minted by a newer server.
 var ErrCursorUnknownVersion = errors.New("query: unknown cursor version")
 
-// cursorVersion is the envelope's format version. The byte sits outside the
-// JSON so a future body format is a clean version bump.
-const cursorVersion = 1
+const cursorPrefixV1 = "gec1_"
 
-// maxCursorBytes caps the encoded string length DecodeEventCursor accepts,
-// bounding decode work on hostile input. Encode enforces the same cap so an
-// oversized envelope fails at mint rather than on the resume that follows.
-// Sized above anything the request pipeline can produce: the serving stack
-// caps request bodies at 512 KiB (internal/jsonrpc), and an envelope
-// re-wraps roughly the request's filter content.
+// maxCursorBytes caps the token length DecodeEventCursor accepts. Encode
+// enforces the same cap so an oversized envelope fails at mint rather than
+// on the resume that follows. Sized above anything the request pipeline can
+// produce: the serving stack caps request bodies at 512 KiB
+// (internal/jsonrpc), and an envelope re-wraps roughly the request's filter
+// content.
 const maxCursorBytes = 1 << 20
 
 // maxCursorFilters caps the filter count in both codec directions. It
@@ -48,21 +52,47 @@ const maxCursorFilters = 256
 
 const contractIDLen = 32
 
+// Version-1 body layout, big-endian, in field order: flags u8, minLedger
+// u32, maxLedger u32 if flagHasMax, position 5xu32 (ledger, tx, op, event,
+// ledgerOrdinal) if flagHasPos, scannedLedger u32, filter count u16, then per filter:
+// fflags u8, contract 32 bytes if fflagContract, and per set topic bit a
+// nonzero u32 length plus that many bytes. Reserved bits must be zero; the
+// #904 filter fields take the next fflags bits under a version bump.
+// One envelope has one encoding: decode consumes the body exactly and
+// re-encodes byte-identically.
+const (
+	flagDescending = 1 << 0
+	flagHasMax     = 1 << 1
+	flagHasPos     = 1 << 2
+	flagsKnown     = byte(flagDescending | flagHasMax | flagHasPos)
+
+	fflagContract = 1 << 0
+	fflagsKnown   = byte(fflagContract | ((1<<protocol.MaxTopicCount)-1)<<1)
+)
+
+func topicBit(i int) byte { return 1 << (1 + i) } //nolint:mnd // bit 0 is the contract
+
 // EventPosition is the ledger-denominated identity of a delivered event: the
 // TOID fields (Ledger, Tx, Op) plus the event index within the operation, and
-// K, the within-ledger index over all stored events of the ledger. K is
-// portable across nodes only while ingest preserves the close meta's
-// within-ledger stream order and the store's inclusion rule stays fixed.
+// LedgerOrdinal, the index over all stored events of the ledger. The latter
+// is portable across nodes only while ingest preserves the close meta's
+// within-ledger stream order and the store's inclusion rule stays fixed. The
+// pager (#774) does resume arithmetic and self-validation against these
+// fields.
 type EventPosition struct {
-	Ledger, Tx, Op, Event, K uint32
+	Ledger, Tx, Op, Event, LedgerOrdinal uint32
 }
 
 // EventCursorQuery is the canonical (engine) form of the original query the
-// cursor pins: ledger bounds, direction, and the engine's filters.
+// cursor pins: ledger bounds, direction, and the engine's filters. A nil
+// MaxLedger is the proposal's open upper bound: an ascending query that
+// follows the chain tip across pages. Descending queries always carry one,
+// pinned at query start.
 type EventCursorQuery struct {
-	MinLedger, MaxLedger uint32
-	Dir                  Direction
-	Filters              []event.Filter
+	MinLedger uint32
+	MaxLedger *uint32
+	Dir       Direction
+	Filters   []event.Filter
 }
 
 // EventCursor is the envelope: the server-minted structure inside the opaque
@@ -75,107 +105,64 @@ type EventCursor struct {
 	ScannedLedger uint32
 }
 
-// The structs below define the envelope's JSON body. Their tags are the
-// version-1 format: cursors never expire, so once v1 ships the key names are
-// frozen and any change to them is a version bump. event.Filter carries no
-// JSON tags and stays serialization-free; these conversions own the body
-// shape instead. []byte fields serialize as standard base64 via
-// encoding/json.
-
-type envelopeJSON struct {
-	Query    queryJSON     `json:"query"`
-	Position *positionJSON `json:"position,omitempty"`
-	Scanned  uint32        `json:"scanned"`
-}
-
-type queryJSON struct {
-	Min     uint32       `json:"min"`
-	Max     uint32       `json:"max"`
-	Dir     string       `json:"dir"`
-	Filters []filterJSON `json:"filters"`
-}
-
-// filterJSON is event.Filter in the body: "contract" is the raw 32-byte
-// contract ID, omitted when unconstrained; "topics" is always MaxTopicCount
-// entries with null for wildcard positions. A filter with no constraints at
-// all is legal (match-all).
+// Encode serializes the envelope as a version-1 token. Encode fails on what
+// no decode accepts: an invalid Direction, a descending query without
+// MaxLedger, MinLedger above a present MaxLedger, a wrong-length ContractID,
+// more than maxCursorFilters filters, or output beyond maxCursorBytes — a
+// minting bug fails on the page that has it rather than on the resume that
+// follows.
 //
-// Reserved key for the #904 filter fields: "type" (event type), omitempty,
-// to be mapped when that PR merges since v2 filters carry it. #904's
-// TopicCount is v1-only arity semantics that no envelope producer sets;
-// when the coverage tripwire fires at the rebase, either map it for
-// completeness (it needs two keys, "count" and "exact") or reject a set
-// TopicCount at Encode. Decide then; do not drop it silently.
-type filterJSON struct {
-	Contract []byte                         `json:"contract,omitempty"`
-	Topics   [protocol.MaxTopicCount][]byte `json:"topics"`
-}
-
-type positionJSON struct {
-	Ledger uint32 `json:"ledger"`
-	Tx     uint32 `json:"tx"`
-	Op     uint32 `json:"op"`
-	Event  uint32 `json:"event"`
-	K      uint32 `json:"k"`
-}
-
-// Direction's serialized spelling. The Direction int values never
-// serialize, so reordering the constants cannot silently break minted
-// cursors.
-const (
-	directionAsc  = "asc"
-	directionDesc = "desc"
-)
-
-// Encode serializes the envelope as base64url over (version byte ||
-// JSON). Encode fails on an invalid Direction, a wrong-length ContractID,
-// more than maxCursorFilters filters, or output beyond maxCursorBytes.
-//
-// Absent values must be nil: the wire format cannot tell nil from empty, so
-// empty non-nil values decode back as nil (no exact round-trip). Inverted
-// ledger bounds encode without error but fail the next decode.
+// Absent values must be nil: a zero-length non-nil ContractID or topic
+// encodes as absent and decodes back as nil (no exact round-trip for them).
 func (e *EventCursor) Encode() (string, error) {
-	dir, err := directionToJSON(e.Query.Dir)
-	if err != nil {
-		return "", err
+	var flags byte
+	switch e.Query.Dir {
+	case Ascending:
+	case Descending:
+		flags |= flagDescending
+	default:
+		return "", fmt.Errorf("query: encode cursor: invalid direction %d", e.Query.Dir)
+	}
+	if e.Query.MaxLedger != nil {
+		flags |= flagHasMax
+		if e.Query.MinLedger > *e.Query.MaxLedger {
+			return "", fmt.Errorf("query: encode cursor: min ledger %d > max ledger %d",
+				e.Query.MinLedger, *e.Query.MaxLedger)
+		}
+	} else if e.Query.Dir == Descending {
+		return "", errors.New("query: encode cursor: descending without a max ledger")
+	}
+	if e.Position != nil {
+		flags |= flagHasPos
 	}
 	if len(e.Query.Filters) > maxCursorFilters {
 		return "", fmt.Errorf("query: encode cursor: %d filters exceeds the %d-filter cap",
 			len(e.Query.Filters), maxCursorFilters)
 	}
-	w := envelopeJSON{
-		Query: queryJSON{
-			Min:     e.Query.MinLedger,
-			Max:     e.Query.MaxLedger,
-			Dir:     dir,
-			Filters: make([]filterJSON, 0, len(e.Query.Filters)),
-		},
-		Scanned: e.ScannedLedger,
-	}
-	for i := range e.Query.Filters {
-		f, err := filterToJSON(&e.Query.Filters[i])
-		if err != nil {
-			return "", fmt.Errorf("query: encode cursor filter %d: %w", i, err)
-		}
-		w.Query.Filters = append(w.Query.Filters, f)
+
+	body := []byte{flags}
+	body = binary.BigEndian.AppendUint32(body, e.Query.MinLedger)
+	if e.Query.MaxLedger != nil {
+		body = binary.BigEndian.AppendUint32(body, *e.Query.MaxLedger)
 	}
 	if e.Position != nil {
-		w.Position = &positionJSON{
-			Ledger: e.Position.Ledger,
-			Tx:     e.Position.Tx,
-			Op:     e.Position.Op,
-			Event:  e.Position.Event,
-			K:      e.Position.K,
+		for _, v := range [...]uint32{
+			e.Position.Ledger, e.Position.Tx, e.Position.Op, e.Position.Event, e.Position.LedgerOrdinal,
+		} {
+			body = binary.BigEndian.AppendUint32(body, v)
 		}
 	}
-	body, err := json.Marshal(w)
-	if err != nil {
-		return "", fmt.Errorf("query: encode cursor: %w", err)
+	body = binary.BigEndian.AppendUint32(body, e.ScannedLedger)
+	count := uint16(len(e.Query.Filters)) //nolint:gosec // capped at maxCursorFilters above
+	body = binary.BigEndian.AppendUint16(body, count)
+	for i := range e.Query.Filters {
+		var err error
+		if body, err = appendFilter(body, &e.Query.Filters[i]); err != nil {
+			return "", fmt.Errorf("query: encode cursor filter %d: %w", i, err)
+		}
 	}
-	buf := make([]byte, 0, 1+len(body))
-	buf = append(buf, cursorVersion)
-	buf = append(buf, body...)
-	enc := base64.RawURLEncoding.EncodeToString(buf)
+
+	enc := cursorPrefixV1 + base64.RawURLEncoding.EncodeToString(body)
 	if len(enc) > maxCursorBytes {
 		return "", fmt.Errorf("query: encode cursor: %d bytes exceeds the %d-byte decode cap",
 			len(enc), maxCursorBytes)
@@ -183,9 +170,38 @@ func (e *EventCursor) Encode() (string, error) {
 	return enc, nil
 }
 
-// DecodeEventCursor parses a cursor string into its envelope. Malformed
-// input returns an error matching ErrCursorMalformed; a cursor whose version
-// byte this build cannot decode returns one matching ErrCursorUnknownVersion.
+func appendFilter(body []byte, f *event.Filter) ([]byte, error) {
+	var fflags byte
+	if n := len(f.ContractID); n > 0 {
+		if n != contractIDLen {
+			return nil, fmt.Errorf("contract ID is %d bytes, want %d", n, contractIDLen)
+		}
+		fflags |= fflagContract
+	}
+	for i := range f.Topics {
+		if len(f.Topics[i]) > 0 {
+			fflags |= topicBit(i)
+		}
+	}
+	body = append(body, fflags)
+	if fflags&fflagContract != 0 {
+		body = append(body, f.ContractID...)
+	}
+	for i := range f.Topics {
+		if topic := f.Topics[i]; len(topic) > 0 {
+			if uint64(len(topic)) > math.MaxUint32 {
+				return nil, fmt.Errorf("topic %d is %d bytes, beyond the u32 length field", i, len(topic))
+			}
+			body = binary.BigEndian.AppendUint32(body, uint32(len(topic))) //nolint:gosec // bounded above
+			body = append(body, topic...)
+		}
+	}
+	return body, nil
+}
+
+// DecodeEventCursor parses a cursor token into its envelope. Malformed
+// input returns an error matching ErrCursorMalformed; a token whose version
+// this build cannot decode returns one matching ErrCursorUnknownVersion.
 func DecodeEventCursor(s string) (*EventCursor, error) {
 	if s == "" {
 		return nil, fmt.Errorf("%w: empty input", ErrCursorMalformed)
@@ -194,127 +210,193 @@ func DecodeEventCursor(s string) (*EventCursor, error) {
 		return nil, fmt.Errorf("%w: %d bytes exceeds the %d-byte cap",
 			ErrCursorMalformed, len(s), maxCursorBytes)
 	}
-	raw, err := base64.RawURLEncoding.DecodeString(s)
-	if err != nil {
-		return nil, fmt.Errorf("%w: base64: %w", ErrCursorMalformed, err)
-	}
-	if len(raw) == 0 {
-		return nil, fmt.Errorf("%w: missing version byte", ErrCursorMalformed)
-	}
-	if raw[0] != cursorVersion {
-		return nil, fmt.Errorf("%w: %d", ErrCursorUnknownVersion, raw[0])
-	}
-	// Bound unmarshal allocation before parsing: every legal string value in
-	// the body is base64 or a direction token, none of which contain '{', so
-	// the brace count equals the object count (envelope + query + optional
-	// position + one per filter). The post-unmarshal filter cap below stays
-	// the authoritative check.
-	if bytes.Count(raw[1:], []byte("{")) > maxCursorFilters+3 {
-		return nil, fmt.Errorf("%w: object count exceeds the %d-filter cap",
-			ErrCursorMalformed, maxCursorFilters)
-	}
-	var w envelopeJSON
-	if err := json.Unmarshal(raw[1:], &w); err != nil {
-		return nil, fmt.Errorf("%w: json: %w", ErrCursorMalformed, err)
-	}
-
-	dir, err := directionFromJSON(w.Query.Dir)
+	payload, err := cursorPayloadV1(s)
 	if err != nil {
 		return nil, err
 	}
-	if w.Query.Min > w.Query.Max {
-		return nil, fmt.Errorf("%w: min ledger %d > max ledger %d",
-			ErrCursorMalformed, w.Query.Min, w.Query.Max)
+	// The base64 decoder silently skips CR and LF; reject them so one token
+	// means one body.
+	if strings.ContainsAny(payload, "\r\n") {
+		return nil, fmt.Errorf("%w: whitespace in payload", ErrCursorMalformed)
 	}
-	if len(w.Query.Filters) > maxCursorFilters {
-		return nil, fmt.Errorf("%w: %d filters exceeds the %d-filter cap",
-			ErrCursorMalformed, len(w.Query.Filters), maxCursorFilters)
+	body, err := base64.RawURLEncoding.Strict().DecodeString(payload)
+	if err != nil {
+		return nil, fmt.Errorf("%w: base64: %w", ErrCursorMalformed, err)
 	}
-	env := &EventCursor{
-		Query: EventCursorQuery{
-			MinLedger: w.Query.Min,
-			MaxLedger: w.Query.Max,
-			Dir:       dir,
-		},
-		ScannedLedger: w.Scanned,
+	r := cursorReader{body: body}
+	env, err := readEnvelope(&r)
+	if err != nil {
+		return nil, err
 	}
-	if len(w.Query.Filters) > 0 {
-		env.Query.Filters = make([]event.Filter, len(w.Query.Filters))
-		for i := range w.Query.Filters {
-			f, err := filterFromJSON(&w.Query.Filters[i])
-			if err != nil {
-				return nil, fmt.Errorf("filter %d: %w", i, err)
-			}
-			env.Query.Filters[i] = f
-		}
-	}
-	if w.Position != nil {
-		env.Position = &EventPosition{
-			Ledger: w.Position.Ledger,
-			Tx:     w.Position.Tx,
-			Op:     w.Position.Op,
-			Event:  w.Position.Event,
-			K:      w.Position.K,
-		}
+	if rest := len(r.body) - r.off; rest != 0 {
+		return nil, fmt.Errorf("%w: %d trailing bytes", ErrCursorMalformed, rest)
 	}
 	return env, nil
 }
 
-// filterToJSON and filterFromJSON normalize zero-length values to nil in
-// both directions, keeping the absent-means-nil contract exact even for
-// bodies a legitimate encoder never produces.
-
-func filterToJSON(f *event.Filter) (filterJSON, error) {
-	var j filterJSON
-	if n := len(f.ContractID); n > 0 {
-		if n != contractIDLen {
-			return filterJSON{}, fmt.Errorf("contract ID is %d bytes, want %d", n, contractIDLen)
-		}
-		j.Contract = f.ContractID
+func cursorPayloadV1(s string) (string, error) {
+	rest, ok := strings.CutPrefix(s, "gec")
+	if !ok {
+		return "", fmt.Errorf("%w: not a gec token", ErrCursorMalformed)
 	}
-	for i, topic := range f.Topics {
-		if len(topic) > 0 {
-			j.Topics[i] = topic
+	sep := strings.IndexByte(rest, '_')
+	if sep <= 0 {
+		return "", fmt.Errorf("%w: missing version", ErrCursorMalformed)
+	}
+	version := rest[:sep]
+	for i := range len(version) {
+		if version[i] < '0' || version[i] > '9' {
+			return "", fmt.Errorf("%w: version %q", ErrCursorMalformed, version)
 		}
 	}
-	return j, nil
+	if version != "1" {
+		return "", fmt.Errorf("%w: %s", ErrCursorUnknownVersion, version)
+	}
+	return rest[sep+1:], nil
 }
 
-func filterFromJSON(j *filterJSON) (event.Filter, error) {
-	var f event.Filter
-	if n := len(j.Contract); n > 0 {
-		if n != contractIDLen {
-			return event.Filter{}, fmt.Errorf("%w: contract ID is %d bytes, want %d",
-				ErrCursorMalformed, n, contractIDLen)
-		}
-		f.ContractID = j.Contract
-	}
-	for i, topic := range j.Topics {
-		if len(topic) > 0 {
-			f.Topics[i] = topic
-		}
-	}
-	return f, nil
+// cursorReader walks the fixed-layout body. Every read checks the remaining
+// length first, so decode work and allocation are bounded by input length.
+// Byte slices alias the decode buffer, which is owned by the returned
+// envelope.
+type cursorReader struct {
+	body []byte
+	off  int
 }
 
-func directionToJSON(d Direction) (string, error) {
-	switch d {
-	case Ascending:
-		return directionAsc, nil
-	case Descending:
-		return directionDesc, nil
-	default:
-		return "", fmt.Errorf("query: encode cursor: invalid direction %d", d)
+var errTruncated = fmt.Errorf("%w: truncated body", ErrCursorMalformed)
+
+func (r *cursorReader) take(n int) ([]byte, error) {
+	if len(r.body)-r.off < n {
+		return nil, errTruncated
 	}
+	b := r.body[r.off : r.off+n]
+	r.off += n
+	return b, nil
 }
 
-func directionFromJSON(s string) (Direction, error) {
-	switch s {
-	case directionAsc:
-		return Ascending, nil
-	case directionDesc:
-		return Descending, nil
-	default:
-		return 0, fmt.Errorf("%w: dir %q", ErrCursorMalformed, s)
+func (r *cursorReader) u8() (byte, error) {
+	b, err := r.take(1)
+	if err != nil {
+		return 0, err
 	}
+	return b[0], nil
+}
+
+func (r *cursorReader) u16() (uint16, error) {
+	b, err := r.take(2)
+	if err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint16(b), nil
+}
+
+func (r *cursorReader) u32() (uint32, error) {
+	b, err := r.take(4)
+	if err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint32(b), nil
+}
+
+func readEnvelope(r *cursorReader) (*EventCursor, error) {
+	flags, err := r.u8()
+	if err != nil {
+		return nil, err
+	}
+	if flags&^flagsKnown != 0 {
+		return nil, fmt.Errorf("%w: reserved flag bits in %#02x", ErrCursorMalformed, flags)
+	}
+	env := &EventCursor{}
+	if flags&flagDescending != 0 {
+		env.Query.Dir = Descending
+	}
+	if env.Query.MinLedger, err = r.u32(); err != nil {
+		return nil, err
+	}
+	switch {
+	case flags&flagHasMax != 0:
+		maxLedger, err := r.u32()
+		if err != nil {
+			return nil, err
+		}
+		if env.Query.MinLedger > maxLedger {
+			return nil, fmt.Errorf("%w: min ledger %d > max ledger %d",
+				ErrCursorMalformed, env.Query.MinLedger, maxLedger)
+		}
+		env.Query.MaxLedger = &maxLedger
+	case flags&flagDescending != 0:
+		return nil, fmt.Errorf("%w: descending without a max ledger", ErrCursorMalformed)
+	}
+	if flags&flagHasPos != 0 {
+		var p EventPosition
+		for _, dst := range [...]*uint32{&p.Ledger, &p.Tx, &p.Op, &p.Event, &p.LedgerOrdinal} {
+			if *dst, err = r.u32(); err != nil {
+				return nil, err
+			}
+		}
+		env.Position = &p
+	}
+	if env.ScannedLedger, err = r.u32(); err != nil {
+		return nil, err
+	}
+	if env.Query.Filters, err = readFilters(r); err != nil {
+		return nil, err
+	}
+	return env, nil
+}
+
+func readFilters(r *cursorReader) ([]event.Filter, error) {
+	count, err := r.u16()
+	if err != nil {
+		return nil, err
+	}
+	if int(count) > maxCursorFilters {
+		return nil, fmt.Errorf("%w: %d filters exceeds the %d-filter cap",
+			ErrCursorMalformed, count, maxCursorFilters)
+	}
+	if count == 0 {
+		return nil, nil
+	}
+	filters := make([]event.Filter, count)
+	for i := range filters {
+		if err := readFilter(r, &filters[i]); err != nil {
+			return nil, fmt.Errorf("filter %d: %w", i, err)
+		}
+	}
+	return filters, nil
+}
+
+func readFilter(r *cursorReader, f *event.Filter) error {
+	fflags, err := r.u8()
+	if err != nil {
+		return err
+	}
+	if fflags&^fflagsKnown != 0 {
+		return fmt.Errorf("%w: reserved filter flag bits in %#02x", ErrCursorMalformed, fflags)
+	}
+	if fflags&fflagContract != 0 {
+		if f.ContractID, err = r.take(contractIDLen); err != nil {
+			return err
+		}
+	}
+	for i := range f.Topics {
+		if fflags&topicBit(i) == 0 {
+			continue
+		}
+		n, err := r.u32()
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return fmt.Errorf("%w: topic %d present with zero length", ErrCursorMalformed, i)
+		}
+		if uint64(n) > uint64(len(r.body)-r.off) { //nolint:gosec // off never exceeds len(body)
+			return errTruncated
+		}
+		if f.Topics[i], err = r.take(int(n)); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/cmd/stellar-rpc/internal/rpcv2/query/event_cursor_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/query/event_cursor_test.go
@@ -3,8 +3,8 @@ package query
 import (
 	"bytes"
 	"encoding/base64"
+	"encoding/binary"
 	"errors"
-	"fmt"
 	"math"
 	"reflect"
 	"strings"
@@ -22,102 +22,144 @@ func testContract(b byte) []byte { return bytes.Repeat([]byte{b}, contractIDLen)
 
 func testTopic(b byte) []byte { return bytes.Repeat([]byte{b}, 8) }
 
-var cursorRoundTripCases = []struct {
-	name string
-	env  EventCursor
-}{
-	{
-		name: "ascending with position, zero filters (match-all)",
-		env: EventCursor{
-			Query:         EventCursorQuery{MinLedger: 100, MaxLedger: 200, Dir: Ascending},
-			Position:      &EventPosition{Ledger: 150, Tx: 3, Op: 1, Event: 2, K: 41},
-			ScannedLedger: 150,
-		},
-	},
-	{
-		name: "ascending watermark-only (nil position)",
-		env: EventCursor{
-			Query:         EventCursorQuery{MinLedger: 100, MaxLedger: 200, Dir: Ascending},
-			ScannedLedger: 175,
-		},
-	},
-	{
-		name: "descending with position, contract-only filter",
-		env: EventCursor{
-			Query: EventCursorQuery{
-				MinLedger: 50, MaxLedger: 900, Dir: Descending,
-				Filters: []event.Filter{{ContractID: testContract(0xC1)}},
-			},
-			Position:      &EventPosition{Ledger: 700, Tx: 12, Op: 0, Event: 5, K: 9},
-			ScannedLedger: 700,
-		},
-	},
-	{
-		name: "descending watermark-only, topics with gaps (t0 and t2 set)",
-		env: EventCursor{
-			Query: EventCursorQuery{
-				MinLedger: 1, MaxLedger: 10, Dir: Descending,
-				Filters: []event.Filter{{
-					Topics: [protocol.MaxTopicCount][]byte{testTopic(0xA0), nil, testTopic(0xA2), nil},
-				}},
-			},
-			ScannedLedger: 4,
-		},
-	},
-	{
-		name: "full filter",
-		env: EventCursor{
-			Query: EventCursorQuery{
-				MinLedger: 20002, MaxLedger: 30001, Dir: Ascending,
-				Filters: []event.Filter{{
-					ContractID: testContract(0xC2),
-					Topics: [protocol.MaxTopicCount][]byte{
-						testTopic(1), testTopic(2), testTopic(3), testTopic(4),
-					},
-				}},
-			},
-			Position:      &EventPosition{Ledger: 25000, Tx: 1, Op: 1, Event: 0, K: 0},
-			ScannedLedger: 25000,
-		},
-	},
-	{
-		name: "multiple filters including an empty match-all filter",
-		env: EventCursor{
-			Query: EventCursorQuery{
-				MinLedger: 5, MaxLedger: 6, Dir: Descending,
-				Filters: []event.Filter{
-					{ContractID: testContract(0xC3)},
-					{Topics: [protocol.MaxTopicCount][]byte{nil, testTopic(0xB1), nil, nil}},
-					{},
-				},
-			},
-			Position:      &EventPosition{Ledger: 6, Tx: 2, Op: 3, Event: 4, K: 5},
-			ScannedLedger: 5,
-		},
-	},
-	{
-		// A present all-zero position must stay distinct from nil.
-		name: "all-zero position",
-		env: EventCursor{
-			Query:    EventCursorQuery{MinLedger: 1, MaxLedger: 2, Dir: Ascending},
-			Position: &EventPosition{},
-		},
-	},
-	{
-		name: "max uint32 field values",
-		env: EventCursor{
-			Query: EventCursorQuery{MinLedger: math.MaxUint32, MaxLedger: math.MaxUint32, Dir: Ascending},
-			Position: &EventPosition{
-				Ledger: math.MaxUint32, Tx: math.MaxUint32, Op: math.MaxUint32,
-				Event: math.MaxUint32, K: math.MaxUint32,
-			},
-			ScannedLedger: math.MaxUint32,
-		},
-	},
+func maxPtr(v uint32) *uint32 { return new(v) }
+
+// tokV1 wraps a raw body in the version-1 prefix so the failure under test
+// is the body, not the prefix.
+func tokV1(body []byte) string {
+	return cursorPrefixV1 + base64.RawURLEncoding.EncodeToString(body)
+}
+
+func be16(v uint16) []byte { return binary.BigEndian.AppendUint16(nil, v) }
+
+func be32(v uint32) []byte { return binary.BigEndian.AppendUint32(nil, v) }
+
+func cat(parts ...[]byte) []byte {
+	var out []byte
+	for _, p := range parts {
+		out = append(out, p...)
+	}
+	return out
 }
 
 func TestCursorRoundTrip(t *testing.T) {
-	for _, tc := range cursorRoundTripCases {
+	cases := []cursorRoundTripCase{
+		{
+			name: "ascending unbounded (nil max), watermark-only, match-all",
+			env: EventCursor{
+				Query:         EventCursorQuery{MinLedger: 100, Dir: Ascending},
+				ScannedLedger: 175,
+			},
+		},
+		{
+			name: "ascending unbounded with position",
+			env: EventCursor{
+				Query:         EventCursorQuery{MinLedger: 100, Dir: Ascending},
+				Position:      &EventPosition{Ledger: 150, Tx: 3, Op: 1, Event: 2, LedgerOrdinal: 41},
+				ScannedLedger: 150,
+			},
+		},
+		{
+			name: "ascending bounded with position, zero filters (match-all)",
+			env: EventCursor{
+				Query:         EventCursorQuery{MinLedger: 100, MaxLedger: maxPtr(200), Dir: Ascending},
+				Position:      &EventPosition{Ledger: 150, Tx: 3, Op: 1, Event: 2, LedgerOrdinal: 41},
+				ScannedLedger: 150,
+			},
+		},
+		{
+			// A present all-zero position must stay distinct from nil.
+			name: "all-zero position",
+			env: EventCursor{
+				Query:    EventCursorQuery{MinLedger: 1, MaxLedger: maxPtr(2), Dir: Ascending},
+				Position: &EventPosition{},
+			},
+		},
+		{
+			name: "max uint32 field values",
+			env: EventCursor{
+				Query: EventCursorQuery{
+					MinLedger: math.MaxUint32, MaxLedger: maxPtr(math.MaxUint32), Dir: Ascending,
+				},
+				Position: &EventPosition{
+					Ledger: math.MaxUint32, Tx: math.MaxUint32, Op: math.MaxUint32,
+					Event: math.MaxUint32, LedgerOrdinal: math.MaxUint32,
+				},
+				ScannedLedger: math.MaxUint32,
+			},
+		},
+	}
+	runCursorRoundTrips(t, cases)
+}
+
+func TestCursorRoundTripFilters(t *testing.T) {
+	cases := []cursorRoundTripCase{
+		{
+			name: "descending with position, contract-only filter",
+			env: EventCursor{
+				Query: EventCursorQuery{
+					MinLedger: 50, MaxLedger: maxPtr(900), Dir: Descending,
+					Filters: []event.Filter{{ContractID: testContract(0xC1)}},
+				},
+				Position:      &EventPosition{Ledger: 700, Tx: 12, Op: 0, Event: 5, LedgerOrdinal: 9},
+				ScannedLedger: 700,
+			},
+		},
+		{
+			name: "descending watermark-only, topics with gaps (t0 and t2 set)",
+			env: EventCursor{
+				Query: EventCursorQuery{
+					MinLedger: 1, MaxLedger: maxPtr(10), Dir: Descending,
+					Filters: []event.Filter{{
+						Topics: [protocol.MaxTopicCount][]byte{testTopic(0xA0), nil, testTopic(0xA2), nil},
+					}},
+				},
+				ScannedLedger: 4,
+			},
+		},
+		{
+			name: "full filter",
+			env: EventCursor{
+				Query: EventCursorQuery{
+					MinLedger: 20002, MaxLedger: maxPtr(30001), Dir: Ascending,
+					Filters: []event.Filter{{
+						ContractID: testContract(0xC2),
+						Topics: [protocol.MaxTopicCount][]byte{
+							testTopic(1), testTopic(2), testTopic(3), testTopic(4),
+						},
+					}},
+				},
+				Position:      &EventPosition{Ledger: 25000, Tx: 1, Op: 1, Event: 0, LedgerOrdinal: 0},
+				ScannedLedger: 25000,
+			},
+		},
+		{
+			name: "multiple filters including an empty match-all filter",
+			env: EventCursor{
+				Query: EventCursorQuery{
+					MinLedger: 5, MaxLedger: maxPtr(6), Dir: Descending,
+					Filters: []event.Filter{
+						{ContractID: testContract(0xC3)},
+						{Topics: [protocol.MaxTopicCount][]byte{nil, testTopic(0xB1), nil, nil}},
+						{},
+					},
+				},
+				Position:      &EventPosition{Ledger: 6, Tx: 2, Op: 3, Event: 4, LedgerOrdinal: 5},
+				ScannedLedger: 5,
+			},
+		},
+	}
+	runCursorRoundTrips(t, cases)
+}
+
+type cursorRoundTripCase struct {
+	name string
+	env  EventCursor
+}
+
+func runCursorRoundTrips(t *testing.T, cases []cursorRoundTripCase) {
+	t.Helper()
+	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			enc, err := tc.env.Encode()
 			require.NoError(t, err)
@@ -128,16 +170,74 @@ func TestCursorRoundTrip(t *testing.T) {
 	}
 }
 
-func TestCursorVersionRejection(t *testing.T) {
-	env := EventCursor{Query: EventCursorQuery{MinLedger: 1, MaxLedger: 2, Dir: Ascending}}
-	enc, err := env.Encode()
-	require.NoError(t, err)
-	for _, version := range []byte{0, 2} {
-		t.Run(fmt.Sprintf("version %d", version), func(t *testing.T) {
-			raw, err := base64.RawURLEncoding.DecodeString(enc)
+// TestCursorGoldenV1 pins the version-1 layout against literal bytes:
+// round-trip tests pass a layout change in lockstep, the literals do not.
+// The minimal vector doubles as the unbounded-ascending shape (no max bit),
+// likely the most common cursor in the wild.
+func TestCursorGoldenV1(t *testing.T) {
+	cases := []struct {
+		name string
+		env  EventCursor
+		body []byte
+	}{
+		{
+			name: "minimal: ascending unbounded, watermark-only, match-all",
+			env: EventCursor{
+				Query:         EventCursorQuery{MinLedger: 100, Dir: Ascending},
+				ScannedLedger: 175,
+			},
+			body: cat(
+				[]byte{0x00}, // flags: ascending, no max, no position
+				be32(100),    // min
+				be32(175),    // scanned
+				be16(0),      // filter count
+			),
+		},
+		{
+			name: "full: descending, max, position, contract+topic1 filter",
+			env: EventCursor{
+				Query: EventCursorQuery{
+					MinLedger: 1, MaxLedger: maxPtr(2), Dir: Descending,
+					Filters: []event.Filter{{
+						ContractID: testContract(0xC5),
+						Topics:     [protocol.MaxTopicCount][]byte{nil, testTopic(0xB2), nil, nil},
+					}},
+				},
+				Position:      &EventPosition{Ledger: 3, Tx: 4, Op: 5, Event: 6, LedgerOrdinal: 7},
+				ScannedLedger: 8,
+			},
+			body: cat(
+				[]byte{0x07},                                // flags: descending | hasMax | hasPos
+				be32(1),                                     // min
+				be32(2),                                     // max
+				be32(3), be32(4), be32(5), be32(6), be32(7), // position
+				be32(8),            // scanned
+				be16(1),            // filter count
+				[]byte{0x05},       // fflags: contract | topic1
+				testContract(0xC5), // contract
+				be32(8),            // topic1 length
+				testTopic(0xB2),    // topic1
+			),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			enc, err := tc.env.Encode()
 			require.NoError(t, err)
-			raw[0] = version
-			got, err := DecodeEventCursor(base64.RawURLEncoding.EncodeToString(raw))
+			assert.Equal(t, tokV1(tc.body), enc)
+
+			got, err := DecodeEventCursor(tokV1(tc.body))
+			require.NoError(t, err)
+			assert.Equal(t, &tc.env, got)
+		})
+	}
+}
+
+func TestCursorVersionRejection(t *testing.T) {
+	payload := base64.RawURLEncoding.EncodeToString(cat([]byte{0x00}, be32(1), be32(0), be16(0)))
+	for _, version := range []string{"0", "2", "42", "01"} {
+		t.Run("version "+version, func(t *testing.T) {
+			got, err := DecodeEventCursor("gec" + version + "_" + payload)
 			require.ErrorIs(t, err, ErrCursorUnknownVersion)
 			assert.Nil(t, got)
 		})
@@ -145,196 +245,109 @@ func TestCursorVersionRejection(t *testing.T) {
 }
 
 func TestCursorMalformedInputs(t *testing.T) {
-	b64 := func(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
-	// v1 wraps a raw body in a valid version byte so the failure under test is
-	// the body, not the version.
-	v1 := func(body string) string { return b64(append([]byte{cursorVersion}, body...)) }
-	contract31 := base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{1}, 31))
-	overCap := `{"query":{"min":1,"max":2,"dir":"asc","filters":[` +
-		strings.TrimSuffix(strings.Repeat(`{},`, maxCursorFilters+1), ",") +
-		`]},"scanned":0}`
+	// minimalBody is a valid ascending unbounded envelope to mutate.
+	minimalBody := cat([]byte{0x00}, be32(1), be32(0), be16(0))
+	minimalToken := tokV1(minimalBody)
+
+	// A structurally valid token over the size cap: only the cap rejects it.
+	overCapToken := tokV1(cat([]byte{0x00}, be32(1), be32(0), be16(1),
+		[]byte{0x02}, be32(maxCursorBytes), bytes.Repeat([]byte{7}, maxCursorBytes)))
+
+	// A valid token with a newline the base64 decoder would silently skip:
+	// only the whitespace check rejects it.
+	newlineToken := minimalToken[:len(minimalToken)-4] + "\n" + minimalToken[len(minimalToken)-4:]
+
+	// The minimal token with a padding bit set in its final character: it
+	// decodes to the same body under lenient base64, so only Strict rejects
+	// this second spelling.
+	const b64url = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+	last := strings.IndexByte(b64url, minimalToken[len(minimalToken)-1])
+	nonCanonicalToken := minimalToken[:len(minimalToken)-1] + string(b64url[last|1])
+	require.NotEqual(t, minimalToken, nonCanonicalToken)
 
 	cases := []struct {
 		name string
 		in   string
-		want error
 	}{
-		{"empty string", "", ErrCursorMalformed},
-		{"not base64", "not base64!!", ErrCursorMalformed},
-		{"garbage bytes", b64([]byte{0x9B, 0x00, 0xFF, 0x13, 0x37}), ErrCursorUnknownVersion},
-		{"valid version byte, invalid JSON", v1("{{{not json"), ErrCursorMalformed},
-		{
-			"unknown dir",
-			v1(`{"query":{"min":1,"max":2,"dir":"sideways","filters":[]},"scanned":0}`),
-			ErrCursorMalformed,
-		},
-		{
-			"contract of 31 bytes",
-			v1(`{"query":{"min":1,"max":2,"dir":"asc","filters":[{"contract":"` +
-				contract31 + `","topics":[null,null,null,null]}]},"scanned":0}`),
-			ErrCursorMalformed,
-		},
-		{
-			"contract of invalid base64",
-			v1(`{"query":{"min":1,"max":2,"dir":"asc","filters":[{"contract":"!!!not-b64",` +
-				`"topics":[null,null,null,null]}]},"scanned":0}`),
-			ErrCursorMalformed,
-		},
-		{
-			"topic of invalid base64",
-			v1(`{"query":{"min":1,"max":2,"dir":"asc","filters":[{"topics":["!!!not-b64",` +
-				`null,null,null]}]},"scanned":0}`),
-			ErrCursorMalformed,
-		},
+		{"empty string", ""},
+		{"oversized input", "gec1_" + strings.Repeat("A", maxCursorBytes)},
+		{"oversized but structurally valid", overCapToken},
+		{"newline inside a valid payload", newlineToken},
+		{"non-canonical base64 trailing bits", nonCanonicalToken},
+		{"not a gec token", "opaque"},
+		{"v1-style base64 without prefix", base64.RawURLEncoding.EncodeToString(minimalBody)},
+		{"empty version", "gec_" + base64.RawURLEncoding.EncodeToString(minimalBody)},
+		{"non-digit version", "gecx_AAAA"},
+		{"no version separator", "gec1"},
+		{"bad base64", "gec1_!!!"},
+		{"padding in payload", "gec1_AAAA=="},
+		{"newline in payload", "gec1_AA\nAA"},
+		{"carriage return in payload", "gec1_AA\rAA"},
+		{"empty body", "gec1_"},
+		{"truncated after flags", tokV1([]byte{0x00})},
+		{"truncated inside position", tokV1(cat([]byte{0x04}, be32(1), be32(2), be32(3)))},
+		{"truncated before filter count", tokV1(cat([]byte{0x00}, be32(1), be32(0)))},
+		{"reserved envelope flag bit", tokV1(cat([]byte{0x08}, be32(1), be32(0), be16(0)))},
+		{"descending without max", tokV1(cat([]byte{0x01}, be32(1), be32(0), be16(0)))},
 		{
 			"min greater than max",
-			v1(`{"query":{"min":3,"max":2,"dir":"asc","filters":[]},"scanned":0}`),
-			ErrCursorMalformed,
-		},
-		{"filter count over cap", v1(overCap), ErrCursorMalformed},
-		// Rejected by the pre-unmarshal brace guard: a quarter-million empty
-		// filters fit the size cap but must not reach json.Unmarshal.
-		{
-			"quarter-million empty filters",
-			v1(`{"query":{"min":1,"max":2,"dir":"asc","filters":[` +
-				strings.TrimSuffix(strings.Repeat(`{},`, 250_000), ",") +
-				`]},"scanned":0}`),
-			ErrCursorMalformed,
-		},
-		{"oversized input", strings.Repeat("A", maxCursorBytes+1), ErrCursorMalformed},
-		{"empty body after version byte", v1(""), ErrCursorMalformed},
-		// A structurally empty body must never decode to a usable zero
-		// envelope; the dir check is what rejects it.
-		{"empty JSON object body", v1(`{}`), ErrCursorMalformed},
-		// Numeric strictness is inherited from encoding/json; pinned so a
-		// lenient unmarshaller swap cannot change it.
-		{
-			"uint32 overflow",
-			v1(`{"query":{"min":1,"max":4294967296,"dir":"asc","filters":[]},"scanned":0}`),
-			ErrCursorMalformed,
+			tokV1(cat([]byte{0x02}, be32(3), be32(2), be32(0), be16(0))),
 		},
 		{
-			"negative number",
-			v1(`{"query":{"min":-1,"max":2,"dir":"asc","filters":[]},"scanned":0}`),
-			ErrCursorMalformed,
+			"filter count over cap",
+			tokV1(cat([]byte{0x00}, be32(1), be32(0), be16(maxCursorFilters+1))),
 		},
 		{
-			"non-integer number",
-			v1(`{"query":{"min":1.5,"max":2,"dir":"asc","filters":[]},"scanned":0}`),
-			ErrCursorMalformed,
+			// Valid empty filters follow the over-cap count: only the cap
+			// check rejects this before allocation.
+			"filter count over cap with filter bytes present",
+			tokV1(cat([]byte{0x00}, be32(1), be32(0), be16(maxCursorFilters+1),
+				bytes.Repeat([]byte{0x00}, maxCursorFilters+1))),
+		},
+		{
+			"filter count without filter bytes",
+			tokV1(cat([]byte{0x00}, be32(1), be32(0), be16(1))),
+		},
+		{
+			"reserved filter flag bit",
+			tokV1(cat([]byte{0x00}, be32(1), be32(0), be16(1), []byte{0x20})),
+		},
+		{
+			"topic bit set with zero length",
+			tokV1(cat([]byte{0x00}, be32(1), be32(0), be16(1), []byte{0x02}, be32(0))),
+		},
+		{
+			"topic length past end of body",
+			tokV1(cat([]byte{0x00}, be32(1), be32(0), be16(1), []byte{0x02}, be32(1000))),
+		},
+		{
+			"contract shorter than 32 bytes",
+			tokV1(cat([]byte{0x00}, be32(1), be32(0), be16(1), []byte{0x01}, testTopic(0xC0))),
+		},
+		{
+			"trailing bytes",
+			tokV1(cat(minimalBody, []byte{0x00})),
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := DecodeEventCursor(tc.in)
-			require.ErrorIs(t, err, tc.want)
+			require.ErrorIs(t, err, ErrCursorMalformed)
 			assert.Nil(t, got)
 		})
 	}
 }
 
-// TestCursorGoldenV1 pins the version-1 body against literal JSON: round-trip
-// tests pass a tag rename in lockstep, the literals do not. The minimal
-// vector pins the absent-field shapes ("filters":[], no "position" key).
-func TestCursorGoldenV1(t *testing.T) {
-	contract := testContract(0xC5)
-	topic := testTopic(0xB2)
-	cases := []struct {
-		name string
-		env  EventCursor
-		body string
-	}{
-		{
-			name: "full envelope",
-			env: EventCursor{
-				Query: EventCursorQuery{
-					MinLedger: 1, MaxLedger: 2, Dir: Ascending,
-					Filters: []event.Filter{{
-						ContractID: contract,
-						Topics:     [protocol.MaxTopicCount][]byte{nil, topic, nil, nil},
-					}},
-				},
-				Position:      &EventPosition{Ledger: 3, Tx: 4, Op: 5, Event: 6, K: 7},
-				ScannedLedger: 8,
-			},
-			body: fmt.Sprintf(
-				`{"query":{"min":1,"max":2,"dir":"asc","filters":[{"contract":%q,"topics":[null,%q,null,null]}]},`+
-					`"position":{"ledger":3,"tx":4,"op":5,"event":6,"k":7},"scanned":8}`,
-				base64.StdEncoding.EncodeToString(contract),
-				base64.StdEncoding.EncodeToString(topic),
-			),
-		},
-		{
-			name: "minimal watermark-only match-all",
-			env: EventCursor{
-				Query:         EventCursorQuery{MinLedger: 100, MaxLedger: 200, Dir: Descending},
-				ScannedLedger: 175,
-			},
-			body: `{"query":{"min":100,"max":200,"dir":"desc","filters":[]},"scanned":175}`,
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			enc, err := tc.env.Encode()
-			require.NoError(t, err)
-			raw, err := base64.RawURLEncoding.DecodeString(enc)
-			require.NoError(t, err)
-			require.NotEmpty(t, raw)
-			assert.Equal(t, byte(cursorVersion), raw[0])
-			assert.Equal(t, tc.body, string(raw[1:]))
-
-			golden := base64.RawURLEncoding.EncodeToString(append([]byte{cursorVersion}, tc.body...))
-			got, err := DecodeEventCursor(golden)
-			require.NoError(t, err)
-			assert.Equal(t, &tc.env, got)
-		})
-	}
-}
-
-// Go's JSON decoder drops extra "topics" elements and zero-fills missing
-// ones; only a forger can produce either. Pinned so a stricter unmarshaller
-// cannot change the behavior undetected.
-func TestCursorTopicsArityLenient(t *testing.T) {
-	v1 := func(body string) string {
-		return base64.RawURLEncoding.EncodeToString(append([]byte{cursorVersion}, body...))
-	}
-	topic := base64.StdEncoding.EncodeToString(testTopic(0xA7))
-
-	t.Run("five elements: fifth dropped", func(t *testing.T) {
-		got, err := DecodeEventCursor(v1(
-			`{"query":{"min":1,"max":2,"dir":"asc","filters":[{"topics":[` +
-				fmt.Sprintf("%q", topic) + `,null,null,null,` + fmt.Sprintf("%q", topic) +
-				`]}]},"scanned":0}`))
-		require.NoError(t, err)
-		require.Len(t, got.Query.Filters, 1)
-		assert.Equal(t, testTopic(0xA7), got.Query.Filters[0].Topics[0])
-		for i := 1; i < protocol.MaxTopicCount; i++ {
-			assert.Nil(t, got.Query.Filters[0].Topics[i])
-		}
-	})
-	t.Run("two elements: rest zero-filled", func(t *testing.T) {
-		got, err := DecodeEventCursor(v1(
-			`{"query":{"min":1,"max":2,"dir":"asc","filters":[{"topics":[null,` +
-				fmt.Sprintf("%q", topic) + `]}]},"scanned":0}`))
-		require.NoError(t, err)
-		require.Len(t, got.Query.Filters, 1)
-		assert.Nil(t, got.Query.Filters[0].Topics[0])
-		assert.Equal(t, testTopic(0xA7), got.Query.Filters[0].Topics[1])
-		assert.Nil(t, got.Query.Filters[0].Topics[2])
-		assert.Nil(t, got.Query.Filters[0].Topics[3])
-	})
-}
-
 func TestCursorEncodeDeterministic(t *testing.T) {
 	env := EventCursor{
 		Query: EventCursorQuery{
-			MinLedger: 1, MaxLedger: 1000, Dir: Descending,
+			MinLedger: 1, MaxLedger: maxPtr(1000), Dir: Descending,
 			Filters: []event.Filter{{
 				ContractID: testContract(0xC4),
 				Topics:     [protocol.MaxTopicCount][]byte{testTopic(1), nil, testTopic(3), nil},
 			}},
 		},
-		Position:      &EventPosition{Ledger: 500, Tx: 1, Op: 2, Event: 3, K: 4},
+		Position:      &EventPosition{Ledger: 500, Tx: 1, Op: 2, Event: 3, LedgerOrdinal: 4},
 		ScannedLedger: 500,
 	}
 	first, err := env.Encode()
@@ -344,42 +357,70 @@ func TestCursorEncodeDeterministic(t *testing.T) {
 	assert.Equal(t, first, second)
 }
 
-func TestCursorEncodeRejectsBadContractLength(t *testing.T) {
-	env := EventCursor{
-		Query: EventCursorQuery{
-			MinLedger: 1, MaxLedger: 2, Dir: Ascending,
-			Filters: []event.Filter{{ContractID: bytes.Repeat([]byte{1}, 31)}},
+// Encode fails a minting bug on the page that has it: everything it rejects
+// is something no decode accepts, and none of its errors carry the decode
+// sentinels the handler maps to client-facing cursor errors.
+func TestCursorEncodeRejects(t *testing.T) {
+	cases := []struct {
+		name string
+		env  EventCursor
+	}{
+		{
+			name: "invalid direction",
+			env:  EventCursor{Query: EventCursorQuery{MinLedger: 1, Dir: Direction(99)}},
+		},
+		{
+			name: "descending without max",
+			env:  EventCursor{Query: EventCursorQuery{MinLedger: 1, Dir: Descending}},
+		},
+		{
+			name: "min greater than max",
+			env:  EventCursor{Query: EventCursorQuery{MinLedger: 3, MaxLedger: maxPtr(2), Dir: Ascending}},
+		},
+		{
+			name: "bad contract length",
+			env: EventCursor{
+				Query: EventCursorQuery{
+					MinLedger: 1, Dir: Ascending,
+					Filters: []event.Filter{{ContractID: bytes.Repeat([]byte{1}, 31)}},
+				},
+			},
+		},
+		{
+			name: "too many filters",
+			env: EventCursor{
+				Query: EventCursorQuery{
+					MinLedger: 1, Dir: Ascending,
+					Filters: make([]event.Filter, maxCursorFilters+1),
+				},
+			},
+		},
+		{
+			// Legitimate traffic cannot reach the size cap, hence the
+			// oversized topic.
+			name: "oversized output",
+			env: EventCursor{
+				Query: EventCursorQuery{
+					MinLedger: 1, Dir: Ascending,
+					Filters: []event.Filter{{
+						Topics: [protocol.MaxTopicCount][]byte{bytes.Repeat([]byte{7}, maxCursorBytes)},
+					}},
+				},
+			},
 		},
 	}
-	_, err := env.Encode()
-	require.Error(t, err)
-}
-
-func TestCursorEncodeRejectsInvalidDirection(t *testing.T) {
-	env := EventCursor{Query: EventCursorQuery{MinLedger: 1, MaxLedger: 2, Dir: Direction(99)}}
-	_, err := env.Encode()
-	require.Error(t, err)
-}
-
-// Encode refuses output DecodeEventCursor would reject. Legitimate traffic
-// cannot reach the cap, hence the oversized topic.
-func TestCursorEncodeRejectsOversized(t *testing.T) {
-	env := EventCursor{
-		Query: EventCursorQuery{
-			MinLedger: 1, MaxLedger: 2, Dir: Ascending,
-			Filters: []event.Filter{{
-				Topics: [protocol.MaxTopicCount][]byte{bytes.Repeat([]byte{7}, maxCursorBytes)},
-			}},
-		},
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.env.Encode()
+			require.Error(t, err)
+			require.NotErrorIs(t, err, ErrCursorMalformed)
+			require.NotErrorIs(t, err, ErrCursorUnknownVersion)
+		})
 	}
-	_, err := env.Encode()
-	require.Error(t, err)
-	require.NotErrorIs(t, err, ErrCursorMalformed)
 }
 
-// The logged worst-case size (256 full filters) feeds the plan's
-// JSON-versus-binary decision. No size is asserted; the envelope must
-// round-trip.
+// The logged worst-case size (256 full filters) records the frozen format's
+// practical maximum. No size is asserted; the envelope must round-trip.
 func TestCursorSizeWorstCase(t *testing.T) {
 	filters := make([]event.Filter, maxCursorFilters)
 	for i := range filters {
@@ -389,10 +430,12 @@ func TestCursorSizeWorstCase(t *testing.T) {
 		}
 	}
 	env := EventCursor{
-		Query: EventCursorQuery{MinLedger: 1, MaxLedger: math.MaxUint32, Dir: Ascending, Filters: filters},
+		Query: EventCursorQuery{
+			MinLedger: 1, MaxLedger: maxPtr(math.MaxUint32), Dir: Ascending, Filters: filters,
+		},
 		Position: &EventPosition{
 			Ledger: math.MaxUint32, Tx: math.MaxUint32, Op: math.MaxUint32,
-			Event: math.MaxUint32, K: math.MaxUint32,
+			Event: math.MaxUint32, LedgerOrdinal: math.MaxUint32,
 		},
 		ScannedLedger: math.MaxUint32,
 	}
@@ -404,45 +447,70 @@ func TestCursorSizeWorstCase(t *testing.T) {
 	require.Equal(t, &env, got)
 }
 
-// Trips when event.Filter grows a field the conversions do not map, which
-// would silently drop that constraint from minted cursors. Adding a field?
-// Map it in filterJSON (keys are reserved there), extend the golden vector,
-// and update the count.
-func TestCursorJSONCoversFilter(t *testing.T) {
+// Trips when event.Filter grows a field the codec does not map, which would
+// silently drop that constraint from minted cursors. Adding a field? Map it
+// in appendFilter and readFilter under a version bump (the #904 fields take
+// the reserved fflags bits), extend the golden vector, and update the count.
+func TestCursorCodecCoversFilter(t *testing.T) {
 	require.Equal(t, 2, reflect.TypeFor[event.Filter]().NumField(),
 		"event.Filter has fields the cursor body does not carry")
 }
 
-// canonicalizationSlack bounds how much larger a decoded envelope's
-// canonical re-encoding can be than the accepted input: omitted optional
-// keys reappear on encode, at most a few dozen bytes per filter. Within
-// this distance of maxCursorBytes, a forged non-canonical input can decode
-// yet re-encode past the cap.
-const canonicalizationSlack = 64 << 10
+// Zero-length non-nil values encode as absent, byte-identically to nil. The
+// wire cannot represent them: a set topic bit must carry a nonzero length.
+func TestCursorEmptyValuesEncodeAsAbsent(t *testing.T) {
+	withEmpty := EventCursor{
+		Query: EventCursorQuery{
+			MinLedger: 1, MaxLedger: maxPtr(2), Dir: Ascending,
+			Filters: []event.Filter{{
+				ContractID: []byte{},
+				Topics:     [protocol.MaxTopicCount][]byte{{}, {}, {}, {}},
+			}},
+		},
+	}
+	withNil := EventCursor{
+		Query: EventCursorQuery{
+			MinLedger: 1, MaxLedger: maxPtr(2), Dir: Ascending,
+			Filters: []event.Filter{{}},
+		},
+	}
+	encEmpty, err := withEmpty.Encode()
+	require.NoError(t, err)
+	encNil, err := withNil.Encode()
+	require.NoError(t, err)
+	require.Equal(t, encNil, encEmpty)
+}
 
 // FuzzDecodeEventCursor pins the codec's hostile-input promise: decode never
-// panics, and anything it accepts is stable under re-encode and re-decode,
-// except forged input within canonicalizationSlack of the size cap.
+// panics, errors are always typed, and any accepted token re-encodes to the
+// exact input bytes — one envelope, one encoding, no exceptions.
 func FuzzDecodeEventCursor(f *testing.F) {
 	valid := EventCursor{
 		Query: EventCursorQuery{
-			MinLedger: 1, MaxLedger: 2, Dir: Ascending,
+			MinLedger: 1, MaxLedger: maxPtr(2), Dir: Ascending,
 			Filters: []event.Filter{{ContractID: testContract(0xC0)}},
 		},
-		Position:      &EventPosition{Ledger: 1, Tx: 2, Op: 3, Event: 4, K: 5},
+		Position:      &EventPosition{Ledger: 1, Tx: 2, Op: 3, Event: 4, LedgerOrdinal: 5},
 		ScannedLedger: 1,
 	}
 	seed, err := valid.Encode()
 	if err != nil {
 		f.Fatal(err)
 	}
+	unbounded := EventCursor{Query: EventCursorQuery{MinLedger: 9, Dir: Ascending}}
+	seed2, err := unbounded.Encode()
+	if err != nil {
+		f.Fatal(err)
+	}
 	f.Add(seed)
+	f.Add(seed2)
 	f.Add("")
-	f.Add("not base64!!")
-	f.Add(base64.RawURLEncoding.EncodeToString([]byte{cursorVersion}))
-	f.Add(base64.RawURLEncoding.EncodeToString(append([]byte{cursorVersion}, `{}`...)))
-	f.Add(base64.RawURLEncoding.EncodeToString(append([]byte{cursorVersion},
-		`{"query":{"min":1,"max":2,"dir":"asc","filters":[{"topics":["AQ==","","","",""]}]},"scanned":0}`...)))
+	f.Add("gec1_")
+	f.Add("gec2_AAAA")
+	f.Add("not a cursor")
+	f.Add(tokV1(cat([]byte{0x00}, be32(1), be32(0), be16(0))))
+	f.Add(tokV1(cat([]byte{0x07}, be32(1), be32(2), be32(3), be32(4), be32(5), be32(6),
+		be32(7), be32(8), be16(1), []byte{0x05}, testContract(0xC5), be32(8), testTopic(0xB2))))
 	f.Fuzz(func(t *testing.T, s string) {
 		env, err := DecodeEventCursor(s)
 		if err != nil {
@@ -453,61 +521,10 @@ func FuzzDecodeEventCursor(f *testing.F) {
 		}
 		enc, err := env.Encode()
 		if err != nil {
-			if len(s) > maxCursorBytes-canonicalizationSlack {
-				return
-			}
 			t.Fatalf("accepted envelope failed to re-encode: %v", err)
 		}
-		again, err := DecodeEventCursor(enc)
-		if err != nil {
-			t.Fatalf("re-encoded cursor failed to decode: %v", err)
+		if enc != s {
+			t.Fatalf("re-encode is not byte-identical:\n in: %q\nout: %q", s, enc)
 		}
-		require.Equal(t, env, again)
 	})
-}
-
-func TestCursorEncodeRejectsTooManyFilters(t *testing.T) {
-	env := EventCursor{
-		Query: EventCursorQuery{
-			MinLedger: 1, MaxLedger: 2, Dir: Ascending,
-			Filters: make([]event.Filter, maxCursorFilters+1),
-		},
-	}
-	_, err := env.Encode()
-	require.Error(t, err)
-	require.NotErrorIs(t, err, ErrCursorMalformed)
-}
-
-// Empty non-nil values normalize to nil in both codec directions: a body
-// carrying "" values decodes to nil fields, and an envelope minted with
-// empty non-nil values encodes byte-identically to its nil form.
-func TestCursorEmptyValuesNormalizeToNil(t *testing.T) {
-	body := `{"query":{"min":1,"max":2,"dir":"asc","filters":[{"contract":"",` +
-		`"topics":["","","",""]}]},"scanned":0}`
-	enc := base64.RawURLEncoding.EncodeToString(append([]byte{cursorVersion}, body...))
-	got, err := DecodeEventCursor(enc)
-	require.NoError(t, err)
-	require.Len(t, got.Query.Filters, 1)
-	require.Equal(t, event.Filter{}, got.Query.Filters[0])
-
-	withEmpty := EventCursor{
-		Query: EventCursorQuery{
-			MinLedger: 1, MaxLedger: 2, Dir: Ascending,
-			Filters: []event.Filter{{
-				ContractID: []byte{},
-				Topics:     [protocol.MaxTopicCount][]byte{{}, {}, {}, {}},
-			}},
-		},
-	}
-	withNil := EventCursor{
-		Query: EventCursorQuery{
-			MinLedger: 1, MaxLedger: 2, Dir: Ascending,
-			Filters: []event.Filter{{}},
-		},
-	}
-	encEmpty, err := withEmpty.Encode()
-	require.NoError(t, err)
-	encNil, err := withNil.Encode()
-	require.NoError(t, err)
-	require.Equal(t, encNil, encEmpty)
 }

--- a/cmd/stellar-rpc/internal/rpcv2/query/event_cursor_test.go
+++ b/cmd/stellar-rpc/internal/rpcv2/query/event_cursor_test.go
@@ -1,0 +1,513 @@
+package query
+
+import (
+	"bytes"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
+
+	"github.com/stellar/stellar-rpc/cmd/stellar-rpc/internal/rpcv2/stores/event"
+)
+
+func testContract(b byte) []byte { return bytes.Repeat([]byte{b}, contractIDLen) }
+
+func testTopic(b byte) []byte { return bytes.Repeat([]byte{b}, 8) }
+
+var cursorRoundTripCases = []struct {
+	name string
+	env  EventCursor
+}{
+	{
+		name: "ascending with position, zero filters (match-all)",
+		env: EventCursor{
+			Query:         EventCursorQuery{MinLedger: 100, MaxLedger: 200, Dir: Ascending},
+			Position:      &EventPosition{Ledger: 150, Tx: 3, Op: 1, Event: 2, K: 41},
+			ScannedLedger: 150,
+		},
+	},
+	{
+		name: "ascending watermark-only (nil position)",
+		env: EventCursor{
+			Query:         EventCursorQuery{MinLedger: 100, MaxLedger: 200, Dir: Ascending},
+			ScannedLedger: 175,
+		},
+	},
+	{
+		name: "descending with position, contract-only filter",
+		env: EventCursor{
+			Query: EventCursorQuery{
+				MinLedger: 50, MaxLedger: 900, Dir: Descending,
+				Filters: []event.Filter{{ContractID: testContract(0xC1)}},
+			},
+			Position:      &EventPosition{Ledger: 700, Tx: 12, Op: 0, Event: 5, K: 9},
+			ScannedLedger: 700,
+		},
+	},
+	{
+		name: "descending watermark-only, topics with gaps (t0 and t2 set)",
+		env: EventCursor{
+			Query: EventCursorQuery{
+				MinLedger: 1, MaxLedger: 10, Dir: Descending,
+				Filters: []event.Filter{{
+					Topics: [protocol.MaxTopicCount][]byte{testTopic(0xA0), nil, testTopic(0xA2), nil},
+				}},
+			},
+			ScannedLedger: 4,
+		},
+	},
+	{
+		name: "full filter",
+		env: EventCursor{
+			Query: EventCursorQuery{
+				MinLedger: 20002, MaxLedger: 30001, Dir: Ascending,
+				Filters: []event.Filter{{
+					ContractID: testContract(0xC2),
+					Topics: [protocol.MaxTopicCount][]byte{
+						testTopic(1), testTopic(2), testTopic(3), testTopic(4),
+					},
+				}},
+			},
+			Position:      &EventPosition{Ledger: 25000, Tx: 1, Op: 1, Event: 0, K: 0},
+			ScannedLedger: 25000,
+		},
+	},
+	{
+		name: "multiple filters including an empty match-all filter",
+		env: EventCursor{
+			Query: EventCursorQuery{
+				MinLedger: 5, MaxLedger: 6, Dir: Descending,
+				Filters: []event.Filter{
+					{ContractID: testContract(0xC3)},
+					{Topics: [protocol.MaxTopicCount][]byte{nil, testTopic(0xB1), nil, nil}},
+					{},
+				},
+			},
+			Position:      &EventPosition{Ledger: 6, Tx: 2, Op: 3, Event: 4, K: 5},
+			ScannedLedger: 5,
+		},
+	},
+	{
+		// A present all-zero position must stay distinct from nil.
+		name: "all-zero position",
+		env: EventCursor{
+			Query:    EventCursorQuery{MinLedger: 1, MaxLedger: 2, Dir: Ascending},
+			Position: &EventPosition{},
+		},
+	},
+	{
+		name: "max uint32 field values",
+		env: EventCursor{
+			Query: EventCursorQuery{MinLedger: math.MaxUint32, MaxLedger: math.MaxUint32, Dir: Ascending},
+			Position: &EventPosition{
+				Ledger: math.MaxUint32, Tx: math.MaxUint32, Op: math.MaxUint32,
+				Event: math.MaxUint32, K: math.MaxUint32,
+			},
+			ScannedLedger: math.MaxUint32,
+		},
+	},
+}
+
+func TestCursorRoundTrip(t *testing.T) {
+	for _, tc := range cursorRoundTripCases {
+		t.Run(tc.name, func(t *testing.T) {
+			enc, err := tc.env.Encode()
+			require.NoError(t, err)
+			got, err := DecodeEventCursor(enc)
+			require.NoError(t, err)
+			require.Equal(t, &tc.env, got)
+		})
+	}
+}
+
+func TestCursorVersionRejection(t *testing.T) {
+	env := EventCursor{Query: EventCursorQuery{MinLedger: 1, MaxLedger: 2, Dir: Ascending}}
+	enc, err := env.Encode()
+	require.NoError(t, err)
+	for _, version := range []byte{0, 2} {
+		t.Run(fmt.Sprintf("version %d", version), func(t *testing.T) {
+			raw, err := base64.RawURLEncoding.DecodeString(enc)
+			require.NoError(t, err)
+			raw[0] = version
+			got, err := DecodeEventCursor(base64.RawURLEncoding.EncodeToString(raw))
+			require.ErrorIs(t, err, ErrCursorUnknownVersion)
+			assert.Nil(t, got)
+		})
+	}
+}
+
+func TestCursorMalformedInputs(t *testing.T) {
+	b64 := func(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
+	// v1 wraps a raw body in a valid version byte so the failure under test is
+	// the body, not the version.
+	v1 := func(body string) string { return b64(append([]byte{cursorVersion}, body...)) }
+	contract31 := base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{1}, 31))
+	overCap := `{"query":{"min":1,"max":2,"dir":"asc","filters":[` +
+		strings.TrimSuffix(strings.Repeat(`{},`, maxCursorFilters+1), ",") +
+		`]},"scanned":0}`
+
+	cases := []struct {
+		name string
+		in   string
+		want error
+	}{
+		{"empty string", "", ErrCursorMalformed},
+		{"not base64", "not base64!!", ErrCursorMalformed},
+		{"garbage bytes", b64([]byte{0x9B, 0x00, 0xFF, 0x13, 0x37}), ErrCursorUnknownVersion},
+		{"valid version byte, invalid JSON", v1("{{{not json"), ErrCursorMalformed},
+		{
+			"unknown dir",
+			v1(`{"query":{"min":1,"max":2,"dir":"sideways","filters":[]},"scanned":0}`),
+			ErrCursorMalformed,
+		},
+		{
+			"contract of 31 bytes",
+			v1(`{"query":{"min":1,"max":2,"dir":"asc","filters":[{"contract":"` +
+				contract31 + `","topics":[null,null,null,null]}]},"scanned":0}`),
+			ErrCursorMalformed,
+		},
+		{
+			"contract of invalid base64",
+			v1(`{"query":{"min":1,"max":2,"dir":"asc","filters":[{"contract":"!!!not-b64",` +
+				`"topics":[null,null,null,null]}]},"scanned":0}`),
+			ErrCursorMalformed,
+		},
+		{
+			"topic of invalid base64",
+			v1(`{"query":{"min":1,"max":2,"dir":"asc","filters":[{"topics":["!!!not-b64",` +
+				`null,null,null]}]},"scanned":0}`),
+			ErrCursorMalformed,
+		},
+		{
+			"min greater than max",
+			v1(`{"query":{"min":3,"max":2,"dir":"asc","filters":[]},"scanned":0}`),
+			ErrCursorMalformed,
+		},
+		{"filter count over cap", v1(overCap), ErrCursorMalformed},
+		// Rejected by the pre-unmarshal brace guard: a quarter-million empty
+		// filters fit the size cap but must not reach json.Unmarshal.
+		{
+			"quarter-million empty filters",
+			v1(`{"query":{"min":1,"max":2,"dir":"asc","filters":[` +
+				strings.TrimSuffix(strings.Repeat(`{},`, 250_000), ",") +
+				`]},"scanned":0}`),
+			ErrCursorMalformed,
+		},
+		{"oversized input", strings.Repeat("A", maxCursorBytes+1), ErrCursorMalformed},
+		{"empty body after version byte", v1(""), ErrCursorMalformed},
+		// A structurally empty body must never decode to a usable zero
+		// envelope; the dir check is what rejects it.
+		{"empty JSON object body", v1(`{}`), ErrCursorMalformed},
+		// Numeric strictness is inherited from encoding/json; pinned so a
+		// lenient unmarshaller swap cannot change it.
+		{
+			"uint32 overflow",
+			v1(`{"query":{"min":1,"max":4294967296,"dir":"asc","filters":[]},"scanned":0}`),
+			ErrCursorMalformed,
+		},
+		{
+			"negative number",
+			v1(`{"query":{"min":-1,"max":2,"dir":"asc","filters":[]},"scanned":0}`),
+			ErrCursorMalformed,
+		},
+		{
+			"non-integer number",
+			v1(`{"query":{"min":1.5,"max":2,"dir":"asc","filters":[]},"scanned":0}`),
+			ErrCursorMalformed,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := DecodeEventCursor(tc.in)
+			require.ErrorIs(t, err, tc.want)
+			assert.Nil(t, got)
+		})
+	}
+}
+
+// TestCursorGoldenV1 pins the version-1 body against literal JSON: round-trip
+// tests pass a tag rename in lockstep, the literals do not. The minimal
+// vector pins the absent-field shapes ("filters":[], no "position" key).
+func TestCursorGoldenV1(t *testing.T) {
+	contract := testContract(0xC5)
+	topic := testTopic(0xB2)
+	cases := []struct {
+		name string
+		env  EventCursor
+		body string
+	}{
+		{
+			name: "full envelope",
+			env: EventCursor{
+				Query: EventCursorQuery{
+					MinLedger: 1, MaxLedger: 2, Dir: Ascending,
+					Filters: []event.Filter{{
+						ContractID: contract,
+						Topics:     [protocol.MaxTopicCount][]byte{nil, topic, nil, nil},
+					}},
+				},
+				Position:      &EventPosition{Ledger: 3, Tx: 4, Op: 5, Event: 6, K: 7},
+				ScannedLedger: 8,
+			},
+			body: fmt.Sprintf(
+				`{"query":{"min":1,"max":2,"dir":"asc","filters":[{"contract":%q,"topics":[null,%q,null,null]}]},`+
+					`"position":{"ledger":3,"tx":4,"op":5,"event":6,"k":7},"scanned":8}`,
+				base64.StdEncoding.EncodeToString(contract),
+				base64.StdEncoding.EncodeToString(topic),
+			),
+		},
+		{
+			name: "minimal watermark-only match-all",
+			env: EventCursor{
+				Query:         EventCursorQuery{MinLedger: 100, MaxLedger: 200, Dir: Descending},
+				ScannedLedger: 175,
+			},
+			body: `{"query":{"min":100,"max":200,"dir":"desc","filters":[]},"scanned":175}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			enc, err := tc.env.Encode()
+			require.NoError(t, err)
+			raw, err := base64.RawURLEncoding.DecodeString(enc)
+			require.NoError(t, err)
+			require.NotEmpty(t, raw)
+			assert.Equal(t, byte(cursorVersion), raw[0])
+			assert.Equal(t, tc.body, string(raw[1:]))
+
+			golden := base64.RawURLEncoding.EncodeToString(append([]byte{cursorVersion}, tc.body...))
+			got, err := DecodeEventCursor(golden)
+			require.NoError(t, err)
+			assert.Equal(t, &tc.env, got)
+		})
+	}
+}
+
+// Go's JSON decoder drops extra "topics" elements and zero-fills missing
+// ones; only a forger can produce either. Pinned so a stricter unmarshaller
+// cannot change the behavior undetected.
+func TestCursorTopicsArityLenient(t *testing.T) {
+	v1 := func(body string) string {
+		return base64.RawURLEncoding.EncodeToString(append([]byte{cursorVersion}, body...))
+	}
+	topic := base64.StdEncoding.EncodeToString(testTopic(0xA7))
+
+	t.Run("five elements: fifth dropped", func(t *testing.T) {
+		got, err := DecodeEventCursor(v1(
+			`{"query":{"min":1,"max":2,"dir":"asc","filters":[{"topics":[` +
+				fmt.Sprintf("%q", topic) + `,null,null,null,` + fmt.Sprintf("%q", topic) +
+				`]}]},"scanned":0}`))
+		require.NoError(t, err)
+		require.Len(t, got.Query.Filters, 1)
+		assert.Equal(t, testTopic(0xA7), got.Query.Filters[0].Topics[0])
+		for i := 1; i < protocol.MaxTopicCount; i++ {
+			assert.Nil(t, got.Query.Filters[0].Topics[i])
+		}
+	})
+	t.Run("two elements: rest zero-filled", func(t *testing.T) {
+		got, err := DecodeEventCursor(v1(
+			`{"query":{"min":1,"max":2,"dir":"asc","filters":[{"topics":[null,` +
+				fmt.Sprintf("%q", topic) + `]}]},"scanned":0}`))
+		require.NoError(t, err)
+		require.Len(t, got.Query.Filters, 1)
+		assert.Nil(t, got.Query.Filters[0].Topics[0])
+		assert.Equal(t, testTopic(0xA7), got.Query.Filters[0].Topics[1])
+		assert.Nil(t, got.Query.Filters[0].Topics[2])
+		assert.Nil(t, got.Query.Filters[0].Topics[3])
+	})
+}
+
+func TestCursorEncodeDeterministic(t *testing.T) {
+	env := EventCursor{
+		Query: EventCursorQuery{
+			MinLedger: 1, MaxLedger: 1000, Dir: Descending,
+			Filters: []event.Filter{{
+				ContractID: testContract(0xC4),
+				Topics:     [protocol.MaxTopicCount][]byte{testTopic(1), nil, testTopic(3), nil},
+			}},
+		},
+		Position:      &EventPosition{Ledger: 500, Tx: 1, Op: 2, Event: 3, K: 4},
+		ScannedLedger: 500,
+	}
+	first, err := env.Encode()
+	require.NoError(t, err)
+	second, err := env.Encode()
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+}
+
+func TestCursorEncodeRejectsBadContractLength(t *testing.T) {
+	env := EventCursor{
+		Query: EventCursorQuery{
+			MinLedger: 1, MaxLedger: 2, Dir: Ascending,
+			Filters: []event.Filter{{ContractID: bytes.Repeat([]byte{1}, 31)}},
+		},
+	}
+	_, err := env.Encode()
+	require.Error(t, err)
+}
+
+func TestCursorEncodeRejectsInvalidDirection(t *testing.T) {
+	env := EventCursor{Query: EventCursorQuery{MinLedger: 1, MaxLedger: 2, Dir: Direction(99)}}
+	_, err := env.Encode()
+	require.Error(t, err)
+}
+
+// Encode refuses output DecodeEventCursor would reject. Legitimate traffic
+// cannot reach the cap, hence the oversized topic.
+func TestCursorEncodeRejectsOversized(t *testing.T) {
+	env := EventCursor{
+		Query: EventCursorQuery{
+			MinLedger: 1, MaxLedger: 2, Dir: Ascending,
+			Filters: []event.Filter{{
+				Topics: [protocol.MaxTopicCount][]byte{bytes.Repeat([]byte{7}, maxCursorBytes)},
+			}},
+		},
+	}
+	_, err := env.Encode()
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrCursorMalformed)
+}
+
+// The logged worst-case size (256 full filters) feeds the plan's
+// JSON-versus-binary decision. No size is asserted; the envelope must
+// round-trip.
+func TestCursorSizeWorstCase(t *testing.T) {
+	filters := make([]event.Filter, maxCursorFilters)
+	for i := range filters {
+		filters[i].ContractID = bytes.Repeat([]byte{byte(i)}, contractIDLen)
+		for j := range filters[i].Topics {
+			filters[i].Topics[j] = bytes.Repeat([]byte{byte(i + j)}, 64)
+		}
+	}
+	env := EventCursor{
+		Query: EventCursorQuery{MinLedger: 1, MaxLedger: math.MaxUint32, Dir: Ascending, Filters: filters},
+		Position: &EventPosition{
+			Ledger: math.MaxUint32, Tx: math.MaxUint32, Op: math.MaxUint32,
+			Event: math.MaxUint32, K: math.MaxUint32,
+		},
+		ScannedLedger: math.MaxUint32,
+	}
+	enc, err := env.Encode()
+	require.NoError(t, err)
+	t.Logf("worst-case encoded cursor: %d bytes", len(enc))
+	got, err := DecodeEventCursor(enc)
+	require.NoError(t, err)
+	require.Equal(t, &env, got)
+}
+
+// Trips when event.Filter grows a field the conversions do not map, which
+// would silently drop that constraint from minted cursors. Adding a field?
+// Map it in filterJSON (keys are reserved there), extend the golden vector,
+// and update the count.
+func TestCursorJSONCoversFilter(t *testing.T) {
+	require.Equal(t, 2, reflect.TypeFor[event.Filter]().NumField(),
+		"event.Filter has fields the cursor body does not carry")
+}
+
+// canonicalizationSlack bounds how much larger a decoded envelope's
+// canonical re-encoding can be than the accepted input: omitted optional
+// keys reappear on encode, at most a few dozen bytes per filter. Within
+// this distance of maxCursorBytes, a forged non-canonical input can decode
+// yet re-encode past the cap.
+const canonicalizationSlack = 64 << 10
+
+// FuzzDecodeEventCursor pins the codec's hostile-input promise: decode never
+// panics, and anything it accepts is stable under re-encode and re-decode,
+// except forged input within canonicalizationSlack of the size cap.
+func FuzzDecodeEventCursor(f *testing.F) {
+	valid := EventCursor{
+		Query: EventCursorQuery{
+			MinLedger: 1, MaxLedger: 2, Dir: Ascending,
+			Filters: []event.Filter{{ContractID: testContract(0xC0)}},
+		},
+		Position:      &EventPosition{Ledger: 1, Tx: 2, Op: 3, Event: 4, K: 5},
+		ScannedLedger: 1,
+	}
+	seed, err := valid.Encode()
+	if err != nil {
+		f.Fatal(err)
+	}
+	f.Add(seed)
+	f.Add("")
+	f.Add("not base64!!")
+	f.Add(base64.RawURLEncoding.EncodeToString([]byte{cursorVersion}))
+	f.Add(base64.RawURLEncoding.EncodeToString(append([]byte{cursorVersion}, `{}`...)))
+	f.Add(base64.RawURLEncoding.EncodeToString(append([]byte{cursorVersion},
+		`{"query":{"min":1,"max":2,"dir":"asc","filters":[{"topics":["AQ==","","","",""]}]},"scanned":0}`...)))
+	f.Fuzz(func(t *testing.T, s string) {
+		env, err := DecodeEventCursor(s)
+		if err != nil {
+			if !errors.Is(err, ErrCursorMalformed) && !errors.Is(err, ErrCursorUnknownVersion) {
+				t.Fatalf("untyped decode error: %v", err)
+			}
+			return
+		}
+		enc, err := env.Encode()
+		if err != nil {
+			if len(s) > maxCursorBytes-canonicalizationSlack {
+				return
+			}
+			t.Fatalf("accepted envelope failed to re-encode: %v", err)
+		}
+		again, err := DecodeEventCursor(enc)
+		if err != nil {
+			t.Fatalf("re-encoded cursor failed to decode: %v", err)
+		}
+		require.Equal(t, env, again)
+	})
+}
+
+func TestCursorEncodeRejectsTooManyFilters(t *testing.T) {
+	env := EventCursor{
+		Query: EventCursorQuery{
+			MinLedger: 1, MaxLedger: 2, Dir: Ascending,
+			Filters: make([]event.Filter, maxCursorFilters+1),
+		},
+	}
+	_, err := env.Encode()
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrCursorMalformed)
+}
+
+// Empty non-nil values normalize to nil in both codec directions: a body
+// carrying "" values decodes to nil fields, and an envelope minted with
+// empty non-nil values encodes byte-identically to its nil form.
+func TestCursorEmptyValuesNormalizeToNil(t *testing.T) {
+	body := `{"query":{"min":1,"max":2,"dir":"asc","filters":[{"contract":"",` +
+		`"topics":["","","",""]}]},"scanned":0}`
+	enc := base64.RawURLEncoding.EncodeToString(append([]byte{cursorVersion}, body...))
+	got, err := DecodeEventCursor(enc)
+	require.NoError(t, err)
+	require.Len(t, got.Query.Filters, 1)
+	require.Equal(t, event.Filter{}, got.Query.Filters[0])
+
+	withEmpty := EventCursor{
+		Query: EventCursorQuery{
+			MinLedger: 1, MaxLedger: 2, Dir: Ascending,
+			Filters: []event.Filter{{
+				ContractID: []byte{},
+				Topics:     [protocol.MaxTopicCount][]byte{{}, {}, {}, {}},
+			}},
+		},
+	}
+	withNil := EventCursor{
+		Query: EventCursorQuery{
+			MinLedger: 1, MaxLedger: 2, Dir: Ascending,
+			Filters: []event.Filter{{}},
+		},
+	}
+	encEmpty, err := withEmpty.Encode()
+	require.NoError(t, err)
+	encNil, err := withNil.Encode()
+	require.NoError(t, err)
+	require.Equal(t, encNil, encEmpty)
+}


### PR DESCRIPTION
### What

The server-minted, opaque, versioned cursor behind getEvents v2 pagination ([proposal](https://github.com/orgs/stellar/discussions/1872)): `EventCursor` (canonical query, optional position of the last delivered event, scanned-ledger watermark) encoded as a `gec1_`-prefixed base64url token over a fixed-layout binary body. Decode checks well-formedness only and returns typed errors (`ErrCursorMalformed`, `ErrCursorUnknownVersion`) for the handler to map; validation against the serving window and budgets stays with the handler.

### Why

v2 pagination needs a cursor that carries the whole query and resume state, works identically over a 7-day window and full history, and never expires. This PR is the codec foundation; the cross-chunk pager and the getEventsV2 handler build on it in follow-ups.

### Notes for review

- The format version is cleartext in the token prefix, so version skew is greppable in logs and a future body format is a clean version bump; every version's decoder stays supported forever.
- One envelope has one encoding: presence bits for optional fields, exact-consume decode, strict base64. Decode-then-encode is byte-identical, pinned by the fuzz target. A cleared max-ledger bit is the proposal's open upper bound (ascending follows the tip) — no sentinel value.
- Every decode read checks remaining length first, and the filter cap applies before allocation, so a forged cursor cannot make decode allocate beyond its own size. Encode enforces the same checks as decode, so a minting bug fails on the page that has it rather than on the resume.
- Golden vectors pin the v1 layout as literal bytes; the malformed table's rows are mutation-verified — each guard has an input only that guard can reject.
- The worst-case measurement (256 full filters) encodes to ~102 KiB, well under the 1 MiB cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
