### PR TITLE
Fix integration-test flake: reserve captive-core ports outside the ephemeral port range

### DIFF
--- a/cmd/stellar-rpc/internal/integrationtest/infrastructure/test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/infrastructure/test.go
@@ -669,9 +669,8 @@ func (i *Test) fillRPCDaemonPorts() {
 }
 
 func (i *Test) spawnRPCDaemon() {
-	// We need to dynamically allocate port numbers since tests run in parallel.
-	// Unfortunately this isn't completely clash-free, but there is no way to
-	// tell core to allocate the port dynamically.
+	// We need to allocate port numbers dynamically since tests run in parallel,
+	// and there is no way to tell core to allocate its ports dynamically.
 	// Allocate both ports together so the OS doesn't hand out the same port twice.
 	ports := getFreeTCPPorts(i.t, 2)
 	i.testPorts.captiveCorePeerPort = ports[0]

--- a/cmd/stellar-rpc/internal/integrationtest/infrastructure/util.go
+++ b/cmd/stellar-rpc/internal/integrationtest/infrastructure/util.go
@@ -1,9 +1,13 @@
 package infrastructure
 
 import (
+	"errors"
+	"fmt"
+	"math/rand/v2"
 	"net"
 	"path/filepath"
 	"runtime"
+	"syscall"
 
 	"github.com/stretchr/testify/require"
 
@@ -16,25 +20,53 @@ func GetCurrentDirectory() string {
 	return filepath.Dir(currentFilename)
 }
 
-// getFreeTCPPorts allocates n distinct free TCP ports. It keeps all listeners
-// open until all ports are assigned, preventing the OS from handing out the
-// same port twice.
+// Ports reserved for captive core are picked from this range, which sits below
+// the kernel's ephemeral port range (32768+ on Linux, 49152+ on macOS). Sockets
+// bound to "localhost:0" (e.g. the RPC daemon's endpoints) always get ephemeral
+// ports, so they can never receive a port reserved here — even after the
+// reservation listeners below are closed. Reserving straight from "localhost:0"
+// caused exactly that collision: core would fail to start with "bind: Address
+// already in use" because the daemon had been handed the reserved port.
+const (
+	reservedPortRangeStart = 20000
+	reservedPortRangeEnd   = 30000
+)
+
+// getFreeTCPPorts allocates n distinct free TCP ports from the reserved range.
+// It keeps all listeners open until all ports are assigned, preventing the OS
+// from handing out the same port twice.
 func getFreeTCPPorts(t require.TestingT, n int) []uint16 {
-	listeners := make([]*net.TCPListener, n)
-	ports := make([]uint16, n)
-	for i := range n {
-		a, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	const maxAttempts = 1000
+	listeners := make([]*net.TCPListener, 0, n)
+	defer func() {
+		for _, l := range listeners {
+			l.Close()
+		}
+	}()
+	ports := make([]uint16, 0, n)
+	for range maxAttempts {
+		if len(ports) == n {
+			break
+		}
+		port := reservedPortRangeStart + rand.IntN(reservedPortRangeEnd-reservedPortRangeStart)
+		a, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:%d", port))
 		require.NoError(t, err)
 		l, err := net.ListenTCP("tcp", a)
-		require.NoError(t, err)
-		listeners[i] = l
-		tcpAddr, ok := l.Addr().(*net.TCPAddr)
-		require.True(t, ok, "expected *net.TCPAddr")
-		ports[i] = uint16(tcpAddr.Port)
+		if err != nil {
+			if errors.Is(err, syscall.EADDRINUSE) {
+				// Port already in use (possibly by a previous iteration of this
+				// loop, since we hold our listeners open). Try another one.
+				continue
+			}
+			// Any other error (permissions, fd exhaustion, ...) will not be
+			// fixed by retrying, so report it instead of burning all attempts.
+			require.NoError(t, err)
+		}
+		listeners = append(listeners, l)
+		ports = append(ports, uint16(port))
 	}
-	for _, l := range listeners {
-		l.Close()
-	}
+	require.Len(t, ports, n, "could not find %d free ports in [%d, %d)",
+		n, reservedPortRangeStart, reservedPortRangeEnd)
 	return ports
 }
 

--- a/cmd/stellar-rpc/internal/integrationtest/infrastructure/util_test.go
+++ b/cmd/stellar-rpc/internal/integrationtest/infrastructure/util_test.go
@@ -1,0 +1,19 @@
+package infrastructure
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetFreeTCPPorts(t *testing.T) {
+	ports := getFreeTCPPorts(t, 5)
+	require.Len(t, ports, 5)
+	seen := make(map[uint16]bool)
+	for _, port := range ports {
+		require.GreaterOrEqual(t, port, uint16(reservedPortRangeStart))
+		require.Less(t, port, uint16(reservedPortRangeEnd))
+		require.False(t, seen[port], "port %d handed out twice", port)
+		seen[port] = true
+	}
+}


### PR DESCRIPTION
### What

`getFreeTCPPorts` now reserves captive core's ports from a fixed range
(20000–29999) below the kernel's ephemeral range, instead of binding
`localhost:0` and closing the listener. 

### Why

The RPC daemon binds its endpoints at `localhost:0` and the OS can hand it a
port just reserved for captive core. Core then fails every launch with
`bind: Address already in use`, ingestion retries forever, and the test times
out with "RPC never got healthy". Ports bound at `localhost:0` always come
from the ephemeral range (32768+ on Linux), so reserving below it removes the
collision entirely.

Example: https://github.com/stellar/stellar-rpc/actions/runs/31057807498/job/92490453138
(`TestGetTransactionsEvents` — daemon endpoint and core's `HTTP_QUERY_PORT`
both got port 40439).