### PR TITLE
Bump P28 core package and image to 28.0.0-3494.a9b861321

### DIFF
--- a/.github/workflows/stellar-rpc.yml
+++ b/.github/workflows/stellar-rpc.yml
@@ -89,8 +89,8 @@ jobs:
     uses: ./.github/workflows/integration-tests.yml
     with:
       protocol_version: '27'
-      core_deb_version: '28.0.0-3486.2332980a1.jammy'
-      core_docker_img: 'stellar/unsafe-stellar-core:28.0.0-3486.2332980a1.jammy'
+      core_deb_version: '28.0.0-3494.a9b861321.jammy'
+      core_docker_img: 'stellar/unsafe-stellar-core:28.0.0-3494.a9b861321.jammy'
 
   integration-p28-pkg:
     name: Integration tests (P28)
@@ -101,8 +101,8 @@ jobs:
       # rs-soroban-env v28.0.0 (ba37ea5f) — the same release soroban-env-host-curr
       # pins from crates.io, keeping simulation cost models identical to
       # apply-time metering.
-      core_deb_version: '28.0.0-3486.2332980a1.jammy'
-      core_docker_img: 'stellar/unsafe-stellar-core:28.0.0-3486.2332980a1.jammy'
+      core_deb_version: '28.0.0-3494.a9b861321.jammy'
+      core_docker_img: 'stellar/unsafe-stellar-core:28.0.0-3494.a9b861321.jammy'
 
   # integration-p25-src:
   #   name: Integration tests (p25, core from source)


### PR DESCRIPTION
Propagates the new stellar-core GA build `28.0.0-3494.a9b861321` into CI. Both
integration legs (P27 and P28) move to it, per the release-train convention that
every leg runs the new binaries.

* deb `28.0.0-3494.a9b861321.jammy` — published in apt `jammy unstable` + `testing`
* image `stellar/unsafe-stellar-core:28.0.0-3494.a9b861321.jammy` — published
  2026-08-06 (the `stellar/stellar-core` GA docker repo still has no 28.0.0 tags;
  the unsafe→GA swap remains the release-time step)

The new build is 11 commits ahead of `3486.2332980a1` and touches only
bucket/ledger/overlay code — no `src/protocol-curr/xdr` and no `src/rust/soroban`
change. `src/rust/src/dep-trees/p27-expect.txt` and `p28-expect.txt` are
byte-identical between the two revisions, so `scripts/check-dependencies.bash`
sees the same rs-stellar-xdr expectations (verified locally: output unchanged).

Part of the Protocol 28 GA release train (stellar/go-stellar-sdk#5967).